### PR TITLE
Add session memory persistence with CLI session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,14 +565,18 @@ chemgraph [OPTIONS] -q "YOUR_QUERY"
 
 **Core Arguments:**
 
-| Option         | Short | Description                                  | Default        |
-| -------------- | ----- | -------------------------------------------- | -------------- |
-| `--query`      | `-q`  | The computational chemistry query to execute | Required       |
-| `--model`      | `-m`  | LLM model to use                             | `gpt-4o-mini`  |
-| `--workflow`   | `-w`  | Workflow type                                | `single_agent` |
-| `--output`     | `-o`  | Output format (`state`, `last_message`)      | `state`        |
-| `--structured` | `-s`  | Use structured output format                 | `False`        |
-| `--report`     | `-r`  | Generate detailed report                     | `False`        |
+| Option              | Short | Description                                           | Default        |
+| ------------------- | ----- | ----------------------------------------------------- | -------------- |
+| `--query`           | `-q`  | The computational chemistry query to execute          | Required       |
+| `--model`           | `-m`  | LLM model to use                                     | `gpt-4o-mini`  |
+| `--workflow`        | `-w`  | Workflow type                                        | `single_agent` |
+| `--output`          | `-o`  | Output format (`state`, `last_message`)              | `state`        |
+| `--structured`      | `-s`  | Use structured output format                         | `False`        |
+| `--report`          | `-r`  | Generate detailed report                             | `False`        |
+| `--resume`          |       | Resume from a previous session ID (prefix supported) |                |
+| `--list-sessions`   |       | List recent sessions from the memory database        |                |
+| `--show-session`    |       | Show conversation for a session (prefix supported)   |                |
+| `--delete-session`  |       | Delete a session from the memory database            |                |
 
 **Model Selection:**
 
@@ -635,19 +639,25 @@ chemgraph --interactive
 
 **Interactive Features:**
 - **Persistent conversation**: Maintain context across queries
+- **Session memory**: Conversations are automatically saved to a local SQLite database (`~/.chemgraph/sessions.db`) and can be resumed later
 - **Model switching**: Change models mid-conversation
 - **Workflow switching**: Switch between different agent types
-- **Built-in commands**: Help, clear, config, etc.
+- **Built-in commands**: Help, clear, config, session management, etc.
 
 **Interactive Commands:**
 ```bash
 # In interactive mode, type:
 help                    # Show available commands
 clear                   # Clear screen
-config                  # Show current configuration
+config                  # Show current configuration and session ID
 quit                    # Exit interactive mode
 model gpt-4o           # Change model
 workflow multi_agent   # Change workflow
+
+# Session management:
+history                 # List recent sessions
+show <session_id>       # Show a session's conversation
+resume <session_id>     # Resume from a previous session
 ```
 
 #### Utility Commands
@@ -666,6 +676,34 @@ chemgraph --check-keys
 ```bash
 chemgraph --help
 ```
+
+#### Session Memory
+
+ChemGraph automatically saves every conversation to a local SQLite database at `~/.chemgraph/sessions.db`. This allows you to browse past sessions, review tool calls and results, and resume previous conversations with full context.
+
+**List Recent Sessions:**
+```bash
+chemgraph --list-sessions
+```
+
+**View a Session's Conversation:**
+```bash
+# Full session ID or prefix (first few characters)
+chemgraph --show-session a3b2
+```
+
+**Resume From a Previous Session:**
+```bash
+# Injects previous conversation context into the new query
+chemgraph -q "Now optimize the geometry at 500K" --resume a3b2
+```
+
+**Delete a Session:**
+```bash
+chemgraph --delete-session a3b2c1d4
+```
+
+Session IDs support prefix matching -- you only need to type enough characters to uniquely identify the session.
 
 #### Configuration File Support
 
@@ -800,11 +838,15 @@ chemgraph/
 │   ├── chemgraph/             # Top-level package
 │   │   ├── agent/             # Agent-based task management
 │   │   ├── graphs/            # Workflow graph utilities
-│   │   ├── models/            # Different Pydantic models
-│   │   ├── prompt/            # Agent prompt
-│   │   ├── state/             # Agent state
+│   │   ├── mcp/               # MCP servers (stdio/streamable HTTP)
+│   │   ├── memory/            # Session memory (SQLite-backed persistence)
+│   │   ├── models/            # LLM provider integrations
+│   │   ├── prompt/            # Agent prompt templates
+│   │   ├── schemas/           # Pydantic data models
+│   │   ├── state/             # Agent state definitions
 │   │   ├── tools/             # Tools for molecular simulations
 │   │   ├── utils/             # Other utility functions
+│   ├── ui/                    # CLI and Streamlit UI
 │
 ├── pyproject.toml             # Project configuration
 └── README.md                  # Project documentation

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -202,14 +202,18 @@ chemgraph [OPTIONS] -q "YOUR_QUERY"
 
 **Core Arguments:**
 
-| Option         | Short | Description                                  | Default        |
-| -------------- | ----- | -------------------------------------------- | -------------- |
-| `--query`      | `-q`  | The computational chemistry query to execute | Required       |
-| `--model`      | `-m`  | LLM model to use                             | `gpt-4o-mini`  |
-| `--workflow`   | `-w`  | Workflow type                                | `single_agent` |
-| `--output`     | `-o`  | Output format (`state`, `last_message`)      | `state`        |
-| `--structured` | `-s`  | Use structured output format                 | `False`        |
-| `--report`     | `-r`  | Generate detailed report                     | `False`        |
+| Option              | Short | Description                                           | Default        |
+| ------------------- | ----- | ----------------------------------------------------- | -------------- |
+| `--query`           | `-q`  | The computational chemistry query to execute          | Required       |
+| `--model`           | `-m`  | LLM model to use                                     | `gpt-4o-mini`  |
+| `--workflow`        | `-w`  | Workflow type                                        | `single_agent` |
+| `--output`          | `-o`  | Output format (`state`, `last_message`)              | `state`        |
+| `--structured`      | `-s`  | Use structured output format                         | `False`        |
+| `--report`          | `-r`  | Generate detailed report                             | `False`        |
+| `--resume`          |       | Resume from a previous session ID (prefix supported) |                |
+| `--list-sessions`   |       | List recent sessions from the memory database        |                |
+| `--show-session`    |       | Show conversation for a session (prefix supported)   |                |
+| `--delete-session`  |       | Delete a session from the memory database            |                |
 
 **Model Selection:**
 
@@ -272,19 +276,25 @@ chemgraph --interactive
 
 **Interactive Features:**
 - **Persistent conversation**: Maintain context across queries
+- **Session memory**: Conversations are automatically saved to a local SQLite database (`~/.chemgraph/sessions.db`) and can be resumed later
 - **Model switching**: Change models mid-conversation
 - **Workflow switching**: Switch between different agent types
-- **Built-in commands**: Help, clear, config, etc.
+- **Built-in commands**: Help, clear, config, session management, etc.
 
 **Interactive Commands:**
 ```bash
 # In interactive mode, type:
 help                    # Show available commands
 clear                   # Clear screen
-config                  # Show current configuration
+config                  # Show current configuration and session ID
 quit                    # Exit interactive mode
 model gpt-4o           # Change model
 workflow multi_agent   # Change workflow
+
+# Session management:
+history                 # List recent sessions
+show <session_id>       # Show a session's conversation
+resume <session_id>     # Resume from a previous session
 ```
 
 #### Utility Commands
@@ -303,6 +313,34 @@ chemgraph --check-keys
 ```bash
 chemgraph --help
 ```
+
+#### Session Memory
+
+ChemGraph automatically saves every conversation to a local SQLite database at `~/.chemgraph/sessions.db`. This allows you to browse past sessions, review tool calls and results, and resume previous conversations with full context.
+
+**List Recent Sessions:**
+```bash
+chemgraph --list-sessions
+```
+
+**View a Session's Conversation:**
+```bash
+# Full session ID or prefix (first few characters)
+chemgraph --show-session a3b2
+```
+
+**Resume From a Previous Session:**
+```bash
+# Injects previous conversation context into the new query
+chemgraph -q "Now optimize the geometry at 500K" --resume a3b2
+```
+
+**Delete a Session:**
+```bash
+chemgraph --delete-session a3b2c1d4
+```
+
+Session IDs support prefix matching -- you only need to type enough characters to uniquely identify the session.
 
 #### Configuration File Support
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,10 @@
 
     ChemGraph supports diverse simulation backends, including ab initio quantum chemistry methods (e.g. coupled-cluster, DFT via NWChem, ORCA), semi-empirical methods (e.g., XTB via TBLite), and machine learning potentials (e.g, MACE, UMA) through a modular integration with `ASE`.
 
+!!! info "Session Memory"
+
+    ChemGraph automatically persists every conversation to a local SQLite database. You can browse past sessions, review tool calls and results, and resume previous conversations with full context using the CLI (`--list-sessions`, `--show-session`, `--resume`) or interactive mode (`history`, `show`, `resume`).
+
 !!! tip "Docker Image"
 
     ChemGraph Docker images are published to GHCR at `ghcr.io/argonne-lcf/chemgraph`.

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -5,10 +5,12 @@ chemgraph/
 │   ├── chemgraph/             # Top-level package
 │   │   ├── agent/             # Agent-based task management
 │   │   ├── graphs/            # Workflow graph utilities
-│   │   ├── models/            # Different Pydantic models
 │   │   ├── mcp/               # MCP servers (stdio/streamable HTTP)
-│   │   ├── prompt/            # Agent prompt
-│   │   ├── state/             # Agent state
+│   │   ├── memory/            # Session memory (SQLite-backed persistence)
+│   │   ├── models/            # LLM provider integrations
+│   │   ├── prompt/            # Agent prompt templates
+│   │   ├── schemas/           # Pydantic data models
+│   │   ├── state/             # Agent state definitions
 │   │   ├── tools/             # Tools for molecular simulations
 │   │   ├── utils/             # Other utility functions
 │   ├── ui/                    # CLI and Streamlit UI package

