### PR TITLE
Fix Streamlit UI bugs: render crash, IR modes, math heuristic, config…

### DIFF
--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -921,6 +921,65 @@ def _resolve_artifact_path(filename: str, directory: Optional[str]) -> str:
     return filename
 
 
+def _is_linear_geometry(atoms) -> bool:
+    """Return whether an ASE ``Atoms`` object is (near-)linear.
+
+    A linear molecule has one vanishing principal moment of inertia.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        Structure to inspect.
+
+    Returns
+    -------
+    bool
+        ``True`` when the geometry is linear.
+    """
+    try:
+        moments = sorted(abs(float(m)) for m in atoms.get_moments_of_inertia())
+    except Exception:
+        return False
+    if len(moments) < 3 or moments[-1] <= 0:
+        return False
+    return moments[0] < 1e-3 * moments[-1]
+
+
+def _num_nonvibrational_modes(total_modes: int, log_dir: Optional[str]) -> int:
+    """Return how many leading translational/rotational modes to skip.
+
+    Non-linear molecules have 6 (3 translations + 3 rotations); linear
+    molecules have only 5.  Hardcoding 6 silently dropped a genuine
+    vibration for linear species (CO2, HCN, diatomics).
+
+    Parameters
+    ----------
+    total_modes : int
+        Total number of rows in the frequency table (``3N``).
+    log_dir : str, optional
+        Directory to search for a structure file used to test linearity.
+
+    Returns
+    -------
+    int
+        Number of leading modes to discard.
+    """
+    n_atoms = total_modes // 3
+    if n_atoms <= 2:
+        # Single atom -> no vibrations; diatomic -> always linear (5 modes).
+        return min(total_modes, 5)
+    if log_dir:
+        xyz = find_latest_xyz_file_in_dir(log_dir)
+        if xyz:
+            try:
+                atoms = ase_read(xyz)
+                if _is_linear_geometry(atoms):
+                    return 5
+            except Exception:
+                pass
+    return 6
+
+
 def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
     """Render IR spectrum plot, frequency table, and trajectory viewer.
 
@@ -960,7 +1019,8 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
                 index_col=False,
                 names=["filename", "frequency"],
             )
-            modes = df.iloc[6:] if len(df) > 6 else df
+            n_skip = _num_nonvibrational_modes(len(df), log_dir)
+            modes = df.iloc[n_skip:] if len(df) > n_skip else df
 
             if modes.empty:
                 st.warning("No vibrational frequencies found.")

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -4,11 +4,19 @@ Configuration management for ChemGraph Streamlit app.
 
 import toml
 import os
-from typing import Dict, Any
+from pathlib import Path
+from typing import Dict, Any, Optional
 from chemgraph.utils.config_utils import flatten_config as _flatten_config
 
+# Anchor the default config to the repository root (the directory the app is
+# meant to be launched from per the README) rather than the current working
+# directory.  With a bare ``"config.toml"`` the file resolved relative to the
+# launch directory, so starting Streamlit from anywhere else silently created
+# and used a throw-away default config instead of the real one.
+_DEFAULT_CONFIG_PATH = str(Path(__file__).resolve().parents[2] / "config.toml")
 
-def load_config(config_path: str = "config.toml") -> Dict[str, Any]:
+
+def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
     """Load configuration from a TOML file.
 
     Parameters
@@ -21,6 +29,8 @@ def load_config(config_path: str = "config.toml") -> Dict[str, Any]:
     dict[str, Any]
         Nested configuration dictionary with defaults filled in.
     """
+    if config_path is None:
+        config_path = _DEFAULT_CONFIG_PATH
     try:
         if os.path.exists(config_path):
             with open(config_path, "r") as f:
@@ -57,7 +67,7 @@ def load_config(config_path: str = "config.toml") -> Dict[str, Any]:
         return get_default_config()
 
 
-def save_config(config: Dict[str, Any], config_path: str = "config.toml") -> bool:
+def save_config(config: Dict[str, Any], config_path: Optional[str] = None) -> bool:
     """Save configuration to a TOML file.
 
     Parameters
