### PR TITLE
Add RAG Agent to ChemGraph

### DIFF
--- a/notebooks/Demo_rag_agent_Argo.ipynb
+++ b/notebooks/Demo_rag_agent_Argo.ipynb
@@ -1,0 +1,614 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "953a0ae8-c496-4286-8619-17844af03c4c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tpham2/work/projects/ChemGraph/env/chemgraph_env/lib/python3.10/site-packages/google/api_core/_python_version_support.py:266: FutureWarning: You are using a Python version (3.10.19) which Google will stop supporting in new releases of google.api_core once it reaches its end of life (2026-10-04). Please upgrade to the latest Python version, or at least Python 3.11, to continue receiving updates for google.api_core past that date.\n",
+      "  warnings.warn(message, FutureWarning)\n",
+      "WARNING:root:fairchem is not installed. .\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2026-03-13 08:22:17,785 - chemgraph.models.openai - INFO - OpenAI API key not found in environment variables.\n"
+     ]
+    },
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Please enter your OpenAI API key:  ········\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2026-03-13 08:22:21,078 - chemgraph.models.openai - INFO - Using custom base URL: https://apps-dev.inside.anl.gov/argoapi/v1\n",
+      "2026-03-13 08:22:21,080 - chemgraph.models.openai - INFO - Using Argo user from config/ARGO_USER/default: chemgraph\n",
+      "2026-03-13 08:22:21,194 - chemgraph.models.openai - INFO - Requested model: gpt4o\n",
+      "2026-03-13 08:22:21,194 - chemgraph.models.openai - INFO - OpenAI model loaded successfully\n",
+      "2026-03-13 08:22:21,195 - chemgraph.graphs.rag_agent - INFO - Constructing RAG agent graph\n",
+      "2026-03-13 08:22:21,197 - chemgraph.graphs.rag_agent - INFO - RAG agent graph construction completed\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/5b/vkn1l5ys6pz8nyp5rbcprw800000gp/T/ipykernel_74555/3299937957.py:5: UserWarning: WARNING! user is not default parameter.\n",
+      "                user was transferred to model_kwargs.\n",
+      "                Please confirm that user is what you intended.\n",
+      "  cg = ChemGraph(model_name='gpt4o', workflow_type = workflow_type, structured_output=False, return_option=\"state\", base_url=\"https://apps-dev.inside.anl.gov/argoapi/api/v1/resource/chat/\")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'        +-----------+         \\n        | __start__ |         \\n        +-----------+         \\n               *              \\n               *              \\n               *              \\n         +----------+         \\n         | RAGAgent |         \\n         +----------+         \\n          .         .         \\n        ..           ..       \\n       .               .      \\n+---------+         +-------+ \\n| __end__ |         | tools | \\n+---------+         +-------+ '"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from chemgraph.agent.llm_agent import ChemGraph\n",
+    "\n",
+    "workflow_type = \"rag_agent\"\n",
+    "\n",
+    "cg = ChemGraph(model_name='gpt4o', workflow_type = workflow_type, structured_output=False, return_option=\"state\", base_url=\"https://apps-dev.inside.anl.gov/argoapi/api/v1/resource/chat/\")\n",
+    "cg.visualize()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "5f385ade-f22d-4ecc-840a-5d3dca57b8d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 1}\n",
+      "DEBUG: validated config={'thread_id': 1, 'configurable': {'thread_id': '1'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Calculate the thermochemistry of CO2 at 298K using Mace_mp, medium model\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  molecule_name_to_smiles (call_v5hJUwjgzZ9ansjZ0l0sVsfK)\n",
+      " Call ID: call_v5hJUwjgzZ9ansjZ0l0sVsfK\n",
+      "  Args:\n",
+      "    name: CO2\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: molecule_name_to_smiles\n",
+      "\n",
+      "{\"name\": \"CO2\", \"smiles\": \"C(=O)=O\"}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  smiles_to_coordinate_file (call_0hGnJzuAhJH94v5wU0gZgFs9)\n",
+      " Call ID: call_0hGnJzuAhJH94v5wU0gZgFs9\n",
+      "  Args:\n",
+      "    smiles: C(=O)=O\n",
+      "    output_file: CO2.xyz\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: smiles_to_coordinate_file\n",
+      "\n",
+      "{\"ok\": true, \"artifact\": \"coordinate_file\", \"path\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/cg_logs/session_2026-03-13_08-06-57_e2ea3278/CO2.xyz\", \"smiles\": \"C(=O)=O\", \"natoms\": 3}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  run_ase (call_1mbf4kfqm2HEIHiAGFfrRwOs)\n",
+      " Call ID: call_1mbf4kfqm2HEIHiAGFfrRwOs\n",
+      "  Args:\n",
+      "    params: {'input_structure_file': '/Users/tpham2/work/projects/ChemGraph/notebooks/cg_logs/session_2026-03-13_08-06-57_e2ea3278/CO2.xyz', 'driver': 'thermo', 'temperature': 298, 'calculator': {'calculator_type': 'mace_mp', 'model': 'medium'}}\n",
+      "Using Materials Project MACE for MACECalculator with /Users/tpham2/.cache/mace/20231203mace128L1_epoch199model\n",
+      "Using float64 for MACECalculator, which is slower but more accurate. Recommended for geometry optimization.\n",
+      "Using head Default out of ['Default']\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 08:08:58      -22.448774        4.816974\n",
+      "BFGS:    1 08:08:58      -22.775942        0.628958\n",
+      "BFGS:    2 08:08:58      -22.779029        0.232159\n",
+      "BFGS:    3 08:08:58      -22.779542        0.006288\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tpham2/work/projects/ChemGraph/env/chemgraph_env/lib/python3.10/site-packages/mace/calculators/mace.py:197: UserWarning: Environment variable TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD detected, since the`weights_only` argument was not explicitly passed to `torch.load`, forcing weights_only=False.\n",
+      "  torch.load(f=model_path, map_location=device)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Enthalpy components at T = 298.00 K:\n",
+      "===============================\n",
+      "E_pot                -22.780 eV\n",
+      "E_ZPE                  0.322 eV\n",
+      "Cv_trans (0->T)        0.039 eV\n",
+      "Cv_rot (0->T)          0.026 eV\n",
+      "Cv_vib (0->T)          0.006 eV\n",
+      "(C_v -> C_p)           0.026 eV\n",
+      "-------------------------------\n",
+      "H                    -22.361 eV\n",
+      "===============================\n",
+      "Entropy components at T = 298.00 K and P = 101325.0 Pa:\n",
+      "=================================================\n",
+      "                           S               T*S\n",
+      "S_trans (1 bar)    0.0016173 eV/K        0.482 eV\n",
+      "S_rot              0.0005690 eV/K        0.170 eV\n",
+      "S_elec             0.0000000 eV/K        0.000 eV\n",
+      "S_vib              0.0000265 eV/K        0.008 eV\n",
+      "S (1 bar -> P)    -0.0000011 eV/K       -0.000 eV\n",
+      "-------------------------------------------------\n",
+      "S                  0.0022116 eV/K        0.659 eV\n",
+      "=================================================\n",
+      "Enthalpy components at T = 298.00 K:\n",
+      "===============================\n",
+      "E_pot                -22.780 eV\n",
+      "E_ZPE                  0.322 eV\n",
+      "Cv_trans (0->T)        0.039 eV\n",
+      "Cv_rot (0->T)          0.026 eV\n",
+      "Cv_vib (0->T)          0.006 eV\n",
+      "(C_v -> C_p)           0.026 eV\n",
+      "-------------------------------\n",
+      "H                    -22.361 eV\n",
+      "===============================\n",
+      "\n",
+      "Entropy components at T = 298.00 K and P = 101325.0 Pa:\n",
+      "=================================================\n",
+      "                           S               T*S\n",
+      "S_trans (1 bar)    0.0016173 eV/K        0.482 eV\n",
+      "S_rot              0.0005690 eV/K        0.170 eV\n",
+      "S_elec             0.0000000 eV/K        0.000 eV\n",
+      "S_vib              0.0000265 eV/K        0.008 eV\n",
+      "S (1 bar -> P)    -0.0000011 eV/K       -0.000 eV\n",
+      "-------------------------------------------------\n",
+      "S                  0.0022116 eV/K        0.659 eV\n",
+      "=================================================\n",
+      "\n",
+      "Free energy components at T = 298.00 K and P = 101325.0 Pa:\n",
+      "=======================\n",
+      "    H        -22.361 eV\n",
+      " -T*S         -0.659 eV\n",
+      "-----------------------\n",
+      "    G        -23.020 eV\n",
+      "=======================\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: run_ase\n",
+      "\n",
+      "{\"status\": \"success\", \"result\": {\"thermochemistry\": {\"enthalpy\": -22.361307552320906, \"entropy\": 0.002211644325335715, \"gibbs_free_energy\": -23.020377561270948, \"unit\": \"eV\"}}, \"message\": \"Thermochemistry computed and returned. Full results (structure, vibrations, thermochemistry and metadata) saved to /Users/tpham2/work/projects/ChemGraph/notebooks/cg_logs/session_2026-03-13_08-06-57_e2ea3278/output.json\"}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The thermochemistry of CO2 at 298K using the Mace_mp calculator with the medium model has been computed. Here are the results:\n",
+      "\n",
+      "- **Enthalpy**: -22.361 eV\n",
+      "- **Entropy**: 0.00221 eV/K\n",
+      "- **Gibbs Free Energy**: -23.020 eV\n",
+      "\n",
+      "These values are in electron volts (eV). The full results, including structure, vibrations, thermochemistry, and metadata, have been saved to a file.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run geometry optimization using MACE MP\n",
+    "query = \"Calculate the thermochemistry of CO2 at 298K using Mace_mp, medium model\"\n",
+    "result = await cg.run(query, {\"thread_id\": 1})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ac2e9b2d-c504-457f-9ced-990fa2d2c26b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 2}\n",
+      "DEBUG: validated config={'thread_id': 2, 'configurable': {'thread_id': '2'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Read FDMNES_Manual.txt and tell me what it is about\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  load_document (call_qasASpAPsgDKCwmDJWZcewuQ)\n",
+      " Call ID: call_qasASpAPsgDKCwmDJWZcewuQ\n",
+      "  Args:\n",
+      "    file_path: FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: load_document\n",
+      "\n",
+      "{\"ok\": true, \"file_path\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\", \"num_chunks\": 220, \"chunk_size\": 1000, \"chunk_overlap\": 200, \"embedding_provider\": \"openai\"}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_xRhmLGeiGnU09rFAMuapUrp8)\n",
+      " Call ID: call_xRhmLGeiGnU09rFAMuapUrp8\n",
+      "  Args:\n",
+      "    query: summary of FDMNES_Manual.txt\n",
+      "    file_path: /Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"summary of FDMNES_Manual.txt\", \"num_results\": 5, \"results\": [{\"content\": \"==================== PAGE 1 ====================\\n\\n-  - 1\\n\\nFDMNES\\nUser’s Guide\\n\\nYves Joly\\n\\nyves.joly@neel.cnrs.fr\\nInstitut Néel, CNRS, BP 166\\n38042 Grenoble Cedex 9, France\\n\\nMarch 2025\\n\\n\\n\\n==================== PAGE 2 ====================\\n\\nFDMNES User’s Guide\\n -2-\\n\\n\\n\\n==================== PAGE 3 ====================\\n\\nFDMNES User’s Guide\\n -3-\\n\\nOutline\\n\\n Introduction           5\\n\\nA) General Presentation           7\\nB) Some advices to make the best possible simulation  11\\nC) Main input file         15\\nD) Convolution         61\\nE) Parameter optimization       71\\nF) Extraction of DAFS scan and spectra    77\\nG) Unit cell modification       79\\nH) FDMX user’s guide        81\\nI) 2D diffraction         85\\n\\nList of the fdmnes keywords      95\\n\\n\\n\\n==================== PAGE 4 ====================\\n\\nFDMNES User’s Guide\\n -4-\\n\\n\\n\\n==================== PAGE 5 ====================\\n\\nFDMNES User’s Guide\\n -5-\\nIntroduction\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"==================== PAGE 8 ====================\\n\\nFDMNES User’s Guide\\n -8-\\n\\nV- Parallelization\\n\\n Thanks to Sergey Guda, Keisuke Hatada, Kuniko Hayakawa and Rainer Wilcke, the\\nusers having the access to a cluster of computers can, using the MPI library, run the program in\\nparallel mode. For this purpose, one has to delete the files \\\"mpif.h\\\" and \\\"not_mpi.f\\\" when\\ncompiling and makes the call to the corresponding library.\\n\\nVI- Running\\n\\nAfter compilation, the program can be run following the usual procedure available on\\nyour system.\\nAs soon as the program is running, it calls the file \\\"fdmfile.txt\\\". This file must also be in\\nthe same directory than the executable file. It only contains the number of independent\\ncalculation to perform, followed the name of the input file of each of these calculations. For\\nexample:\\n\\n! Input file for fdmnes\\n1                                                          number of input files\\nSim/cu/in/cu_inp.txt             name of the input file\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"==================== PAGE 80 ====================\\n\\nManuel FDMNES\\n - 80 -\\n\\n\\n\\n==================== PAGE 81 ====================\\n\\nManuel FDMNES\\n - 81 -\\nH - FDMX User’s guide\\n\\n FDMX is an extension from J. Bourke and C. Chantler, University of Melbourne,\\nAustralia. When using it, thanks to cite:\\n\\nJay Daniel Bourke, Christopher Thomas Chantler and Yves Joly\\n \\\"Extended X-ray Absorption Fine Structure Calculations Using the Finite Difference Method\\\"\\nJ. Synchrotron Rad. 23, 551-559 (2016).\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"==================== PAGE 7 ====================\\n\\nFDMNES User’s Guide\\n -7-\\nA- General presentation\\n\\nI- Computer configuration\\n\\nFDMNES run on all the computers, under LINUX, Mac or Windows. The programming\\nlanguage is Fortran 2003. Executables are furnished for Windows 32 and 64 bits, Linux 64 bits\\nfor sequential calculations and for parallel calculations under MPI.\\nUsers can also compile the code themselves. The code needs then MUMPS, LAPACK\\nand BLAS libraries (and MPI for parallel). When they are not available, it is possible, but not\\nrecommended to use a gaussian solver routine furnished with the other routines\\n\\nII- The packages\\n\\n Different packages for the different operating systems (Windows 32, Windows 64,\\nLinux 64, Mac) can be downloaded. They contain the corresponding executable, a set of\\nexamples of input files, the user’s guide and other information:\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"FDMNES User’s Guide\\n -9-\\n4) When using downloaded input files, some problems of compatibility between\\nsystems can occur. It can be better to write again completely these files.\\n\\n When the program stops without “fdmnes_error.txt” file, it can be due to a problem of\\nspace memory. Sometimes one gets a message with “stacking fault”. In this case try again\\nputting in the input file the keyword “Memory_save”. This keyword can be useful when there\\nare many non-equivalent atoms. An approximation (in fact very good) is then done on the\\npotential calculation. This option saves some memory space.\\n\\n VIII- Structure of the calculation\\n\\nFor a complete calculation one has the following scheme:\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The FDMNES Manual is a comprehensive guide for the FDMNES software, which is used for simulating X-ray absorption spectra using the finite difference method. Here's a summary of its contents:\n",
+      "\n",
+      "1. **Introduction and General Presentation**: The manual begins with an introduction to the software, detailing its compatibility with various operating systems like Linux, Mac, and Windows. It is programmed in Fortran 2003 and can be run on different systems with the necessary libraries like MUMPS, LAPACK, and BLAS.\n",
+      "\n",
+      "2. **Parallelization and Running the Program**: The manual provides instructions for running the program in parallel using the MPI library, which is beneficial for users with access to a computer cluster. It also explains the process of running the program, including the necessary input files and their structure.\n",
+      "\n",
+      "3. **Main Input File and Parameter Optimization**: Detailed guidance is provided on creating and optimizing the main input file for simulations. This includes advice on making the best possible simulations and handling potential compatibility issues with input files.\n",
+      "\n",
+      "4. **Convolution and Extraction of Spectra**: The manual covers the convolution process and how to extract DAFS (Diffraction Anomalous Fine Structure) scans and spectra from the simulations.\n",
+      "\n",
+      "5. **Unit Cell Modification and 2D Diffraction**: Instructions are given on modifying the unit cell and performing 2D diffraction simulations.\n",
+      "\n",
+      "6. **FDMX User’s Guide**: An extension of the software, FDMX, is discussed, which is used for extended X-ray absorption fine structure calculations. The manual includes a citation for using this extension.\n",
+      "\n",
+      "7. **Troubleshooting and Memory Management**: The manual addresses common issues such as memory problems and provides solutions like using the \"Memory_save\" keyword to manage memory usage effectively.\n",
+      "\n",
+      "Overall, the FDMNES Manual serves as a detailed resource for users to effectively utilize the FDMNES software for X-ray absorption simulations, providing both technical instructions and troubleshooting advice.\n"
+     ]
+    }
+   ],
+   "source": [
+    "os.environ[\"OPENAI_BASE_URL\"] =\"https://apps-dev.inside.anl.gov/argoapi/v1\"\n",
+    "\n",
+    "query = \"Read FDMNES_Manual.txt and tell me what it is about\"\n",
+    "result = await cg.run(query, {\"thread_id\": 2})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "6ab1d655-2d0d-4b6e-9676-3aa02306dd02",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 2}\n",
+      "DEBUG: validated config={'thread_id': 2, 'configurable': {'thread_id': '2'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What are the default output file extensions?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_oqbgcl8l9FAcRPqict74EJCi)\n",
+      " Call ID: call_oqbgcl8l9FAcRPqict74EJCi\n",
+      "  Args:\n",
+      "    query: default output file extensions\n",
+      "    file_path: /Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"default output file extensions\", \"num_results\": 5, \"results\": [{\"content\": \"All the keywords related to the convolution or to the fit of the parameters are treated in\\nchapter C and D.\\n\\n\\n\\n==================== PAGE 16 ====================\\n\\nFDMNES User’s Guide\\n -16-\\n\\nOutput file names\\n\\nBy default the output file name is fdmnes_out. This name can be modified by the use of\\nthe keyword \\\"filout\\\" followed by the name we want (without extension). Then one gets several\\noutput files with the extensions:\\n_bav.txt  output file giving details\\n.txt   contains only the spectra by column\\n_nrixs.txt  contains only the spectra by column for NRIXS simulations\\nIf a calculation is performed on several non-equivalent crystallographic sites, one gets the\\nextensions:\\n_i.txt, _j.txt … in which i and j are the index of the sites (see keyword absorber)\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"In option or depending on the type of calculation, one can also get the files:\\n_conv.txt             convoluted spectra scan (keyword Convolution).\\n_scan.txt   dafs versus angles for azimuthal scan (keyword DAFS).\\n_sda.txt  state density for the atom number a (keyword Density).\\n_atoma.txt  results for one atom at position number ’a’ (keyword Allsite).\\n_atoma_scan.txt DAFS scan results for the atom a (keyword Allsite and DAFS).\\n_tddft.txt   output with the TDDFT option (keyword Tddft).\\n_tddft_scan.txt  azimuthal scan in the TDDFT option (keyword DAFS and Tddft).\\n_tddft_conv.txt convoluted spectra in TDDFT (keyword Convolution and Tddft).\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"The name of the convolution output file is by default the input file name with the added\\nsuffix \\\"_conv.txt\\\". Anyway it is possible to impose another name with the keyword:\\n\\nConv_out\\nFe_rs64_sum_conv   name of the convoluted spectra file\\n\\n To specify a working directory put the keyword \\\"Directory\\\" followed by the directory\\nname with at the end the separator \\\"/\\\":\\n\\nDirectory\\nC:/Documents and Settings/joly/Mes documents/xanes/xanout/v2o3/\\n\\nWhen there are more than one absorbing sites, it is possible to have not only the total\\nconvoluted file but also the individual convolutions. For this write the keyword:\\n\\nAll_conv\\n\\n Before the edge, the absorption is zero. It is possible to take into account the background\\ncoming from the edges of lower energy from all the chemical elements in the material. For this\\nuse the keyword:\\n\\nAbs_before\\n\\n2) Fermi level\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Ray_max_dirac\\n12.   value of the radius of the new atomic orbitals in Å.\\n\\n 18) Header and lecture by Xas Viewer (Larix)\\n\\nIt is possible to have a header at the beginning of the output files giving the code release, the\\ndate and time of calculation. By this way the files are also more easily readable by Xas Viewer\\n(Larix). It also gives for the file after convolution the convolution parameters and the edge\\nenergy.\\n\\nHeader\\n\\n 19) Output files format\\n\\nThe output files containing the spectra of x-ray absorption cross sections and diffracted\\nintensities have column names containing parenthesis. Some soft-wares used for plotting\\nmisunderstand these parentheses. It is thus possible to substitute them by underlines “_” using\\nthe keyword:\\n\\nPython\\n\\n 20) Cluster rotation\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"For the analysis of the cartesian tensors (keyword cartesian):\\n_car_atoma.txt cartesian tensors of the atom a.\\n_car_xtal.txt  cartesian tensors for the crystal\\n_car_xtal_rxsi.txt cartesian tensors for the crystal for the DAFS reflection number i.\\n\\n\\n\\n==================== PAGE 17 ====================\\n\\nFDMNES User’s Guide\\n -17-\\nII- Basic keywords\\n\\n1) Output file names\\n\\n The different output files have names with the same root. The extensions automatically\\nadded depending on the chosen option. To define this root use :\\n\\nFilout      or \\\"File_out\\\"\\n  Sim/Cu/Cu_out    Name of the output files (without extension)\\n\\n The files can eventually be in a subdirectory.\\n\\n2) Radius of the cluster\\n\\n The final states are calculated inside a sphere, whose radius is defined with the keyword\\n\\\"Radius\\\". Only the atoms inside this sphere are considered. By default, the sphere is centered\\non the absorbing atom.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The default output file extensions in the FDMNES software are as follows:\n",
+      "\n",
+      "1. **_bav.txt**: This file provides detailed output information.\n",
+      "2. **.txt**: Contains only the spectra by column.\n",
+      "3. **_nrixs.txt**: Contains spectra by column for NRIXS simulations.\n",
+      "4. **_i.txt, _j.txt, ...**: These extensions are used when calculations are performed on several non-equivalent crystallographic sites, where 'i' and 'j' are the indices of the sites.\n",
+      "\n",
+      "Additionally, depending on the type of calculation or options used, other output files may include:\n",
+      "- **_conv.txt**: Convoluted spectra scan.\n",
+      "- **_scan.txt**: DAFS versus angles for azimuthal scan.\n",
+      "- **_sda.txt**: State density for a specific atom.\n",
+      "- **_atoma.txt**: Results for one atom at a specific position.\n",
+      "- **_atoma_scan.txt**: DAFS scan results for a specific atom.\n",
+      "- **_tddft.txt**: Output with the TDDFT option.\n",
+      "- **_tddft_scan.txt**: Azimuthal scan in the TDDFT option.\n",
+      "- **_tddft_conv.txt**: Convoluted spectra in TDDFT.\n",
+      "\n",
+      "The output file name can be modified using the keyword \"filout\" followed by the desired name without an extension.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What are the default output file extensions?\"\n",
+    "result = await cg.run(query, {\"thread_id\": 2})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "08b5b1ec-0c28-42f7-928c-22b4ad45e046",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 2}\n",
+      "DEBUG: validated config={'thread_id': 2, 'configurable': {'thread_id': '2'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "How does the program determine which atom is the 'absorber' by default??\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_eqrblaqxHWtyZb6Pa7n8qGnW)\n",
+      " Call ID: call_eqrblaqxHWtyZb6Pa7n8qGnW\n",
+      "  Args:\n",
+      "    query: default absorber atom determination\n",
+      "    file_path: /Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"default absorber atom determination\", \"num_results\": 5, \"results\": [{\"content\": \"In the example above the atoms 1 and 2 of the list under \\\"Crystal\\\" have the configuration 3d54p1.\\nThe atom 3 has the configuration 3d6. The remaining atoms have the default configuration.\\n\\n\\n\\n==================== PAGE 21 ====================\\n\\nFDMNES User’s Guide\\n -21-\\n\\nWhen one wants to give a configuration for a doping element (see keyword  \\\"Doping \\\"),\\none must write « 0 » for the atom index:\\nAtom_conf\\n1  0    2   3 2   5.  4 1 1.   nbr of atom (1), then index = 0\\n\\n5) Absorbing atoms\\n\\n All the atoms present in the structure participate to the absorption or scattering. By\\ndefault, the calculated spectra correspond to the sum of the scattering or absorption produced\\nby all the atoms of the same atomic number than the first one in the list under \\\"Crystal\\\" or\\n\\\"Molecule\\\".\\nFor clarity, or when the structure is given in a cif or pdb files, it can be convenient to\\ndefine explicitly the atomic number by the use of the keyword \\\"Z_absorber\\\":\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Z_absorber\\n 26    all the atoms with Z = 26 are absorbing atoms\\n\\nWith the same keyword, it is also possible to calculate the spectra and their sum of atoms of\\ndifferent atomic number (but of the same edge, K…):\\n\\nZ_absorber\\n 26  27   all the atoms with Z = 26 or Z = 27 are absorbing atoms\\n\\n In some cases, one can be interested by the calculation of the cross-section spectra of a\\nsingle (or some) site in a structure containing several atoms of the same atomic number. For\\nthis purpose, instead of \\\"Z_Absorber\\\", use the keyword \\\"Absorber\\\", with below the index of\\nthe site, in the list under \\\"Crystal\\\" or \\\"Molecule\\\" :\\n\\nAbsorber\\n3  absorbing atom number (here the 3rd in the list).\\n\\nTo have several non-equivalent sites, just write the different indexes:\\n\\nAbsorber\\n1 5  atom numbers whom results will in output files “filename_1” and “file_name_5”\\n\\n6) Energy range\\n\\n\\n\\n==================== PAGE 22 ====================\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"24) Atomic spectra\\n\\n To get in last column the atomic absorption spectra (without the neighbour atoms), put\\nthe keyword:\\nXan_atom\\n\\n25) Different absorbing atoms calculated in one run\\n\\n The electronic structure is calculated in all the cluster of calculation and thus in all atoms\\nin it. Consequently, it is in principal possible to get the absorption spectra of all the atoms in\\nonly one run. In principal, the absorbing atom is nevertheless “excited”, thus becomes\\nintrinsically different and one calculation must be performed for each absorbing atom. When\\nneglecting this difference, it is possible to get all the absorption spectra of the all the atoms,\\nequivalent and non-equivalent by symmetry operation, of the same chemical specie in only one\\nrun using the keyword:\\n\\nOne_run\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Spgroup\\n  Fd-3m:1\\n\\n Crystal\\n      8.3940   8.3940   8.3940   90.0   90.0   90.0\\n\\n  26   .6250    .6250    .6250\\n  26   .0000    .0000    .0000\\n   8   .3800    .3800    .3800\\n\\n Convolution\\n\\nEnd\\n\\nOne must remember that by default:\\n- The absorbing chemical specie is the first one in the list under \\\"Crystal\\\" (or \\\"Molecule\\\").\\nIf it is not the case, use the keyword \\\"Z_absorber\\\" and below write the absorbing atomic\\nnumber.\\n- The absorption edge is K, in the other case use the keyword \\\"Edge\\\".\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"17) Calculation area boundary\\n\\nBy default in FDM, the meshing is performed in a sphere extending up to the last atom\\ninside the sphere of radius given under \\\"Radius\\\" plus the atomic radius (by default 0.65 Å) plus\\none inter-point distance (0.2 Å by default). In order to use a bigger sphere use:\\n\\nOverad\\n1.2   distance over the last atom + its radius to take into account.\\n\\n18) Displacement of the absorbing atom\\n\\n To move the absorbing atom in reference to its position given under \\\"molecule\\\" or\\n\\\"crystal\\\" use:\\n\\n Dpos\\n0.2 0.0 0.0  displacement vector in Angstrom\\n\\n19) Energy shift of the spectra\\n\\n If one has gotten a reference for the initial orbital, it is possible to give it under the\\nkeyword \\\"Epsii\\\". This will produce a shift of the output spectra equal to the difference between\\nthis energy and the energy calculated in the program. It is safer to perform this operation with\\nthe shift parameters during the convolution step.\\n\\nEpsii\\n6253.1   positive value in eV.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "By default, the FDMNES program determines the 'absorber' atom as the first atom listed under the \"Crystal\" or \"Molecule\" section in the input file. This means that the calculated spectra will correspond to the sum of the scattering or absorption produced by all atoms of the same atomic number as this first atom. \n",
+      "\n",
+      "If a different atom is intended to be the absorber, the user can explicitly define the absorbing atomic number using the keyword `Z_absorber`. For example, specifying `Z_absorber 26` would set all atoms with atomic number 26 as absorbing atoms. Additionally, if the user wants to calculate the spectra for specific sites, they can use the keyword `Absorber` followed by the index of the site in the list under \"Crystal\" or \"Molecule\".\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"How does the program determine which atom is the 'absorber' by default??\"\n",
+    "result = await cg.run(query, {\"thread_id\": 2})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1a5c00c3-c210-429e-af8d-d033e547d47b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 2}\n",
+      "DEBUG: validated config={'thread_id': 2, 'configurable': {'thread_id': '2'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What is the difference between the 'Green' and 'FDM' calculation modes?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_rLZ6dKUlliqt4DunKFyw9Bre)\n",
+      " Call ID: call_rLZ6dKUlliqt4DunKFyw9Bre\n",
+      "  Args:\n",
+      "    query: difference between 'Green' and 'FDM' calculation modes\n",
+      "    file_path: /Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"difference between 'Green' and 'FDM' calculation modes\", \"num_results\": 5, \"results\": [{\"content\": \"As calculations using FDMX may take several hours, particularly for structures with few or no\\naxes of symmetry, it is strongly recommended that you compile and run the code using the\\nMUMPS libraries.\\n\\nfdmx\\n\\n   Activates FDMX computation and optimization of parameters with respect to energy,\\nallowing for accurate EXAFS spectra, and triggers the processing routine at the end of the\\ncalculation. When this keyword is used, the Radius keyword is no longer required.\\n\\nfdmx_proc\\n\\n   Use to activate a post-processing routine from FDMX, implementing thermal, inelastic\\nscattering, background, and other effects without explicitly calculating the absorption spectra.\\nThis requires an existing output file with absorption cross sections from a previous calculation.\\n\\nE_cut\\n 4.0     ! Val\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"adimp\\n0.24  0.  100.  0.20  250.  0.16  400.  0.12  500.  0.08     !  Val, En, Val …\\n\\n Allows the user to specify how the inter-point distance (grid density) changes with energy. By\\ndefault, the inter-point distance is set (as above) to 0.25 Å for energies up to 0 eV, then 0.22 Å\\nfor energies up to 10 eV, then 0.18 Å etcetera. Using a high or constant inter-point distance at\\nhigh energies may produce inaccurate results, while low values will lead to long calculations.\\n\\nGamma_hole\\n  2.3    ! Val\\n\\n By default, FDMX will include a core-hole relaxation based on K-shell tabulations from\\nScofield and Kostroun (Z=21-50) and “B” (Z=51-100)? Alternatively one may provide an\\nexplicit core-hole lifetime (in eV) with the keyword Gamma_hole or suppress this effect by\\nusing the keyword:\\n\\nnohole\\n\\n It is required that you use either Gamma_hole or nohole for calculations involving edges other\\nthan K.\\n\\nIMFPin\\nimfpdatafile.txt    ! Filename\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Jay Daniel Bourke, Christopher Thomas Chantler and Yves Joly\\n \\\"Extended X-ray Absorption Fine Structure Calculations Using the Finite Difference Method\\\"\\nJ. Synchrotron Rad. 23, 551-559 (2016).\\n\\nFDMX is an enhanced approach to calculating both XANES and XAFS spectra using\\nthe finite difference method and the core routines of FDMNES. The easiest way to use FDMX\\nis to simply include the keyword fdmx in your regular input file, and the code will automatically\\noptimize computational parameters to ensure accuracy over a wide energy range. FDMX will\\nprocess the spectrum to include thermal effects and electron/hole lifetimes, and add background\\nabsorption from more loosely bound electrons. The code is currently designed for use with K-\\nedge calculations only, however most functionality will also work with other edges (note\\nkeywords for hole widths and background absorption). Additional (optional) controls for\\nFDMX are possible with specific keywords.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"The FDMNES program calculates the spectra of different spectroscopies related to the\\nreal or virtual absorption of x-ray in material. It gives the absorption cross sections around the\\nionization edges, that is in the XANES energy range. Calculations can be performed along all\\nthe conditions of linear or circular polarization. In the same way, it calculates the structure\\nfactors and intensities of anomalous or resonant diffraction spectra (DAFS or RXD) for 3D\\ndiffraction and for surface diffraction (SRXRD). FDMNES also allows the comparison of the\\nsimulated spectra to experimental ones with the help of objective criteria.\\nFDMNES is mainly a fully relativistic DFT-LSDA code. Optionally Hubbard correction\\n(LSDA+U) can be used. It uses two techniques. The first one is based on the Finite Difference\\nMethod (FDM) to solve the Schrödinger equation. In that way the shape of the potential is free\\nand in particular avoid the muffin-tin approximation. The second one uses the Green formalism\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"2) First calculation\\n\\nFor the first calculation of a new material, one must always start with the simplest input file,\\nthat is:\\n1) Keep all the fdmnes default options and so describing only the atomic structure, the\\nenergy range and terminating with a \\\"Convolution\\\"\\n2) Make the calculation with a small radius (\\\"Radius\\\" = 3, for example)\\n3) Use the multiple scattering theory (keyword \\\"Green\\\")\\n4) No self-consistent calculation\\n\\nAn example for magnetite:\\n\\n\\n\\n==================== PAGE 12 ====================\\n\\nFDMNES User’s Guide\\n -12-\\nFilout\\nSim/Test/Fe3O4\\n\\n Range\\n  -5. 0.1 5. 0.2  10.  0.5 20. 1. 30. 2. 60. 4. 100.\\n\\n Radius\\n  3.0\\n\\n Green\\n\\nSpgroup\\n  Fd-3m:1\\n\\n Crystal\\n      8.3940   8.3940   8.3940   90.0   90.0   90.0\\n\\n  26   .6250    .6250    .6250\\n  26   .0000    .0000    .0000\\n   8   .3800    .3800    .3800\\n\\n Convolution\\n\\nEnd\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The FDMNES software offers two main calculation modes: the \"Green\" mode and the \"FDM\" (Finite Difference Method) mode. Here's a summary of the differences between them:\n",
+      "\n",
+      "1. **Green Mode**:\n",
+      "   - This mode uses the multiple scattering theory, which is suitable for initial calculations of new materials.\n",
+      "   - It is recommended to start with this mode using a simple input file, a small radius, and without self-consistent calculations.\n",
+      "   - The Green mode is generally used for simpler and faster calculations, especially when exploring new materials or when computational resources are limited.\n",
+      "\n",
+      "2. **FDM Mode**:\n",
+      "   - The Finite Difference Method (FDM) is used to solve the Schrödinger equation without the muffin-tin approximation, allowing for a more accurate representation of the potential.\n",
+      "   - This mode is more computationally intensive and is suitable for detailed and precise calculations.\n",
+      "   - FDM is particularly useful for avoiding approximations that might limit the accuracy of the results, making it ideal for complex systems where potential shapes are not well-defined by simpler models.\n",
+      "\n",
+      "In summary, the Green mode is typically used for initial, less resource-intensive calculations, while the FDM mode is used for more detailed and accurate simulations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What is the difference between the 'Green' and 'FDM' calculation modes?\"\n",
+    "result = await cg.run(query, {\"thread_id\": 2})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "47fc34f1-1639-4a92-8e20-035ade0e0061",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 2}\n",
+      "DEBUG: validated config={'thread_id': 2, 'configurable': {'thread_id': '2'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "How can a user simulate a doping element in a crystal structure?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_GDotozEMCK1VxuYuZsNt8yZr)\n",
+      " Call ID: call_GDotozEMCK1VxuYuZsNt8yZr\n",
+      "  Args:\n",
+      "    query: simulate a doping element in a crystal structure\n",
+      "    file_path: /Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"simulate a doping element in a crystal structure\", \"num_results\": 5, \"results\": [{\"content\": \"To calculate the transmission through a sample of a specific thickness and to check\\nchange in polarization to the sample, it is necessary to calculate an absorption - matrix. This\\nis done with the keyword:\\n\\nMat_polar\\n0. 0. 1.  1.  0.  0.  polarization  and wave vector\\n\\nSee also the keywords: “Sample_thickness”, “Stokes” and “Stokes_name” to define the sample\\nthickness, incoming polarization matrix and analyzer angles.\\n\\nII-10) Doping\\n\\n It is possible, more specifically for crystal to calculate the absorption of a doping\\nelement set in substitution in place of another one. For this one uses the keyword « Doping »,\\nfollowed by the atomic number of the doping element and the index of the atom to substitute in\\nthe list under « Crystal »:\\n\\nDoping\\n27  1  substitution by Cobalt of the atom in the first site.\\n\\nThe doping atom is supposed to be at low concentration, thus the cluster built around it, is the\\nsame than the one given by the crystal. Symmetries are kept.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"In the example above the atoms 1 and 2 of the list under \\\"Crystal\\\" have the configuration 3d54p1.\\nThe atom 3 has the configuration 3d6. The remaining atoms have the default configuration.\\n\\n\\n\\n==================== PAGE 21 ====================\\n\\nFDMNES User’s Guide\\n -21-\\n\\nWhen one wants to give a configuration for a doping element (see keyword  \\\"Doping \\\"),\\none must write « 0 » for the atom index:\\nAtom_conf\\n1  0    2   3 2   5.  4 1 1.   nbr of atom (1), then index = 0\\n\\n5) Absorbing atoms\\n\\n All the atoms present in the structure participate to the absorption or scattering. By\\ndefault, the calculated spectra correspond to the sum of the scattering or absorption produced\\nby all the atoms of the same atomic number than the first one in the list under \\\"Crystal\\\" or\\n\\\"Molecule\\\".\\nFor clarity, or when the structure is given in a cif or pdb files, it can be convenient to\\ndefine explicitly the atomic number by the use of the keyword \\\"Z_absorber\\\":\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Atom     keyword preceding the atomic electronic densities\\n26   2  3 2  6. 4 0 2.   atomic number of the chemical specie of type 1, number\\n8     2  2 0  2. 2 1 4.  of valence orbital and (n,l,pop) of each of these orbitals\\n\\nMolecule\\n         1.900  1.900  1.900   90.  90.  90.      a, b, c, \\n  1     0.0      0.0      0.0    Atom type, position\\n  2     1.0      0.0      0.0\\n  2    -1.0      0.0      0.0\\n  2     0.0      1.0      0.0\\n  2     0.0     -1.0      0.0\\n  2     0.0      0.0      1.0\\n  2     0.0      0.0     -1.0\\n\\nImportant remark: contrary to what one can think, the formal charges attributed to the atoms in\\nthe ionic compounds are far from the true charge. Thus one has to perform exchange of charge\\nbetween atoms with care and in a moderate way. A good technique is, for example for 3d\\nelements,  the good number of  \\\"d\\\" electron, following the formal charge, but keeping the\\nneutral atom, putting electrons in the large radius 4s or 4p orbitals.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Spgroup\\n  Fd-3m:1\\n\\n Crystal\\n      8.3940   8.3940   8.3940   90.0   90.0   90.0\\n\\n  26   .6250    .6250    .6250\\n  26   .0000    .0000    .0000\\n   8   .3800    .3800    .3800\\n\\n Convolution\\n\\nEnd\\n\\nOne must remember that by default:\\n- The absorbing chemical specie is the first one in the list under \\\"Crystal\\\" (or \\\"Molecule\\\").\\nIf it is not the case, use the keyword \\\"Z_absorber\\\" and below write the absorbing atomic\\nnumber.\\n- The absorption edge is K, in the other case use the keyword \\\"Edge\\\".\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"To simulate the effect of a plane of atoms, possibly charged, at a certain distance from\\nthe surface plane, as in the Helmholtz model, it is preferable to use the concept of counter-\\natoms, which allows, unlike the Helmholtz model seen above, to have a construction of the\\npotential responding to a chemical reality. For this we use the keyword \\\"Counter_atom\\\", which\\nallows to list a series of atoms positioned relative to the surface atoms, possibly having a certain\\ncharge, and therefore the potential is convolved by a Gaussian to simulate the positioning\\ndisorder:\\n\\nCounter_atom\\n1 2.5 8 0.5 0.1 1.  index of referent atom (in the list under \\\"Surface\\\"), the counter-atom is\\njust above it), distance from reference atom (2.5 Å), atomic number, Z =\\n8 is for oxygen, width of the gaussian distribution 𝜎 = 0.5 Å, ch = 0.1,\\ncharge on the atom and occupancy (which is optional, default is 1).\\n\\nIt is possible to shift the counter atom position parallel to the surface versus the refence atom:\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "To simulate a doping element in a crystal structure using FDMNES, you can use the `Doping` keyword. This allows you to substitute a doping element in place of another atom within the crystal structure. Here’s how you can do it:\n",
+      "\n",
+      "1. **Keyword Usage**: Use the `Doping` keyword followed by the atomic number of the doping element and the index of the atom to be substituted in the list under \"Crystal\".\n",
+      "\n",
+      "   Example:\n",
+      "   ```\n",
+      "   Doping\n",
+      "   27  1  # This substitutes the atom in the first site with Cobalt (atomic number 27).\n",
+      "   ```\n",
+      "\n",
+      "2. **Assumptions**: The doping atom is assumed to be at a low concentration. Therefore, the cluster built around it remains the same as that given by the crystal, and symmetries are preserved.\n",
+      "\n",
+      "This method allows you to simulate the effects of a doping element on the absorption properties of the crystal structure.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"How can a user simulate a doping element in a crystal structure?\"\n",
+    "result = await cg.run(query, {\"thread_id\": 2})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2abfde09-a458-40c5-a68c-623d65e56cd8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 2}\n",
+      "DEBUG: validated config={'thread_id': 2, 'configurable': {'thread_id': '2'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What are the default values for the energy range and step?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_5OYhZGE66VDpi3Bt9jDCNPrC)\n",
+      " Call ID: call_5OYhZGE66VDpi3Bt9jDCNPrC\n",
+      "  Args:\n",
+      "    query: default values for the energy range and step\n",
+      "    file_path: /Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"default values for the energy range and step\", \"num_results\": 5, \"results\": [{\"content\": \"Absorber\\n1 5  atom numbers whom results will in output files “filename_1” and “file_name_5”\\n\\n6) Energy range\\n\\n\\n\\n==================== PAGE 22 ====================\\n\\nFDMNES User’s Guide\\n -22-\\nThe energy range E that one defines in the input is the energy of the photoelectron\\nrelative to the Fermi level.\\nBy default the energy range is -5 to 60 eV by 0.5 eV step. One can change the range,\\nthe step or even have a variable step using:\\n\\nRange    keyword for the energy range\\n  1. 0.5  60.   Emin, step, Emax\\n\\nOther example with variable step:\\n\\nRange\\n1. 0.1 10. 0.5 20. 1. 60.00   E min, step, E intermediate, step …\\n\\nTo get a continuously increasing step (k step constant) put:\\n\\nRangel\\n1. 0.1 200.   E min, step at the Fermi level, E max\\n\\n By default, the output energy range is relatively to the Fermi level. If one wants that the\\noutput energy is the photon energy put the keyword:\\n\\nEnergpho\\n\\n7) Multiple scattering mode\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"Default values for Elarg , Ecent and m are respectively: 30, 30 and 15 eV. It is possible to modify\\nthem with the keywords:\\n\\nEcent\\n30.        Ecent\\n\\nElarg\\n30.        Elarg\\n\\nGamma_max\\n20.      m\\n\\n In the convolution, along the integration it is the width of the running energy which is\\ntaken. It is possible to use the width of the final state energy corresponding to the energy of the\\nelastic photon. One then makes the integration with a constant width. This procedure improves\\nthe agreement with experiment especially in the pre-edge range in which the other procedure\\nincreases the background. To impose nevertheless a variable width along the integration in\\nXANES uses the keyword :\\n\\nGamma_var\\n\\nIt is also possible to use the Seah-Dench formula for the calculation of the broadening.\\nIn this case one gets:\\nHolepm\\npm\\nAE\\nEA \\n ,\\nm\\np\\np\\nE\\nEA  1 ,   with:  E p = E – EF.\\nThis is performed with the keyword:\\n\\nSeah\\n1. 20.         A,m\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"By default the metric distances are calculated in all the energy range is the intersection\\nbetween the experimental and calculated spectra. It is possible to cut the lower or and the higher\\nenergy part of the spectra by the use of the keyword:\\n\\nEmin\\n-10.     Minimum energy for all the spectra\\n\\nEmax\\n100.    Maximum energy for all the spectra\\n\\nIt is possible to have different values for the different spectra:\\n\\nEmin\\n-10.  -5. -20. -20.   Minimum energy for each spectra\\n\\nEmax\\n45. 100. 100. 100.   Maximum energy for each spectra\\n\\nIf the energy of the experimental spectra is in keV and not in eV, put the keyword:\\n\\nKev\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"17) Calculation area boundary\\n\\nBy default in FDM, the meshing is performed in a sphere extending up to the last atom\\ninside the sphere of radius given under \\\"Radius\\\" plus the atomic radius (by default 0.65 Å) plus\\none inter-point distance (0.2 Å by default). In order to use a bigger sphere use:\\n\\nOverad\\n1.2   distance over the last atom + its radius to take into account.\\n\\n18) Displacement of the absorbing atom\\n\\n To move the absorbing atom in reference to its position given under \\\"molecule\\\" or\\n\\\"crystal\\\" use:\\n\\n Dpos\\n0.2 0.0 0.0  displacement vector in Angstrom\\n\\n19) Energy shift of the spectra\\n\\n If one has gotten a reference for the initial orbital, it is possible to give it under the\\nkeyword \\\"Epsii\\\". This will produce a shift of the output spectra equal to the difference between\\nthis energy and the energy calculated in the program. It is safer to perform this operation with\\nthe shift parameters during the convolution step.\\n\\nEpsii\\n6253.1   positive value in eV.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}, {\"content\": \"noIMFP\\n\\n Use to omit the effects of photoelectron lifetime, and hence represent an infinite IMFP.\\n\\nTmeas\\n 298     ! Val\\n\\n Use to define the temperature, in Kelvin, at which the absorption is being calculated. This value\\nwill affect the Debye-Waller Factor, and is set to 0 by default.\\n\\nTDebye\\n 345   ! Val\\n\\n Use to define a Debye temperature (in Kelvin). This is strongly recommended for compound\\nstructures.\\n\\nDWfactor\\n  0.13    ! Val\\n\\n Use to define an effective Debye-Waller factor (in Å). By default, this will otherwise be\\ncalculated based on the dominant oscillators contributing to the high energy XAFS spectrum.\\n\\nnoDW\\n\\n Use to omit thermal effects – effectively a zero Debye-Waller factor.\\n\\n\\n\\n==================== PAGE 84 ====================\\n\\nManuel FDMNES\\n - 84 -\\nnoBG\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.txt\", \"file_type\": \".txt\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The default values for the energy range and step in the FDMNES software are as follows:\n",
+      "\n",
+      "- **Energy Range**: The default energy range is from -5 to 60 eV.\n",
+      "- **Step**: The default step size is 0.5 eV.\n",
+      "\n",
+      "These values can be modified by specifying the `Range` keyword in the input file, allowing you to set different minimum and maximum energies and step sizes. Additionally, you can define a variable step size by specifying intermediate energies and their corresponding steps.\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"What are the default values for the energy range and step?\"\n",
+    "result = await cg.run(query, {\"thread_id\": 2})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "15e50e79-5437-42c2-895b-728f50534f4f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG: run called with config={'thread_id': 3}\n",
+      "DEBUG: validated config={'thread_id': 3, 'configurable': {'thread_id': '3'}, 'recursion_limit': 50}\n",
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Read FDMNES_Manual.pdf and tell me what it is about\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  load_document (call_ZoNU2srS5GmJkmQDp115ovy5)\n",
+      " Call ID: call_ZoNU2srS5GmJkmQDp115ovy5\n",
+      "  Args:\n",
+      "    file_path: FDMNES_Manual.pdf\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: load_document\n",
+      "\n",
+      "{\"ok\": true, \"file_path\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.pdf\", \"file_type\": \".pdf\", \"num_chunks\": 238, \"chunk_size\": 1000, \"chunk_overlap\": 200, \"embedding_provider\": \"openai\"}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "Tool Calls:\n",
+      "  query_knowledge_base (call_Y36nkC9ulhwahMEZfioG55jw)\n",
+      " Call ID: call_Y36nkC9ulhwahMEZfioG55jw\n",
+      "  Args:\n",
+      "    query: summary of the document\n",
+      "    file_path: FDMNES_Manual.pdf\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: query_knowledge_base\n",
+      "\n",
+      "{\"ok\": true, \"query\": \"summary of the document\", \"num_results\": 5, \"results\": [{\"content\": \"-  - 1\\n \\n \\n  \\n \\n \\n \\n  \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\nFDMNES \\nUser’s Guide \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\n \\nYves Joly \\n \\nyves.joly@neel.cnrs.fr \\nInstitut Néel, CNRS, BP 166 \\n38042 Grenoble Cedex 9, France \\n \\nMarch 2025 \\n\\n\\nFDMNES User’s Guide \\n \\n-2- \\n \\n \\n\\n\\nFDMNES User’s Guide \\n \\n-3- \\n \\nOutline \\n \\n \\n \\n \\n \\nIntroduction  \\n \\n \\n \\n \\n \\n \\n \\n  5 \\n \\nA) General Presentation  \\n \\n \\n \\n \\n \\n  \\n  7 \\nB) Some advices to make the best possible simulation \\n11 \\nC) Main input file  \\n \\n \\n \\n \\n \\n \\n \\n15 \\nD) Convolution \\n \\n \\n \\n \\n \\n \\n \\n \\n61 \\nE) Parameter optimization \\n \\n \\n \\n \\n \\n \\n71 \\nF) Extraction of DAFS scan and spectra \\n \\n \\n \\n77 \\nG) Unit cell modification \\n \\n \\n \\n \\n \\n \\n79 \\nH) FDMX user’s guide  \\n \\n \\n \\n \\n \\n \\n81 \\nI) 2D diffraction \\n \\n \\n \\n \\n \\n \\n \\n \\n85 \\n \\nList of the fdmnes keywords  \\n \\n \\n \\n \\n95 \\n \\n \\n \\n \\n\\n\\nFDMNES User’s Guide \\n \\n-4-\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.pdf\", \"file_type\": \".pdf\"}}, {\"content\": \"FDMNES User’s Guide \\n \\n-10- \\nmany calculations are limited to the step “XANES and DAFS calculation” and “Convolution \\nand calculation of DAFS intensities”. These two steps can also be performed together or \\nseparately.  \\n \\n \\nIn the output files, the absorption cross section are in Mbarn (1 Mbarn = 10-18 cm2) and \\nsummed up over the atoms of same chemical specie in the unit cell or in the cluster. To convert \\nin number of electron one has to multiply by 𝐶=\\nħఠ೐ೇ\\n଼଴଴గమ௔బమఈோ= 0.004555352 × ħ𝜔௘௏, where \\nR,  and a0 are respectively the Rydberg constant, the fine structure constant and the Bohr \\nradius in Angstrom, ħ𝜔௘௏ is the photon energy in eV. One has also to divide by the number of \\natoms if one wants the result per atom. The intensities of the reflections are in square of number \\nof electrons. \\n \\nThe next chapter treats about the principal input file for the step “XANES and DAFS \\ncalculation”. Generally, this file is sufficient to describe all the necessary data for the calculation\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.pdf\", \"file_type\": \".pdf\"}}, {\"content\": \"The next chapter treats about the principal input file for the step “XANES and DAFS \\ncalculation”. Generally, this file is sufficient to describe all the necessary data for the calculation \\nbecause the program calculates its atomic bases and the potential. Nevertheless, the user can \\nprefer use its own atomic bases or uses directly the potential calculated by the band structure \\nprogram FLAPW WIEN-2k. In both cases, some other files must be furnished. They are \\ndescribed further in the manual. The input necessary for the steps “Convolution”, “comparison \\nwith the experimental spectra” and “Extraction of azimuth scan or spectra” can be set in the \\nsame input file, but they are explained separately in the sections D, E and F.\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.pdf\", \"file_type\": \".pdf\"}}, {\"content\": \"FDMNES User’s Guide \\n \\n-5- \\nIntroduction \\n \\nThe FDMNES program calculates the spectra of different spectroscopies related to the \\nreal or virtual absorption of x-ray in material. It gives the absorption cross sections around the \\nionization edges, that is in the XANES energy range. Calculations can be performed along all \\nthe conditions of linear or circular polarization. In the same way, it calculates the structure \\nfactors and intensities of anomalous or resonant diffraction spectra (DAFS or RXD) for 3D \\ndiffraction and for surface diffraction (SRXRD). FDMNES also allows the comparison of the \\nsimulated spectra to experimental ones with the help of objective criteria.  \\nFDMNES is mainly a fully relativistic DFT-LSDA code. Optionally Hubbard correction \\n(LSDA+U) can be used. It uses two techniques. The first one is based on the Finite Difference \\nMethod (FDM) to solve the Schrödinger equation. In that way the shape of the potential is free\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.pdf\", \"file_type\": \".pdf\"}}, {\"content\": \"FDMNES User’s Guide \\n \\n-15- \\nC- Main input file \\n \\n \\n \\nI- General Structure \\n \\nIt contains most of the inputs necessary for the calculation. All the data in input and \\noutput are in Angstrom and electron-Volt. Many options are chosen by default. One can modify \\nor add other options using keywords. Text can be in upper or lower case. Blank lines or \\nbeginning by “!” are not considered. Between number, one must put at least one blank. When \\ngetting problem when opening these input files, one has to check if their name is correct. \\nMoreover, some compilers do not like files written under other system (MAC, DOS, \\nLINUX…). In case of difficulties when the program wants to open one of these downloaded \\nfiles, it can be useful to completely write them again.   \\nThe input file contains several blocks of data, each one starting with a specific keyword. \\nThe end of the input file is noted by the keyword \\\"End\\\". Whatever is after is not red. Here \\ncomes an example of input file:\", \"metadata\": {\"source\": \"/Users/tpham2/work/projects/ChemGraph/notebooks/FDMNES_Manual.pdf\", \"file_type\": \".pdf\"}}]}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "The FDMNES manual provides a comprehensive guide to the FDMNES program, which is used for calculating spectra related to the absorption of x-rays in materials. Here are the key points from the document:\n",
+      "\n",
+      "1. **Purpose and Capabilities**: \n",
+      "   - FDMNES calculates the spectra of various spectroscopies associated with x-ray absorption, particularly around ionization edges in the XANES energy range.\n",
+      "   - It can perform calculations under conditions of linear or circular polarization.\n",
+      "   - The program also calculates structure factors and intensities for anomalous or resonant diffraction spectra (DAFS or RXD) for both 3D and surface diffraction (SRXRD).\n",
+      "   - It allows for the comparison of simulated spectra with experimental data using objective criteria.\n",
+      "\n",
+      "2. **Technical Details**:\n",
+      "   - FDMNES is primarily a fully relativistic DFT-LSDA code, with an optional Hubbard correction (LSDA+U).\n",
+      "   - It employs the Finite Difference Method (FDM) to solve the Schrödinger equation, allowing for flexibility in the potential shape.\n",
+      "\n",
+      "3. **Input and Output**:\n",
+      "   - The main input file contains most of the necessary data for calculations, with inputs and outputs in Angstroms and electron-Volts.\n",
+      "   - The manual provides guidance on setting up the input file, including the use of keywords and handling different file systems.\n",
+      "\n",
+      "4. **Additional Features**:\n",
+      "   - The manual includes sections on parameter optimization, convolution, extraction of DAFS scans and spectra, and unit cell modification.\n",
+      "   - It also provides a list of keywords used in FDMNES and advice for optimizing simulations.\n",
+      "\n",
+      "Overall, the FDMNES manual serves as a detailed resource for users to effectively utilize the program for x-ray absorption and diffraction calculations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"OPENAI_BASE_URL\"] =\"https://apps-dev.inside.anl.gov/argoapi/v1\"\n",
+    "\n",
+    "query = \"Read FDMNES_Manual.pdf and tell me what it is about\"\n",
+    "result = await cg.run(query, {\"thread_id\": 3})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c54969-bcd2-43b6-b61b-3efde446e44d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ ui = [
 parsl = [
     "parsl",
 ]