--- a/scripts/memory_example/test_session_memory.py
+++ b/scripts/memory_example/test_session_memory.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Test script for ChemGraph session memory features.
+
+Tests the full lifecycle:
+  1. Run a query and verify session is created
+  2. List sessions via SessionStore
+  3. Show session details and messages
+  4. Resume from the previous session with a follow-up query
+  5. Verify resumed session has context injected
+  6. Clean up test sessions
+
+Usage:
+    python scripts/test_session_memory.py
+
+Requires:
+    - Argo API access (uses gpt4o via Argo endpoint)
+    - ARGO_USER env var or defaults to 'chemgraph'
+"""
+
+import asyncio
+import sys
+import os
+
+# ---------------------------------------------------------------------------
+# Configuration — edit these to match your setup
+# ---------------------------------------------------------------------------
+MODEL_NAME = "gpt4o"
+BASE_URL = "https://apps-dev.inside.anl.gov/argoapi/api/v1/resource/chat/"
+WORKFLOW_TYPE = "single_agent"
+# ---------------------------------------------------------------------------
+
+
+async def main():
+    from chemgraph.agent.llm_agent import ChemGraph
+    from chemgraph.memory.store import SessionStore
+
+    # Use a temp database so we don't pollute the real session store
+    import tempfile
+
+    tmp_db = os.path.join(tempfile.mkdtemp(), "test_sessions.db")
+    print(f"Using temp database: {tmp_db}\n")
+
+    # ------------------------------------------------------------------
+    # Step 1: First run — create a session
+    # ------------------------------------------------------------------
+    print("=" * 60)
+    print("STEP 1: First run — Calculate thermochemistry of CO2")
+    print("=" * 60)
+
+    cg = ChemGraph(
+        model_name=MODEL_NAME,
+        workflow_type=WORKFLOW_TYPE,
+        structured_output=False,
+        return_option="state",
+        base_url=BASE_URL,
+        memory_db_path=tmp_db,
+    )
+
+    print(f"Agent UUID:      {cg.uuid}")
+    print(f"Agent session_id:{cg.session_id}")
+    print(f"Log dir:         {cg.log_dir}")
+    print()
+
+    # Visualize the workflow graph
+    print("Workflow graph:")
+    print(cg.visualize())
+    print()
+
+    query1 = "Calculate the thermochemistry of CO2 at 298K using Mace_mp, medium model"
+    print(f"Query: {query1}\n")
+
+    result1 = await cg.run(query1, {"thread_id": 1})
+    session1_id = cg.session_id
+
+    print(f"\nSession 1 ID: {session1_id}")
+    print(f"Session created: {cg._session_created}")
+
+    # ------------------------------------------------------------------
+    # Step 2: List sessions
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("STEP 2: List sessions")
+    print("=" * 60)
+
+    store = SessionStore(db_path=tmp_db)
+    sessions = store.list_sessions()
+
+    print(f"Total sessions: {store.session_count()}")
+    for s in sessions:
+        print(
+            f"  [{s.session_id}] {s.title} "
+            f"| model={s.model_name} "
+            f"| queries={s.query_count} "
+            f"| messages={s.message_count} "
+            f"| {s.updated_at.strftime('%Y-%m-%d %H:%M')}"
+        )
+
+    # ------------------------------------------------------------------
+    # Step 3: Show session details
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print(f"STEP 3: Show session {session1_id}")
+    print("=" * 60)
+
+    session = store.get_session(session1_id)
+    if session:
+        print(f"Title:    {session.title}")
+        print(f"Model:    {session.model_name}")
+        print(f"Workflow: {session.workflow_type}")
+        print(f"Log dir:  {session.log_dir}")
+        print(f"Messages: {len(session.messages)}")
+        print()
+        for msg in session.messages:
+            role_label = {"human": "User", "ai": "Assistant", "tool": "Tool"}.get(
+                msg.role, msg.role
+            )
+            tool_suffix = f" [{msg.tool_name}]" if msg.tool_name else ""
+            content = msg.content
+            if len(content) > 200:
+                content = content[:200] + "..."
+            print(f"  {role_label}{tool_suffix}: {content}")
+    else:
+        print(f"ERROR: Session {session1_id} not found!")
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Step 4: Build context summary (what --resume injects)
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("STEP 4: Context summary (preview of what --resume injects)")
+    print("=" * 60)
+
+    summary = store.build_context_summary(session1_id)
+    print(summary)
+
+    # ------------------------------------------------------------------
+    # Step 5: Resume from session 1 with a follow-up query
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("STEP 5: Resume — follow-up query using previous session context")
+    print("=" * 60)
+
+    # Clear CHEMGRAPH_LOG_DIR so second agent creates its own log dir
+    if "CHEMGRAPH_LOG_DIR" in os.environ:
+        del os.environ["CHEMGRAPH_LOG_DIR"]
+
+    cg2 = ChemGraph(
+        model_name=MODEL_NAME,
+        workflow_type=WORKFLOW_TYPE,
+        structured_output=False,
+        return_option="state",
+        base_url=BASE_URL,
+        memory_db_path=tmp_db,
+    )
+
+    query2 = "Now calculate the same thermochemistry but at 500K instead"
+    print(f"Query: {query2}")
+    print(f"Resuming from session: {session1_id}\n")
+
+    result2 = await cg2.run(query2, {"thread_id": 1}, resume_from=session1_id)
+    session2_id = cg2.session_id
+
+    print(f"\nSession 2 ID: {session2_id}")
+
+    # ------------------------------------------------------------------
+    # Step 6: Verify both sessions exist
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("STEP 6: Final session listing")
+    print("=" * 60)
+
+    sessions = store.list_sessions()
+    print(f"Total sessions: {store.session_count()}")
+    for s in sessions:
+        print(
+            f"  [{s.session_id}] {s.title} "
+            f"| queries={s.query_count} "
+            f"| messages={s.message_count}"
+        )
+
+    # ------------------------------------------------------------------
+    # Step 7: Test prefix matching
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("STEP 7: Prefix matching")
+    print("=" * 60)
+
+    prefix = session1_id[:4]
+    resolved = store.get_session(prefix)
+    if resolved:
+        print(f"Prefix '{prefix}' resolved to: {resolved.session_id}")
+    else:
+        print(f"Prefix '{prefix}' did not resolve (may be ambiguous)")
+
+    # ------------------------------------------------------------------
+    # Step 8: Test load_previous_context from agent API
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("STEP 8: load_previous_context() via agent API")
+    print("=" * 60)
+
+    context = cg2.load_previous_context(session1_id)
+    if context:
+        # Show first 500 chars
+        preview = context[:500] + "..." if len(context) > 500 else context
+        print(f"Context loaded ({len(context)} chars):")
+        print(preview)
+    else:
+        print("WARNING: No context returned")
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 60)
+    print("SUMMARY")
+    print("=" * 60)
+    print(f"Session 1: {session1_id} (initial query)")
+    print(f"Session 2: {session2_id} (resumed from session 1)")
+    print(f"Database:  {tmp_db}")
+    print(f"Log dir 1: {cg.log_dir}")
+    print(f"Log dir 2: {cg2.log_dir}")
+    print()
+    print("To explore further with the CLI:")
+    print(f"  chemgraph --list-sessions")
+    print(f"  chemgraph --show-session {session1_id}")
+    print(f"  chemgraph -q 'Your query' --resume {session1_id}")
+    print()
+    print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -1,8 +1,10 @@
 import datetime
 import os
-from typing import List
+from typing import List, Optional
 import uuid
 
+from chemgraph.memory.store import SessionStore
+from chemgraph.memory.schemas import SessionMessage
 from chemgraph.models.openai import load_openai_model
 from chemgraph.models.alcf_endpoints import load_alcf_model
 from chemgraph.models.local_model import load_ollama_model
@@ -135,13 +137,18 @@ class ChemGraph:
         support_structured_output: bool = True,
         tools: List = None,
         data_tools: List = None,
+        session_store: Optional[SessionStore] = None,
+        enable_memory: bool = True,
+        memory_db_path: Optional[str] = None,
     ):
+        # Always generate a unique identifier for this instance
+        self.uuid = str(uuid.uuid4())[:8]
+
         # Initialize log directory
         self.log_dir = os.environ.get("CHEMGRAPH_LOG_DIR")
         if not self.log_dir:
             # Create a new session log directory under cg_logs/
             timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-            self.uuid = str(uuid.uuid4())[:8]
             # Use abspath to ensure tools getting this env var have a full path
             self.log_dir = os.path.join(
                 os.getcwd(), "cg_logs", f"session_{timestamp}_{self.uuid}"
@@ -149,8 +156,18 @@ class ChemGraph:
             os.makedirs(self.log_dir, exist_ok=True)
             # Set env var for tools to pick up
             os.environ["CHEMGRAPH_LOG_DIR"] = self.log_dir
+
+        # Initialize session memory store
+        if session_store is not None:
+            self.session_store = session_store
+        elif enable_memory:
+            self.session_store = SessionStore(db_path=memory_db_path)
         else:
-            self.uuid = None
+            self.session_store = None
+
+        # Track whether session has been registered in the memory store
+        self._session_created: bool = False
+        self._session_title: Optional[str] = None
 
         try:
             # Use hardcoded optimal values for tool calling
@@ -431,7 +448,7 @@ class ChemGraph:
                 )
                 os.makedirs(log_dir, exist_ok=True)
                 if not file_name:
-                    file_name = f"state_thread_{thread_id}_{timestamp}.json"
+                    file_name = f"state_thread_{thread_id}_{self.uuid}_{timestamp}.json"
                 file_path = os.path.join(log_dir, file_name)
 
             state = self.get_state(config=config)
@@ -509,11 +526,120 @@ class ChemGraph:
             print("Error with write_state: ", str(e))
             return "Error"
 
-    async def run(self, query: str, config=None):
+    @property
+    def session_id(self) -> str:
+        """Current session ID (always available, derived from self.uuid)."""
+        return self.uuid
+
+    def _ensure_session(self, query: str) -> None:
+        """Create a session record on first run if memory is enabled."""
+        if self.session_store is None:
+            return
+        if self._session_created:
+            return
+
+        self._session_title = SessionStore.generate_title(query)
+        self.session_store.create_session(
+            session_id=self.uuid,
+            model_name=self.model_name,
+            workflow_type=self.workflow_type,
+            title=self._session_title,
+            log_dir=self.log_dir,
+        )
+        self._session_created = True
+        logger.info(f"Created session {self.uuid}: {self._session_title}")
+
+    def _save_messages_to_store(self, last_state: dict, query: str) -> None:
+        """Extract messages from workflow state and persist to session store."""
+        if self.session_store is None or not self._session_created:
+            return
+
+        try:
+            messages_to_save = []
+            state_messages = last_state.get("messages", [])
+
+            for msg in state_messages:
+                role = None
+                content = ""
+                tool_name = None
+
+                if hasattr(msg, "type"):
+                    # LangChain message objects
+                    if msg.type == "human":
+                        role = "human"
+                    elif msg.type == "ai":
+                        role = "ai"
+                    elif msg.type == "tool":
+                        role = "tool"
+                        tool_name = getattr(msg, "name", None)
+                    content = getattr(msg, "content", str(msg))
+                elif isinstance(msg, dict):
+                    role = msg.get("type") or msg.get("role")
+                    content = msg.get("content", "")
+                    tool_name = msg.get("name")
+
+                if role and content:
+                    messages_to_save.append(
+                        SessionMessage(
+                            role=role,
+                            content=content,
+                            tool_name=tool_name,
+                        )
+                    )
+
+            self.session_store.save_messages(
+                session_id=self.uuid,
+                messages=messages_to_save,
+                title=self._session_title,
+            )
+            logger.info(
+                f"Saved {len(messages_to_save)} messages to session {self.uuid}"
+            )
+        except Exception as e:
+            logger.warning(f"Failed to save messages to session store: {e}")
+
+    def load_previous_context(
+        self,
+        session_id: str,
+        max_messages: Optional[int] = None,
+    ) -> str:
+        """Load context from a previous session as a summary string.
+
+        This can be injected into the conversation to give the agent
+        awareness of prior work.
+
+        Parameters
+        ----------
+        session_id : str
+            Previous session ID (or unique prefix).
+        max_messages : int, optional
+            Limit the number of messages included.
+
+        Returns
+        -------
+        str
+            Formatted context summary, or empty string if not found.
+        """
+        if self.session_store is None:
+            logger.warning("Memory is disabled; cannot load previous context.")
+            return ""
+        return self.session_store.build_context_summary(session_id)
+
+    async def run(self, query: str, config=None, resume_from: Optional[str] = None):
         """
         Async-only runner. Requires `self.workflow.astream(...)`.
         Streams values, logs new messages, writes state, and returns according to
         `self.return_option` ("last_message" or "state").
