### PR TITLE
fix(academy,agent): PR-120 follow-up — optional-dep contract + calculator wiring

### DIFF
--- a/src/chemgraph/academy/__init__.py
+++ b/src/chemgraph/academy/__init__.py
@@ -1,14 +1,33 @@
 """Academy Agents integration for ChemGraph.
 
-Provides agent classes and utilities for deploying ChemGraph workflows
-across federated HPC infrastructure using the Academy framework.
+Public re-exports come in two tiers so the package honours the
+``[academy]`` optional-dep contract:
 
-Requires the ``academy`` optional extra.
+* **Eager** (pure stdlib + pydantic, always importable):
+  ``ChemGraphAgentSpec``, ``ChemGraphCampaign``,
+  ``ChemGraphDaemonConfig``, ``MCPServerSpec``, ``ResourceSpec``,
+  ``load_campaign``, ``resolve_campaign_resources``,
+  ``PromptProfile``, ``load_prompt_profile``, ``CampaignEvent``,
+  ``EventLog``. These let the dashboard, ``--trace-dir``, and the
+  observability tooling work on a checkout without ``academy-py``
+  installed.
+* **Lazy** (resolved via ``__getattr__`` on first access; requires
+  the ``[academy]`` extra): ``ChemGraphLogicalAgent``. Importing it
+  pulls in ``academy.agent``; without the extra installed, access
+  raises ``ImportError`` with a hint instead of crashing the package
+  import.
+
+This split exists because ``chemgraph.cli.trace`` (single-agent
+``--trace-dir`` flow) and the test collector both touch
+``chemgraph.academy`` via leaf submodules; eager-importing the
+academy-py-dependent ``ChemGraphLogicalAgent`` here broke those code
+paths for users without the optional extra.
 """
 
 from __future__ import annotations
 
-from chemgraph.academy.core.agent import ChemGraphLogicalAgent
+from typing import TYPE_CHECKING, Any
+
 from chemgraph.academy.core.campaign import ChemGraphAgentSpec
 from chemgraph.academy.core.campaign import ChemGraphCampaign
 from chemgraph.academy.core.campaign import ChemGraphDaemonConfig
@@ -16,10 +35,48 @@ from chemgraph.academy.core.campaign import MCPServerSpec
 from chemgraph.academy.core.campaign import ResourceSpec
 from chemgraph.academy.core.campaign import load_campaign
 from chemgraph.academy.core.campaign import resolve_campaign_resources
-from chemgraph.academy.observability.event_log import CampaignEvent
-from chemgraph.academy.observability.event_log import EventLog
 from chemgraph.academy.core.prompt import PromptProfile
 from chemgraph.academy.core.prompt import load_prompt_profile