+rag = [
+    "faiss-cpu>=1.7.4",
+    "langchain-text-splitters",
+    "langchain-huggingface",
+    "sentence-transformers>=2.2.2",
+    "pymupdf>=1.24.0",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/argonne-lcf/ChemGraph"

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -38,6 +38,8 @@ from chemgraph.graphs.mock_agent import construct_mock_agent_graph
 from chemgraph.graphs.single_agent_mcp import construct_single_agent_mcp_graph
 from chemgraph.graphs.multi_agent_mcp import construct_multi_agent_mcp_graph
 from chemgraph.graphs.graspa_mcp import construct_graspa_mcp_graph
+from chemgraph.graphs.rag_agent import construct_rag_agent_graph
+from chemgraph.prompt.rag_prompt import rag_agent_prompt
 
 import logging
 
@@ -261,6 +263,7 @@ class ChemGraph:
             "single_agent_mcp": {"constructor": construct_single_agent_mcp_graph},
             "multi_agent_mcp": {"constructor": construct_multi_agent_mcp_graph},
             "graspa_mcp": {"constructor": construct_graspa_mcp_graph},
+            "rag_agent": {"constructor": construct_rag_agent_graph},
         }
 
         if workflow_type not in self.workflow_map:
@@ -326,6 +329,14 @@ class ChemGraph:
                 llm=llm,
                 executor_tools=self.tools,
                 analysis_tools=self.data_tools,