+
+        Parameters
+        ----------
+        query : str
+            The user query to execute.
+        config : dict, optional
+            LangGraph config with thread_id, etc.
+        resume_from : str, optional
+            Session ID to load context from. The previous conversation
+            summary is prepended to the query.
         """
 
         def _validate_config(cfg):
@@ -561,6 +687,20 @@ class ChemGraph:
         if not os.environ.get("CHEMGRAPH_LOG_DIR"):
             os.environ["CHEMGRAPH_LOG_DIR"] = self.log_dir
 
+        # Ensure session exists in memory store
+        self._ensure_session(query)
+
+        # If resuming from a previous session, prepend context
+        if resume_from and self.session_store:
+            context = self.session_store.build_context_summary(resume_from)
+            if context:
+                query = (
+                    f"{context}\n\n"
+                    f"Now, continuing from the previous session above, "
+                    f"please help with the following:\n\n{query}"
+                )
+                logger.info(f"Injected context from session {resume_from}")
+
         inputs = {"messages": query}
 
         prev_messages = []
@@ -581,6 +721,9 @@ class ChemGraph:
 
             if last_state is None:
                 raise RuntimeError("Workflow produced no states.")
+
+            # Save messages to persistent session store
+            self._save_messages_to_store(last_state, query)
 
             return _save_state_and_select_return(last_state, config)
 

--- a/src/chemgraph/memory/__init__.py
+++ b/src/chemgraph/memory/__init__.py
@@ -1,0 +1,11 @@
+"""
+ChemGraph Memory Module
+
+Provides persistent session storage for ChemGraph conversations,
+enabling users to review past sessions and resume from previous context.
+"""
+
+from chemgraph.memory.store import SessionStore
+from chemgraph.memory.schemas import Session, SessionMessage, SessionSummary
+
+__all__ = ["SessionStore", "Session", "SessionMessage", "SessionSummary"]

--- a/src/chemgraph/memory/schemas.py
+++ b/src/chemgraph/memory/schemas.py
@@ -1,0 +1,52 @@
+"""
+Pydantic schemas for ChemGraph session memory.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SessionMessage(BaseModel):
+    """A single message in a session conversation."""
+
+    role: str = Field(description="Message role: 'human', 'ai', or 'tool'")
+    content: str = Field(description="Message content text")
+    tool_name: Optional[str] = Field(
+        default=None, description="Tool name if role is 'tool'"
+    )
+    timestamp: datetime = Field(default_factory=datetime.now)
+
+
+class Session(BaseModel):
+    """Full session record with messages and metadata."""
+
+    session_id: str = Field(description="Unique session identifier (UUID)")
+    title: str = Field(
+        default="", description="Human-readable session title (auto-generated)"
+    )
+    model_name: str = Field(description="LLM model used")
+    workflow_type: str = Field(description="Workflow type used")
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+    messages: list[SessionMessage] = Field(
+        default_factory=list, description="Conversation messages"
+    )
+    log_dir: Optional[str] = Field(
+        default=None, description="Path to session log directory"
+    )
+    query_count: int = Field(default=0, description="Number of user queries")
+
+
+class SessionSummary(BaseModel):
+    """Lightweight session summary for listing sessions."""
+
+    session_id: str
+    title: str
+    model_name: str
+    workflow_type: str
+    created_at: datetime
+    updated_at: datetime
+    query_count: int
+    message_count: int