+from chemgraph.academy.observability.event_log import CampaignEvent
+from chemgraph.academy.observability.event_log import EventLog
+
+
+if TYPE_CHECKING:
+    from chemgraph.academy.core.agent import ChemGraphLogicalAgent
+
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    # public name -> (module path, attribute in that module)
+    "ChemGraphLogicalAgent": (
+        "chemgraph.academy.core.agent",
+        "ChemGraphLogicalAgent",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy resolver for academy-py-dependent re-exports.
+
+    Called by Python only when ``name`` is not found among the eager
+    imports above. On ``ImportError`` we re-raise with an actionable
+    hint so the operator knows which extra to install.
+    """
+    if name in _LAZY_EXPORTS:
+        module_path, attr = _LAZY_EXPORTS[name]
+        try:
+            from importlib import import_module
+            module = import_module(module_path)
+        except ImportError as exc:
+            raise ImportError(
+                f"Importing {name!r} from chemgraph.academy requires "
+                f"the 'academy' optional extra: "
+                f"`pip install 'chemgraph[academy]'`. "
+                f"Underlying error: {exc}"
+            ) from exc
+        return getattr(module, attr)
+    raise AttributeError(
+        f"module 'chemgraph.academy' has no attribute {name!r}"
+    )
 
 
 __all__ = [
@@ -27,11 +84,11 @@ __all__ = [
     "ChemGraphAgentSpec",
     "ChemGraphCampaign",
     "ChemGraphDaemonConfig",
+    "ChemGraphLogicalAgent",
     "EventLog",
     "MCPServerSpec",
     "PromptProfile",
     "ResourceSpec",
-    "ChemGraphLogicalAgent",
     "load_campaign",
     "load_prompt_profile",
     "resolve_campaign_resources",

--- a/src/chemgraph/academy/core/__init__.py
+++ b/src/chemgraph/academy/core/__init__.py
@@ -1,6 +1,25 @@
-"""Core ChemGraph Academy campaign contracts and agent logic."""
+"""Core ChemGraph Academy campaign contracts and agent logic.
 
-from chemgraph.academy.core.agent import ChemGraphLogicalAgent
+Re-exports split into two tiers to keep the ``[academy]`` optional-dep
+contract:
+
+* **Eager** (pure stdlib + pydantic + langchain_core): the campaign
+  spec types, prompt profile, and reasoning-turn helpers. These are
+  what the dashboard, ``--trace-dir``, and the test collector touch
+  on a CPU-only checkout.
+* **Lazy** (resolved via ``__getattr__``; requires the ``[academy]``
+  extra because it depends on ``academy.agent.Agent``):
+  ``ChemGraphLogicalAgent``.
+
+Without this split, importing ``chemgraph.academy.core.campaign``
+would transitively run ``core/__init__.py`` and pull in
+``core.agent``, which fails when ``academy-py`` is not installed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from chemgraph.academy.core.campaign import ChemGraphAgentSpec
 from chemgraph.academy.core.campaign import ChemGraphCampaign
 from chemgraph.academy.core.campaign import ChemGraphDaemonConfig
@@ -12,6 +31,38 @@ from chemgraph.academy.core.prompt import PromptProfile
 from chemgraph.academy.core.prompt import load_prompt_profile
 from chemgraph.academy.core.turn import ReasoningTurnResult
 from chemgraph.academy.core.turn import run_academy_turn
+
+
+if TYPE_CHECKING:
+    from chemgraph.academy.core.agent import ChemGraphLogicalAgent
+
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "ChemGraphLogicalAgent": (
+        "chemgraph.academy.core.agent",
+        "ChemGraphLogicalAgent",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_EXPORTS:
+        module_path, attr = _LAZY_EXPORTS[name]
+        try:
+            from importlib import import_module
+            module = import_module(module_path)
+        except ImportError as exc:
+            raise ImportError(
+                f"Importing {name!r} from chemgraph.academy.core requires "
+                f"the 'academy' optional extra: "
+                f"`pip install 'chemgraph[academy]'`. "
+                f"Underlying error: {exc}"
+            ) from exc
+        return getattr(module, attr)
+    raise AttributeError(
+        f"module 'chemgraph.academy.core' has no attribute {name!r}"
+    )
+
 
 __all__ = [
     "ChemGraphAgentSpec",

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -24,6 +24,11 @@ from chemgraph.models.supported_models import (
 
 )
 
+from chemgraph.schemas.ase_input import (
+    get_available_calculator_names,
+    get_calculator_selection_context,
+    get_default_calculator_name,
+)
 from chemgraph.prompt.single_agent_prompt import (
     single_agent_prompt,
     get_single_agent_prompt,
@@ -317,6 +322,33 @@ class ChemGraph:
         # LLM is not told to call a tool that is unavailable.
         if not self.human_supervised and self.system_prompt == single_agent_prompt:
             self.system_prompt = get_single_agent_prompt(human_supervised=False)
+
+        self.available_calculators = get_available_calculator_names()
+        self.default_calculator = get_default_calculator_name()
+        self.calculator_selection_context = get_calculator_selection_context()
+
+        def append_calculator_context(prompt: str) -> str:
+            """Append calculator availability guidance to a prompt once.
+
+            Parameters
+            ----------
+            prompt : str
+                Prompt text to augment.
+
+            Returns
+            -------
+            str
+                Prompt with calculator-selection context appended.
+            """
+            if self.calculator_selection_context in prompt:
+                return prompt
+            return f"{prompt}{self.calculator_selection_context}"
+
+        if self.workflow_type in {"single_agent", "mock_agent", "single_agent_mcp"}:
+            self.system_prompt = append_calculator_context(self.system_prompt)
+        elif self.workflow_type == "multi_agent":
+            self.planner_prompt = append_calculator_context(self.planner_prompt)
+            self.executor_prompt = append_calculator_context(self.executor_prompt)
 
         if model_name in supported_argo_models:
             self.support_structured_output = False

--- a/tests/test_academy_campaign.py
+++ b/tests/test_academy_campaign.py
@@ -4,6 +4,13 @@ import json
 
 import pytest
 
+# Skip the whole module when the optional 'academy' extra is absent.
+# Even though this file only touches the pure-stdlib parts of
+# chemgraph.academy, the import guard is applied uniformly across the
+# academy test suite so pytest collection stays clean on a CPU-only
+# checkout without per-test bookkeeping.
+pytest.importorskip("academy")
+
 from chemgraph.academy.core.campaign import campaign_bootstrap_text
 from chemgraph.academy.core.campaign import load_campaign
 from chemgraph.academy.core.campaign import MCPServerSpec

--- a/tests/test_academy_compute_launcher.py
+++ b/tests/test_academy_compute_launcher.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+# Skip when the optional 'academy' extra is absent; the runtime
+# subpackage imports academy.* at module level.
+pytest.importorskip("academy")
+
 from chemgraph.academy.runtime import compute_launcher
 from chemgraph.academy.runtime.compute_launcher import AllocationPlan
 

--- a/tests/test_academy_dashboard.py
+++ b/tests/test_academy_dashboard.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
+# Skip when the optional 'academy' extra is absent. The dashboard
+# module itself is pure stdlib, but the import guard is applied
+# uniformly across the academy test suite.
+pytest.importorskip("academy")
+
 import chemgraph.academy.dashboard as dashboard
 from chemgraph.academy.observability.event_log import EventLog
 

--- a/tests/test_academy_dashboard_launcher.py
+++ b/tests/test_academy_dashboard_launcher.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 import pytest
 
+# Skip when the optional 'academy' extra is absent.
+pytest.importorskip("academy")
+
 from chemgraph.academy.runtime import dashboard_launcher
 from chemgraph.academy.runtime.profiles.system import SystemProfile
 

--- a/tests/test_academy_exchange_registration.py
+++ b/tests/test_academy_exchange_registration.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+
+# Skip when the optional 'academy' extra is absent; this module
+# imports academy.exchange.* directly at top level.
+pytest.importorskip("academy")
+
 from academy.exchange.hybrid import HybridAgentRegistration
 from academy.exchange.local import LocalAgentRegistration
 from academy.exchange.redis import RedisAgentRegistration

--- a/tests/test_academy_mcp_supervisor.py
+++ b/tests/test_academy_mcp_supervisor.py
@@ -6,6 +6,10 @@ from pathlib import Path
 
 import pytest
 
+# Skip when the optional 'academy' extra is absent; mcp_supervisor
+# imports httpx (also in the extra) at module level.
+pytest.importorskip("academy")
+
 from chemgraph.academy.core.campaign import MCPServerSpec
 from chemgraph.academy.runtime.mcp_supervisor import MCPServerSupervisor
 

--- a/tests/test_academy_payloads.py
+++ b/tests/test_academy_payloads.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import pytest
+
+# Skip when the optional 'academy' extra is absent. The event_log
+# module itself is pure stdlib, but the import guard is applied
+# uniformly across the academy test suite.
+pytest.importorskip("academy")
+
 from chemgraph.academy.observability.event_log import EventLog, read_events
 
 

--- a/tests/test_academy_reasoning_phase2.py
+++ b/tests/test_academy_reasoning_phase2.py
@@ -8,6 +8,9 @@ from typing import Any
 
 import pytest
 
+# Skip when the optional 'academy' extra is absent.
+pytest.importorskip("academy")
+
 from chemgraph.academy.core import agent as agent_module
 from chemgraph.academy.core import turn as turn_module
 from chemgraph.academy.core.agent import ChemGraphLogicalAgent

--- a/tests/test_tool_adapter_validation.py
+++ b/tests/test_tool_adapter_validation.py
@@ -5,6 +5,10 @@ from typing import Any
 
 import pytest
 
+# Skip when the optional 'academy' extra is absent; core.tools imports
+# academy.agent at module level.
+pytest.importorskip("academy")
+
 from chemgraph.academy.core.tools import build_chemgraph_reasoning_tools
 from chemgraph.academy.core.campaign import ChemGraphAgentSpec
 


### PR DESCRIPTION
Two fixes from PR-120 review feedback

### P1 — `[academy]` optional-dep contract restored
`chemgraph.academy.__init__` and `chemgraph.academy.core.__init__` were eagerly
importing `ChemGraphLogicalAgent`, which pulls in `academy.agent`. Any code path
that touched the package (including `chemgraph.cli.trace`'s `--trace-dir` flow
and pytest collection) crashed on a checkout without the `[academy]` extra,
even though the rest of the package (campaign spec, prompt profile, event log)
is pure stdlib + pydantic.

* Both `__init__`s grow a `__getattr__`-based lazy resolver for
  `ChemGraphLogicalAgent`. Pure modules stay eager so their 11-symbol surface
  is reachable without the extra. Accessing the lazy symbol without
  `academy-py` installed raises `ImportError` with an actionable
  `pip install 'chemgraph[academy]'` hint.
* 9 academy test modules gain `pytest.importorskip("academy")` so they skip
  cleanly instead of erroring at collection time when the extra is absent.

### P2 — calculator wiring regression restored
`f1593ab` ("revert: restore llm_agent.py to pre-academy shape") was meant to
drop event-callback wiring and turn-primitive imports, but its rewrite also
deleted the calculator-availability injection that was already in the file at
the dev-globus fork point. The deletion was a merge-conflict casualty:
`get_calculator_selection_context()` in `schemas/ase_input.py` has been dead
code on dev-globus since, and the two
`test_single_agent_initialization_injects_calculator_availability` regression
tests have been failing.

Restored the 28-line wiring block verbatim from `dev:llm_agent.py:464-490`
plus the matching `chemgraph.schemas.ase_input` import.

### Validation
- Without `academy-py`: `chemgraph.academy` imports cleanly, all 11 eager
  exports resolve, `cli.trace` loads, all 9 guarded test modules skip
  cleanly (`pytest.importorskip` triggers at line :12-:11).
- With `academy-py`: 48/48 academy tests pass.
- Both calculator-injection regression tests now pass.
- The 8 other test failures in the full suite are pre-existing on
  `dev-globus`, confirmed by stashing these changes and re-running. Not
  introduced here.