+            )
+        elif self.workflow_type == "rag_agent":
+            self.workflow = self.workflow_map[workflow_type]["constructor"](
+                llm=llm,
+                system_prompt=self.system_prompt
+                if self.system_prompt != single_agent_prompt
+                else rag_agent_prompt,
+                tools=self.tools,
             )
 
     def visualize(self, method: str = "ascii"):
@@ -447,7 +458,12 @@ class ChemGraph:
             }
 
             # Add prompts depending on workflow_type
-            if self.workflow_type in {"single_agent", "graspa", "python_relp"}:
+            if self.workflow_type in {
+                "single_agent",
+                "graspa",
+                "python_relp",
+                "rag_agent",
+            }:
                 output_data.update(
                     {
                         "system_prompt": self.system_prompt,

--- a/src/chemgraph/graphs/rag_agent.py
+++ b/src/chemgraph/graphs/rag_agent.py
@@ -1,0 +1,223 @@
+"""LangGraph workflow for the RAG (Retrieval-Augmented Generation) agent.
+
+This graph combines document retrieval tools (load_document,
+query_knowledge_base) with the standard chemistry tools so the agent
+can answer questions grounded in user-provided text documents *and*
+run molecular simulations when needed.
+
+Graph structure
+---------------
+
+    START
+      |
+      v
+  RAGAgent  <-------+
+      |              |
+     (route)         |
+     / \\             |
+    v    v           |
+  tools  done-->END  |
+    |                |
+    +----------------+
+
+The agent loops through a ReAct cycle: it can call any combination of
+RAG tools and chemistry tools, inspect the results, and decide whether
+to call more tools or produce a final answer.
+"""
+
+from langgraph.graph import StateGraph, START, END
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import ToolNode
+
+from chemgraph.tools.rag_tools import load_document, query_knowledge_base
+from chemgraph.tools.ase_tools import (
+    run_ase,
+    save_atomsdata_to_file,
+    file_to_atomsdata,
+)
+from chemgraph.tools.cheminformatics_tools import (
+    molecule_name_to_smiles,
+    smiles_to_coordinate_file,
+)
+from chemgraph.tools.generic_tools import calculator
+from chemgraph.prompt.rag_prompt import rag_agent_prompt
+from chemgraph.state.state import State
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers (reuse the repeated-tool-call detection from single_agent)
+# ---------------------------------------------------------------------------
+def _tool_call_signature(tool_calls) -> tuple:
+    """Create a comparable signature for a list of tool calls."""
+    signature = []
+    for call in tool_calls or []:
+        name = call.get("name") if isinstance(call, dict) else None
+        args = call.get("args", {}) if isinstance(call, dict) else {}
+        if isinstance(args, dict):
+            args_sig = tuple(sorted(args.items()))
+        else:
+            args_sig = str(args)
+        signature.append((name, args_sig))
+    return tuple(signature)
+
+
+def _is_repeated_tool_cycle(messages) -> bool:
+    """Detect if the most recent AI tool-call set repeats the previous one."""
+    ai_with_calls = [
+        m
+        for m in messages
+        if hasattr(m, "tool_calls") and getattr(m, "tool_calls", None)
+    ]
+    if len(ai_with_calls) < 2:
+        return False
+    last = _tool_call_signature(ai_with_calls[-1].tool_calls)
+    prev = _tool_call_signature(ai_with_calls[-2].tool_calls)
+    return bool(last) and last == prev
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+def route_tools(state: State):
+    """Route to 'tools' if the last message has tool calls, else 'done'.
+
+    Parameters
+    ----------
+    state : State
+        Current graph state.
+
+    Returns
+    -------
+    str
+        ``"tools"`` or ``"done"``.
+    """
+    if isinstance(state, list):
+        ai_message = state[-1]
+    elif messages := state.get("messages", []):
+        ai_message = messages[-1]
+    else:
+        raise ValueError(f"No messages found in input state: {state}")
+
+    if hasattr(ai_message, "tool_calls") and len(ai_message.tool_calls) > 0:
+        if not isinstance(state, list) and _is_repeated_tool_cycle(messages):
+            return "done"
+        return "tools"
+    return "done"
+
+
+# ---------------------------------------------------------------------------
+# Agent node
+# ---------------------------------------------------------------------------
+def RAGAgent(state: State, llm, system_prompt: str, tools=None):
+    """LLM node that can retrieve from documents and run chemistry tools.
+
+    Parameters
+    ----------
+    state : State
+        Current graph state with messages.
+    llm : BaseChatModel
+        The bound language model.
+    system_prompt : str
+        System prompt guiding the agent's behaviour.
+    tools : list, optional
+        Tools available to the agent. Uses the default RAG + chemistry
+        tool set when ``None``.
+
+    Returns
+    -------
+    dict
+        Updated state with the LLM's response appended to messages.
+    """
+    if tools is None:
+        tools = _default_tools()
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": f"{state['messages']}"},
+    ]
+    llm_with_tools = llm.bind_tools(tools=tools)
+    return {"messages": [llm_with_tools.invoke(messages)]}
+
+
+# ---------------------------------------------------------------------------
+# Default tool set
+# ---------------------------------------------------------------------------
+def _default_tools():
+    """Return the combined RAG + chemistry tool list."""
+    return [
+        # RAG tools
+        load_document,
+        query_knowledge_base,
+        # Chemistry tools
+        file_to_atomsdata,
+        smiles_to_coordinate_file,
+        run_ase,
+        molecule_name_to_smiles,
+        save_atomsdata_to_file,
+        calculator,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Graph constructor
+# ---------------------------------------------------------------------------
+def construct_rag_agent_graph(
+    llm,
+    system_prompt: str = rag_agent_prompt,
+    tools: list = None,
+):
+    """Construct a RAG agent graph with document retrieval and chemistry tools.
+
+    Parameters
+    ----------
+    llm : BaseChatModel
+        The language model to power the agent.
+    system_prompt : str, optional
+        System prompt for the RAG agent, by default ``rag_agent_prompt``.
+    tools : list, optional
+        Custom tool list. When ``None`` the default RAG + chemistry
+        tools are used.
+
+    Returns
+    -------
+    CompiledStateGraph
+        The compiled LangGraph workflow ready for execution.
+    """
+    try:
+        logger.info("Constructing RAG agent graph")
+        checkpointer = MemorySaver()
+
+        if tools is None:
+            tools = _default_tools()
+
+        tool_node = ToolNode(tools=tools)
+        graph_builder = StateGraph(State)
+
+        # Nodes
+        graph_builder.add_node(
+            "RAGAgent",
+            lambda state: RAGAgent(
+                state, llm, system_prompt=system_prompt, tools=tools
+            ),
+        )
+        graph_builder.add_node("tools", tool_node)
+
+        # Edges
+        graph_builder.add_edge(START, "RAGAgent")
+        graph_builder.add_conditional_edges(
+            "RAGAgent",
+            route_tools,
+            {"tools": "tools", "done": END},
+        )
+        graph_builder.add_edge("tools", "RAGAgent")
+
+        graph = graph_builder.compile(checkpointer=checkpointer)
+        logger.info("RAG agent graph construction completed")
+        return graph
+
+    except Exception as e:
+        logger.error(f"Error constructing RAG agent graph: {e}")
+        raise

--- a/src/chemgraph/prompt/rag_prompt.py
+++ b/src/chemgraph/prompt/rag_prompt.py
@@ -1,0 +1,25 @@
+"""System prompts for the RAG agent workflow."""
+
+rag_agent_prompt = """You are an expert research assistant specializing in computational chemistry and scientific literature analysis. You have access to tools for:
+
+1. **Document retrieval** -- loading documents (.txt or .pdf) and querying them for relevant information.
+2. **Computational chemistry** -- molecular simulations, structure generation, and property calculations.
+
+Instructions:
+1. When the user asks a question about a document, ALWAYS use `query_knowledge_base` to retrieve relevant passages before answering.
+2. If no document has been loaded yet, use `load_document` first with the file path provided by the user.
+3. Base your answers on the retrieved context. Cite or quote relevant passages when appropriate.
+4. If the retrieved context does not contain enough information to answer the question, clearly state what is missing and what you found instead.
+5. If the user asks you to perform a computational chemistry task (e.g., calculate energy, optimize geometry), use the appropriate chemistry tools.
+6. Never fabricate information. If the document does not contain the answer, say so.
+7. When summarizing, be thorough but concise. Organize information logically.
+"""
+
+rag_retriever_prompt = """You are a retrieval agent. Your task is to:
+1. Determine if a document needs to be loaded (use `load_document`).
+2. Formulate effective search queries based on the user's question.
+3. Use `query_knowledge_base` to retrieve relevant passages.
+4. Pass the retrieved context to the main agent for answer generation.
+
+Always retrieve context before the main agent generates an answer.
+"""

--- a/src/chemgraph/state/rag_state.py
+++ b/src/chemgraph/state/rag_state.py
@@ -1,0 +1,30 @@
+"""LangGraph state definition for the RAG agent workflow."""
+
+from typing import TypedDict, Annotated, Optional
+from langgraph.graph import add_messages
+from langgraph.managed.is_last_step import RemainingSteps
+
+
+class RAGState(TypedDict):
+    """State for the RAG agent workflow.
+
+    Extends the base message-passing state with fields to track
+    the loaded document path and retrieved context.
+
+    Attributes
+    ----------
+    messages : list
+        Accumulated conversation messages (managed by LangGraph).
+    remaining_steps : RemainingSteps
+        Counter for recursion-limit enforcement.
+    document_path : str or None
+        Path to the currently loaded document, if any.
+    retrieved_context : str or None
+        The most recently retrieved context from the vector store,
+        injected into the agent's prompt for grounded answers.
+    """
+
+    messages: Annotated[list, add_messages]
+    remaining_steps: RemainingSteps
+    document_path: Optional[str]
+    retrieved_context: Optional[str]

--- a/src/chemgraph/tools/rag_tools.py
+++ b/src/chemgraph/tools/rag_tools.py
@@ -1,0 +1,349 @@
+"""RAG (Retrieval-Augmented Generation) tools for ChemGraph.
+
+Provides tools to load documents (.txt and .pdf) into a FAISS vector
+store and query them for relevant context. Supports OpenAI and
+HuggingFace embeddings with automatic fallback.
+"""
+
+import os
+import logging
+from typing import Optional
+
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level vector store registry
+# ---------------------------------------------------------------------------
+# Maps a document identifier (file path or user-provided name) to a
+# FAISS vector store instance so that documents loaded during a session
+# remain queryable across multiple tool calls.
+_vector_stores: dict = {}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas for tool inputs
+# ---------------------------------------------------------------------------
+class LoadDocumentInput(BaseModel):
+    """Input schema for the load_document tool."""
+
+    file_path: str = Field(
+        description="Absolute or relative path to a .txt or .pdf file to ingest."
+    )
+    chunk_size: int = Field(
+        default=1000,
+        description="Maximum number of characters per text chunk.",
+    )
+    chunk_overlap: int = Field(
+        default=200,
+        description="Number of overlapping characters between consecutive chunks.",
+    )
+    embedding_provider: str = Field(
+        default="openai",
+        description=(
+            "Embedding provider to use: 'openai' (requires OPENAI_API_KEY) "
+            "or 'huggingface' (local, no API key needed). "
+            "Falls back to huggingface if openai is unavailable."
+        ),
+    )
+
+
+class QueryKnowledgeBaseInput(BaseModel):
+    """Input schema for the query_knowledge_base tool."""
+
+    query: str = Field(description="The question or search query.")
+    file_path: Optional[str] = Field(
+        default=None,
+        description=(
+            "Path of a previously loaded document to search. "
+            "If None, searches the most recently loaded document."
+        ),
+    )
+    top_k: int = Field(
+        default=5,
+        description="Number of most relevant chunks to retrieve.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Supported file types
+# ---------------------------------------------------------------------------
+_SUPPORTED_EXTENSIONS = {".txt", ".pdf"}
+
+
+# ---------------------------------------------------------------------------
+# PDF text extraction
+# ---------------------------------------------------------------------------
+def _extract_text_from_pdf(file_path: str) -> str:
+    """Extract text content from a PDF file using PyMuPDF.
+
+    Parameters
+    ----------
+    file_path : str
+        Absolute path to the PDF file.
+
+    Returns
+    -------
+    str
+        Concatenated text from all pages, separated by newlines.
+
+    Raises
+    ------
+    ImportError
+        If PyMuPDF (``fitz``) is not installed.
+    """
+    try:
+        import fitz  # PyMuPDF
+    except ImportError as exc:
+        raise ImportError(
+            "PyMuPDF is required for PDF support. "
+            "Install the 'rag' extra: pip install chemgraphagent[rag]"
+        ) from exc
+
+    pages: list[str] = []
+    with fitz.open(file_path) as doc:
+        for page_num, page in enumerate(doc):
+            page_text = page.get_text()
+            if page_text.strip():
+                pages.append(page_text)
+    return "\n\n".join(pages)
+
+
+# ---------------------------------------------------------------------------
+# Embedding helpers
+# ---------------------------------------------------------------------------
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _get_embeddings(provider: str = "openai"):
+    """Return an embeddings instance for the requested provider.
+
+    Supports OpenAI-compatible custom endpoints via OPENAI_BASE_URL.
+    Falls back to HuggingFace if OpenAI embeddings are unavailable.
+    """
+    if provider == "openai":
+        try:
+            from langchain_openai import OpenAIEmbeddings
+
+            api_key = os.environ.get("OPENAI_API_KEY")
+            base_url = os.environ.get("OPENAI_BASE_URL") 
+
+            if not api_key:
+                raise EnvironmentError("OPENAI_API_KEY not set")
+
+            kwargs = {
+                "model": os.environ.get("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large"),
+                "api_key": api_key,
+                "check_embedding_ctx_length":False,
+
+            }
+
+            if base_url:
+                kwargs["base_url"] = base_url
+
+            return OpenAIEmbeddings(**kwargs)
+
+        except Exception as exc:
+            logger.warning(
+                "OpenAI embeddings unavailable (%s); falling back to HuggingFace.",
+                exc,
+            )
+            provider = "huggingface"
+
+    try:
+        from langchain_huggingface import HuggingFaceEmbeddings
+
+        return HuggingFaceEmbeddings(
+            model_name="all-MiniLM-L6-v2",
+            model_kwargs={"device": "cpu"},
+        )
+    except ImportError as exc:
+        raise ImportError(
+            "Neither langchain-openai nor langchain-huggingface is installed. "
+            "Install the 'rag' extra: pip install chemgraphagent[rag]"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+@tool(args_schema=LoadDocumentInput)
+def load_document(
+    file_path: str,
+    chunk_size: int = 1000,
+    chunk_overlap: int = 200,
+    embedding_provider: str = "openai",
+) -> dict:
+    """Load a document (.txt or .pdf), split it into chunks, and index it in a FAISS vector store.
+
+    The document remains available for querying via ``query_knowledge_base``
+    for the duration of the session.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the ``.txt`` or ``.pdf`` file to ingest.
+    chunk_size : int, optional
+        Max characters per chunk, by default 1000.
+    chunk_overlap : int, optional
+        Overlap between consecutive chunks, by default 200.
+    embedding_provider : str, optional
+        ``"openai"`` or ``"huggingface"``, by default ``"openai"``.
+
+    Returns
+    -------
+    dict
+        Status information including the number of chunks created.
+    """
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+    from langchain_community.vectorstores import FAISS
+
+    resolved_path = os.path.abspath(file_path)
+    if not os.path.isfile(resolved_path):
+        return {"ok": False, "error": f"File not found: {resolved_path}"}
+
+    _, ext = os.path.splitext(resolved_path)
+    ext = ext.lower()
+    if ext not in _SUPPORTED_EXTENSIONS:
+        supported = ", ".join(sorted(_SUPPORTED_EXTENSIONS))
+        return {
+            "ok": False,
+            "error": (f"Unsupported file type '{ext}'. Supported formats: {supported}"),
+        }
+
+    # ----- Extract text based on file type -----
+    if ext == ".pdf":
+        try:
+            text = _extract_text_from_pdf(resolved_path)
+        except ImportError as exc:
+            return {"ok": False, "error": str(exc)}
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": f"Failed to extract text from PDF: {exc}",
+            }
+    else:
+        # .txt
+        with open(resolved_path, "r", encoding="utf-8") as fh:
+            text = fh.read()
+
+    if not text.strip():
+        return {"ok": False, "error": "File is empty or contains no extractable text."}
+
+    # Split into chunks
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        length_function=len,
+        separators=["\n\n", "\n", ". ", " ", ""],
+    )
+    chunks = splitter.create_documents(
+        [text],
+        metadatas=[{"source": resolved_path, "file_type": ext}],
+    )
+
+    # Build FAISS index
+    embeddings = _get_embeddings(provider=embedding_provider)
+    vector_store = FAISS.from_documents(chunks, embeddings)
+
+    # Register in module-level store
+    _vector_stores[resolved_path] = vector_store
+    # Also track the most-recently loaded path for convenience
+    _vector_stores["__latest__"] = resolved_path
+
+    logger.info(
+        "Loaded '%s' (%s) into FAISS vector store (%d chunks, chunk_size=%d, overlap=%d).",
+        resolved_path,
+        ext,
+        len(chunks),
+        chunk_size,
+        chunk_overlap,
+    )
+
+    return {
+        "ok": True,
+        "file_path": resolved_path,
+        "file_type": ext,
+        "num_chunks": len(chunks),
+        "chunk_size": chunk_size,
+        "chunk_overlap": chunk_overlap,
+        "embedding_provider": embedding_provider,
+    }
+
+
+@tool(args_schema=QueryKnowledgeBaseInput)
+def query_knowledge_base(
+    query: str,
+    file_path: Optional[str] = None,
+    top_k: int = 5,
+) -> dict:
+    """Search a previously loaded document for passages relevant to a query.
+
+    Parameters
+    ----------
+    query : str
+        The natural-language question or search query.
+    file_path : str, optional
+        Path of a previously loaded document. If ``None``, the most
+        recently loaded document is searched.
+    top_k : int, optional
+        Number of top-matching chunks to return, by default 5.
+
+    Returns
+    -------
+    dict
+        A dict with ``"ok"``, ``"query"``, ``"num_results"``, and
+        ``"results"`` (list of dicts with ``"content"`` and ``"metadata"``).
+    """
+    # Resolve which vector store to query
+    if file_path is not None:
+        resolved_path = os.path.abspath(file_path)
+    else:
+        resolved_path = _vector_stores.get("__latest__")
+
+    if resolved_path is None or resolved_path not in _vector_stores:
+        available = [k for k in _vector_stores if k != "__latest__"]
+        return {
+            "ok": False,
+            "error": (
+                "No document loaded yet. Use the load_document tool first."
+                if not available
+                else f"Document '{file_path}' not found. Available: {available}"
+            ),
+        }
+
+    vector_store = _vector_stores[resolved_path]
+    docs = vector_store.similarity_search(query, k=top_k)
+
+    results = [
+        {
+            "content": doc.page_content,
+            "metadata": doc.metadata,
+        }
+        for doc in docs
+    ]
+
+    return {
+        "ok": True,
+        "query": query,
+        "num_results": len(results),
+        "results": results,
+    }
+
+
+def get_loaded_documents() -> list[str]:
+    """Return a list of file paths currently loaded in the vector store.
+
+    This is a plain helper (not a tool) for programmatic access.
+    """
+    return [k for k in _vector_stores if k != "__latest__"]
+
+
+def clear_vector_stores() -> None:
+    """Remove all loaded vector stores. Useful for testing and cleanup."""
+    _vector_stores.clear()


### PR DESCRIPTION
- Add RAG agent via `rag_agent` workflow type.
- Add a demo using Argo to run RAG.