--- a/src/chemgraph/memory/store.py
+++ b/src/chemgraph/memory/store.py
@@ -1,0 +1,479 @@
+"""
+SQLite-based session storage for ChemGraph conversations.
+
+Provides persistent storage for session metadata and message history,
+enabling session listing, resumption, and context injection.
+"""
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from chemgraph.memory.schemas import Session, SessionMessage, SessionSummary
+
+logger = logging.getLogger(__name__)
+
+# Default database path: ~/.chemgraph/sessions.db
+DEFAULT_DB_DIR = os.path.join(Path.home(), ".chemgraph")
+DEFAULT_DB_PATH = os.path.join(DEFAULT_DB_DIR, "sessions.db")
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id   TEXT PRIMARY KEY,
+    title        TEXT NOT NULL DEFAULT '',
+    model_name   TEXT NOT NULL,
+    workflow_type TEXT NOT NULL,
+    log_dir      TEXT,
+    query_count  INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id  TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+    role        TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    tool_name   TEXT,
+    timestamp   TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_session
+    ON messages(session_id);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_updated
+    ON sessions(updated_at DESC);
+"""
+
+
+class SessionStore:
+    """SQLite-backed persistent session store.
+
+    Parameters
+    ----------
+    db_path : str, optional
+        Path to SQLite database file. Defaults to ``~/.chemgraph/sessions.db``.
+        The parent directory is created automatically if needed.
+    """
+
+    def __init__(self, db_path: Optional[str] = None):
+        self.db_path = db_path or DEFAULT_DB_PATH
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Database lifecycle
+    # ------------------------------------------------------------------
+
+    def _init_db(self):
+        """Create tables and indexes if they don't exist."""
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA_SQL)
+
+    def _connect(self) -> sqlite3.Connection:
+        """Return a new connection with WAL mode and FK enforcement."""
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    # ------------------------------------------------------------------
+    # Session CRUD
+    # ------------------------------------------------------------------
+
+    def create_session(
+        self,
+        session_id: str,
+        model_name: str,
+        workflow_type: str,
+        title: str = "",
+        log_dir: Optional[str] = None,
+    ) -> Session:
+        """Create a new session record.
+
+        Parameters
+        ----------
+        session_id : str
+            Unique session identifier (typically a UUID fragment).
+        model_name : str
+            LLM model name.
+        workflow_type : str
+            Workflow type (e.g., ``single_agent``).
+        title : str, optional
+            Human-readable title. Auto-generated later if empty.
+        log_dir : str, optional
+            Path to session log directory.
+
+        Returns
+        -------
+        Session
+            The newly created session.
+        """
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO sessions
+                    (session_id, title, model_name, workflow_type, log_dir,
+                     query_count, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+                """,
+                (session_id, title, model_name, workflow_type, log_dir, now, now),
+            )
+        return Session(
+            session_id=session_id,
+            title=title,
+            model_name=model_name,
+            workflow_type=workflow_type,
+            log_dir=log_dir,
+            created_at=datetime.fromisoformat(now),
+            updated_at=datetime.fromisoformat(now),
+        )
+
+    def save_messages(
+        self,
+        session_id: str,
+        messages: list[SessionMessage],
+        title: Optional[str] = None,
+    ) -> None:
+        """Append messages to a session and update metadata.
+
+        Parameters
+        ----------
+        session_id : str
+            Target session identifier.
+        messages : list[SessionMessage]
+            Messages to append.
+        title : str, optional
+            Update the session title (e.g., auto-generated from first query).
+        """
+        if not messages:
+            return
+
+        now = datetime.now().isoformat()
+        human_count = sum(1 for m in messages if m.role == "human")
+
+        with self._connect() as conn:
+            conn.executemany(
+                """
+                INSERT INTO messages (session_id, role, content, tool_name, timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        session_id,
+                        m.role,
+                        m.content,
+                        m.tool_name,
+                        m.timestamp.isoformat(),
+                    )
+                    for m in messages
+                ],
+            )
+
+            update_fields = ["updated_at = ?", "query_count = query_count + ?"]
+            update_params: list = [now, human_count]
+
+            if title:
+                update_fields.append("title = ?")
+                update_params.append(title)
+
+            update_params.append(session_id)
+            conn.execute(
+                f"UPDATE sessions SET {', '.join(update_fields)} WHERE session_id = ?",
+                update_params,
+            )
+
+    def get_session(self, session_id: str) -> Optional[Session]:
+        """Load a full session with all messages.
+
+        Parameters
+        ----------
+        session_id : str
+            Session identifier. Supports prefix matching if unique.
+
+        Returns
+        -------
+        Session or None
+            The session with messages populated, or None if not found.
+        """
+        resolved_id = self._resolve_session_id(session_id)
+        if resolved_id is None:
+            return None
+
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?", (resolved_id,)
+            ).fetchone()
+            if not row:
+                return None
+
+            msg_rows = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                (resolved_id,),
+            ).fetchall()
+
+        messages = [
+            SessionMessage(
+                role=m["role"],
+                content=m["content"],
+                tool_name=m["tool_name"],
+                timestamp=datetime.fromisoformat(m["timestamp"]),
+            )
+            for m in msg_rows
+        ]
+
+        return Session(
+            session_id=row["session_id"],
+            title=row["title"],
+            model_name=row["model_name"],
+            workflow_type=row["workflow_type"],
+            log_dir=row["log_dir"],
+            query_count=row["query_count"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+            messages=messages,
+        )
+
+    def list_sessions(
+        self,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionSummary]:
+        """List sessions ordered by most recently updated.
+
+        Parameters
+        ----------
+        limit : int
+            Maximum number of sessions to return.
+        offset : int
+            Offset for pagination.
+
+        Returns
+        -------
+        list[SessionSummary]
+            Lightweight session summaries.
+        """
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT s.*,
+                       (SELECT COUNT(*) FROM messages m
+                        WHERE m.session_id = s.session_id) AS message_count
+                FROM sessions s
+                ORDER BY s.updated_at DESC
+                LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            ).fetchall()
+
+        return [
+            SessionSummary(
+                session_id=r["session_id"],
+                title=r["title"],
+                model_name=r["model_name"],
+                workflow_type=r["workflow_type"],
+                created_at=datetime.fromisoformat(r["created_at"]),
+                updated_at=datetime.fromisoformat(r["updated_at"]),
+                query_count=r["query_count"],
+                message_count=r["message_count"],
+            )
+            for r in rows
+        ]
+
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a session and all its messages.
+
+        Parameters
+        ----------
+        session_id : str
+            Session identifier. Supports prefix matching.
+
+        Returns
+        -------
+        bool
+            True if a session was deleted, False if not found.
+        """
+        resolved_id = self._resolve_session_id(session_id)
+        if resolved_id is None:
+            return False
+
+        with self._connect() as conn:
+            # Messages are cascade-deleted via FK constraint
+            cursor = conn.execute(
+                "DELETE FROM sessions WHERE session_id = ?", (resolved_id,)
+            )
+            return cursor.rowcount > 0
+
+    def session_count(self) -> int:
+        """Return total number of stored sessions."""
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) as cnt FROM sessions").fetchone()
+            return row["cnt"]
+
+    # ------------------------------------------------------------------
+    # Context building for session resume
+    # ------------------------------------------------------------------
+
+    def build_context_messages(
+        self,
+        session_id: str,
+        max_messages: Optional[int] = None,
+        roles: Optional[list[str]] = None,
+    ) -> list[dict]:
+        """Build a list of message dicts suitable for injecting as LangGraph context.
+
+        Extracts human, AI, and tool messages in chronological order.
+
+        Parameters
+        ----------
+        session_id : str
+            Session to extract context from.
+        max_messages : int, optional
+            Maximum number of messages to include (from the end).
+        roles : list[str], optional
+            Roles to include. Defaults to ``["human", "ai", "tool"]``.
+
+        Returns
+        -------
+        list[dict]
+            List of ``{"role": ..., "content": ...}`` dicts.
+        """
+        session = self.get_session(session_id)
+        if session is None:
+            return []
+
+        if roles is None:
+            roles = ["human", "ai", "tool"]
+
+        filtered = [m for m in session.messages if m.role in roles]
+
+        if max_messages and len(filtered) > max_messages:
+            filtered = filtered[-max_messages:]
+
+        return [{"role": m.role, "content": m.content} for m in filtered]
+
+    def build_context_summary(self, session_id: str) -> str:
+        """Build a text summary of a previous session for context injection.
+
+        This creates a concise summary that can be prepended to the system
+        prompt or injected as a context message when resuming from a
+        previous session.
+
+        Parameters
+        ----------
+        session_id : str
+            Session to summarize.
+
+        Returns
+        -------
+        str
+            A formatted summary string, or empty string if session not found.
+        """
+        session = self.get_session(session_id)
+        if session is None:
+            return ""
+
+        human_msgs = [m for m in session.messages if m.role == "human"]
+        ai_msgs = [m for m in session.messages if m.role == "ai"]
+
+        lines = [
+            f"=== Previous Session Context ===",
+            f"Session: {session.session_id}",
+            f"Title: {session.title or 'Untitled'}",
+            f"Model: {session.model_name}",
+            f"Workflow: {session.workflow_type}",
+            f"Date: {session.created_at.strftime('%Y-%m-%d %H:%M')}",
+            f"Queries: {len(human_msgs)}",
+            "",
+            "Conversation:",
+        ]
+
+        for msg in session.messages:
+            if msg.role == "human":
+                lines.append(f"  User: {msg.content}")
+            elif msg.role == "ai":
+                # Truncate long AI responses for context
+                content = msg.content
+                if len(content) > 500:
+                    content = content[:500] + "..."
+                lines.append(f"  Assistant: {content}")
+            elif msg.role == "tool":
+                tool_label = f" [{msg.tool_name}]" if msg.tool_name else ""
+                content = msg.content
+                if len(content) > 500:
+                    content = content[:500] + "..."
+                lines.append(f"  Tool{tool_label}: {content}")
+
+        lines.append("=== End Previous Session ===")
+        return "\n".join(lines)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_session_id(self, session_id: str) -> Optional[str]:
+        """Resolve a (possibly prefix) session ID to a full ID.
+
+        Allows users to type just the first few characters of a UUID.
+        Returns None if no match or ambiguous.
+        """
+        with self._connect() as conn:
+            # Try exact match first
+            row = conn.execute(
+                "SELECT session_id FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if row:
+                return row["session_id"]
+
+            # Try prefix match
+            rows = conn.execute(
+                "SELECT session_id FROM sessions WHERE session_id LIKE ?",
+                (session_id + "%",),
+            ).fetchall()
+
+            if len(rows) == 1:
+                return rows[0]["session_id"]
+            elif len(rows) > 1:
+                logger.warning(
+                    f"Ambiguous session ID prefix '{session_id}' matches "
+                    f"{len(rows)} sessions. Please provide more characters."
+                )
+                return None
+            return None
+
+    @staticmethod
+    def generate_title(query: str, max_length: int = 200) -> str:
+        """Generate a session title from the first user query.
+
+        Parameters
+        ----------
+        query : str
+            The first user query.
+        max_length : int
+            Maximum title length.
+
+        Returns
+        -------
+        str
+            A cleaned-up title derived from the query.
+        """
+        title = query.strip()
+        # Remove common prefixes
+        for prefix in ["please ", "can you ", "could you ", "i want to ", "help me "]:
+            if title.lower().startswith(prefix):
+                title = title[len(prefix) :]
+                break
+        # Capitalize first letter
+        if title:
+            title = title[0].upper() + title[1:]
+        # Truncate
+        if len(title) > max_length:
+            title = title[: max_length - 3] + "..."
+        return title

--- a/src/ui/cli.py
+++ b/src/ui/cli.py
@@ -35,6 +35,7 @@ from chemgraph.utils.config_utils import (
     get_argo_user_from_flat_config,
     get_base_url_for_model_from_flat_config,
 )
+from chemgraph.memory.store import SessionStore
 
 # Initialize rich console
 console = Console()
@@ -80,7 +81,6 @@ def check_api_keys(model_name: str) -> tuple[bool, str]:
                 False,
                 "OpenAI API key not found. Please set OPENAI_API_KEY environment variable.",
             )
-    
 
     # Check Anthropic models
     elif "claude" in model_lower:
@@ -142,6 +142,12 @@ Examples:
   %(prog)s --interactive
   %(prog)s --list-models
   %(prog)s --check-keys
+
+Session management:
+  %(prog)s --list-sessions
+  %(prog)s --show-session a3b2
+  %(prog)s --delete-session a3b2c1d4
+  %(prog)s -q "Optimize the geometry" --resume a3b2
         """,
     )
 
@@ -210,6 +216,34 @@ Examples:
     # Check API keys
     parser.add_argument(
         "--check-keys", action="store_true", help="Check API key availability"
+    )
+
+    # Session management
+    parser.add_argument(
+        "--list-sessions",
+        action="store_true",
+        help="List recent sessions from the memory database",
+    )
+
+    parser.add_argument(
+        "--show-session",
+        type=str,
+        metavar="ID",
+        help="Show conversation for a session (supports prefix matching)",
+    )
+
+    parser.add_argument(
+        "--delete-session",
+        type=str,
+        metavar="ID",
+        help="Delete a session from the memory database",
+    )
+
+    parser.add_argument(
+        "--resume",
+        type=str,
+        metavar="ID",
+        help="Resume from a previous session (injects context into new query)",
     )
 
     # Verbose output
@@ -354,6 +388,125 @@ def check_api_keys_status():
     console.print("• [cyan]OpenAI:[/cyan] https://platform.openai.com/api-keys")
     console.print("• [cyan]Anthropic:[/cyan] https://console.anthropic.com/")
     console.print("• [cyan]Google:[/cyan] https://aistudio.google.com/apikey")
