### PR TITLE
Temporarily use forked version of PubChemPy from keceli/PubChemPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "langchain-anthropic>=0.3.13",
     "pydantic",
     "pandas",
-    "pubchempy",
+    "pubchempy @ git+https://github.com/keceli/PubChemPy.git@main",
     "pyppeteer",
     "numpy>=2",
     "langchain-experimental>=0.3.4",


### PR DESCRIPTION
See:
https://github.com/mcs07/PubChemPy/pull/93
https://github.com/mcs07/PubChemPy/issues/99
https://github.com/mcs07/PubChemPy/issues/101
https://github.com/mcs07/PubChemPy/pull/102