### PR TITLE
Rename PyPI distribution to chemgraph + add README long_description

### DIFF
--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -26,9 +26,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
 
-    - name: Install chemgraphagent from PyPI
+    - name: Install chemgraph from PyPI
       run: |
-        pip install --no-cache-dir --upgrade "chemgraphagent==${{ inputs.version }}"
+        pip install --no-cache-dir --upgrade "chemgraph==${{ inputs.version }}"
 
     - name: Verify package installation
       run: |
@@ -47,5 +47,5 @@ jobs:
 
     - name: Check package version
       run: |
-        pip show chemgraphagent
-        python -c "from importlib.metadata import version; v=version('chemgraphagent'); print('Installed:', v); assert v=='${{ inputs.version }}', f'Expected ${{ inputs.version }}, got {v}'"
+        pip show chemgraph
+        python -c "from importlib.metadata import version; v=version('chemgraph'); print('Installed:', v); assert v=='${{ inputs.version }}', f'Expected ${{ inputs.version }}, got {v}'"

--- a/.opencode/skills/chemgraph/SKILL.md
+++ b/.opencode/skills/chemgraph/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 ## What is ChemGraph
 
-ChemGraph is a Python framework (package name `chemgraphagent`) built at Argonne National Laboratory that automates computational chemistry workflows using LLMs. It connects natural language queries to molecular simulations via an agent architecture built on LangGraph/LangChain, ASE (Atomic Simulation Environment), RDKit, and MCP (Model Context Protocol) servers.
+ChemGraph is a Python framework (package name `chemgraph`) built at Argonne National Laboratory that automates computational chemistry workflows using LLMs. It connects natural language queries to molecular simulations via an agent architecture built on LangGraph/LangChain, ASE (Atomic Simulation Environment), RDKit, and MCP (Model Context Protocol) servers.
 
 Key capabilities: molecule lookup (PubChem), 3D structure generation (RDKit), geometry optimization, vibrational analysis, thermochemistry, IR spectra, and HPC-scale ensemble simulations via Parsl.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For `config.toml` options and provider/base URL settings, see [`docs/configurati
 The easiest way to install ChemGraph is from PyPI:
 
 ```bash
-pip install chemgraphagent
+pip install chemgraph
 ```
 
 > Default installation does **not** require `tblite`.
@@ -90,7 +90,7 @@ pip install chemgraphagent
 
 To install with calculator extras (includes `tblite`):
 ```bash
-pip install chemgraphagent[calculators]
+pip install chemgraph[calculators]
 ```
 
 > Note: On some platforms/Python combinations (especially where no prebuilt `tblite`
@@ -175,7 +175,7 @@ If you need to install from source for the latest version:
 > 
 > **For PyPI installations**, you can try:
 > ```bash
-> pip install chemgraphagent[uma]
+> pip install chemgraph[uma]
 > ```
 > However, this may fail due to the e3nn version conflict. If it does, you'll need to install from source using the workaround below.
 >

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 ## Install from PyPI (recommended)
 
 ```bash
-pip install chemgraphagent
+pip install chemgraph
 ```
 
 Default installation does not require `tblite`.
@@ -12,7 +12,7 @@ Default installation does not require `tblite`.
 To include optional calculator extras (including `tblite`):
 
 ```bash
-pip install "chemgraphagent[calculators]"
+pip install "chemgraph[calculators]"
 ```
 
 !!! warning
@@ -57,7 +57,7 @@ Use separate environments if you need both MACE and UMA.
 PyPI attempt:
 
 ```bash
-pip install "chemgraphagent[uma]"
+pip install "chemgraph[uma]"
 ```
 
 From source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,10 @@ requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "chemgraphagent"
+name = "chemgraph"
 version = "0.6.0"
 description = "A computational chemistry agent for molecular simulation tasks."
+readme = "README.md"
 authors = [
     { name = "Thang Pham", email = "tpham@anl.gov" },
     { name = "Murat Keçeli", email = "keceli@anl.gov" },

--- a/src/chemgraph/execution/ensemble_launcher_backend.py
+++ b/src/chemgraph/execution/ensemble_launcher_backend.py
@@ -6,7 +6,7 @@ cluster-mode API (``EnsembleLauncher.start()`` + ``ClusterClient``) so
 that tasks can be submitted dynamically.
 
 EnsembleLauncher must be installed separately
-(``pip install chemgraphagent[ensemble_launcher]``).
+(``pip install chemgraph[ensemble_launcher]``).
 """
 
 from __future__ import annotations

--- a/src/chemgraph/execution/globus_compute_backend.py
+++ b/src/chemgraph/execution/globus_compute_backend.py
@@ -12,7 +12,7 @@ automatically provisions and manages batch jobs as tasks arrive.
 
 **Prerequisites**
 
-1. Install the SDK: ``pip install chemgraphagent[globus_compute]``
+1. Install the SDK: ``pip install chemgraph[globus_compute]``
 2. On the HPC system, configure and start an endpoint::
 
        globus-compute-endpoint configure chemgraph-polaris
@@ -70,7 +70,7 @@ class GlobusComputeBackend(ExecutionBackend):
         except ImportError as exc:
             raise ImportError(
                 "globus-compute-sdk is required for the GlobusComputeBackend. "
-                "Install it with: pip install chemgraphagent[globus_compute]"
+                "Install it with: pip install chemgraph[globus_compute]"
             ) from exc
 
         endpoint_id = kwargs.get("endpoint_id")

--- a/src/chemgraph/execution/parsl_backend.py
+++ b/src/chemgraph/execution/parsl_backend.py
@@ -4,7 +4,7 @@ Wraps `Parsl <https://parsl-project.org/>`_ to conform to the
 :class:`ExecutionBackend` interface.  Python tasks are dispatched via
 ``@python_app`` and shell tasks via ``@bash_app``.
 
-Parsl must be installed separately (``pip install chemgraphagent[parsl]``).
+Parsl must be installed separately (``pip install chemgraph[parsl]``).
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ class ParslBackend(ExecutionBackend):
         except ImportError as exc:
             raise ImportError(
                 "Parsl is required for the ParslBackend. "
-                "Install it with: pip install chemgraphagent[parsl]"
+                "Install it with: pip install chemgraph[parsl]"
             ) from exc
 
         from chemgraph.hpc_configs.loader import load_parsl_config

--- a/src/chemgraph/tools/rag_tools.py
+++ b/src/chemgraph/tools/rag_tools.py
@@ -99,7 +99,7 @@ def _extract_text_from_pdf(file_path: str) -> str:
     except ImportError as exc:
         raise ImportError(
             "PyMuPDF is required for PDF support. "
-            "Install the 'rag' extra: pip install chemgraphagent[rag]"
+            "Install the 'rag' extra: pip install chemgraph[rag]"
         ) from exc
 
     pages: list[str] = []
@@ -169,7 +169,7 @@ def _get_embeddings(provider: str = "openai"):
     except ImportError as exc:
         raise ImportError(
             "Neither langchain-openai nor langchain-huggingface is installed. "
-            "Install the 'rag' extra: pip install chemgraphagent[rag]"
+            "Install the 'rag' extra: pip install chemgraph[rag]"
         ) from exc
 
 


### PR DESCRIPTION
- pyproject: name chemgraphagent -> chemgraph; add readme = README.md so the PyPI project page renders the description (fixes twine long_description warning).
- Update install instructions in README, docs/installation, and the test-pypi-package workflow to 'pip install chemgraph[...]'.
- Update pip-install hints in backend/rag error messages and the skill doc.
- Leave _DISTRIBUTION_NAMES = (chemgraphagent, chemgraph) so version lookup still works for existing chemgraphagent installs.

Built + twine check pass; artifacts are chemgraph-0.6.0.{tar.gz,whl}; fresh install exposes 'import chemgraph' and the chemgraph CLI.