+
+
+def list_sessions(limit: int = 20, db_path: str = None):
+    """Display recent sessions in a formatted table."""
+    store = SessionStore(db_path=db_path)
+    sessions = store.list_sessions(limit=limit)
+
+    if not sessions:
+        console.print("[dim]No sessions found.[/dim]")
+        return
+
+    console.print(Panel(f"Recent Sessions ({len(sessions)})", style="bold cyan"))
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Session ID", style="cyan", width=10)
+    table.add_column("Title", style="white", width=40)
+    table.add_column("Model", style="green", width=16)
+    table.add_column("Workflow", style="yellow", width=14)
+    table.add_column("Queries", style="white", justify="right", width=8)
+    table.add_column("Messages", style="white", justify="right", width=9)
+    table.add_column("Date", style="dim", width=16)
+
+    for s in sessions:
+        table.add_row(
+            s.session_id,
+            s.title or "[dim]Untitled[/dim]",
+            s.model_name,
+            s.workflow_type,
+            str(s.query_count),
+            str(s.message_count),
+            s.updated_at.strftime("%Y-%m-%d %H:%M"),
+        )
+
+    console.print(table)
+    console.print(
+        "\n[dim]Use --show-session <id> to view a session's conversation. "
+        "Prefix matching is supported (e.g. first few chars).[/dim]"
+    )
+
+
+def show_session(session_id: str, db_path: str = None, max_content: int = 500):
+    """Display a session's full conversation."""
+    store = SessionStore(db_path=db_path)
+    session = store.get_session(session_id)
+
+    if session is None:
+        console.print(
+            f"[red]Session '{session_id}' not found. "
+            f"The ID may be ambiguous or nonexistent.[/red]"
+        )
+        console.print("[dim]Use --list-sessions to see available sessions.[/dim]")
+        return
+
+    # Session metadata header
+    meta_table = Table(show_header=False, box=None, padding=(0, 2))
+    meta_table.add_column("Key", style="bold cyan")
+    meta_table.add_column("Value")
+    meta_table.add_row("Session ID", session.session_id)
+    meta_table.add_row("Title", session.title or "Untitled")
+    meta_table.add_row("Model", session.model_name)
+    meta_table.add_row("Workflow", session.workflow_type)
+    meta_table.add_row("Queries", str(session.query_count))
+    meta_table.add_row("Created", session.created_at.strftime("%Y-%m-%d %H:%M:%S"))
+    meta_table.add_row("Updated", session.updated_at.strftime("%Y-%m-%d %H:%M:%S"))
+    if session.log_dir:
+        meta_table.add_row("Log Dir", session.log_dir)
+
+    console.print(Panel(meta_table, title="Session Info", style="bold cyan"))
+
+    if not session.messages:
+        console.print("[dim]No messages in this session.[/dim]")
+        return
+
+    # Display conversation
+    console.print(f"\n[bold]Conversation ({len(session.messages)} messages):[/bold]\n")
+
+    for msg in session.messages:
+        if msg.role == "human":
+            label = "[bold cyan]User[/bold cyan]"
+        elif msg.role == "ai":
+            label = "[bold green]Assistant[/bold green]"
+        elif msg.role == "tool":
+            tool_label = f" ({msg.tool_name})" if msg.tool_name else ""
+            label = f"[bold yellow]Tool{tool_label}[/bold yellow]"
+        else:
+            label = f"[dim]{msg.role}[/dim]"
+
+        content = msg.content
+        if max_content and len(content) > max_content:
+            content = (
+                content[:max_content]
+                + f"\n... [truncated, {len(msg.content)} chars total]"
+            )
+
+        timestamp = msg.timestamp.strftime("%H:%M:%S") if msg.timestamp else ""
+
+        console.print(f"  {label} [dim]{timestamp}[/dim]")
+        console.print(f"    {content}\n")
+
+
+def delete_session_cmd(session_id: str, db_path: str = None):
+    """Delete a session from the database."""
+    store = SessionStore(db_path=db_path)
+
+    # Show session info before deleting
+    session = store.get_session(session_id)
+    if session is None:
+        console.print(f"[red]Session '{session_id}' not found.[/red]")
+        return
+
+    console.print(
+        f"[yellow]Deleting session: {session.session_id} "
+        f"({session.title or 'Untitled'})[/yellow]"
+    )
+
+    if store.delete_session(session_id):
+        console.print("[green]Session deleted.[/green]")
+    else:
+        console.print("[red]Failed to delete session.[/red]")
 
 
 def load_config(config_file: str) -> Dict[str, Any]:
@@ -540,11 +693,19 @@ def format_response(result, verbose: bool = False):
         )
 
 
-def run_query(agent, query: str, thread_id: int, verbose: bool = False):
+def run_query(
+    agent,
+    query: str,
+    thread_id: int,
+    verbose: bool = False,
+    resume_from: str = None,
+):
     """Execute a query with the agent."""
     if verbose:
         console.print(f"[blue]Executing query:[/blue] {query}")
         console.print(f"[blue]Thread ID:[/blue] {thread_id}")
+        if resume_from:
+            console.print(f"[blue]Resuming from session:[/blue] {resume_from}")
 
     with Progress(
         SpinnerColumn(),
@@ -556,7 +717,9 @@ def run_query(agent, query: str, thread_id: int, verbose: bool = False):
 
         try:
             config = {"configurable": {"thread_id": thread_id}}
-            result = run_async_callable(lambda: agent.run(query, config=config))
+            result = run_async_callable(
+                lambda: agent.run(query, config=config, resume_from=resume_from)
+            )
 
             progress.update(task, description="[green]Query completed!")
             time.sleep(0.5)
@@ -591,9 +754,7 @@ def interactive_mode():
     )
 
     # Initialize agent
-    agent = initialize_agent(
-        model, workflow, False, "state", True, 20, verbose=True
-    )
+    agent = initialize_agent(model, workflow, False, "state", True, 20, verbose=True)
     if not agent:
         return
 
@@ -620,6 +781,11 @@ Available commands:
 • model <name> - Change model
 • workflow <type> - Change workflow type
 
+Session commands:
+• history - List recent sessions
+• show <id> - Show a session's conversation
+• resume <id> - Resume from a previous session
+
 Example queries:
 • What is the SMILES string for water?
 • Optimize the geometry of methane
@@ -637,6 +803,37 @@ Example queries:
             elif query.lower() == "config":
                 console.print(f"Model: {model}")
                 console.print(f"Workflow: {workflow}")
+                if hasattr(agent, "session_id"):
+                    console.print(f"Session ID: {agent.session_id}")
+                continue
+            elif query.lower() == "history":
+                list_sessions()
+                continue
+            elif query.lower().startswith("show "):
+                sid = query[5:].strip()
+                if sid:
+                    show_session(sid)
+                else:
+                    console.print("[red]Usage: show <session_id>[/red]")
+                continue
+            elif query.lower().startswith("resume "):
+                sid = query[7:].strip()
+                if not sid:
+                    console.print("[red]Usage: resume <session_id>[/red]")
+                    continue
+                resume_query = Prompt.ask(
+                    "[bold cyan]Enter query to continue with[/bold cyan]"
+                )
+                if resume_query.strip():
+                    result = run_query(
+                        agent,
+                        resume_query,
+                        1,
+                        verbose=False,
+                        resume_from=sid,
+                    )
+                    if result:
+                        format_response(result, verbose=False)
                 continue
             elif query.startswith("model "):
                 new_model = query[6:].strip()
@@ -700,6 +897,18 @@ def main():
         check_api_keys_status()
         return
 
+    if args.list_sessions:
+        list_sessions()
+        return
+
+    if args.show_session:
+        show_session(args.show_session)
+        return
+
+    if args.delete_session:
+        delete_session_cmd(args.delete_session)
+        return
+
     if args.interactive:
         interactive_mode()
         return
@@ -755,7 +964,9 @@ def main():
 
     # Execute query
     console.print(f"[bold blue]Query:[/bold blue] {args.query}")
-    result = run_query(agent, args.query, 1, args.verbose)
+    if args.resume:
+        console.print(f"[bold blue]Resuming from:[/bold blue] {args.resume}")
+    result = run_query(agent, args.query, 1, args.verbose, resume_from=args.resume)
 
     if result:
         format_response(result, args.verbose)