@@ -72,6 +82,8 @@ def save_config(config: Dict[str, Any], config_path: str = "config.toml") -> boo
     bool
         ``True`` if the file was written successfully.
     """
+    if config_path is None:
+        config_path = _DEFAULT_CONFIG_PATH
     try:
         with open(config_path, "w") as f:
             toml.dump(config, f)

--- a/src/ui/message_utils.py
+++ b/src/ui/message_utils.py
@@ -230,7 +230,15 @@ def _convert_parenthetical_inline_math(text: str) -> str:
             continue
 
         body = text[index + 1 : close_index].strip()
-        has_latex = bool(re.search(r"\\[A-Za-z]+|\\\s|[_^{}]", body))
+        # A parenthetical is treated as inline math only on a strong signal:
+        # a LaTeX command (``\alpha``, ``\,``) or grouping braces, or a
+        # sub/superscript that appears alongside an ``=`` (an actual equation).
+        # A bare ``_``/``^`` is left alone so prose like "(a_1 symmetry)" or
+        # "(k_B T)" is not mangled into broken KaTeX.
+        has_command = bool(re.search(r"\\[A-Za-z]+|\\[\s,;:!]", body))
+        has_grouping = "{" in body or "}" in body
+        has_script_equation = bool(re.search(r"[_^]", body)) and "=" in body
+        has_latex = has_command or has_grouping or has_script_equation
         if body and has_latex:
             chunks.append(f"${body}$")
         else:
@@ -360,38 +368,32 @@ def extract_molecular_structure(message_content: str) -> Optional[dict]:
 
     # Try JSON first
     try:
-        if message_content.strip().startswith("{") and message_content.strip().endswith(
-            "}"
-        ):
+        stripped = message_content.strip()
+        if stripped.startswith("{") and stripped.endswith("}"):
             json_data = json.loads(message_content)
 
+            # Only dict payloads can carry structure data. Note ``answer`` is
+            # frequently a plain text string (or list) that merely *mentions*
+            # the words "numbers"/"positions" -- treating it as a mapping there
+            # raised an uncaught TypeError and crashed the whole chat render.
             structure_data = None
-            if "answer" in json_data:
-                structure_data = json_data["answer"]
-            elif "numbers" in json_data and "positions" in json_data:
-                structure_data = json_data
-            elif "atomic_numbers" in json_data and "positions" in json_data:
-                structure_data = json_data
+            if isinstance(json_data, dict):
+                answer = json_data.get("answer")
+                if isinstance(answer, dict):
+                    structure_data = answer
+                elif "positions" in json_data and (
+                    "numbers" in json_data or "atomic_numbers" in json_data
+                ):
+                    structure_data = json_data
 
-            if (
-                structure_data
-                and "numbers" in structure_data
-                and "positions" in structure_data
-            ):
-                return {
-                    "atomic_numbers": structure_data["numbers"],
-                    "positions": structure_data["positions"],
-                }
-            elif (
-                structure_data
-                and "atomic_numbers" in structure_data
-                and "positions" in structure_data
-            ):
-                return {
-                    "atomic_numbers": structure_data["atomic_numbers"],
-                    "positions": structure_data["positions"],
-                }
-    except (json.JSONDecodeError, KeyError):
+            if isinstance(structure_data, dict):
+                numbers = structure_data.get("numbers")
+                if numbers is None:
+                    numbers = structure_data.get("atomic_numbers")
+                positions = structure_data.get("positions")
+                if isinstance(numbers, list) and isinstance(positions, list):
+                    return {"atomic_numbers": numbers, "positions": positions}
+    except (json.JSONDecodeError, KeyError, TypeError):
         pass
 
     # Plain-text format fallback

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -2,7 +2,7 @@ from contextlib import nullcontext
 import os
 
 from ui._pages import main_interface as main_ui
-from ui.message_utils import normalize_latex_delimiters
+from ui.message_utils import extract_molecular_structure, normalize_latex_delimiters
 
 
 class _SessionState(dict):
@@ -136,6 +136,71 @@ def test_available_calculators_sidebar_replaces_quick_settings(monkeypatch):
     assert "Mace (default)" in rendered_text
     assert "TBLite (xTB, GFN1-xTB, GFN2-xTB)" in rendered_text
     assert "Quick Settings" not in rendered_text
+
+
+def test_extract_structure_ignores_non_dict_answer_without_crashing():
+    # A JSON message whose "answer" is prose/list that merely mentions the
+    # words numbers/positions must not raise (previously TypeError).
+    assert (
+        extract_molecular_structure(
+            '{"answer": "the numbers and positions are unknown"}'
+        )
+        is None
+    )
+    assert (
+        extract_molecular_structure('{"answer": ["numbers", "positions"]}') is None
+    )
+    # Null structure fields should not be reported as a structure.
+    assert extract_molecular_structure('{"numbers": null, "positions": null}') is None
+
+
+def test_extract_structure_parses_valid_payloads():
+    flat = extract_molecular_structure(
+        '{"numbers": [1, 8, 1], "positions": [[0,0,0],[0,0,1],[0,1,0]]}'
+    )
+    assert flat == {
+        "atomic_numbers": [1, 8, 1],
+        "positions": [[0, 0, 0], [0, 0, 1], [0, 1, 0]],
+    }
+    nested = extract_molecular_structure(
+        '{"answer": {"atomic_numbers": [8, 1, 1], '
+        '"positions": [[0,0,0],[0,0,1],[0,1,0]]}}'
+    )
+    assert nested == {
+        "atomic_numbers": [8, 1, 1],
+        "positions": [[0, 0, 0], [0, 0, 1], [0, 1, 0]],
+    }
+
+
+def test_parenthetical_prose_is_not_mangled_into_math():
+    # Prose with a bare subscript must stay untouched...
+    assert (
+        normalize_latex_delimiters("The energy is -76.4 eV (a_1 symmetry).")
+        == "The energy is -76.4 eV (a_1 symmetry)."
+    )
+    assert normalize_latex_delimiters("Rate (k_B T) term.") == "Rate (k_B T) term."
+    # ...while genuine equations still convert to inline math.
+    assert normalize_latex_delimiters("Momentum (E = mc^2) here.") == (
+        "Momentum $E = mc^2$ here."
+    )
+
+
+def test_num_nonvibrational_modes_handles_linear_and_small_systems():
+    # No geometry available -> conservative default of 6 for polyatomics.
+    assert main_ui._num_nonvibrational_modes(9, None) == 6
+    # Diatomic is always linear (5 non-vibrational modes).
+    assert main_ui._num_nonvibrational_modes(6, None) == 5
+    # Single atom has no vibrations.
+    assert main_ui._num_nonvibrational_modes(3, None) == 3
+
+
+def test_is_linear_geometry_detects_linear_molecules():
+    from ase import Atoms
+
+    co2 = Atoms("CO2", positions=[[0, 0, 0], [0, 0, 1.16], [0, 0, -1.16]])
+    h2o = Atoms("H2O", positions=[[0, 0, 0], [0, 0.76, 0.59], [0, -0.76, 0.59]])
+    assert main_ui._is_linear_geometry(co2) is True
+    assert main_ui._is_linear_geometry(h2o) is False
 
 
 def test_latex_delimiters_are_normalized_for_streamlit_markdown():


### PR DESCRIPTION
Fixes four bugs found while auditing the Streamlit UI, plus unifies on a single config.toml.

1. Chat-render crash (message_utils.extract_molecular_structure) A message whose JSON "answer" was a string or list that merely mentioned the words "numbers"/"positions" hit `"numbers" in answer` (a substring check) and then `answer["numbers"]`, raising an uncaught TypeError that crashed the entire conversation render. Now structure data must be a dict and the values must be lists; TypeError is caught.

2. Linear-molecule IR modes (_pages/main_interface._render_ir_spectrum) The frequency table hardcoded `df.iloc[6:]` to drop translational and rotational modes. Linear molecules (CO2, HCN, diatomics) have only 5 such modes, so one genuine vibration was silently dropped. Added _num_nonvibrational_modes()/_is_linear_geometry() to detect linearity from the run's structure (5 vs 6), defaulting to 6 when unknown.

3. Parenthetical math false positives (message_utils) The inline-math heuristic treated a bare "_" or "^" as math, so prose like "(a_1 symmetry)" or "(k_B T)" was mangled into broken KaTeX. Conversion now requires a LaTeX command, grouping braces, or a sub/superscript alongside "=" (a real equation). "(E = mc^2)" and "(\mathrm{...})" still convert.

4. CWD-dependent config path (ui/config.py) + single config.toml load_config/save_config defaulted to a cwd-relative "config.toml", so launching Streamlit from any other directory silently created and used a throw-away default. They now anchor to the repo-root config.toml. Removed the orphaned src/ui/config.toml (it was never loaded), so the app and CLI share one config.toml.

Adds regression tests for all four; UI suite passes 22/22.