### PR TITLE
Add support for gemini-2.5-flash and gemini-2.5-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ pip install -e ".[uma]"
 
    # Set Anthropic API token
    export ANTHROPIC_API_KEY="your_anthropic_api_key_here"
+   
+   # Set Google API token
+   export GOOGLE_API_KEY="your_google_api_key_here"
    ```
 
 2. **Explore Example Notebooks**: Navigate to the `notebooks/` directory to explore various example notebooks demonstrating different capabilities of ChemGraph.
@@ -380,6 +383,7 @@ agent = ChemGraph(
 **Available Environment Variables for External Services:**
 - `OPENAI_API_KEY`: For OpenAI models
 - `ANTHROPIC_API_KEY`: For Anthropic Claude models
+- `GOOGLE_API_KEY`: For Gemini models
 
 ### Working with Example Notebooks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "deepdiff",
     "pymatgen",
     "mace-torch>=0.3.13",
+    "langsmith<0.4"
     ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "langchain-openai>=0.2.12",
     "langchain-ollama>=0.2.1",
     "langchain-anthropic>=0.3.13",
+    "langchain-google-genai",
     "pydantic",
     "pandas",
     "pubchempy @ git+https://github.com/keceli/PubChemPy.git@main",
@@ -31,7 +32,7 @@ dependencies = [
     "deepdiff",
     "pymatgen",
     "mace-torch>=0.3.13",
-    "langsmith<0.4"
+    "langsmith<0.4",
     ]
 
 [project.optional-dependencies]

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -3,7 +3,12 @@ Lists of supported models for different LLM providers.
 """
 
 # OpenAI models that are supported
-supported_openai_models = ["gpt-4o-mini", "gpt-4o", "gpt-4.1", "gpt-3.5-turbo-0125"]
+supported_openai_models = [
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-3.5-turbo-0125",
+]
 
 # Ollama models that are supported
 supported_ollama_models = ["llama3.2", "llama3.1"]
@@ -34,6 +39,12 @@ supported_anthropic_models = [
     "claude-3-opus-20240229",
     "claude-3-sonnet-20240229",
     "claude-3-haiku-20240307",
+]
+
+# Gemini models. gemini-2.0 doesn't work with toolcall in our last test.
+supported_gemini_models = [
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
 ]
 
 supported_argo_models = [

--- a/src/chemgraph/tools/gemini_loader.py
+++ b/src/chemgraph/tools/gemini_loader.py
@@ -1,0 +1,96 @@
+"""Load Gemini models using LangChain."""
+
+import os
+from getpass import getpass
+from langchain_google_genai import ChatGoogleGenerativeAI
+from chemgraph.models.supported_models import supported_gemini_models
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def load_gemini_model(
+    model_name: str,
+    temperature: float,
+    api_key: str = None,
+    prompt: str = None,
+    base_url: str = None,
+) -> ChatGoogleGenerativeAI:
+    """Load an Gemini chat model into LangChain.
+
+    This function loads an Gemini model and configures it for use with LangChain.
+    It handles API key management, including prompting for the key if not provided
+    or if the provided key is invalid.
+
+    Parameters
+    ----------
+    model_name : str
+        The name of the Gemini chat model to load. See supported_gemini_models for list
+        of supported models.
+    temperature : float
+        Controls the randomness of the generated text. Higher values (e.g., 0.8)
+        make the output more random, while lower values (e.g., 0.2) make it more
+        deterministic.
+    api_key : str, optional
+        The Google API key. If not provided, the function will attempt to retrieve it
+        from the environment variable `GOOGLE_API_KEY`.
+    prompt : str, optional
+        Custom prompt to use when requesting the API key from the user.
+
+    Returns
+    -------
+    ChatGoogleGenerativeAI
+        An instance of LangChain's ChatGoogleGenerativeAI model.
+
+    Raises
+    ------
+    ValueError
+        If the model name is not in the list of supported models.
+    Exception
+        If there is an error loading the model or if the API key is invalid.
+
+    Notes
+    -----
+    The function will:
+    1. Check for the API key in the environment variables
+    2. Prompt for the key if not found
+    3. Validate the model name against supported models
+    4. Attempt to load the model
+    5. Handle any authentication errors by prompting for a new key
+    """
+
+    if api_key is None:
+        api_key = os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            logger.info("Google API key not found in environment variables.")
+            api_key = getpass("Please enter your Google API key: ")
+            os.environ["GOOGLE_API_KEY"] = api_key
+
+    if model_name not in supported_gemini_models:
+        raise ValueError(
+            f"Unsupported model '{model_name}'. Supported models are: {supported_gemini_models}."
+        )
+
+    try:
+        logger.info(f"Loading Gemini model: {model_name}")
+        llm = ChatGoogleGenerativeAI(
+            model=model_name,
+            temperature=temperature,
+            api_key=api_key,
+            max_output_tokens=5000,
+        )
+        # No guarantee that api_key is valid, authentication happens only during invocation
+        logger.info(f"Requested model: {model_name}")
+        logger.info("Gemini model loaded successfully")
+        return llm
+    except Exception as e:
+        # Can remove this since authentication happens only during invocation
+        if "AuthenticationError" in str(e) or "invalid_api_key" in str(e):
+            logger.warning("Invalid Google API key.")
+            api_key = getpass("Please enter a valid Google API key: ")
+            os.environ["GOOGLE_API_KEY"] = api_key
+            # Retry with new API key
+            return load_gemini_model(model_name, temperature, api_key, prompt)
+        else:
+            logger.error(f"Error loading Google model: {str(e)}")
+            raise


### PR DESCRIPTION
- Update [README.md](https://github.com/argonne-lcf/ChemGraph/compare/dev-gemini?expand=1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with GOOGLE_API_KEY
- Update [pyproject.toml](https://github.com/argonne-lcf/ChemGraph/compare/dev-gemini?expand=1#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711). Add langchain-google-genai dependency and limit LangSmith version.
- Update [src/chemgraph/agent/llm_agent.py](https://github.com/argonne-lcf/ChemGraph/compare/dev-gemini?expand=1#diff-398c61f9d7de68b775bbeb7690c22a2b6a2acce574b6b31ac1fdd1ee9f883ae6) with gemini models init.
- Add gemini-2.5 models in [src/chemgraph/models/supported_models.py](https://github.com/argonne-lcf/ChemGraph/compare/dev-gemini?expand=1#diff-843eaf239ac5bfd14fd9aaddae772927b3d953159b53e6ecc4e0876653d7df80). Note: Our initial shows gemini-2.0 model doesn't work well with ChemGraph. Need more tests before adding gemini-2.0
- Add gemini_loader [src/chemgraph/tools/gemini_loader.py](https://github.com/argonne-lcf/ChemGraph/compare/dev-gemini?expand=1#diff-f90b0eaa0b66e4890f422b2bedbba0eea4a3f0d3b288f7711566131582d13982)