### PR TITLE
Fix target-scoped single-agent tool validation

### DIFF
--- a/src/chemgraph/graphs/single_agent.py
+++ b/src/chemgraph/graphs/single_agent.py
@@ -21,6 +21,12 @@ from chemgraph.prompt.single_agent_prompt import (
 )
 from chemgraph.utils.logging_config import setup_logger
 from chemgraph.utils.parsing import parse_response_formatter
+from chemgraph.utils.tool_validation import (
+    build_tool_validation_messages,
+    latest_user_query,
+    message_tool_calls,
+    validate_target_scoped_tool_calls,
+)
 from chemgraph.state.state import State
 
 logger = setup_logger(__name__)
@@ -153,16 +159,41 @@ def route_tools(state: State):
         Either 'tools' or 'done' based on the state conditions
     """
     if isinstance(state, list):
+        messages = state
         ai_message = state[-1]
     elif messages := state.get("messages", []):
         ai_message = messages[-1]
     else:
         raise ValueError(f"No messages found in input state to tool_edge: {state}")
-    if hasattr(ai_message, "tool_calls") and len(ai_message.tool_calls) > 0:
+    tool_calls = message_tool_calls(ai_message)
+    if tool_calls:
+        if not isinstance(state, list):
+            validation = validate_target_scoped_tool_calls(
+                latest_user_query(messages[:-1]),
+                messages[:-1],
+                tool_calls,
+            )
+            if not validation.get("allowed", True):
+                return "validate"
         if not isinstance(state, list) and _is_repeated_tool_cycle(messages):
             return "done"
         return "tools"
     return "done"
+
+
+def ToolValidationFeedback(state: State):
+    """Return tool-call feedback when deterministic validation blocks a call."""
+    messages = state if isinstance(state, list) else state.get("messages", [])
+    if not messages:
+        return {}
+    tool_calls = message_tool_calls(messages[-1])
+    validation = validate_target_scoped_tool_calls(
+        latest_user_query(messages[:-1]),
+        messages[:-1],
+        tool_calls,
+    )
+    feedback = build_tool_validation_messages(tool_calls, validation)
+    return {"messages": feedback} if feedback else {}
 
 
 def route_report_tools(state: State):
@@ -474,6 +505,7 @@ def construct_single_agent_graph(
                 ),
             )
             graph_builder.add_node("tools", tool_node)
+            graph_builder.add_node("tool_validation_feedback", ToolValidationFeedback)
             graph_builder.add_edge(START, "ChemGraphAgent")
 
             if generate_report:
@@ -489,9 +521,14 @@ def construct_single_agent_graph(
                 graph_builder.add_conditional_edges(
                     "ChemGraphAgent",
                     route_tools,
-                    {"tools": "tools", "done": "ReportAgent"},
+                    {
+                        "tools": "tools",
+                        "validate": "tool_validation_feedback",
+                        "done": "ReportAgent",
+                    },
                 )
                 graph_builder.add_edge("tools", "ChemGraphAgent")
+                graph_builder.add_edge("tool_validation_feedback", "ChemGraphAgent")
                 graph_builder.add_conditional_edges(
                     "ReportAgent",
                     route_report_tools,
@@ -506,9 +543,14 @@ def construct_single_agent_graph(
                 graph_builder.add_conditional_edges(
                     "ChemGraphAgent",
                     route_tools,
-                    {"tools": "tools", "done": END},
+                    {
+                        "tools": "tools",
+                        "validate": "tool_validation_feedback",
+                        "done": END,
+                    },
                 )
                 graph_builder.add_edge("tools", "ChemGraphAgent")
+                graph_builder.add_edge("tool_validation_feedback", "ChemGraphAgent")
 
             graph = graph_builder.compile(checkpointer=checkpointer)
             logger.info("Graph construction completed")
@@ -525,6 +567,7 @@ def construct_single_agent_graph(
                 ),
             )
             graph_builder.add_node("tools", tool_node)
+            graph_builder.add_node("tool_validation_feedback", ToolValidationFeedback)
             graph_builder.add_node(
                 "ResponseAgent",
                 lambda state: ResponseAgent(
@@ -537,9 +580,14 @@ def construct_single_agent_graph(
             graph_builder.add_conditional_edges(
                 "ChemGraphAgent",
                 route_tools,
-                {"tools": "tools", "done": "ResponseAgent"},
+                {
+                    "tools": "tools",
+                    "validate": "tool_validation_feedback",
+                    "done": "ResponseAgent",
+                },
             )
             graph_builder.add_edge("tools", "ChemGraphAgent")
+            graph_builder.add_edge("tool_validation_feedback", "ChemGraphAgent")
             graph_builder.add_edge(START, "ChemGraphAgent")
             graph_builder.add_edge("ResponseAgent", END)
 

--- a/src/chemgraph/utils/tool_validation.py
+++ b/src/chemgraph/utils/tool_validation.py
@@ -1,0 +1,389 @@
+"""Deterministic guardrails for single-agent tool calls.
+
+This module intentionally covers a small, high-impact case: a follow-up query
+for one molecule should not execute ``run_ase`` on a coordinate file produced
+for a different molecule earlier in the conversation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+from langchain_core.messages import ToolMessage
+
+
+_PROPERTY_PATTERNS = (
+    "dipolemoment",
+    "dipole moment",
+    "dipole",
+    "ir spectrum",
+    "infrared spectrum",
+    "vibrational frequencies",
+    "vibrational frequency",
+    "vibration",
+    "energy",
+    "enthalpy",
+    "gibbs free energy",
+)
+
+_TARGET_STOP_WORDS = (
+    " using ",
+    " with ",
+    " from ",
+    " at ",
+    " in ",
+    " for ",
+    "?",
+    ".",
+)
+
+
+def normalize_tool_call(call: Any) -> dict[str, Any] | None:
+    """Normalize LangChain/OpenAI tool-call payloads."""
+    if not isinstance(call, dict):
+        return None
+
+    if "function" in call:
+        function = call.get("function") or {}
+        raw_args = function.get("arguments") or {}
+        if isinstance(raw_args, str):
+            try:
+                args = json.loads(raw_args)
+            except json.JSONDecodeError:
+                args = {}
+        else:
+            args = raw_args
+        return {
+            "id": call.get("id"),
+            "name": function.get("name"),
+            "args": args if isinstance(args, dict) else {},
+        }
+
+    return {
+        "id": call.get("id"),
+        "name": call.get("name"),
+        "args": call.get("args") if isinstance(call.get("args"), dict) else {},
+    }
+
+
+def message_tool_calls(message: Any) -> list[dict[str, Any]]:
+    """Return normalized tool calls from a message-like object."""
+    if isinstance(message, dict):
+        raw_calls = message.get("tool_calls")
+        if not raw_calls:
+            raw_calls = (message.get("additional_kwargs") or {}).get("tool_calls")
+    else:
+        raw_calls = getattr(message, "tool_calls", None)
+        if not raw_calls:
+            raw_calls = (
+                getattr(message, "additional_kwargs", {}) or {}
+            ).get("tool_calls")
+
+    calls = [normalize_tool_call(call) for call in raw_calls or []]
+    return [call for call in calls if call and call.get("name")]
+
+
+def latest_user_query(messages: Iterable[Any]) -> str:
+    """Extract the latest human/user query from a message sequence."""
+    for message in reversed(list(messages or [])):
+        role = _message_role(message)
+        if role in {"human", "user"}:
+            return _message_content(message)
+    return ""
+
+
+def validate_target_scoped_tool_calls(
+    query: str,
+    prior_messages: Iterable[Any],
+    tool_calls: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Validate that molecule-property tool calls use current-target files."""
+    calls = [normalize_tool_call(call) for call in tool_calls or []]
+    calls = [call for call in calls if call and call.get("name")]
+    target = infer_query_target(query)
+    if not target:
+        return _allowed()
+
+    coordinate_species = _collect_coordinate_species(prior_messages)
+    for call in calls:
+        if call.get("name") != "run_ase":
+            continue
+
+        input_file = _run_ase_input_file(call.get("args") or {})
+        if not input_file:
+            continue
+
+        species = _species_for_file(input_file, coordinate_species)
+        if species and not _species_matches(species, target):
+            return {
+                "allowed": False,
+                "blocked_tool": "run_ase",
+                "blocked_tool_call_ids": [call.get("id")],
+                "target": target,
+                "observed_species": species,
+                "input_file": str(input_file),
+                "reason": (
+                    f"The current query targets {target!r}, but run_ase was "
+                    f"called with coordinate file {str(input_file)!r} for "
+                    f"{species!r}."
+                ),
+                "repair_instruction": (
+                    f"Resolve {target!r}, generate or reuse a coordinate file "
+                    "for that current target, then call run_ase on that file. "
+                    "Do not reuse coordinate artifacts from a previous molecule."
+                ),
+            }
+
+    return _allowed()
+
+
+def build_tool_validation_messages(
+    tool_calls: Iterable[dict[str, Any]],
+    validation: dict[str, Any],
+) -> list[ToolMessage]:
+    """Build ToolMessage feedback for blocked tool calls."""
+    if validation.get("allowed", True):
+        return []
+
+    blocked_ids = {
+        str(call_id)
+        for call_id in validation.get("blocked_tool_call_ids", [])
+        if call_id
+    }
+    messages: list[ToolMessage] = []
+    content = (
+        "Tool call blocked by deterministic validation.\n"
+        f"Reason: {validation.get('reason', 'not specified')}\n"
+        f"Repair: {validation.get('repair_instruction', 'Retry with valid inputs.')}"
+    )
+
+    for call in tool_calls or []:
+        normalized = normalize_tool_call(call)
+        if not normalized:
+            continue
+        call_id = normalized.get("id")
+        if blocked_ids and str(call_id) not in blocked_ids:
+            continue
+        if call_id:
+            messages.append(ToolMessage(content=content, tool_call_id=str(call_id)))
+
+    return messages
+
+
+def infer_query_target(query: str) -> str | None:
+    """Infer a single molecule target from common property-query phrasing."""
+    text = " ".join(str(query or "").strip().split())
+    if not text:
+        return None
+    lowered = text.lower()
+    if "reaction" in lowered or "combustion" in lowered:
+        return None
+
+    for prop in _PROPERTY_PATTERNS:
+        match = re.search(rf"\b{re.escape(prop)}\b", lowered)
+        if not match:
+            continue
+
+        before = text[: match.start()].strip(" :,-")
+        after = text[match.end() :].strip(" :,-")
+
+        of_match = re.search(r"\bof\s+(.+)$", before, flags=re.IGNORECASE)
+        if of_match:
+            target = _clean_target(of_match.group(1))
+            if target:
+                return target
+
+        after_of = re.match(r"^(?:of|for)\s+(.+)$", after, flags=re.IGNORECASE)
+        if after_of:
+            target = _clean_target(after_of.group(1))
+            if target:
+                return target
+
+        target = _clean_target(before)
+        if target:
+            return target
+
+    return None
+
+
+def _allowed() -> dict[str, Any]:
+    return {
+        "allowed": True,
+        "blocked_tool": None,
+        "blocked_tool_call_ids": [],
+        "reason": "",
+        "repair_instruction": "",
+    }
+
+
+def _message_role(message: Any) -> str:
+    if isinstance(message, dict):
+        return str(message.get("role") or message.get("type") or "").lower()
+    role = getattr(message, "role", None) or getattr(message, "type", None)
+    if role:
+        return str(role).lower()
+    class_name = message.__class__.__name__.lower()
+    if "human" in class_name:
+        return "human"
+    if "ai" in class_name:
+        return "ai"
+    if "tool" in class_name:
+        return "tool"
+    return ""
+
+
+def _message_name(message: Any) -> str | None:
+    if isinstance(message, dict):
+        name = message.get("name")
+    else:
+        name = getattr(message, "name", None)
+    return str(name) if name else None
+
+
+def _message_content(message: Any) -> str:
+    if isinstance(message, dict):
+        content = message.get("content", "")
+    else:
+        content = getattr(message, "content", "")
+    return "" if content is None else str(content)
+
+
+def _json_content(message: Any) -> dict[str, Any]:
+    content = _message_content(message).strip()
+    if not content:
+        return {}
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _collect_coordinate_species(messages: Iterable[Any]) -> dict[str, str]:
+    coordinate_species: dict[str, str] = {}
+    last_species: str | None = None
+
+    for message in messages or []:
+        name = _message_name(message)
+        payload = _json_content(message)
+
+        if name == "molecule_name_to_smiles":
+            last_species = _payload_species(payload) or last_species
+            continue
+
+        if name != "smiles_to_coordinate_file":
+            continue
+
+        file_path = _payload_coordinate_file(payload)
+        if not file_path:
+            continue
+
+        species = _payload_species(payload) or _species_from_file(file_path)
+        if not species or _is_generic_species(species):
+            species = last_species or species
+        for key in _file_keys(file_path):
+            coordinate_species[key] = species
+
+    return coordinate_species
+
+
+def _payload_species(payload: dict[str, Any]) -> str | None:
+    for key in (
+        "name",
+        "molecule",
+        "molecule_name",
+        "input_name",
+        "resolved_name",
+        "representative_of",
+    ):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _payload_coordinate_file(payload: dict[str, Any]) -> str | None:
+    for key in (
+        "path",
+        "file_path",
+        "input_file",
+        "input_structure_file",
+        "xyz_file",
+        "filename",
+        "output_file",
+    ):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _run_ase_input_file(args: dict[str, Any]) -> str | None:
+    params = args.get("params") if isinstance(args.get("params"), dict) else args
+    for key in ("input_structure_file", "input_file", "file_path", "xyz_file"):
+        value = params.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _species_for_file(
+    file_path: str,
+    coordinate_species: dict[str, str],
+) -> str | None:
+    for key in _file_keys(file_path):
+        if key in coordinate_species:
+            return coordinate_species[key]
+    return _species_from_file(file_path)
+
+
+def _file_keys(file_path: str) -> list[str]:
+    raw = str(file_path)
+    path = Path(raw)
+    keys = {raw.lower(), path.name.lower(), path.stem.lower()}
+    return [key for key in keys if key]
+
+
+def _species_from_file(file_path: str) -> str | None:
+    stem = Path(str(file_path)).stem
+    stem = re.sub(r"[_-](coord|coords|coordinate|coordinates|opt|optimized)$", "", stem)
+    stem = stem.replace("_", " ").replace("-", " ").strip()
+    return stem or None
+
+
+def _clean_target(value: str) -> str | None:
+    target = str(value or "").strip(" :,-")
+    target = re.sub(
+        r"^(what is|report|calculate|compute|the|a|an)\s+",
+        "",
+        target,
+        flags=re.IGNORECASE,
+    )
+    for stop in _TARGET_STOP_WORDS:
+        index = target.lower().find(stop.strip().lower()) if stop.strip() else -1
+        if index > 0:
+            target = target[:index]
+    target = target.strip(" :,-")
+    return target or None
+
+
+def _normalize_species(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+
+def _species_matches(species: str, target: str) -> bool:
+    species_key = _normalize_species(species)
+    target_key = _normalize_species(target)
+    return bool(species_key and target_key and species_key == target_key)
+
+
+def _is_generic_species(species: str) -> bool:
+    return _normalize_species(species) in {
+        "molecule",
+        "structure",
+        "geometry",
+        "coords",
+    }

--- a/tests/test_single_agent_routing.py
+++ b/tests/test_single_agent_routing.py
@@ -1,6 +1,10 @@
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
-from chemgraph.graphs.single_agent import route_report_tools, route_tools
+from chemgraph.graphs.single_agent import (
+    ToolValidationFeedback,
+    route_report_tools,
+    route_tools,
+)
 
 
 def test_route_report_tools_routes_to_tool_before_report_exists():
@@ -110,6 +114,74 @@ def test_route_tools_continues_on_new_tool_args():
                     {
                         "name": "molecule_name_to_smiles",
                         "args": {"name": "caffeine"},
+                        "id": "call_2",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+        ]
+    }
+
+    assert route_tools(state) == "tools"
+
+
+def test_route_tools_blocks_stale_target_coordinate_reuse():
+    state = {
+        "messages": [
+            HumanMessage(content="What is the IR spectrum of methane?"),
+            {
+                "name": "smiles_to_coordinate_file",
+                "content": '{"path": "/tmp/methane.xyz"}',
+            },
+            HumanMessage(content="glucose dipolemoment"),
+            AIMessage(
+                content="calling stale coordinate",
+                tool_calls=[
+                    {
+                        "name": "run_ase",
+                        "args": {
+                            "params": {
+                                "input_structure_file": "/tmp/methane.xyz",
+                                "driver": "dipole",
+                            }
+                        },
+                        "id": "call_1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+        ]
+    }
+
+    assert route_tools(state) == "validate"
+
+    update = ToolValidationFeedback(state)
+    feedback = update["messages"][0]
+    assert feedback.tool_call_id == "call_1"
+    assert "glucose" in feedback.content
+    assert "methane" in feedback.content
+    assert "coordinate file" in feedback.content
+
+
+def test_route_tools_allows_current_target_coordinate_file():
+    state = {
+        "messages": [
+            HumanMessage(content="glucose dipolemoment"),
+            {
+                "name": "smiles_to_coordinate_file",
+                "content": '{"path": "/tmp/glucose.xyz"}',
+            },
+            AIMessage(
+                content="calling current coordinate",
+                tool_calls=[
+                    {
+                        "name": "run_ase",
+                        "args": {
+                            "params": {
+                                "input_structure_file": "/tmp/glucose.xyz",
+                                "driver": "dipole",
+                            }
+                        },
                         "id": "call_2",
                         "type": "tool_call",
                     }


### PR DESCRIPTION
## Summary
- Add a deterministic guard before the single-agent `ToolNode` executes `run_ase`.
- Block follow-up tool calls that reuse a coordinate file from a previous molecule target.
- Feed the agent a `ToolMessage` repair instruction so it can generate/reuse coordinates for the current target instead of running on stale artifacts.
- Cover the stale-target case with routing tests.

## Why
This addresses the smallest validation/routing slice discussed in #135: a follow-up such as `glucose dipolemoment` should not execute `run_ase` on a coordinate file produced earlier for another molecule, such as methane.

## Demo scenario
Run the Streamlit UI:

```bash
streamlit run src/ui/app.py
```

Then use a single chat session:

1. Ask for a property that creates a coordinate artifact for one molecule, for example:

   ```text
   What is the IR spectrum of methane?
   ```

2. Follow up with a different molecule target:

   ```text
   glucose dipolemoment
   ```

3. The routing risk is when the model tries to call `run_ase` with the old file, for example:

   ```json
   {
     "name": "run_ase",
     "args": {
       "params": {
         "input_structure_file": "/tmp/methane.xyz",
         "driver": "dipole"
       }
     }
   }
   ```

Without this guard, that stale tool call can reach `ToolNode`. After this PR, it is blocked and the agent receives feedback to resolve/generate coordinates for the current target, `glucose`, before calling `run_ase`.

```mermaid
sequenceDiagram
    participant User
    participant Agent
    participant Validator
    participant ToolNode

    User->>Agent: What is the IR spectrum of methane?
    Agent->>ToolNode: smiles_to_coordinate_file -> /tmp/methane.xyz
    User->>Agent: glucose dipolemoment
    Agent->>Validator: run_ase(input_structure_file=/tmp/methane.xyz)
    Validator-->>Agent: Blocked: current target is glucose, file belongs to methane
    Agent->>ToolNode: generate/reuse glucose coordinates, then run_ase on glucose
```

The focused test is `test_route_tools_blocks_stale_target_coordinate_reuse` in `tests/test_single_agent_routing.py`.

## Validation
- `git diff --check`
- `PYTHONPATH=src python -m py_compile src/chemgraph/utils/tool_validation.py src/chemgraph/graphs/single_agent.py`
- `PYTHONPATH=src python -m pytest tests/test_single_agent_routing.py -q` -> 6 passed
- `PYTHONPATH=src python -m pytest tests/test_single_agent_routing.py tests/test_graphs.py tests/test_llm_agent.py tests/test_ui_main_interface.py -q` -> 37 passed
- `PYTHONPATH=src python -m pytest -q` -> 168 passed, 6 skipped

Refs #135