--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -1,0 +1,62 @@
+import os
+import shutil
+import pytest
+from unittest.mock import patch, Mock
+import datetime
+import uuid
+from chemgraph.agent.llm_agent import ChemGraph
+
+
+@pytest.fixture
+def clean_env():
+    # Cache and clear relevant env vars
+    old_log_dir = os.environ.get("CHEMGRAPH_LOG_DIR")
+
+    if "CHEMGRAPH_LOG_DIR" in os.environ:
+        del os.environ["CHEMGRAPH_LOG_DIR"]
+
+    yield
+
+    # Restore
+    if old_log_dir:
+        os.environ["CHEMGRAPH_LOG_DIR"] = old_log_dir
+    elif "CHEMGRAPH_LOG_DIR" in os.environ:
+        del os.environ["CHEMGRAPH_LOG_DIR"]
+
+
+def test_init_generates_log_dir(clean_env):
+    with (
+        patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load,
+        patch("chemgraph.agent.llm_agent.construct_single_agent_graph") as mock_graph,
+    ):
+        mock_load.return_value = Mock()
+        mock_graph.return_value = Mock()
+
+        agent = ChemGraph()
+
+        assert agent.log_dir is not None
+        assert agent.uuid is not None
+        assert "logs/session_" in agent.log_dir
+        assert os.environ.get("CHEMGRAPH_LOG_DIR") == agent.log_dir
+
+        # Cleanup created dir
+        if os.path.exists(agent.log_dir):
+            shutil.rmtree(agent.log_dir, ignore_errors=True)
+
+
+def test_init_respects_env_var(clean_env):
+    with (
+        patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load,
+        patch("chemgraph.agent.llm_agent.construct_single_agent_graph") as mock_graph,
+    ):
+        mock_load.return_value = Mock()
+        mock_graph.return_value = Mock()
+
+        test_dir = "/tmp/test_chemgraph_logs_custom"
+        os.environ["CHEMGRAPH_LOG_DIR"] = test_dir
+
+        agent = ChemGraph()
+        assert agent.log_dir == test_dir
+        # uuid should always be set now, even when CHEMGRAPH_LOG_DIR is pre-set
+        assert agent.uuid is not None
+        assert len(agent.uuid) == 8

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -1,0 +1,575 @@
+"""
+Tests for ChemGraph agent session/memory integration.
+
+Covers:
+- Memory initialization options (enable_memory, custom store, db_path)
+- uuid and session_id consistency
+- _ensure_session idempotency
+- _save_messages_to_store with LangChain and dict messages
+- write_state file naming with uuid
+- resume_from flow
+- End-to-end session lifecycle
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch, MagicMock
+
+from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.memory.schemas import SessionMessage
+from chemgraph.memory.store import SessionStore
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_env():
+    """Clear CHEMGRAPH_LOG_DIR for test isolation."""
+    old = os.environ.get("CHEMGRAPH_LOG_DIR")
+    if "CHEMGRAPH_LOG_DIR" in os.environ:
+        del os.environ["CHEMGRAPH_LOG_DIR"]
+    yield
+    if old:
+        os.environ["CHEMGRAPH_LOG_DIR"] = old
+    elif "CHEMGRAPH_LOG_DIR" in os.environ:
+        del os.environ["CHEMGRAPH_LOG_DIR"]
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Temporary database file."""
+    return str(tmp_path / "test_sessions.db")
+
+
+@pytest.fixture
+def mock_agent_patches():
+    """Patch LLM loading and graph construction for fast agent creation."""
+    with (
+        patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load,
+        patch("chemgraph.agent.llm_agent.construct_single_agent_graph") as mock_graph,
+    ):
+        mock_load.return_value = Mock()
+        mock_graph.return_value = Mock()
+        yield mock_load, mock_graph
+
+
+def _make_agent(clean_env, mock_agent_patches, tmp_db, **kwargs):
+    """Helper to create a ChemGraph with memory pointed at a temp DB."""
+    defaults = {
+        "model_name": "gpt-4o-mini",
+        "enable_memory": True,
+        "memory_db_path": tmp_db,
+    }
+    defaults.update(kwargs)
+    agent = ChemGraph(**defaults)
+    return agent
+
+
+# ------------------------------------------------------------------
+# Memory initialization
+# ------------------------------------------------------------------
+
+
+class TestMemoryInitialization:
+    def test_enable_memory_true_creates_store(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db, enable_memory=True)
+        assert agent.session_store is not None
+        assert isinstance(agent.session_store, SessionStore)
+
+    def test_enable_memory_false_no_store(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db, enable_memory=False)
+        assert agent.session_store is None
+
+    def test_custom_session_store(self, clean_env, mock_agent_patches, tmp_db):
+        custom_store = SessionStore(db_path=tmp_db)
+        agent = _make_agent(
+            clean_env,
+            mock_agent_patches,
+            tmp_db,
+            session_store=custom_store,
+        )
+        assert agent.session_store is custom_store
+
+    def test_custom_db_path(self, clean_env, mock_agent_patches, tmp_path):
+        db_path = str(tmp_path / "custom.db")
+        agent = _make_agent(
+            clean_env,
+            mock_agent_patches,
+            str(tmp_path / "unused.db"),
+            memory_db_path=db_path,
+        )
+        assert agent.session_store is not None
+        assert agent.session_store.db_path == db_path
+
+    def test_session_created_flag_initially_false(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        assert agent._session_created is False
+
+
+# ------------------------------------------------------------------
+# UUID and session_id
+# ------------------------------------------------------------------
+
+
+class TestUuidSessionId:
+    def test_uuid_always_set(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        assert agent.uuid is not None
+        assert len(agent.uuid) == 8
+
+    def test_uuid_set_when_log_dir_preset(self, mock_agent_patches, tmp_db):
+        """uuid must be set even when CHEMGRAPH_LOG_DIR is already in env."""
+        os.environ["CHEMGRAPH_LOG_DIR"] = "/tmp/preset_log_dir"
+        try:
+            agent = _make_agent(None, mock_agent_patches, tmp_db)
+            assert agent.uuid is not None
+            assert len(agent.uuid) == 8
+            assert agent.log_dir == "/tmp/preset_log_dir"
+        finally:
+            del os.environ["CHEMGRAPH_LOG_DIR"]
+
+    def test_session_id_property_returns_uuid(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        assert agent.session_id == agent.uuid
+
+    def test_session_id_is_str_not_optional(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        assert isinstance(agent.session_id, str)
+
+    def test_two_agents_have_different_uuids(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent1 = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        # Second agent needs a fresh env since first sets CHEMGRAPH_LOG_DIR
+        if "CHEMGRAPH_LOG_DIR" in os.environ:
+            del os.environ["CHEMGRAPH_LOG_DIR"]
+        agent2 = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        assert agent1.uuid != agent2.uuid
+
+
+# ------------------------------------------------------------------
+# _ensure_session
+# ------------------------------------------------------------------
+
+
+class TestEnsureSession:
+    def test_creates_session_in_store(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("What is water?")
+
+        assert agent._session_created is True
+        session = agent.session_store.get_session(agent.uuid)
+        assert session is not None
+        assert session.session_id == agent.uuid
+        assert session.model_name == "gpt-4o-mini"
+        assert session.workflow_type == "single_agent"
+
+    def test_generates_title_from_query(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("Please calculate the energy of water")
+
+        session = agent.session_store.get_session(agent.uuid)
+        assert session.title == "Calculate the energy of water"
+
+    def test_idempotent_on_second_call(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("First query")
+        agent._ensure_session("Second query")
+
+        # Should still have only one session
+        assert agent.session_store.session_count() == 1
+        # Title should be from the first query
+        session = agent.session_store.get_session(agent.uuid)
+        assert "First" in session.title
+
+    def test_stores_log_dir(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("test query")
+
+        session = agent.session_store.get_session(agent.uuid)
+        assert session.log_dir == agent.log_dir
+
+    def test_noop_when_memory_disabled(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db, enable_memory=False)
+        # Should not raise
+        agent._ensure_session("test query")
+        assert agent._session_created is False
+
+
+# ------------------------------------------------------------------
+# _save_messages_to_store
+# ------------------------------------------------------------------
+
+
+class TestSaveMessagesToStore:
+    def test_saves_langchain_messages(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("test query")
+
+        # Simulate LangChain message objects
+        human_msg = Mock()
+        human_msg.type = "human"
+        human_msg.content = "What is water?"
+
+        ai_msg = Mock()
+        ai_msg.type = "ai"
+        ai_msg.content = "Water is H2O."
+
+        tool_msg = Mock()
+        tool_msg.type = "tool"
+        tool_msg.content = '{"smiles": "O"}'
+        tool_msg.name = "molecule_name_to_smiles"
+
+        state = {"messages": [human_msg, ai_msg, tool_msg]}
+        agent._save_messages_to_store(state, "test query")
+
+        session = agent.session_store.get_session(agent.uuid)
+        assert len(session.messages) == 3
+        assert session.messages[0].role == "human"
+        assert session.messages[1].role == "ai"
+        assert session.messages[2].role == "tool"
+        assert session.messages[2].tool_name == "molecule_name_to_smiles"
+
+    def test_saves_dict_messages(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("test query")
+
+        state = {
+            "messages": [
+                {"type": "human", "content": "Hello"},
+                {"role": "ai", "content": "Hi there"},
+            ]
+        }
+        agent._save_messages_to_store(state, "test query")
+
+        session = agent.session_store.get_session(agent.uuid)
+        assert len(session.messages) == 2
+
+    def test_saves_full_content_without_truncation(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("test query")
+
+        long_msg = Mock()
+        long_msg.type = "ai"
+        long_msg.content = "A" * 15000
+
+        state = {"messages": [long_msg]}
+        agent._save_messages_to_store(state, "test query")
+
+        session = agent.session_store.get_session(agent.uuid)
+        assert len(session.messages) == 1
+        # Content should be saved in full — no truncation at save time
+        assert len(session.messages[0].content) == 15000
+        assert session.messages[0].content == "A" * 15000
+
+    def test_noop_when_memory_disabled(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db, enable_memory=False)
+        state = {"messages": [{"type": "human", "content": "Hello"}]}
+        # Should not raise
+        agent._save_messages_to_store(state, "test query")
+
+    def test_noop_when_session_not_created(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        # Don't call _ensure_session
+        state = {"messages": [{"type": "human", "content": "Hello"}]}
+        agent._save_messages_to_store(state, "test query")
+        # Store should have no sessions
+        assert agent.session_store.session_count() == 0
+
+    def test_skips_messages_without_content(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("test query")
+
+        empty_msg = Mock()
+        empty_msg.type = "ai"
+        empty_msg.content = ""
+
+        state = {"messages": [empty_msg]}
+        agent._save_messages_to_store(state, "test query")
+
+        session = agent.session_store.get_session(agent.uuid)
+        assert len(session.messages) == 0  # Empty content is skipped
+
+    def test_handles_exception_gracefully(self, clean_env, mock_agent_patches, tmp_db):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent._ensure_session("test query")
+
+        # Force an exception during save
+        agent.session_store.save_messages = Mock(side_effect=RuntimeError("DB error"))
+
+        msg = Mock()
+        msg.type = "human"
+        msg.content = "Hello"
+        state = {"messages": [msg]}
+
+        # Should not raise — logs a warning instead
+        agent._save_messages_to_store(state, "test query")
+
+
+# ------------------------------------------------------------------
+# write_state file naming
+# ------------------------------------------------------------------
+
+
+class TestWriteStateFileNaming:
+    def test_filename_includes_uuid(
+        self, clean_env, mock_agent_patches, tmp_db, tmp_path
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+
+        # Mock get_state to return something serializable
+        agent.workflow.get_state = Mock(return_value=Mock(values={"messages": []}))
+
+        log_dir = str(tmp_path / "test_logs")
+        os.makedirs(log_dir, exist_ok=True)
+        agent.log_dir = log_dir
+
+        config = {"configurable": {"thread_id": "42"}}
+        result = agent.write_state(config=config)
+
+        assert result != "Error"
+        # Find the file that was written
+        files = os.listdir(log_dir)
+        json_files = [f for f in files if f.endswith(".json")]
+        assert len(json_files) == 1
+        fname = json_files[0]
+
+        # Filename should contain thread_id and uuid
+        assert f"thread_42_{agent.uuid}" in fname
+
+    def test_no_overwrite_same_second(
+        self, clean_env, mock_agent_patches, tmp_db, tmp_path
+    ):
+        """Two agents writing to the same dir at the same second don't collide."""
+        log_dir = str(tmp_path / "shared_logs")
+        os.makedirs(log_dir, exist_ok=True)
+
+        agents = []
+        for _ in range(2):
+            if "CHEMGRAPH_LOG_DIR" in os.environ:
+                del os.environ["CHEMGRAPH_LOG_DIR"]
+            a = _make_agent(clean_env, mock_agent_patches, tmp_db)
+            a.workflow.get_state = Mock(return_value=Mock(values={"messages": []}))
+            a.log_dir = log_dir
+            agents.append(a)
+
+        config = {"configurable": {"thread_id": "1"}}
+        agents[0].write_state(config=config)
+        agents[1].write_state(config=config)
+
+        json_files = [f for f in os.listdir(log_dir) if f.endswith(".json")]
+        # Should be 2 distinct files (or at least not overwritten) thanks to uuid
+        # They may have identical timestamps but different uuids
+        assert agents[0].uuid != agents[1].uuid
+
+
+# ------------------------------------------------------------------
+# resume_from flow
+# ------------------------------------------------------------------
+
+
+class TestResumeFrom:
+    def _make_streamable_agent(self, clean_env, mock_agent_patches, tmp_db):
+        """Create an agent with a mock async workflow."""
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+
+        # Set up a mock astream that yields one state
+        ai_msg = Mock()
+        ai_msg.type = "ai"
+        ai_msg.content = "Test response"
+        ai_msg.pretty_print = Mock()
+
+        final_state = {"messages": [ai_msg]}
+
+        async def mock_astream(inputs, stream_mode, config):
+            yield final_state
+
+        agent.workflow.astream = mock_astream
+        agent.workflow.get_state = Mock(return_value=Mock(values=final_state))
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_resume_prepends_context(self, clean_env, mock_agent_patches, tmp_db):
+        # Create first agent and seed a session
+        agent1 = self._make_streamable_agent(clean_env, mock_agent_patches, tmp_db)
+        await agent1.run("What is water?")
+
+        session_id = agent1.uuid
+
+        # Clear env for second agent
+        if "CHEMGRAPH_LOG_DIR" in os.environ:
+            del os.environ["CHEMGRAPH_LOG_DIR"]
+
+        # Create second agent sharing the same DB
+        agent2 = self._make_streamable_agent(clean_env, mock_agent_patches, tmp_db)
+
+        # Track what inputs are passed to astream
+        captured_inputs = []
+        original_astream = agent2.workflow.astream
+
+        async def tracking_astream(inputs, stream_mode, config):
+            captured_inputs.append(inputs)
+            ai_msg = Mock()
+            ai_msg.type = "ai"
+            ai_msg.content = "Follow-up response"
+            ai_msg.pretty_print = Mock()
+            yield {"messages": [ai_msg]}
+
+        agent2.workflow.astream = tracking_astream
+        agent2.workflow.get_state = Mock(
+            return_value=Mock(
+                values={"messages": [Mock(type="ai", content="Follow-up")]}
+            )
+        )
+
+        await agent2.run("Continue the analysis", resume_from=session_id)
+
+        # The query should contain the previous context
+        assert len(captured_inputs) == 1
+        query = captured_inputs[0]["messages"]
+        assert "Previous Session Context" in query
+        assert "continuing from the previous session" in query
+
+    @pytest.mark.asyncio
+    async def test_resume_from_nonexistent_session(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = self._make_streamable_agent(clean_env, mock_agent_patches, tmp_db)
+
+        captured_inputs = []
+
+        async def tracking_astream(inputs, stream_mode, config):
+            captured_inputs.append(inputs)
+            ai_msg = Mock()
+            ai_msg.type = "ai"
+            ai_msg.content = "Response"
+            ai_msg.pretty_print = Mock()
+            yield {"messages": [ai_msg]}
+
+        agent.workflow.astream = tracking_astream
+        agent.workflow.get_state = Mock(
+            return_value=Mock(values={"messages": [Mock(type="ai", content="resp")]})
+        )
+
+        await agent.run("Hello", resume_from="nonexistent_id")
+
+        # No context should be prepended for a nonexistent session
+        query = captured_inputs[0]["messages"]
+        assert "Previous Session Context" not in query
+        assert query == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_resume_from_ignored_when_memory_disabled(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db, enable_memory=False)
+
+        ai_msg = Mock()
+        ai_msg.type = "ai"
+        ai_msg.content = "Response"
+        ai_msg.pretty_print = Mock()
+
+        captured_inputs = []
+
+        async def tracking_astream(inputs, stream_mode, config):
+            captured_inputs.append(inputs)
+            yield {"messages": [ai_msg]}
+
+        agent.workflow.astream = tracking_astream
+        agent.workflow.get_state = Mock(
+            return_value=Mock(values={"messages": [ai_msg]})
+        )
+
+        await agent.run("Hello", resume_from="some_id")
+
+        query = captured_inputs[0]["messages"]
+        assert query == "Hello"
+
+
+# ------------------------------------------------------------------
+# End-to-end session lifecycle
+# ------------------------------------------------------------------
+
+
+class TestEndToEndSessionLifecycle:
+    @pytest.mark.asyncio
+    async def test_full_lifecycle(self, clean_env, mock_agent_patches, tmp_db):
+        """init -> run -> messages saved -> load_previous_context -> resume"""
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+
+        # Set up mock workflow
+        human_msg = Mock()
+        human_msg.type = "human"
+        human_msg.content = "Calculate energy of H2"
+
+        ai_msg = Mock()
+        ai_msg.type = "ai"
+        ai_msg.content = "The energy of H2 is -1.17 eV using MACE."
+        ai_msg.pretty_print = Mock()
+
+        final_state = {"messages": [human_msg, ai_msg]}
+
+        async def mock_astream(inputs, stream_mode, config):
+            yield final_state
+
+        agent.workflow.astream = mock_astream
+        agent.workflow.get_state = Mock(return_value=Mock(values=final_state))
+
+        # Step 1: Run
+        await agent.run("Calculate energy of H2")
+
+        # Step 2: Verify session was created
+        assert agent._session_created is True
+        session = agent.session_store.get_session(agent.uuid)
+        assert session is not None
+        assert len(session.messages) == 2
+
+        # Step 3: Verify load_previous_context works
+        context = agent.load_previous_context(agent.uuid)
+        assert "Previous Session Context" in context
+        assert "H2" in context
+
+        # Step 4: Verify session_id property
+        assert agent.session_id == agent.uuid
+
+        # Step 5: Create new agent and resume
+        if "CHEMGRAPH_LOG_DIR" in os.environ:
+            del os.environ["CHEMGRAPH_LOG_DIR"]
+
+        agent2 = _make_agent(clean_env, mock_agent_patches, tmp_db)
+        agent2.workflow.astream = mock_astream
+        agent2.workflow.get_state = Mock(return_value=Mock(values=final_state))
+
+        await agent2.run("Now optimize H2", resume_from=agent.uuid)
+
+        # Second agent should also have a session
+        assert agent2._session_created is True
+        assert agent2.uuid != agent.uuid
+
+    @pytest.mark.asyncio
+    async def test_load_previous_context_disabled_memory(
+        self, clean_env, mock_agent_patches, tmp_db
+    ):
+        agent = _make_agent(clean_env, mock_agent_patches, tmp_db, enable_memory=False)
+        result = agent.load_previous_context("some_id")
+        assert result == ""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,490 @@
+"""
+Tests for ChemGraph session memory storage.
+"""
+
+import os
+import tempfile
+from datetime import datetime
+
+import pytest
+
+from chemgraph.memory.schemas import Session, SessionMessage, SessionSummary
+from chemgraph.memory.store import SessionStore
+
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    """Create a temporary database file for testing."""
+    return str(tmp_path / "test_sessions.db")
+
+
+@pytest.fixture
+def store(tmp_db):
+    """Create a SessionStore with a temporary database."""
+    return SessionStore(db_path=tmp_db)
+
+
+# ------------------------------------------------------------------
+# Schema tests
+# ------------------------------------------------------------------
+
+
+class TestSchemas:
+    def test_session_message_creation(self):
+        msg = SessionMessage(role="human", content="Hello world")
+        assert msg.role == "human"
+        assert msg.content == "Hello world"
+        assert msg.tool_name is None
+        assert isinstance(msg.timestamp, datetime)
+
+    def test_session_message_tool(self):
+        msg = SessionMessage(role="tool", content="Result: 42", tool_name="calculator")
+        assert msg.role == "tool"
+        assert msg.tool_name == "calculator"
+
+    def test_session_creation(self):
+        session = Session(
+            session_id="abc12345",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        assert session.session_id == "abc12345"
+        assert session.title == ""
+        assert session.messages == []
+        assert session.query_count == 0
+
+    def test_session_summary(self):
+        summary = SessionSummary(
+            session_id="abc12345",
+            title="Test session",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            query_count=3,
+            message_count=10,
+        )
+        assert summary.query_count == 3
+        assert summary.message_count == 10
+
+
+# ------------------------------------------------------------------
+# Store tests
+# ------------------------------------------------------------------
+
+
+class TestSessionStore:
+    def test_init_creates_db(self, tmp_db):
+        store = SessionStore(db_path=tmp_db)
+        assert os.path.exists(tmp_db)
+
+    def test_create_session(self, store):
+        session = store.create_session(
+            session_id="test1234",
+            model_name="gpt-4o-mini",
+            workflow_type="single_agent",
+            title="Test Session",
+        )
+        assert session.session_id == "test1234"
+        assert session.title == "Test Session"
+        assert session.model_name == "gpt-4o-mini"
+
+    def test_get_session(self, store):
+        store.create_session(
+            session_id="test1234",
+            model_name="gpt-4o-mini",
+            workflow_type="single_agent",
+            title="Test Session",
+        )
+
+        session = store.get_session("test1234")
+        assert session is not None
+        assert session.session_id == "test1234"
+        assert session.title == "Test Session"
+
+    def test_get_session_not_found(self, store):
+        session = store.get_session("nonexistent")
+        assert session is None
+
+    def test_save_and_retrieve_messages(self, store):
+        store.create_session(
+            session_id="msg_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        messages = [
+            SessionMessage(role="human", content="What is water?"),
+            SessionMessage(role="ai", content="Water is H2O."),
+            SessionMessage(
+                role="tool",
+                content='{"smiles": "O"}',
+                tool_name="molecule_name_to_smiles",
+            ),
+        ]
+
+        store.save_messages("msg_test", messages)
+
+        session = store.get_session("msg_test")
+        assert session is not None
+        assert len(session.messages) == 3
+        assert session.messages[0].role == "human"
+        assert session.messages[0].content == "What is water?"
+        assert session.messages[1].role == "ai"
+        assert session.messages[2].tool_name == "molecule_name_to_smiles"
+
+    def test_save_messages_updates_query_count(self, store):
+        store.create_session(
+            session_id="count_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        messages = [
+            SessionMessage(role="human", content="Query 1"),
+            SessionMessage(role="ai", content="Response 1"),
+            SessionMessage(role="human", content="Query 2"),
+            SessionMessage(role="ai", content="Response 2"),
+        ]
+
+        store.save_messages("count_test", messages)
+
+        session = store.get_session("count_test")
+        assert session.query_count == 2  # Only counts human messages
+
+    def test_save_messages_updates_title(self, store):
+        store.create_session(
+            session_id="title_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        messages = [SessionMessage(role="human", content="Hello")]
+        store.save_messages("title_test", messages, title="New Title")
+
+        session = store.get_session("title_test")
+        assert session.title == "New Title"
+
+    def test_list_sessions(self, store):
+        for i in range(5):
+            store.create_session(
+                session_id=f"list_{i}",
+                model_name="gpt-4o",
+                workflow_type="single_agent",
+                title=f"Session {i}",
+            )
+
+        sessions = store.list_sessions()
+        assert len(sessions) == 5
+        # Should be ordered by updated_at DESC
+        for s in sessions:
+            assert isinstance(s, SessionSummary)
+
+    def test_list_sessions_with_limit(self, store):
+        for i in range(10):
+            store.create_session(
+                session_id=f"limit_{i}",
+                model_name="gpt-4o",
+                workflow_type="single_agent",
+            )
+
+        sessions = store.list_sessions(limit=3)
+        assert len(sessions) == 3
+
+    def test_list_sessions_with_offset(self, store):
+        for i in range(5):
+            store.create_session(
+                session_id=f"offset_{i}",
+                model_name="gpt-4o",
+                workflow_type="single_agent",
+            )
+
+        all_sessions = store.list_sessions()
+        offset_sessions = store.list_sessions(offset=2)
+        assert len(offset_sessions) == 3
+
+    def test_delete_session(self, store):
+        store.create_session(
+            session_id="del_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        # Add some messages
+        messages = [
+            SessionMessage(role="human", content="Hello"),
+            SessionMessage(role="ai", content="Hi!"),
+        ]
+        store.save_messages("del_test", messages)
+
+        assert store.delete_session("del_test") is True
+        assert store.get_session("del_test") is None
+
+    def test_delete_session_not_found(self, store):
+        assert store.delete_session("nonexistent") is False
+
+    def test_session_count(self, store):
+        assert store.session_count() == 0
+
+        store.create_session(
+            session_id="count1",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        assert store.session_count() == 1
+
+        store.create_session(
+            session_id="count2",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        assert store.session_count() == 2
+
+    def test_prefix_resolution(self, store):
+        store.create_session(
+            session_id="abcd1234",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        # Exact match
+        session = store.get_session("abcd1234")
+        assert session is not None
+
+        # Prefix match
+        session = store.get_session("abcd")
+        assert session is not None
+        assert session.session_id == "abcd1234"
+
+    def test_ambiguous_prefix(self, store):
+        store.create_session(
+            session_id="abc_one",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        store.create_session(
+            session_id="abc_two",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        # "abc" matches both - should return None
+        session = store.get_session("abc")
+        assert session is None
+
+
+# ------------------------------------------------------------------
+# Context building tests
+# ------------------------------------------------------------------
+
+
+class TestContextBuilding:
+    def test_build_context_messages(self, store):
+        store.create_session(
+            session_id="ctx_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        messages = [
+            SessionMessage(role="human", content="What is water?"),
+            SessionMessage(role="ai", content="Water is H2O."),
+            SessionMessage(role="tool", content="tool output", tool_name="lookup"),
+            SessionMessage(role="human", content="What about ethanol?"),
+            SessionMessage(role="ai", content="Ethanol is C2H5OH."),
+        ]
+        store.save_messages("ctx_test", messages)
+
+        # Default: human + ai + tool
+        ctx = store.build_context_messages("ctx_test")
+        assert len(ctx) == 5  # 2 human + 2 ai + 1 tool
+        assert all(m["role"] in ("human", "ai", "tool") for m in ctx)
+
+    def test_build_context_messages_with_limit(self, store):
+        store.create_session(
+            session_id="ctx_limit",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        messages = [
+            SessionMessage(role="human", content=f"Query {i}") for i in range(10)
+        ]
+        store.save_messages("ctx_limit", messages)
+
+        ctx = store.build_context_messages("ctx_limit", max_messages=3)
+        assert len(ctx) == 3
+        # Should be the last 3
+        assert ctx[0]["content"] == "Query 7"
+
+    def test_build_context_messages_not_found(self, store):
+        ctx = store.build_context_messages("nonexistent")
+        assert ctx == []
+
+    def test_build_context_summary(self, store):
+        store.create_session(
+            session_id="sum_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+            title="Water Analysis",
+        )
+        messages = [
+            SessionMessage(role="human", content="What is water?"),
+            SessionMessage(role="tool", content='{"smiles": "O"}', tool_name="lookup"),
+            SessionMessage(role="ai", content="Water is H2O, a simple molecule."),
+        ]
+        store.save_messages("sum_test", messages)
+
+        summary = store.build_context_summary("sum_test")
+        assert "Previous Session Context" in summary
+        assert "Water Analysis" in summary
+        assert "What is water?" in summary
+        assert "Water is H2O" in summary
+        assert "Tool [lookup]" in summary
+        assert '{"smiles": "O"}' in summary
+
+    def test_build_context_summary_not_found(self, store):
+        summary = store.build_context_summary("nonexistent")
+        assert summary == ""
+
+    def test_build_context_summary_truncates_long_ai(self, store):
+        store.create_session(
+            session_id="trunc_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        long_response = "A" * 1000
+        messages = [
+            SessionMessage(role="human", content="Give me a long answer"),
+            SessionMessage(role="ai", content=long_response),
+        ]
+        store.save_messages("trunc_test", messages)
+
+        summary = store.build_context_summary("trunc_test")
+        assert "..." in summary
+
+
+# ------------------------------------------------------------------
+# Title generation tests
+# ------------------------------------------------------------------
+
+
+class TestTitleGeneration:
+    def test_generate_title_basic(self):
+        title = SessionStore.generate_title("What is the energy of water?")
+        assert title == "What is the energy of water?"
+
+    def test_generate_title_strips_prefix(self):
+        title = SessionStore.generate_title("Please calculate the energy of water")
+        assert title == "Calculate the energy of water"
+
+    def test_generate_title_truncates(self):
+        long_query = "A" * 100
+        title = SessionStore.generate_title(long_query, max_length=20)
+        assert len(title) <= 20
+        assert title.endswith("...")
+
+    def test_generate_title_capitalizes(self):
+        title = SessionStore.generate_title("calculate energy")
+        assert title[0] == "C"
+
+    def test_generate_title_empty(self):
+        title = SessionStore.generate_title("")
+        assert title == ""
+
+
+# ------------------------------------------------------------------
+# Edge cases
+# ------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_messages_save(self, store):
+        store.create_session(
+            session_id="empty_msg",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        # Should not raise
+        store.save_messages("empty_msg", [])
+
+        session = store.get_session("empty_msg")
+        assert len(session.messages) == 0
+
+    def test_multiple_message_batches(self, store):
+        store.create_session(
+            session_id="batch_test",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        # First batch
+        store.save_messages(
+            "batch_test",
+            [SessionMessage(role="human", content="First query")],
+        )
+
+        # Second batch
+        store.save_messages(
+            "batch_test",
+            [SessionMessage(role="human", content="Second query")],
+        )
+
+        session = store.get_session("batch_test")
+        assert len(session.messages) == 2
+        assert session.query_count == 2
+
+    def test_concurrent_stores_same_db(self, tmp_db):
+        """Two store instances sharing the same DB should work (WAL mode)."""
+        store1 = SessionStore(db_path=tmp_db)
+        store2 = SessionStore(db_path=tmp_db)
+
+        store1.create_session(
+            session_id="shared1",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+
+        # store2 should be able to read it
+        session = store2.get_session("shared1")
+        assert session is not None
+
+    def test_special_characters_in_content(self, store):
+        store.create_session(
+            session_id="special_chars",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        messages = [
+            SessionMessage(
+                role="human",
+                content="What's the bond angle in H₂O? Use O'Brien's method.",
+            ),
+            SessionMessage(
+                role="ai",
+                content='The angle is 104.5°. Here\'s the formula: "θ = 2·arcsin(d/2r)"',
+            ),
+        ]
+        store.save_messages("special_chars", messages)
+
+        session = store.get_session("special_chars")
+        assert "O'Brien" in session.messages[0].content
+        assert "104.5°" in session.messages[1].content
+
+    def test_list_sessions_includes_message_count(self, store):
+        store.create_session(
+            session_id="msgcount",
+            model_name="gpt-4o",
+            workflow_type="single_agent",
+        )
+        store.save_messages(
+            "msgcount",
+            [
+                SessionMessage(role="human", content="Q1"),
+                SessionMessage(role="ai", content="A1"),
+                SessionMessage(role="human", content="Q2"),
+            ],
+        )
+
+        summaries = store.list_sessions()
+        assert len(summaries) == 1
+        assert summaries[0].message_count == 3
+        assert summaries[0].query_count == 2


### PR DESCRIPTION
**Summary**

- Add SQLite-backed session memory that automatically persists every agent conversation to ~/.chemgraph/sessions.db, enabling users to browse, inspect, and resume past sessions.
- Add CLI commands (--list-sessions, --show-session, --delete-session, --resume) and interactive mode commands (history, show, resume) for session management
- Fix a potential log file overwrite bug when CHEMGRAPH_LOG_DIR is shared across instances

**Changes**

New module -- memory/
- store.py -- SessionStore class: SQLite CRUD with WAL mode, prefix-based session ID resolution, context extraction for session resume, automatic title generation
- schemas.py -- Pydantic models: SessionMessage, Session, SessionSummary

agent/llm_agent.py
- self.uuid is now always generated (even when CHEMGRAPH_LOG_DIR is pre-set), fixing potential file overwrites in shared log directories
- Added _ensure_session() and _save_messages_to_store() for automatic session persistence on every run() call
- Log filenames now include uuid: state_thread_{thread_id}\_{uuid}\_{timestamp}.json
- Removed save-time content truncation -- full message content is stored in the database; truncation happens only at read time during context injection

memory/store.py -- context building
- build_context_messages() and build_context_summary() 

CLI (src/ui/cli.py)
- New standalone flags: --list-sessions, --show-session <id>, --delete-session <id>, --resume <id>
- New interactive mode commands: history, show <id>, resume <id>
- config command now displays current session ID
- run_query() accepts resume_from parameter, passed through to agent.run()
- All session ID parameters support prefix matching

Tests
- tests/test_agent_session.py (new, 29 tests) -- memory initialization, uuid/session_id consistency, _ensure_session idempotency, _save_messages_to_store with LangChain/dict messages, write_state file naming, resume_from flow, end-to-end lifecycle
- tests/test_agent_logging.py -- fixed stale assertions (uuid is None, log_file references)
- tests/test_memory.py -- updated context building tests to include tool messages

Documentation
- README.md -- CLI options table, interactive commands, Session Memory section, updated project structure
- docs/configuration_with_toml.md -- mirrored CLI and session memory documentation
- docs/project_structure.md -- added memory/ module
- docs/index.md -- added Session Memory feature admonition

Scripts
- scripts/test_session_memory.py -- end-to-end test script for session lifecycle (create, list, show, resume, prefix matching)