### PR TITLE
Fix #84 Gemini API error: Add proper type annotation for dipole_value field

### DIFF
--- a/src/chemgraph/models/ase_input.py
+++ b/src/chemgraph/models/ase_input.py
@@ -175,7 +175,7 @@ class ASEOutputSchema(BaseModel):
         default=None, description="Single-point energy/Potential energy"
     )
     energy_unit: str = Field(default="eV", description="The unit of the energy reported.")
-    dipole_value: list = Field(
+    dipole_value: List[Optional[float]] = Field(
         default=[None, None, None],
         description="The value of the dipole moment reported.",
     )


### PR DESCRIPTION
## Problem
When using Gemini models via the Streamlit web app, queries fail with the error:

Invalid argument provided to Gemini: 400 * GenerateContentRequest.tools[0].function_declarations[0].parameters.properties[ase_output].properties[dipole_value].items: missing field.


The issue was that `dipole_value` in `ASEOutputSchema` was typed as `list` without specifying the item type. Gemini's API requires arrays to have an `items` property that defines the element type.

## Solution
Changed `dipole_value: list` to `dipole_value: List[Optional[float]]` in `src/chemgraph/models/ase_input.py`. This ensures Pydantic generates the correct JSON schema with the `items` field that Gemini expects.

## Testing
- ✅ Verified the fix resolves the Gemini API error in Streamlit web app
- ✅ Confirmed queries now work correctly with Gemini models
- ✅ No breaking changes - the field still accepts the same data types
