### PR TITLE
Add PACMOF2, FairChem/UMA, and Globus Transfer HPC MCP servers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,15 @@ rag = [
     "sentence-transformers>=2.2.2",
     "pymupdf>=1.24.0",
 ]
+pacmof2 = [
+    # PACMOF2 is NOT on PyPI -- install it from source:
+    #   pip install -e .   (from github.com/snurr-group/pacmof2)
+    # scikit-learn is HARD PINNED by PACMOF2 and may conflict with other
+    # packages; prefer an isolated venv / globus_compute endpoint for the
+    # PACMOF2 worker. ase and pymatgen are already core dependencies.
+    "scikit-learn==1.3.2",
+    "huggingface-hub",
+]
 
 [project.urls]
 "Homepage" = "https://github.com/argonne-lcf/ChemGraph"

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -7,6 +7,23 @@ vibrational frequencies + ideal-gas thermo at 298.15 K). Each script
 writes a CSV of electronic energy, enthalpy, entropy, Gibbs free
 energy per molecule and prints a fixed-width summary table.
 
+## Workloads (`--workload`)
+
+The harness is registry-driven (`_demo_chemistry.py`); pick the tool with
+`--workload`:
+
+| Workload | Tool | Items | Extra needed | Notes |
+|----------|------|-------|--------------|-------|
+| `thermo` (default) | MACE-MP | molecule fixtures | (base) | original 5-molecule screen |
+| `ase` | general ASE | molecule fixtures | (base) | selectable `--calculator` |
+| `fairchem` | FairChem/UMA | molecule fixtures | `.[uma]` | `--model-name` (uma-s-1p1); GPU preferred |
+| `graspa` | gRASPA GCMC | CIF paths (`--graspa-cifs`) | (HPC binary) | shared-FS / HPC only |
+| `pacmof2` | PACMOF2 charges | CIF paths (`--pacmof2-cifs`) | `.[pacmof2]` + source install | `--net-charge`; CPU-only; shared-FS / HPC only |
+
+`fairchem` reuses the molecular thermo table; `pacmof2` prints a per-element
+charge summary. `graspa` and `pacmof2` take CIF paths reachable on the compute
+node, not the molecule fixtures.
+
 These complement `scripts/smoke/`:
 
 | Directory | Purpose | Pass criterion |
@@ -159,6 +176,31 @@ bash scripts/demo/run_crux_demo.sh --el-only
 The wrapper activates `.cg_crux_hpc/`, exports `COMPUTE_SYSTEM=crux`, and runs
 `demo_parsl_in_job_direct.py` then `demo_ensemble_launcher_in_job_direct.py`
 with `--device cpu`. CSVs land in `$PBS_O_WORKDIR/demo_{parsl,el}_out_crux/`.
+
+### FairChem/UMA and PACMOF2 in-job
+
+The in-job Parsl/EL demos accept the new workloads (both direct and agent
+variants). Install the extras first (`sync_env.sh --extras ...,uma,pacmof2` and,
+for PACMOF2, the from-source install — see `scripts/hpc_setup/README.md`).
+
+```bash
+# FairChem/UMA thermo screen (GPU)
+python scripts/demo/demo_parsl_in_job_direct.py --workload fairchem --device cuda      # Polaris
+python scripts/demo/demo_parsl_in_job_direct.py --workload fairchem --device xpu       # Aurora
+
+# PACMOF2 charges on CIFs reachable from the compute node (CPU-only, Crux-friendly)
+python scripts/demo/demo_ensemble_launcher_in_job_direct.py \
+    --workload pacmof2 --pacmof2-cifs /lus/.../mof1.cif /lus/.../mof2.cif --net-charge 0
+
+# Crux wrapper passthrough
+bash scripts/demo/run_crux_demo.sh --workload fairchem
+bash scripts/demo/run_crux_demo.sh --workload pacmof2 --pacmof2-cifs /lus/.../mof.cif
+
+# Agent (LLM) variants
+python scripts/demo/demo_parsl_in_job_agent.py --workload fairchem --model argo:gpt-4o
+python scripts/demo/demo_parsl_in_job_agent.py \
+    --workload pacmof2 --pacmof2-cifs /lus/.../mof.cif --model argo:gpt-4o
+```
 
 Agent variants on either system require an LLM key and follow the
 same pattern as `demo_local_agent.py`.

--- a/scripts/demo/_demo_chemistry.py
+++ b/scripts/demo/_demo_chemistry.py
@@ -177,6 +177,61 @@ def build_ase_job(
     return job
 
 
+def build_fairchem_job(
+    name: str,
+    *,
+    device: str,
+    output_dir: Path,
+    inline: bool,
+    model_name: str = "uma-s-1p1",
+    task_name: str | None = "omol",
+    driver: str = "thermo",
+    temperature: float = 298.15,
+    pressure: float = 101325.0,
+    fmax: float = 0.01,
+    steps: int = 200,
+    optimizer: str = "lbfgs",
+) -> dict:
+    """Build the job dict consumed by ``_fairchem_worker`` for one molecule.
+
+    Mirrors :func:`build_thermo_job` but targets the FairChem/UMA server.
+    Job keys match :class:`fairchem_input_schema`; the output key is
+    ``output_result_file`` (as in the FairChem server). For ``inline=True``
+    the structure is embedded and ``_workload="fairchem"`` is set so the
+    inline read-back wrapper picks the FairChem worker.
+    """
+    xyz = molecule_xyz_path(name)
+    job: dict[str, Any] = {
+        "input_structure_file": str(xyz),
+        "driver": driver,
+        "model_name": model_name,
+        "task_name": task_name,
+        "device": device,
+        "temperature": temperature,
+        "pressure": pressure,
+        "fmax": fmax,
+        "steps": steps,
+        "optimizer": optimizer,
+    }
+    if inline:
+        # Relative name only -- resolved into a worker-side tmpdir by
+        # _fairchem_worker. Never bake a laptop path into a remote job.
+        job["output_result_file"] = f"{name}_fairchem.json"
+        job["_workload"] = "fairchem"  # consumed by the inline wrapper
+        from ase.io import read as ase_read
+
+        from chemgraph.tools.ase_core import atoms_to_atomsdata
+
+        atoms = ase_read(str(xyz))
+        job["inline_structure"] = atoms_to_atomsdata(atoms).model_dump()
+    else:
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        job["output_result_file"] = str(
+            (Path(output_dir) / f"{name}_fairchem.json").resolve()
+        )
+    return job
+
+
 def build_graspa_job(
     cif_path: str | Path,
     *,
@@ -204,6 +259,31 @@ def build_graspa_job(
         "temperature": temperature,
         "pressure": pressure,
         "n_cycles": n_cycles,
+    }
+
+
+def build_pacmof2_job(
+    cif_path: str | Path,
+    *,
+    output_dir: Path,
+    identifier: str = "_pacmof",
+    adjust_charge_method: str = "mean",
+    net_charge: int | float | dict = 0,
+) -> dict:
+    """Build the job dict consumed by ``_pacmof2_worker`` for one CIF.
+
+    PACMOF2 mirrors gRASPA: CIF-in, shared/remote filesystem only (no
+    inline transport). It writes the charged CIF next to its input, so
+    ``output_dir`` is only used to keep the harness signature uniform.
+    """
+    cif_path = Path(cif_path)
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    return {
+        "_structure_name": cif_path.stem,
+        "input_structure_file": str(cif_path),
+        "identifier": identifier,
+        "adjust_charge_method": adjust_charge_method,
+        "net_charge": net_charge,
     }
 
 
@@ -270,6 +350,24 @@ def _extract_graspa_properties(name: str, raw: dict, job: dict, *, inline: bool)
     }
 
 
+def _extract_pacmof2_properties(name: str, raw: dict, job: dict, *, inline: bool) -> dict:
+    """Pull the charge summary out of one PACMOF2 job's result.
+
+    ``_pacmof2_worker`` already returns the parsed summary dict (output
+    CIF path, per-element mean charges, sum of charges), so we read
+    directly from ``raw`` -- no output-file round-trip (mirrors gRASPA).
+    """
+    return {
+        "structure": raw.get("structure") or name,
+        "status": raw.get("status", "?"),
+        "n_atoms": raw.get("n_atoms"),
+        "sum_of_charges": raw.get("sum_of_charges"),
+        "charge_range": raw.get("charge_range"),
+        "per_element_mean_charge": raw.get("per_element_mean_charge"),
+        "output_cif_path": raw.get("output_cif_path"),
+    }
+
+
 def _make_worker_with_full_output():
     """Return a backend-side wrapper that runs the per-workload worker, then
     reads its output JSON back in-process and attaches it as ``full_output``.
@@ -317,6 +415,10 @@ def _make_worker_with_full_output():
             from chemgraph.mcp.ase_mcp_hpc import _ase_worker as _worker
             from chemgraph.tools.ase_core import extract_output_json_core as _extract
             out_key = "output_results_file"
+        elif workload == "fairchem":
+            from chemgraph.mcp.fairchem_mcp_hpc import _fairchem_worker as _worker
+            from chemgraph.tools.fairchem_tools import extract_output_json as _extract
+            out_key = "output_result_file"
         else:
             from chemgraph.mcp.mace_mcp_hpc import _mace_worker as _worker
             from chemgraph.tools.parsl_tools import extract_output_json as _extract
@@ -370,6 +472,18 @@ def _graspa_package_worker():
     return _graspa_worker
 
 
+def _fairchem_package_worker():
+    from chemgraph.mcp.fairchem_mcp_hpc import _fairchem_worker
+
+    return _fairchem_worker
+
+
+def _pacmof2_package_worker():
+    from chemgraph.mcp.pacmof2_mcp_hpc import _pacmof2_worker
+
+    return _pacmof2_worker
+
+
 # Registry mapping a --workload value to how the shared harness runs it.
 # ``inline_ok`` marks workloads that support Globus-Compute inline transport
 # (structure embedded in the payload); gRASPA is HPC/shared-FS only.
@@ -392,6 +506,18 @@ WORKLOADS: dict[str, dict[str, Any]] = {
         "extractor": _extract_graspa_properties,
         "inline_ok": False,
     },
+    "fairchem": {
+        "label": "FairChem/UMA",
+        "package_worker": _fairchem_package_worker,
+        "extractor": _extract_properties,
+        "inline_ok": True,
+    },
+    "pacmof2": {
+        "label": "PACMOF2 charges",
+        "package_worker": _pacmof2_package_worker,
+        "extractor": _extract_pacmof2_properties,
+        "inline_ok": False,
+    },
 }
 
 
@@ -407,6 +533,11 @@ def _build_jobs(
     adsorbate: str = "H2O",
     temperature: float = 298.15,
     pressure: float = 101325.0,
+    model_name: str = "uma-s-1p1",
+    task_name: str | None = "omol",
+    net_charge: int | float | dict = 0,
+    identifier: str = "_pacmof",
+    adjust_charge_method: str = "mean",
 ) -> list[dict]:
     """Build the per-item job dicts for *workload*."""
     if workload == "thermo":
@@ -431,6 +562,21 @@ def _build_jobs(
                 job["_workload"] = "ase"  # consumed by the inline wrapper
             jobs.append(job)
         return jobs
+    if workload == "fairchem":
+        return [
+            build_fairchem_job(
+                name,
+                device=device,
+                output_dir=output_dir,
+                inline=inline,
+                model_name=model_name,
+                task_name=task_name,
+                driver=driver,
+                temperature=temperature,
+                pressure=pressure,
+            )
+            for name in items
+        ]
     if workload == "graspa":
         return [
             build_graspa_job(
@@ -442,12 +588,27 @@ def _build_jobs(
             )
             for cif in items
         ]
+    if workload == "pacmof2":
+        return [
+            build_pacmof2_job(
+                cif,
+                output_dir=output_dir,
+                identifier=identifier,
+                adjust_charge_method=adjust_charge_method,
+                net_charge=net_charge,
+            )
+            for cif in items
+        ]
     raise ValueError(f"Unknown workload: {workload!r}")
+
+
+# Workloads whose work items are CIF paths (vs. molecule fixture names).
+_CIF_WORKLOADS = frozenset({"graspa", "pacmof2"})
 
 
 def _item_label(workload: str, item: str) -> str:
     """Short display name for one work item."""
-    return Path(item).stem if workload == "graspa" else item
+    return Path(item).stem if workload in _CIF_WORKLOADS else item
 
 
 def submit_and_collect(
@@ -464,6 +625,11 @@ def submit_and_collect(
     adsorbate: str = "H2O",
     temperature: float = 298.15,
     pressure: float = 101325.0,
+    model_name: str = "uma-s-1p1",
+    task_name: str | None = "omol",
+    net_charge: int | float | dict = 0,
+    identifier: str = "_pacmof",
+    adjust_charge_method: str = "mean",
     timeout: float = 6000.0,
     ppn: int = 1,
 ) -> list[dict]:
@@ -507,6 +673,11 @@ def submit_and_collect(
         adsorbate=adsorbate,
         temperature=temperature,
         pressure=pressure,
+        model_name=model_name,
+        task_name=task_name,
+        net_charge=net_charge,
+        identifier=identifier,
+        adjust_charge_method=adjust_charge_method,
     )
 
     # Inline transport (Globus Compute): the worker writes results to a path
@@ -550,17 +721,23 @@ def submit_and_collect(
 
 
 def write_csv(results: list[dict], csv_path: Path | str) -> Path:
-    """Write the property table to *csv_path*. Returns the path."""
+    """Write the property table to *csv_path*. Returns the path.
+
+    Failed jobs appear as ``None`` in *results*; they are skipped so a
+    batch where every job failed still writes a valid (empty) CSV instead
+    of crashing.
+    """
     csv_path = Path(csv_path)
     csv_path.parent.mkdir(parents=True, exist_ok=True)
-    if not results:
+    rows = [r for r in results if r]
+    if not rows:
         csv_path.write_text("")
         return csv_path
-    fieldnames = list(results[0].keys())
+    fieldnames = list(rows[0].keys())
     with open(csv_path, "w", newline="") as fh:
         writer = csv.DictWriter(fh, fieldnames=fieldnames)
         writer.writeheader()
-        writer.writerows(results)
+        writer.writerows(rows)
     return csv_path
 
 
@@ -616,11 +793,40 @@ def _print_graspa_summary(results: list[dict]) -> None:
     print()
 
 
+def _print_pacmof2_summary(results: list[dict]) -> None:
+    header = (
+        f"{'structure':<16}  {'status':>8}  {'#atoms':>7}  {'sum(q)':>10}  "
+        f"{'q range':>18}  {'output CIF':<40}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        if not r:
+            continue
+        crange = r.get("charge_range")
+        crange_str = (
+            f"[{crange[0]:.3f}, {crange[1]:.3f}]"
+            if isinstance(crange, (list, tuple)) and len(crange) == 2
+            else "-"
+        )
+        cif = r.get("output_cif_path") or "-"
+        print(
+            f"{r.get('structure', '?'):<16}  "
+            f"{_fmt(r.get('status'), 8)}  "
+            f"{_fmt(r.get('n_atoms'), 7, 0)}  "
+            f"{_fmt(r.get('sum_of_charges'), 10, 4)}  "
+            f"{crange_str:>18}  "
+            f"{cif:<40}"
+        )
+    print()
+
+
 def print_summary(results: list[dict], title: str = "", workload: str = "thermo") -> None:
     """Print a fixed-width table of the screening results.
 
-    ``thermo`` and ``ase`` share the molecular-property table; ``graspa``
-    uses a GCMC uptake table.
+    ``thermo``, ``ase`` and ``fairchem`` share the molecular-property
+    table; ``graspa`` uses a GCMC uptake table; ``pacmof2`` uses a charge
+    summary table.
     """
     if title:
         print(f"\n=== {title} ===")
@@ -629,6 +835,8 @@ def print_summary(results: list[dict], title: str = "", workload: str = "thermo"
         return
     if workload == "graspa":
         _print_graspa_summary(results)
+    elif workload == "pacmof2":
+        _print_pacmof2_summary(results)
     else:
         _print_thermo_summary(results)
 
@@ -683,6 +891,29 @@ def agent_prompt_ase(device: str = "cpu", calculator: str = "mace_mp") -> str:
     )
 
 
+def agent_prompt_fairchem(device: str = "cpu", model_name: str = "uma-s-1p1") -> str:
+    """Prompt for the FairChem/UMA (``run_fairchem_single``) agent demos."""
+    files = ", ".join(str(molecule_xyz_path(n)) for n in MOLECULE_NAMES)
+    return (
+        f"Using the FairChem tool (run_fairchem_single) with driver='thermo', "
+        f"model_name='{model_name}', task_name='omol', device='{device}', "
+        f"temperature=298.15 K, pressure=101325 Pa, compute thermochemistry for "
+        f"each of these five molecules:\n"
+        f"  - water:    {molecule_xyz_path('water')}\n"
+        f"  - methane:  {molecule_xyz_path('methane')}\n"
+        f"  - ammonia:  {molecule_xyz_path('ammonia')}\n"
+        f"  - CO2:      {molecule_xyz_path('co2')}\n"
+        f"  - ethanol:  {molecule_xyz_path('ethanol')}\n"
+        f"Call run_fairchem_single once per molecule (do not batch them yourself). "
+        f"For each result, retrieve the optimized electronic energy, enthalpy, "
+        f"entropy and Gibbs free energy by reading the output JSON via "
+        f"extract_output_json. After all five complete, report a markdown table "
+        f"with columns: molecule, energy (eV), H (eV), G (eV), and wall-time then "
+        f"a one-line observation about which molecule has the lowest Gibbs free "
+        f"energy.\n\n(Structure paths for reference: {files})"
+    )
+
+
 def agent_prompt_graspa(
     cif_paths: list[str],
     *,
@@ -706,13 +937,41 @@ def agent_prompt_graspa(
     )
 
 
+def agent_prompt_pacmof2(cif_paths: list[str], *, net_charge: int | float = 0) -> str:
+    """Prompt for the PACMOF2 (``run_pacmof2_ensemble``) agent demos.
+
+    PACMOF2 is shared-FS/HPC-only; ``cif_paths`` should point at CIFs
+    reachable on the remote (shared or pre-staged) filesystem.
+    """
+    listing = "\n".join(f"  - {p}" for p in cif_paths)
+    return (
+        f"Using the PACMOF2 tool (run_pacmof2_ensemble) with net_charge="
+        f"{net_charge}, assign machine-learned partial atomic charges to the "
+        f"following MOF CIF structures:\n"
+        f"{listing}\n"
+        f"After the runs complete, report a markdown table with columns: "
+        f"structure, sum of charges, output CIF path. Report tool errors exactly "
+        f"as they occur."
+    )
+
+
 def prompt_for(workload: str, *, device: str = "cpu", calculator: str = "mace_mp") -> str:
-    """Return the agent prompt for *workload* (thermo/ase; graspa needs CIFs)."""
+    """Return the agent prompt for *workload*.
+
+    ``thermo``/``ase``/``fairchem`` build molecule prompts here; ``graspa``
+    and ``pacmof2`` need explicit CIF paths (call their dedicated builders).
+    """
     if workload == "ase":
         return agent_prompt_ase(device=device, calculator=calculator)
+    if workload == "fairchem":
+        return agent_prompt_fairchem(device=device)
     if workload == "graspa":
         raise ValueError(
             "gRASPA prompts need explicit CIF paths; call agent_prompt_graspa()."
+        )
+    if workload == "pacmof2":
+        raise ValueError(
+            "PACMOF2 prompts need explicit CIF paths; call agent_prompt_pacmof2()."
         )
     return agent_prompt(device=device)
 
@@ -743,6 +1002,18 @@ MCP_SERVER_BY_WORKLOAD: dict[str, dict[str, Any]] = {
         "port": 9001,
         "label": "ChemGraph gRASPA",
         "single_tool": "run_graspa_ensemble",
+    },
+    "fairchem": {
+        "module": "chemgraph.mcp.fairchem_mcp_hpc",
+        "port": 9008,
+        "label": "ChemGraph FairChem",
+        "single_tool": "run_fairchem_single",
+    },
+    "pacmof2": {
+        "module": "chemgraph.mcp.pacmof2_mcp_hpc",
+        "port": 9009,
+        "label": "ChemGraph PACMOF2",
+        "single_tool": "run_pacmof2_ensemble",
     },
 }
 
@@ -787,6 +1058,23 @@ def add_workload_args(parser) -> None:
         default=None,
         help="CIF paths (remote-reachable) for --workload graspa.",
     )
+    parser.add_argument(
+        "--model-name",
+        default="uma-s-1p1",
+        help="FairChem/UMA model for --workload fairchem (e.g. uma-s-1p1, uma-m-1).",
+    )
+    parser.add_argument(
+        "--pacmof2-cifs",
+        nargs="+",
+        default=None,
+        help="CIF paths (remote-reachable) for --workload pacmof2.",
+    )
+    parser.add_argument(
+        "--net-charge",
+        type=float,
+        default=0,
+        help="Target net charge for --workload pacmof2 (default: 0).",
+    )
 
 
 def abort_if_graspa_unsupported(workload: str, backend_name: str) -> None:
@@ -802,10 +1090,15 @@ def abort_if_graspa_unsupported(workload: str, backend_name: str) -> None:
 
 
 def resolve_items(workload: str, *, molecules: list[str], cifs: list[str] | None) -> list[str]:
-    """Return the per-item list for *workload* (molecules or CIF paths)."""
-    if workload == "graspa":
+    """Return the per-item list for *workload* (molecules or CIF paths).
+
+    ``graspa`` and ``pacmof2`` are CIF-based; the caller passes the workload's
+    ``--graspa-cifs`` / ``--pacmof2-cifs`` value as *cifs*.
+    """
+    if workload in _CIF_WORKLOADS:
         if not cifs:
-            print("ERROR: --workload graspa requires --graspa-cifs <CIF> [<CIF> ...].")
+            flag = "--pacmof2-cifs" if workload == "pacmof2" else "--graspa-cifs"
+            print(f"ERROR: --workload {workload} requires {flag} <CIF> [<CIF> ...].")
             sys.exit(2)
         return list(cifs)
     return list(molecules)

--- a/scripts/demo/demo_ensemble_launcher_in_job_agent.py
+++ b/scripts/demo/demo_ensemble_launcher_in_job_agent.py
@@ -26,7 +26,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _demo_chemistry import agent_prompt_graspa, mcp_server_for, prompt_for
+from _demo_chemistry import (
+    agent_prompt_graspa,
+    agent_prompt_pacmof2,
+    mcp_server_for,
+    prompt_for,
+)
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
@@ -117,14 +122,22 @@ def main() -> None:
                         help="GPUs per process for MCP backend tasks")
     parser.add_argument(
         "--workload",
-        choices=["thermo", "ase", "graspa"],
+        choices=["thermo", "ase", "graspa", "fairchem", "pacmof2"],
         default="thermo",
-        help="thermo = MACE; ase = general ASE; graspa = GCMC (needs --graspa-cifs).",
+        help="thermo = MACE; ase = general ASE; graspa = GCMC (needs "
+             "--graspa-cifs); fairchem = FairChem/UMA; pacmof2 = MOF charges "
+             "(needs --pacmof2-cifs).",
     )
     parser.add_argument("--calculator", default="mace_mp",
                         help="ASE calculator for --workload ase.")
     parser.add_argument("--graspa-cifs", nargs="+", default=None,
                         help="CIF paths (node-reachable) for --workload graspa.")
+    parser.add_argument("--model-name", default="uma-s-1p1",
+                        help="FairChem/UMA model for --workload fairchem.")
+    parser.add_argument("--pacmof2-cifs", nargs="+", default=None,
+                        help="CIF paths (node-reachable) for --workload pacmof2.")
+    parser.add_argument("--net-charge", type=float, default=0,
+                        help="Target net charge for --workload pacmof2.")
     parser.add_argument("--query", default=None)
     parser.add_argument("-v", "--verbose", action="count", default=0)
     args = parser.parse_args()
@@ -144,6 +157,10 @@ def main() -> None:
         if not args.graspa_cifs:
             _abort("--workload graspa requires --graspa-cifs <CIF> [<CIF> ...].")
         query = agent_prompt_graspa(args.graspa_cifs)
+    elif args.workload == "pacmof2":
+        if not args.pacmof2_cifs:
+            _abort("--workload pacmof2 requires --pacmof2-cifs <CIF> [<CIF> ...].")
+        query = agent_prompt_pacmof2(args.pacmof2_cifs, net_charge=args.net_charge)
     else:
         query = prompt_for(args.workload, device=device, calculator=args.calculator)
 

--- a/scripts/demo/demo_ensemble_launcher_in_job_direct.py
+++ b/scripts/demo/demo_ensemble_launcher_in_job_direct.py
@@ -81,7 +81,8 @@ def main() -> None:
 
     from chemgraph.execution.config import get_backend
 
-    items = resolve_items(args.workload, molecules=args.molecules, cifs=args.graspa_cifs)
+    cifs = args.pacmof2_cifs if args.workload == "pacmof2" else args.graspa_cifs
+    items = resolve_items(args.workload, molecules=args.molecules, cifs=cifs)
 
     backend = get_backend(backend_name="ensemble_launcher", system=system)
     try:
@@ -95,6 +96,8 @@ def main() -> None:
             calculator=args.calculator,
             driver=args.driver,
             adsorbate=args.adsorbate,
+            model_name=args.model_name,
+            net_charge=args.net_charge,
             timeout=args.timeout,
             ppn=args.ppn,
         )

--- a/scripts/demo/demo_local_direct.py
+++ b/scripts/demo/demo_local_direct.py
@@ -53,7 +53,8 @@ def main() -> None:
     args = parser.parse_args()
 
     abort_if_graspa_unsupported(args.workload, "local")
-    items = resolve_items(args.workload, molecules=args.molecules, cifs=args.graspa_cifs)
+    cifs = args.pacmof2_cifs if args.workload == "pacmof2" else args.graspa_cifs
+    items = resolve_items(args.workload, molecules=args.molecules, cifs=cifs)
 
     from chemgraph.execution.config import get_backend
 
@@ -69,6 +70,8 @@ def main() -> None:
             calculator=args.calculator,
             driver=args.driver,
             adsorbate=args.adsorbate,
+            model_name=args.model_name,
+            net_charge=args.net_charge,
             timeout=1200,
         )
     finally:

--- a/scripts/demo/demo_parsl_in_job_agent.py
+++ b/scripts/demo/demo_parsl_in_job_agent.py
@@ -28,7 +28,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from _demo_chemistry import agent_prompt_graspa, mcp_server_for, prompt_for
+from _demo_chemistry import (
+    agent_prompt_graspa,
+    agent_prompt_pacmof2,
+    mcp_server_for,
+    prompt_for,
+)
 
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langchain_mcp_adapters.tools import load_mcp_tools
@@ -119,14 +124,22 @@ def main() -> None:
     parser.add_argument("--device", default=None)
     parser.add_argument(
         "--workload",
-        choices=["thermo", "ase", "graspa"],
+        choices=["thermo", "ase", "graspa", "fairchem", "pacmof2"],
         default="thermo",
-        help="thermo = MACE; ase = general ASE; graspa = GCMC (needs --graspa-cifs).",
+        help="thermo = MACE; ase = general ASE; graspa = GCMC (needs "
+             "--graspa-cifs); fairchem = FairChem/UMA; pacmof2 = MOF charges "
+             "(needs --pacmof2-cifs).",
     )
     parser.add_argument("--calculator", default="mace_mp",
                         help="ASE calculator for --workload ase.")
     parser.add_argument("--graspa-cifs", nargs="+", default=None,
                         help="CIF paths (node-reachable) for --workload graspa.")
+    parser.add_argument("--model-name", default="uma-s-1p1",
+                        help="FairChem/UMA model for --workload fairchem.")
+    parser.add_argument("--pacmof2-cifs", nargs="+", default=None,
+                        help="CIF paths (node-reachable) for --workload pacmof2.")
+    parser.add_argument("--net-charge", type=float, default=0,
+                        help="Target net charge for --workload pacmof2.")
     parser.add_argument("--query", default=None)
     parser.add_argument("-v", "--verbose", action="count", default=0)
     args = parser.parse_args()
@@ -153,6 +166,10 @@ def main() -> None:
         if not args.graspa_cifs:
             _abort("--workload graspa requires --graspa-cifs <CIF> [<CIF> ...].")
         query = agent_prompt_graspa(args.graspa_cifs)
+    elif args.workload == "pacmof2":
+        if not args.pacmof2_cifs:
+            _abort("--workload pacmof2 requires --pacmof2-cifs <CIF> [<CIF> ...].")
+        query = agent_prompt_pacmof2(args.pacmof2_cifs, net_charge=args.net_charge)
     else:
         query = prompt_for(args.workload, device=device, calculator=args.calculator)
 

--- a/scripts/demo/demo_parsl_in_job_direct.py
+++ b/scripts/demo/demo_parsl_in_job_direct.py
@@ -92,7 +92,8 @@ def main() -> None:
 
     from chemgraph.execution.config import get_backend
 
-    items = resolve_items(args.workload, molecules=args.molecules, cifs=args.graspa_cifs)
+    cifs = args.pacmof2_cifs if args.workload == "pacmof2" else args.graspa_cifs
+    items = resolve_items(args.workload, molecules=args.molecules, cifs=cifs)
 
     backend = get_backend(backend_name="parsl", system=system, run_dir=run_dir)
     try:
@@ -106,6 +107,8 @@ def main() -> None:
             calculator=args.calculator,
             driver=args.driver,
             adsorbate=args.adsorbate,
+            model_name=args.model_name,
+            net_charge=args.net_charge,
             timeout=args.timeout,
         )
     finally:

--- a/scripts/demo/run_crux_demo.sh
+++ b/scripts/demo/run_crux_demo.sh
@@ -5,10 +5,12 @@
 # Must be executed INSIDE an interactive PBS allocation on Crux:
 #   qsub -I -A <proj> -l select=1 -l walltime=01:00:00 -q debug
 #   cd /lus/eagle/projects/ChemGraph/thang/ChemGraph
-#   bash scripts/demo/run_crux_demo.sh                  # both backends
+#   bash scripts/demo/run_crux_demo.sh                  # both backends (MACE thermo)
 #   bash scripts/demo/run_crux_demo.sh --parsl-only
 #   bash scripts/demo/run_crux_demo.sh --el-only
 #   bash scripts/demo/run_crux_demo.sh --molecules water methane
+#   bash scripts/demo/run_crux_demo.sh --workload fairchem
+#   bash scripts/demo/run_crux_demo.sh --workload pacmof2 --pacmof2-cifs a.cif b.cif
 
 set -euo pipefail
 
@@ -26,9 +28,13 @@ while (( $# )); do
     case "$1" in
         --parsl-only) RUN_EL=0; shift ;;
         --el-only) RUN_PARSL=0; shift ;;
-        --molecules) shift; while (( $# )) && [[ "$1" != --* ]]; do PASSTHROUGH+=("$1"); shift; done; PASSTHROUGH=(--molecules "${PASSTHROUGH[@]}") ;;
+        --molecules) shift; MOLS=(); while (( $# )) && [[ "$1" != --* ]]; do MOLS+=("$1"); shift; done; PASSTHROUGH+=(--molecules "${MOLS[@]}") ;;
+        --pacmof2-cifs) shift; CIFS=(); while (( $# )) && [[ "$1" != --* ]]; do CIFS+=("$1"); shift; done; PASSTHROUGH+=(--pacmof2-cifs "${CIFS[@]}") ;;
+        --workload) PASSTHROUGH+=("$1" "$2"); shift 2 ;;
+        --model-name) PASSTHROUGH+=("$1" "$2"); shift 2 ;;
+        --net-charge) PASSTHROUGH+=("$1" "$2"); shift 2 ;;
         --timeout) PASSTHROUGH+=("$1" "$2"); shift 2 ;;
-        -h|--help) sed -n '2,12p' "${BASH_SOURCE[0]}"; exit 0 ;;
+        -h|--help) sed -n '2,14p' "${BASH_SOURCE[0]}"; exit 0 ;;
         *) abort "Unknown argument: $1" ;;
     esac
 done

--- a/src/chemgraph/mcp/fairchem_mcp_hpc.py
+++ b/src/chemgraph/mcp/fairchem_mcp_hpc.py
@@ -1,0 +1,370 @@
+"""Backend-agnostic FairChem/UMA MCP server.
+
+Uses :class:`~chemgraph.mcp.cg_fastmcp.CGFastMCP`. Tool functions are
+plain computation -- the framework handles backend submission, future
+resolution, and async job tracking. Because :class:`CGFastMCP` resolves
+its backend from ``config.toml`` / env vars via
+:func:`chemgraph.execution.config.get_backend`, this server runs on any
+supported backend (local, **EnsembleLauncher / "EL"**, Globus Compute)
+without code changes -- set ``CHEMGRAPH_EXECUTION_BACKEND=ensemble_launcher``
+to use the EL backend.
+
+This mirrors :mod:`chemgraph.mcp.mace_mcp_hpc` but targets the
+FairChem/UMA calculator. The tool bodies delegate to
+:func:`chemgraph.tools.fairchem_tools.run_fairchem_core`.
+
+Transport (local-file embedding, pre-staged remote-path passthrough)
+lives in a single pre-submit hook so the tool bodies stay simple. The
+hook rewrites :class:`~chemgraph.execution.base.TaskSpec` instances
+before submission to attach an inline structure when the input file
+exists on the submitting host, leaving the path untouched when it does
+not (assumed to be remote).
+
+Nothing requiring the backend is initialised at import time so worker
+subprocesses (EnsembleLauncher, Globus Compute) can re-import this
+module safely.
+"""
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from chemgraph.execution.base import TaskSpec
+from chemgraph.execution.config import get_transfer_manager
+from chemgraph.execution.utils import (
+    make_per_structure_output,
+    resolve_structure_files,
+)
+from chemgraph.mcp.cg_fastmcp import CGFastMCP
+from chemgraph.mcp.transfer_tools import register_transfer_tools
+from chemgraph.schemas.fairchem_schema import (
+    fairchem_input_schema,
+    fairchem_input_schema_ensemble,
+)
+from chemgraph.tools.fairchem_tools import extract_output_json, run_fairchem_core
+
+logger = logging.getLogger(__name__)
+
+_JOBS_FILE = Path("~/.chemgraph/fairchem_jobs.json").expanduser()
+
+mcp = CGFastMCP(
+    name="ChemGraph FAIRChem Tools",
+    instructions="""
+        You expose tools for running FairChem/UMA simulations and reading their
+        results. The available tools are:
+        1. run_fairchem_single: run a single FairChem/UMA calculation.
+        2. run_fairchem_ensemble: run FairChem calculations over every structure
+           in a directory (local or pre-staged remote).
+        3. extract_output_json: load simulation results from a JSON file.
+        4. check_job_status / get_job_results / list_jobs / cancel_job: HPC
+           job batch management. Job state persists across sessions.
+        5. transfer_files / check_transfer_status / list_remote_files
+           (when Globus Transfer is configured): stage input files on the
+           remote HPC filesystem before running ensembles in remote mode.
+
+        Guidelines:
+        - Use each tool only when its input schema matches the user request.
+        - Do not guess numerical values; report tool errors exactly as they
+          occur.
+        - Keep responses compact -- full results are written to the output
+          files defined in the schemas.
+        - When returning paths, use absolute paths.
+        - Energies are in eV and wall times are in seconds.
+        - When a tool returns status='submitted' with a batch_id, call
+          get_job_results(batch_id) to retrieve results. If still pending,
+          report the batch_id so the user can check later -- job state is
+          persisted across sessions.
+        - For the `model_name` field, pass a FairChem/UMA model name (e.g.
+          'uma-s-1p1' or 'uma-m-1'). Use `task_name` ('omol', 'omat', 'oc20',
+          'odac', 'omc') to select the prediction head, and `charge` /
+          `multiplicity` for charged or open-shell systems.
+    """,
+)
+
+
+# ── Worker (runs on the backend) ───────────────────────────────────────
+
+
+def _fairchem_worker(job: dict) -> dict:
+    """Execute a single FairChem/UMA simulation on a backend worker.
+
+    Accepts a *job dict* (not the schema) so the pre-submit hook can
+    attach transport keys ``inline_structure`` / ``remote_structure_file``
+    before submission.
+    """
+    import tempfile
+
+    job = dict(job)
+
+    # Pre-staged remote file: use the path directly on the worker FS.
+    remote_file = job.pop("remote_structure_file", None)
+    if remote_file is not None:
+        job["input_structure_file"] = remote_file
+        if not os.path.isabs(job.get("output_result_file", "")):
+            job["output_result_file"] = os.path.join(
+                os.path.dirname(remote_file),
+                job.get("output_result_file", "output.json"),
+            )
+
+    # Inline structure: materialise on the worker's filesystem.
+    inline = job.pop("inline_structure", None)
+    if inline is not None:
+        from ase import Atoms
+        from ase.io import write as ase_write
+
+        atoms = Atoms(
+            numbers=inline["numbers"],
+            positions=inline["positions"],
+            cell=inline.get("cell"),
+            pbc=inline.get("pbc"),
+        )
+        tmpdir = tempfile.mkdtemp(prefix="chemgraph_fairchem_")
+        xyz_path = os.path.join(tmpdir, "structure.xyz")
+        ase_write(xyz_path, atoms)
+        job["input_structure_file"] = xyz_path
+        if not os.path.isabs(job.get("output_result_file", "")):
+            job["output_result_file"] = os.path.join(
+                tmpdir, job.get("output_result_file", "output.json")
+            )
+
+    output_file = job.get("output_result_file")
+    if output_file:
+        os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
+
+    params = fairchem_input_schema(**job)
+    result = run_fairchem_core(params)
+    return result
+
+
+# Force pickle-by-reference for callables that the transport hook installs
+# as `task.callable`. Without this, dill sees `__module__ == "__main__"`
+# (this file is run as ``python -m chemgraph.mcp.fairchem_mcp_hpc``) and
+# falls back to pickle-by-value, which walks the module's globals and tries
+# to serialize the dynamic ``run_fairchem_singleArguments`` class held by
+# ``mcp._tool_manager._tools[...].fn_metadata.arg_model`` -- that class
+# was created by ``pydantic.create_model`` with a ``__module__`` it was
+# never registered into, so dill raises a PicklingError.
+CGFastMCP._fix_module_for_pickle(_fairchem_worker)
+
+
+# ── Pre-submit transport hook ──────────────────────────────────────────
+
+
+def _embed_inline_if_local(job: dict) -> None:
+    """Mutate *job* in-place: attach inline_structure when the input
+    file is readable on the submitting host (and no other transport
+    key has already been set)."""
+    if job.get("remote_structure_file") or job.get("inline_structure"):
+        return
+    input_file = job.get("input_structure_file")
+    if not input_file or not os.path.isfile(input_file):
+        return  # remote path -- worker will read it directly
+
+    from ase.io import read as ase_read
+
+    from chemgraph.tools.ase_core import atoms_to_atomsdata
+
+    atoms = ase_read(input_file)
+    job["inline_structure"] = atoms_to_atomsdata(atoms).model_dump()
+
+
+def _backend_shares_fs() -> bool:
+    """Whether the active backend shares the server's filesystem.
+
+    When it does, inline embedding (and the worker's ``/tmp`` round-trip)
+    is unnecessary -- the worker reads ``input_structure_file`` directly.
+    Defaults to ``True`` (skip embedding) when no backend exists yet."""
+    backend = getattr(mcp, "_backend", None)
+    return getattr(backend, "shares_filesystem", True)
+
+
+def _fairchem_transport_hook(task: TaskSpec) -> TaskSpec:
+    """Route single-tool calls to the dict-based worker and embed
+    local structures only when the backend has no shared filesystem."""
+    logger.debug(
+        "fairchem transport hook: task_id=%s callable=%s",
+        task.task_id,
+        getattr(task.callable, "__qualname__", task.callable),
+    )
+    if task.callable is run_fairchem_single:
+        params = task.kwargs.get("params")
+        if params is None:
+            return task
+        job = (
+            params.model_dump() if hasattr(params, "model_dump") else dict(params)
+        )
+        if not _backend_shares_fs():
+            _embed_inline_if_local(job)
+        task.callable = _fairchem_worker
+        task.kwargs = {"job": job}
+    elif task.callable is _fairchem_worker:
+        job = dict(task.kwargs.get("job", {}))
+        if not _backend_shares_fs():
+            _embed_inline_if_local(job)
+        task.kwargs = {"job": job}
+    return task
+
+
+mcp.set_pre_submit_hook(_fairchem_transport_hook)
+
+
+# ── Single-structure tool ──────────────────────────────────────────────
+
+
+def run_fairchem_single(params: fairchem_input_schema) -> dict:
+    """Run a single FairChem/UMA calculation on the configured backend.
+
+    The pre-submit hook rewrites this call to invoke ``_fairchem_worker``
+    on the backend with a job dict that may carry an embedded inline
+    structure (when the input file exists locally) or a remote path
+    (when it does not).
+    """
+    # Direct-call fallback path (no hook registered) -- delegates to the
+    # same worker.
+    return _fairchem_worker(params.model_dump())
+
+
+# ── Ensemble fanout ────────────────────────────────────────────────────
+
+
+def _ls_remote_files(path: str) -> list[str]:
+    """Backend-side helper: list non-directory entries in *path*."""
+    return sorted(
+        f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))
+    )
+
+
+CGFastMCP._fix_module_for_pickle(_ls_remote_files)
+
+
+def _expand_fairchem_ensemble(params: fairchem_input_schema_ensemble) -> list[dict]:
+    """Server-side expansion of an ensemble request into per-file jobs.
+
+    Local mode: enumerates ``input_structure_directory`` on this host.
+    Remote mode: submits a one-shot probe task to the backend to list
+    files under ``remote_structure_directory``, then builds per-file
+    jobs that the worker reads directly from the remote filesystem.
+    """
+    shared = {
+        "output_result_file": params.output_result_file,
+        "driver": params.driver,
+        "model_name": params.model_name,
+        "task_name": params.task_name,
+        "device": params.device,
+        "charge": params.charge,
+        "multiplicity": params.multiplicity,
+        "inference_settings": params.inference_settings,
+        "seed": params.seed,
+        "temperature": params.temperature,
+        "pressure": params.pressure,
+        "fmax": params.fmax,
+        "steps": params.steps,
+        "optimizer": params.optimizer,
+    }
+    base_output = Path(params.output_result_file)
+
+    if params.remote_structure_directory:
+        remote_dir = params.remote_structure_directory
+        mcp._ensure_backend()
+        probe = TaskSpec(
+            task_id="ls_remote_dir",
+            task_type="python",
+            callable=_ls_remote_files,
+            kwargs={"path": remote_dir},
+        )
+        fut = mcp._backend.submit(probe)
+        try:
+            file_names = fut.result(timeout=30)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not list remote directory {remote_dir}: {exc}"
+            ) from exc
+
+        jobs = []
+        for fname in file_names:
+            per_output = make_per_structure_output(Path(fname), base_output)
+            job = {**shared}
+            job["remote_structure_file"] = f"{remote_dir}/{fname}"
+            job["output_result_file"] = str(per_output)
+            jobs.append(job)
+        return jobs
+
+    if not params.input_structure_directory:
+        raise ValueError(
+            "Either input_structure_directory or remote_structure_directory "
+            "must be provided."
+        )
+
+    structure_files, _ = resolve_structure_files(params.input_structure_directory)
+    return [
+        {
+            **shared,
+            "input_structure_file": str(f),
+            "output_result_file": str(make_per_structure_output(f, base_output)),
+        }
+        for f in structure_files
+    ]
+
+
+def run_fairchem_ensemble(params: fairchem_input_schema_ensemble) -> list[dict]:
+    return _expand_fairchem_ensemble(params)
+
+
+# ── Orchestration tools (no backend involvement) ───────────────────────
+
+
+mcp.add_tool(
+    extract_output_json,
+    name="extract_output_json",
+    description="Load simulation results from an output JSON file.",
+)
+
+
+# ── Globus Transfer (registered only when configured) ──────────────────
+
+_transfer_manager = get_transfer_manager()
+if _transfer_manager is not None:
+    register_transfer_tools(mcp, _transfer_manager)
+    logger.info("Registered Globus Transfer tools on FairChem MCP server.")
+
+
+if __name__ == "__main__":
+    import argparse as _ap
+
+    from chemgraph.mcp.server_utils import run_mcp_server
+
+    _parser = _ap.ArgumentParser(add_help=False)
+    _parser.add_argument("--ppn", type=int, default=1,
+                         help="Processes per node for backend tasks")
+    _parser.add_argument("--ngpus-per-process", type=int, default=0,
+                         help="GPUs per process for backend tasks")
+    _args, _remaining = _parser.parse_known_args()
+    sys.argv = [sys.argv[0]] + _remaining
+
+    mcp.tool(
+        name="run_fairchem_single",
+        description="Run a single FairChem/UMA calculation",
+        processes_per_node=_args.ppn,
+        gpus_per_task=_args.ngpus_per_process,
+    )(run_fairchem_single)
+
+    mcp.schema_fanout_tool(
+        name="run_fairchem_ensemble",
+        description=(
+            "Run FairChem/UMA calculations over every structure in a directory. "
+            "Local mode uses input_structure_directory; remote mode uses "
+            "remote_structure_directory (pre-stage files first with "
+            "transfer_files)."
+        ),
+        worker=_fairchem_worker,
+        processes_per_node=_args.ppn,
+        gpus_per_task=_args.ngpus_per_process,
+    )(run_fairchem_ensemble)
+
+    mcp.init_backend(tracker_kwargs={"persist_file": _JOBS_FILE})
+
+    try:
+        run_mcp_server(mcp, default_port=9008)
+    finally:
+        mcp.shutdown_backend()

--- a/src/chemgraph/mcp/globus_transfer_mcp.py
+++ b/src/chemgraph/mcp/globus_transfer_mcp.py
@@ -1,0 +1,65 @@
+"""Dedicated MCP server for Globus Transfer file staging.
+
+The server deliberately exposes transfer orchestration only.  Chemistry and
+simulation tools remain on their existing MCP servers, allowing an agent to
+combine the two services explicitly when it needs to create and then move an
+artifact between sites.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from chemgraph.execution.config import get_transfer_manager
+from chemgraph.execution.globus_transfer import GlobusTransferManager
+from chemgraph.mcp.transfer_tools import register_transfer_tools
+
+
+_REQUIRED_ENV_VARS = (
+    "GLOBUS_TRANSFER_SOURCE_ENDPOINT_ID",
+    "GLOBUS_TRANSFER_DESTINATION_ENDPOINT_ID",
+    "GLOBUS_TRANSFER_DESTINATION_BASE_PATH",
+)
+
+
+def create_globus_transfer_mcp(
+    transfer_manager: GlobusTransferManager | None = None,
+) -> FastMCP:
+    """Create a transfer-only MCP server from explicit or configured settings."""
+
+    manager = (
+        transfer_manager
+        if transfer_manager is not None
+        else get_transfer_manager()
+    )
+    if manager is None:
+        variables = ", ".join(_REQUIRED_ENV_VARS)
+        raise RuntimeError(
+            "Globus Transfer is not configured. Set the corresponding "
+            "[execution.globus_transfer] values in config.toml or export: "
+            f"{variables}."
+        )
+
+    mcp = FastMCP(
+        name="ChemGraph Globus Transfer Tools",
+        instructions="""
+            You stage files between configured Globus collections.
+            Transfer only paths returned by upstream tools; do not invent paths.
+            Wait for successful completion before handing a destination path to
+            another agent. Report transfer failures exactly as returned.
+        """,
+    )
+    register_transfer_tools(mcp, manager)
+    return mcp
+
+
+def main() -> None:
+    """Run the dedicated transfer server."""
+
+    from chemgraph.mcp.server_utils import run_mcp_server
+
+    run_mcp_server(create_globus_transfer_mcp(), default_port=9006)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chemgraph/mcp/pacmof2_mcp_hpc.py
+++ b/src/chemgraph/mcp/pacmof2_mcp_hpc.py
@@ -1,0 +1,208 @@
+"""Backend-agnostic PACMOF2 MCP server.
+
+Uses :class:`~chemgraph.mcp.cg_fastmcp.CGFastMCP`. Tool functions are
+plain computation -- the framework handles backend submission
+(local / parsl / ensemble_launcher / globus_compute), future resolution,
+and async job tracking.
+
+PACMOF2 assigns ML partial atomic charges to MOF CIFs. The ensemble
+expander emits one job per structure and supports both local input
+directories and pre-staged remote directories (mirrors the gRASPA
+server's local/remote modes). PACMOF2 is CPU-only and fast, so the
+default TaskSpec resource hints (single node, no GPU) are used.
+
+Nothing requiring the backend is initialised at import time so worker
+subprocesses (EnsembleLauncher, Globus Compute) can re-import this
+module safely.
+"""
+
+import logging
+import os
+from pathlib import Path
+
+from chemgraph.execution.base import TaskSpec
+from chemgraph.execution.config import get_transfer_manager
+from chemgraph.execution.utils import resolve_structure_files
+from chemgraph.mcp.cg_fastmcp import CGFastMCP
+from chemgraph.mcp.transfer_tools import register_transfer_tools
+from chemgraph.schemas.pacmof2_schema import pacmof2_input_schema_ensemble
+
+logger = logging.getLogger(__name__)
+
+_JOBS_FILE = Path("~/.chemgraph/pacmof2_jobs.json").expanduser()
+
+mcp = CGFastMCP(
+    name="ChemGraph PACMOF2 Tools",
+    instructions="""
+        You expose tools for assigning PACMOF2 machine-learned partial
+        atomic charges to MOF structures (CIF files). The available tools
+        are:
+        1. run_pacmof2_ensemble: assign charges to every CIF in a
+           directory (or list). Local mode uses input_structures; remote
+           mode uses remote_structure_directory (pre-stage files first
+           with transfer_files).
+        2. check_job_status / get_job_results / list_jobs / cancel_job:
+           HPC job batch management. Job state persists across sessions.
+        3. transfer_files / check_transfer_status / list_remote_files
+           (when Globus Transfer is configured): stage input files on the
+           remote HPC filesystem before running ensembles in remote mode.
+
+        Guidelines:
+        - Use each tool only when its input schema matches the user
+          request.
+        - PACMOF2 writes a charged CIF ('{stem}{identifier}.cif') next to
+          each input CIF, with an _atom_site_charge column. In remote mode
+          the output lands on the endpoint's filesystem; pull it back with
+          a transfer tool if needed.
+        - net_charge is 0 for neutral MOFs, an int/float for a charged
+          framework, or a dict for ionic MOFs.
+        - Do not guess numerical values; report tool errors exactly as
+          they occur.
+        - Keep responses compact -- full per-atom charges live in the
+          output CIF; tools return only a summary.
+        - When returning paths, use absolute paths.
+        - When a tool returns status='submitted' with a batch_id, use
+          check_job_status to poll for progress before calling
+          get_job_results. Job state is persisted across sessions.
+    """,
+)
+
+
+# ── Worker (runs on the backend) ───────────────────────────────────────
+
+
+def _pacmof2_worker(job: dict) -> dict:
+    """Assign PACMOF2 charges to a single structure on a backend worker."""
+    from chemgraph.schemas.pacmof2_schema import pacmof2_input_schema
+    from chemgraph.tools.pacmof2_tools import run_pacmof2_core
+
+    job = dict(job)
+    structure = job.pop("_structure_name", None)
+
+    remote_file = job.pop("remote_structure_file", None)
+    if remote_file is not None:
+        job["input_structure_file"] = remote_file
+
+    params = pacmof2_input_schema(**job)
+    result = run_pacmof2_core(params)
+
+    if isinstance(result, dict):
+        merged = {"structure": structure, **result}
+        merged.setdefault("status", "success")
+        return merged
+    return {"structure": structure, "result": result, "status": "success"}
+
+
+# ── Remote directory listing (runs on the backend) ─────────────────────
+
+
+def _ls_remote_files(path: str) -> list[str]:
+    """Backend-side helper: list non-directory entries in *path*."""
+    return sorted(
+        f for f in os.listdir(path) if os.path.isfile(os.path.join(path, f))
+    )
+
+
+# Submitted as a bare ``callable=`` TaskSpec (not via a decorator), so it must
+# be fixed explicitly for pickle-by-reference when run as ``__main__``. Mirrors
+# the equivalent fix in graspa_mcp_hpc.py.
+CGFastMCP._fix_module_for_pickle(_ls_remote_files)
+
+
+# ── Ensemble fanout ────────────────────────────────────────────────────
+
+
+def _expand_pacmof2_ensemble(params: pacmof2_input_schema_ensemble) -> list[dict]:
+    """Server-side expansion of an ensemble request into per-job dicts.
+
+    Local mode: enumerates ``input_structures`` on this host.
+    Remote mode: submits a one-shot probe task to the backend to list
+    files under ``remote_structure_directory``, then builds per-file jobs
+    that the worker reads directly from the remote filesystem.
+    """
+    if params.remote_structure_directory:
+        remote_dir = params.remote_structure_directory
+        mcp._ensure_backend()
+        probe = TaskSpec(
+            task_id="ls_remote_dir",
+            task_type="python",
+            callable=_ls_remote_files,
+            kwargs={"path": remote_dir},
+        )
+        fut = mcp._backend.submit(probe)
+        try:
+            file_names = fut.result(timeout=30)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Could not list remote directory {remote_dir}: {exc}"
+            ) from exc
+
+        file_names = [f for f in file_names if f.lower().endswith(".cif")]
+        if not file_names:
+            raise ValueError(
+                f"No CIF files found under remote directory {remote_dir}."
+            )
+
+        return [
+            {
+                "_structure_name": Path(fname).stem,
+                "remote_structure_file": f"{remote_dir}/{fname}",
+                "identifier": params.identifier,
+                "adjust_charge_method": params.adjust_charge_method,
+                "net_charge": params.net_charge,
+            }
+            for fname in file_names
+        ]
+
+    if not params.input_structures:
+        raise ValueError(
+            "Either input_structures or remote_structure_directory "
+            "must be provided."
+        )
+
+    structure_files, _ = resolve_structure_files(
+        params.input_structures, extensions={".cif"}
+    )
+    return [
+        {
+            "_structure_name": struct_path.stem,
+            "input_structure_file": str(struct_path),
+            "identifier": params.identifier,
+            "adjust_charge_method": params.adjust_charge_method,
+            "net_charge": params.net_charge,
+        }
+        for struct_path in structure_files
+    ]
+
+
+@mcp.schema_fanout_tool(
+    name="run_pacmof2_ensemble",
+    description=(
+        "Assign PACMOF2 ML partial atomic charges to every CIF in a "
+        "directory (or list). Local mode uses input_structures; remote "
+        "mode uses remote_structure_directory (pre-stage files first with "
+        "transfer_files)."
+    ),
+    worker=_pacmof2_worker,
+)
+def run_pacmof2_ensemble(params: pacmof2_input_schema_ensemble) -> list[dict]:
+    return _expand_pacmof2_ensemble(params)
+
+
+# ── Globus Transfer (registered only when configured) ──────────────────
+
+_transfer_manager = get_transfer_manager()
+if _transfer_manager is not None:
+    register_transfer_tools(mcp, _transfer_manager)
+    logger.info("Registered Globus Transfer tools on PACMOF2 MCP server.")
+
+
+if __name__ == "__main__":
+    from chemgraph.mcp.server_utils import run_mcp_server
+
+    mcp.init_backend(tracker_kwargs={"persist_file": _JOBS_FILE})
+
+    try:
+        run_mcp_server(mcp, default_port=9009)
+    finally:
+        mcp.shutdown_backend()

--- a/src/chemgraph/schemas/fairchem_schema.py
+++ b/src/chemgraph/schemas/fairchem_schema.py
@@ -1,0 +1,209 @@
+"""Pydantic schemas for FairChem/UMA simulations.
+
+These schemas define the API contract for FairChem single and ensemble
+calculations. They mirror :mod:`chemgraph.schemas.mace_parsl_schema` but
+carry the FairChem/UMA-specific fields (model name, task, charge,
+multiplicity, ...) drawn from
+:class:`chemgraph.schemas.calculators.fairchem_calc.FAIRChemCalc`.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from pydantic import BaseModel, Field
+
+
+class fairchem_input_schema(BaseModel):
+    input_structure_file: str = Field(
+        description="Path to the input coordinate file (e.g., CIF, XYZ, POSCAR) containing the atomic structure for the simulation."
+    )
+    output_result_file: str = Field(
+        default="output.json",
+        description="Path to a JSON file where simulation results will be saved.",
+    )
+    driver: str | None = Field(
+        default=None,
+        description="Specifies the type of simulation to run. Options: 'energy' for single-point energy calculations, 'opt' for geometry optimization, 'vib' for vibrational frequency analysis, and 'thermo' for thermochemical properties (including enthalpy, entropy, and Gibbs free energy).",
+    )
+    model_name: str = Field(
+        default="uma-s-1p1",
+        description="FairChem/UMA inference model name (NOT the calculator type). "
+        "Options: 'uma-s-1p1' and 'uma-m-1'. Default is 'uma-s-1p1'.",
+    )
+    task_name: Optional[str] = Field(
+        default=None,
+        description="Prediction task for the model head. Options: 'omol', 'omat', 'oc20', 'odac', or 'omc'.",
+    )
+    device: str = Field(
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        description="Device to run the FairChem calculation on. Options are 'cpu' or 'cuda'.",
+    )
+    charge: Optional[int] = Field(
+        default=0,
+        description="Total system charge. Default is 0.",
+    )
+    multiplicity: Optional[int] = Field(
+        default=1,
+        description="Spin multiplicity (2S+1) of the system. Default is 1 (singlet).",
+        ge=1,
+    )
+    inference_settings: str = Field(
+        default="default",
+        description="Settings for inference. Can be 'default' or 'turbo'.",
+    )
+    seed: int = Field(
+        default=42,
+        description="Random seed for inference reproducibility.",
+    )
+    temperature: float = Field(
+        default=298.15,
+        description="Temperature for thermo property calculations in Kelvin (K).",
+    )
+    pressure: float = Field(
+        default=101325.0,
+        description="Pressure for thermo property calculations in Pascal (Pa).",
+    )
+    fmax: float = Field(
+        default=0.01,
+        description="The convergence criterion for forces (in eV/Å). Optimization stops when all force components are smaller than this value.",
+    )
+    steps: int = Field(
+        default=1000,
+        description="Maximum number of optimization steps. The optimization will terminate if this number is reached, even if forces haven't converged to fmax.",
+    )
+    optimizer: str = Field(
+        default="lbfgs",
+        description="The optimization algorithm used for geometry optimization. Options are 'bfgs', 'lbfgs', 'gpmin', 'fire', 'mdmin'",
+    )
+
+
+class fairchem_input_schema_ensemble(BaseModel):
+    input_structure_directory: str = Field(
+        default="",
+        description="Path to a local folder of input structures. Required unless remote_structure_directory is provided.",
+    )
+    remote_structure_directory: str | None = Field(
+        default=None,
+        description=(
+            "Path to pre-staged structure files on the remote HPC filesystem. "
+            "When provided, workers read structures directly from this path "
+            "instead of using inline structure embedding. Use the "
+            "transfer_files tool to stage files first, then pass the "
+            "remote directory here."
+        ),
+    )
+    output_result_file: str = Field(
+        default="output.json",
+        description="Path to a JSON file where simulation results will be saved.",
+    )
+    driver: str | None = Field(
+        default=None,
+        description="Specifies the type of simulation to run. Options: 'energy' for single-point energy calculations, 'opt' for geometry optimization, 'vib' for vibrational frequency analysis, and 'thermo' for thermochemical properties (including enthalpy, entropy, and Gibbs free energy).",
+    )
+    model_name: str = Field(
+        default="uma-s-1p1",
+        description="FairChem/UMA inference model name (NOT the calculator type). "
+        "Options: 'uma-s-1p1' and 'uma-m-1'. Default is 'uma-s-1p1'.",
+    )
+    task_name: Optional[str] = Field(
+        default=None,
+        description="Prediction task for the model head. Options: 'omol', 'omat', 'oc20', 'odac', or 'omc'.",
+    )
+    device: str = Field(
+        default="cuda" if torch.cuda.is_available() else "cpu",
+        description="Device to run the FairChem calculation on. Options are 'cpu' or 'cuda'.",
+    )
+    charge: Optional[int] = Field(
+        default=0,
+        description="Total system charge. Default is 0.",
+    )
+    multiplicity: Optional[int] = Field(
+        default=1,
+        description="Spin multiplicity (2S+1) of the system. Default is 1 (singlet).",
+        ge=1,
+    )
+    inference_settings: str = Field(
+        default="default",
+        description="Settings for inference. Can be 'default' or 'turbo'.",
+    )
+    seed: int = Field(
+        default=42,
+        description="Random seed for inference reproducibility.",
+    )
+    temperature: float = Field(
+        default=298.15,
+        description="Temperature for thermo property calculations in Kelvin (K).",
+    )
+    pressure: float = Field(
+        default=101325.0,
+        description="Pressure for thermo property calculations in Pascal (Pa).",
+    )
+    fmax: float = Field(
+        default=0.01,
+        description="The convergence criterion for forces (in eV/Å). Optimization stops when all force components are smaller than this value.",
+    )
+    steps: int = Field(
+        default=1000,
+        description="Maximum number of optimization steps. The optimization will terminate if this number is reached, even if forces haven't converged to fmax.",
+    )
+    optimizer: str = Field(
+        default="lbfgs",
+        description="The optimization algorithm used for geometry optimization. Options are 'bfgs', 'lbfgs', 'gpmin', 'fire', 'mdmin'",
+    )
+
+
+class fairchem_output_schema(BaseModel):
+    final_structure_file: str = Field(
+        description="Path to the final coordinate file (e.g., CIF, XYZ, POSCAR) containing the atomic structure for the simulation."
+    )
+    output_result_file: str = Field(
+        description="Path to a JSON file where simulation results is saved.",
+    )
+    model_name: str | None = Field(
+        default=None,
+        description="FairChem/UMA inference model name. Default is 'uma-s-1p1'.",
+    )
+    device: str = Field(
+        default="cpu",
+        description="Device to run the FairChem calculation on. Options are 'cpu' or 'cuda'.",
+    )
+    temperature: float = Field(
+        default=298.15,
+        description="Temperature for thermo property calculations in Kelvin (K).",
+    )
+    pressure: float = Field(
+        default=101325.0,
+        description="Pressure for thermo property calculations in Pascal (Pa).",
+    )
+    fmax: float = Field(
+        default=0.01,
+        description="The convergence criterion for forces (in eV/Å). Optimization stops when all force components are smaller than this value.",
+    )
+    steps: int = Field(
+        default=1000,
+        description="Maximum number of optimization steps. The optimization will terminate if this number is reached, even if forces haven't converged to fmax.",
+    )
+    energy: float = Field(
+        description="The electronic energy of the system in eV",
+    )
+    success: bool = Field(
+        description="Status of the simulation",
+    )
+    vibrational_frequencies: dict = Field(
+        default={},
+        description="Vibrational frequencies (in cm-1) and energies (in eV).",
+    )
+    thermochemistry: dict = Field(
+        default={},
+        description="Thermochemistry data in eV.",
+    )
+    error: str = Field(
+        default="",
+        description="Error captured during the simulation",
+    )
+    wall_time: float | None = Field(
+        default=None,
+        description="Total wall time (in seconds) taken to complete the simulation.",
+    )

--- a/src/chemgraph/schemas/pacmof2_schema.py
+++ b/src/chemgraph/schemas/pacmof2_schema.py
@@ -1,0 +1,64 @@
+# PACMOF2 predicts partial atomic charges for MOFs using ML (scikit-learn).
+# It is a standalone CIF-in/CIF-out engine (not an ASE calculator), so the
+# schemas mirror the gRASPA schemas but drop the temperature/pressure axis.
+from typing import Union
+
+from pydantic import BaseModel, Field
+
+
+class pacmof2_input_schema(BaseModel):
+    input_structure_file: str = Field(
+        description="Path to the input CIF file to assign partial charges to."
+    )
+    identifier: str = Field(
+        default="_pacmof",
+        description=(
+            "Suffix for the output CIF filename, written as "
+            "'{stem}{identifier}.cif' next to the input CIF."
+        ),
+    )
+    adjust_charge_method: str = Field(
+        default="mean",
+        description=(
+            "How residual charge is redistributed so the framework meets the "
+            "target net charge. Either 'mean' or 'magnitude'."
+        ),
+    )
+    net_charge: Union[int, float, dict] = Field(
+        default=0,
+        description=(
+            "Target net charge of the framework. Use 0 for neutral MOFs, an "
+            "int/float for a charged framework, or a dict mapping per-site "
+            "charges for ionic MOFs."
+        ),
+    )
+
+
+class pacmof2_input_schema_ensemble(BaseModel):
+    input_structures: Union[str, list[str]] = Field(
+        default="",
+        description=(
+            "Path to a directory of CIF files OR a specific list of file paths. "
+            "Required unless remote_structure_directory is provided."
+        ),
+    )
+    remote_structure_directory: str | None = Field(
+        default=None,
+        description=(
+            "Path to pre-staged CIF files on the remote HPC filesystem. "
+            "When provided, workers read structures directly from this path. "
+            "Use the transfer_files tool to stage files first."
+        ),
+    )
+    identifier: str = Field(
+        default="_pacmof",
+        description="Suffix for each output CIF filename ('{stem}{identifier}.cif').",
+    )
+    adjust_charge_method: str = Field(
+        default="mean",
+        description="Charge adjustment method applied to every structure ('mean' or 'magnitude').",
+    )
+    net_charge: Union[int, float, dict] = Field(
+        default=0,
+        description="Target net charge applied to every structure in the batch.",
+    )

--- a/src/chemgraph/tools/fairchem_tools.py
+++ b/src/chemgraph/tools/fairchem_tools.py
@@ -1,0 +1,100 @@
+"""FairChem/UMA helpers.
+
+``run_fairchem_core`` converts the FairChem-specific input schema to
+:class:`ASEInputSchema` and delegates to
+:func:`chemgraph.tools.ase_core.run_ase_core`, mirroring
+:func:`chemgraph.tools.parsl_tools.run_mace_core`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.fairchem_schema import (
+    fairchem_input_schema,
+    fairchem_output_schema,
+)
+from chemgraph.tools.ase_core import run_ase_core
+
+# Re-export schemas so existing ``from chemgraph.tools.fairchem_tools import …``
+# statements continue to work.
+__all__ = [
+    "fairchem_input_schema",
+    "fairchem_output_schema",
+    "run_fairchem_core",
+    "extract_output_json",
+]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Core execution — delegates to the unified implementation
+# ---------------------------------------------------------------------------
+
+
+def _fairchem_input_to_ase_input(params: fairchem_input_schema) -> ASEInputSchema:
+    """Convert a FairChem-specific input schema to a generic ASEInputSchema.
+
+    Parameters
+    ----------
+    params : fairchem_input_schema
+        FairChem-specific tool input.
+
+    Returns
+    -------
+    ASEInputSchema
+        Equivalent generic ASE input carrying a ``FAIRChem`` calculator.
+    """
+    return ASEInputSchema(
+        input_structure_file=params.input_structure_file,
+        output_results_file=params.output_result_file,
+        driver=params.driver,
+        optimizer=params.optimizer,
+        calculator={
+            "calculator_type": "FAIRChem",
+            "model_name": params.model_name,
+            "task_name": params.task_name,
+            "device": params.device,
+            "charge": params.charge,
+            "multiplicity": params.multiplicity,
+            "inference_settings": params.inference_settings,
+            "seed": params.seed,
+        },
+        fmax=params.fmax,
+        steps=params.steps,
+        temperature=params.temperature,
+        pressure=params.pressure,
+    )
+
+
+def run_fairchem_core(params: fairchem_input_schema) -> dict:
+    """Run a single FairChem/UMA calculation.
+
+    Converts the FairChem-specific schema to :class:`ASEInputSchema` and
+    delegates to :func:`chemgraph.tools.ase_core.run_ase_core`.
+
+    Parameters
+    ----------
+    params : fairchem_input_schema
+        FairChem-specific input parameters.
+
+    Returns
+    -------
+    dict
+        Simulation result payload.
+    """
+    ase_params = _fairchem_input_to_ase_input(params)
+    return run_ase_core(ase_params)
+
+
+def extract_output_json(json_file: str) -> dict:
+    """Load simulation results from a JSON file produced by run_fairchem."""
+    import json
+
+    try:
+        with open(json_file, "r") as f:
+            ret = json.load(f)
+    except Exception:
+        ret = {}
+    return ret

--- a/src/chemgraph/tools/pacmof2_core.py
+++ b/src/chemgraph/tools/pacmof2_core.py
@@ -1,0 +1,253 @@
+"""Pure-Python PACMOF2 charge-assignment helpers (no LangChain / MCP decorators).
+
+PACMOF2 predicts partial atomic charges for MOFs using machine learning
+(scikit-learn models). It is a standalone CIF-in/CIF-out engine, not an
+ASE calculator. This module wraps ``pacmof2.get_charges`` and reads the
+resulting charged CIF back into a compact summary.
+
+``pacmof2`` (and its hard-pinned ``scikit-learn==1.3.2``) is imported
+lazily inside :func:`run_pacmof2_core` so ChemGraph imports cleanly in
+environments where PACMOF2 is not installed -- e.g. when the actual charge
+assignment runs on a remote globus_compute endpoint with its own env.
+
+Used by the LangChain ``@tool`` wrapper in :mod:`pacmof2_tools` and the
+MCP wrapper in :mod:`chemgraph.mcp.pacmof2_mcp_hpc`.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Optional, Union
+
+from ase.io import read as ase_read
+
+from chemgraph.schemas.pacmof2_schema import pacmof2_input_schema
+
+
+# ---------------------------------------------------------------------------
+# Output parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_atom_site_charges(cif_path: str) -> list[float]:
+    """Fallback parser for the ``_atom_site_charge`` column of a CIF.
+
+    Used when neither ASE nor pymatgen surface per-atom charges. Locates
+    the ``_atom_site_charge`` position within the ``loop_`` header and
+    reads that column from each atom-site row.
+    """
+    charges: list[float] = []
+    with open(cif_path, "r") as fh:
+        lines = fh.readlines()
+
+    # Find the loop_ block whose headers include _atom_site_charge.
+    i = 0
+    n = len(lines)
+    while i < n:
+        if lines[i].strip() == "loop_":
+            headers: list[str] = []
+            j = i + 1
+            while j < n and lines[j].strip().startswith("_"):
+                headers.append(lines[j].strip())
+                j += 1
+            if "_atom_site_charge" in headers:
+                charge_idx = headers.index("_atom_site_charge")
+                for row in lines[j:]:
+                    row = row.strip()
+                    if not row or row.startswith("_") or row == "loop_":
+                        break
+                    fields = row.split()
+                    if len(fields) <= charge_idx:
+                        break
+                    try:
+                        charges.append(float(fields[charge_idx]))
+                    except ValueError:
+                        break
+                return charges
+            i = j
+        else:
+            i += 1
+    return charges
+
+
+def _read_pacmof2_output(
+    output_cif: str,
+    input_cif: Optional[str] = None,
+    net_charge: Union[int, float, dict] = 0,
+) -> dict:
+    """Read a PACMOF2 output CIF and return a compact charge summary.
+
+    Full per-atom charges remain in the output CIF; this returns only an
+    aggregate summary for the agent.
+
+    Parameters
+    ----------
+    output_cif : str
+        Path to the charged CIF written by PACMOF2.
+    input_cif : str, optional
+        Path to the original input CIF (recorded for reference).
+    net_charge : int | float | dict
+        Target net charge requested for the assignment.
+
+    Returns
+    -------
+    dict
+        Summary including status, output path, per-element mean charges,
+        and the sum of charges.
+    """
+    result = {
+        "status": "failure",
+        "output_cif_path": None,
+        "input_cif_path": input_cif,
+        "n_atoms": 0,
+        "net_charge_input": net_charge,
+        "sum_of_charges": None,
+        "per_element_mean_charge": {},
+        "charge_range": None,
+    }
+
+    if not Path(output_cif).exists():
+        return result
+
+    try:
+        atoms = ase_read(output_cif)
+        symbols = list(atoms.get_chemical_symbols())
+        charges = list(atoms.get_initial_charges())
+
+        # ASE may return an all-zero array when it doesn't parse the
+        # _atom_site_charge column; fall back to a manual parse.
+        if not any(charges):
+            parsed = _parse_atom_site_charges(output_cif)
+            if parsed:
+                charges = parsed
+
+        if not charges or len(charges) != len(symbols):
+            raise ValueError(
+                f"Could not read per-atom charges from {output_cif}"
+            )
+
+        per_element_sum: dict[str, float] = defaultdict(float)
+        per_element_count: dict[str, int] = defaultdict(int)
+        for sym, q in zip(symbols, charges):
+            per_element_sum[sym] += q
+            per_element_count[sym] += 1
+
+        per_element_mean = {
+            sym: round(per_element_sum[sym] / per_element_count[sym], 4)
+            for sym in per_element_sum
+        }
+
+        result["status"] = "success"
+        result["output_cif_path"] = str(Path(output_cif).resolve())
+        result["n_atoms"] = len(symbols)
+        result["sum_of_charges"] = round(float(sum(charges)), 4)
+        result["per_element_mean_charge"] = per_element_mean
+        result["charge_range"] = [
+            round(float(min(charges)), 4),
+            round(float(max(charges)), 4),
+        ]
+    except Exception as e:
+        print(f"Error parsing PACMOF2 output in {output_cif}: {e}")
+        result["status"] = "failure"
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Mock (for testing without PACMOF2 installed)
+# ---------------------------------------------------------------------------
+
+
+def mock_pacmof2(params: pacmof2_input_schema) -> dict:
+    """Return mock PACMOF2 results for testing without the pacmof2 package.
+
+    Parameters
+    ----------
+    params : pacmof2_input_schema
+        Input parameters (used only for the output path and net charge).
+
+    Returns
+    -------
+    dict
+        A plausible charge summary matching the shape of the real result.
+    """
+    time.sleep(random.uniform(1, 3))
+
+    cif_path = Path(params.input_structure_file)
+    output_cif = cif_path.with_name(f"{cif_path.stem}{params.identifier}.cif")
+
+    target = params.net_charge if isinstance(params.net_charge, (int, float)) else 0
+    return {
+        "status": "success",
+        "output_cif_path": str(output_cif.resolve()),
+        "input_cif_path": str(cif_path),
+        "n_atoms": 4,
+        "net_charge_input": params.net_charge,
+        "sum_of_charges": round(float(target), 4),
+        "per_element_mean_charge": {
+            "O": round(random.uniform(-0.8, -0.4), 4),
+            "Zn": round(random.uniform(0.6, 1.2), 4),
+            "C": round(random.uniform(-0.2, 0.4), 4),
+        },
+        "charge_range": [-0.8, 1.2],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core runner
+# ---------------------------------------------------------------------------
+
+
+def run_pacmof2_core(params: pacmof2_input_schema) -> dict:
+    """Assign PACMOF2 partial atomic charges to a single MOF CIF.
+
+    Parameters
+    ----------
+    params : pacmof2_input_schema
+        Input parameters for the charge assignment.
+
+    Returns
+    -------
+    dict
+        Parsed charge summary from :func:`_read_pacmof2_output`.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the input CIF does not exist.
+    RuntimeError
+        If the ``pacmof2`` package is not installed.
+    """
+    cif_path = Path(params.input_structure_file).resolve()
+    if not cif_path.exists():
+        raise FileNotFoundError(f"CIF file does not exist: {cif_path}")
+
+    output_cif = cif_path.with_name(f"{cif_path.stem}{params.identifier}.cif")
+
+    try:
+        from pacmof2 import get_charges
+    except ImportError as e:
+        raise RuntimeError(
+            "PACMOF2 is not installed. Install it from source "
+            "(`pip install -e .` from github.com/snurr-group/pacmof2), or run "
+            "this tool on a globus_compute endpoint whose environment has "
+            "pacmof2 and scikit-learn==1.3.2."
+        ) from e
+
+    get_charges(
+        path_to_cif=str(cif_path),
+        output_path=str(output_cif.parent),
+        identifier=params.identifier,
+        multiple_cifs=False,
+        adjust_charge_method=params.adjust_charge_method,
+        net_charge=params.net_charge,
+    )
+
+    return _read_pacmof2_output(
+        output_cif=str(output_cif),
+        input_cif=str(cif_path),
+        net_charge=params.net_charge,
+    )

--- a/src/chemgraph/tools/pacmof2_tools.py
+++ b/src/chemgraph/tools/pacmof2_tools.py
@@ -1,0 +1,51 @@
+"""LangChain ``@tool`` wrapper for PACMOF2 partial-charge assignment.
+
+Delegates to the pure-Python implementation in
+:mod:`chemgraph.tools.pacmof2_core`.
+"""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+from chemgraph.schemas.pacmof2_schema import pacmof2_input_schema
+from chemgraph.tools.pacmof2_core import (
+    # Re-export core helpers so the MCP worker can import them from here.
+    _read_pacmof2_output,
+    mock_pacmof2,
+    run_pacmof2_core,
+)
+
+__all__ = [
+    "_read_pacmof2_output",
+    "mock_pacmof2",
+    "run_pacmof2_core",
+    "run_pacmof2",
+]
+
+
+@tool
+def run_pacmof2(pacmof2_input: pacmof2_input_schema) -> dict:
+    """Assign ML partial atomic charges to a MOF CIF using PACMOF2.
+
+    Returns a compact summary (output CIF path, per-element mean charges,
+    net/sum of charges). The full per-atom charges are written to the
+    output CIF's ``_atom_site_charge`` column.
+
+    Parameters
+    ----------
+    pacmof2_input : pacmof2_input_schema
+        Input parameters for the charge assignment.
+
+    Returns
+    -------
+    dict
+        Charge summary from the core engine.
+    """
+    result = run_pacmof2_core(pacmof2_input)
+
+    if result["status"] == "success":
+        return result
+    raise RuntimeError(
+        f"PACMOF2 charge assignment failed for {pacmof2_input.input_structure_file}"
+    )

--- a/tests/test_fairchem.py
+++ b/tests/test_fairchem.py
@@ -1,0 +1,109 @@
+"""Tests for the FairChem/UMA tool stack.
+
+Mirrors ``tests/test_faircalc.py`` but exercises the dedicated
+``run_fairchem`` surface (schema + core adapter). The schema->ASE
+conversion test runs without FairChem installed; the end-to-end runs
+are skipped unless ``fairchem.core`` is available (and the UMA model is
+HF-gated, so they also require authentication at run time).
+"""
+
+from pathlib import Path
+import importlib.util
+import json
+
+import pytest
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.fairchem_schema import fairchem_input_schema
+from chemgraph.tools.fairchem_tools import (
+    _fairchem_input_to_ase_input,
+    run_fairchem_core,
+)
+
+TEST_DIR = Path(__file__).parent
+
+
+def is_fairchem_installed():
+    try:
+        return importlib.util.find_spec("fairchem.core") is not None
+    except (ImportError, ModuleNotFoundError):
+        return False
+
+
+@pytest.fixture
+def base_fairchem_input():
+    """Base fixture for FairChem input with common parameters."""
+    return {
+        "input_structure_file": str(TEST_DIR / "water.xyz"),
+        "output_result_file": str(TEST_DIR / "water_output.json"),
+        "device": "cpu",
+    }
+
+
+def test_fairchem_schema_defaults(base_fairchem_input):
+    """The FairChem input schema builds with sensible UMA defaults
+    (does not require fairchem to be installed)."""
+    params = fairchem_input_schema(driver="energy", **base_fairchem_input)
+
+    assert params.model_name == "uma-s-1p1"
+    assert params.inference_settings == "default"
+    assert params.charge == 0
+    assert params.multiplicity == 1
+    assert params.driver == "energy"
+    assert params.output_result_file == base_fairchem_input["output_result_file"]
+
+
+@pytest.mark.skipif(not is_fairchem_installed(), reason="FairChem is not installed")
+def test_schema_to_ase_conversion(base_fairchem_input):
+    """The FairChem schema converts to a valid ASEInputSchema carrying a
+    FAIRChem calculator. Requires fairchem installed because ASEInputSchema
+    only permits calculators whose engine is available."""
+    params = fairchem_input_schema(driver="energy", **base_fairchem_input)
+    ase_input = _fairchem_input_to_ase_input(params)
+
+    assert isinstance(ase_input, ASEInputSchema)
+    assert ase_input.driver == "energy"
+    assert ase_input.input_structure_file == base_fairchem_input["input_structure_file"]
+    # output_result_file -> output_results_file
+    assert ase_input.output_results_file == base_fairchem_input["output_result_file"]
+
+    calc = ase_input.calculator
+    calc_type = (
+        calc.get("calculator_type")
+        if isinstance(calc, dict)
+        else getattr(calc, "calculator_type", None)
+    )
+    assert "fairchem" in str(calc_type).lower()
+    model_name = (
+        calc.get("model_name")
+        if isinstance(calc, dict)
+        else getattr(calc, "model_name", None)
+    )
+    assert model_name == "uma-s-1p1"
+
+
+@pytest.mark.skipif(not is_fairchem_installed(), reason="FairChem is not installed")
+def test_run_fairchem_energy(base_fairchem_input):
+    """Test a single-point energy calculation via run_fairchem_core."""
+    params = fairchem_input_schema(driver="energy", **base_fairchem_input)
+    result = run_fairchem_core(params)
+
+    assert isinstance(result, dict)
+    assert result["single_point_energy"] is not None
+    assert result["unit"] == "eV"
+
+
+@pytest.mark.skipif(not is_fairchem_installed(), reason="FairChem is not installed")
+def test_run_fairchem_opt(base_fairchem_input):
+    """Test geometry optimization via run_fairchem_core."""
+    params = fairchem_input_schema(driver="opt", **base_fairchem_input)
+    result = run_fairchem_core(params)
+
+    assert isinstance(result, dict)
+    assert result["status"]
+
+    output_file = Path(base_fairchem_input["output_result_file"])
+    assert output_file.exists()
+    with open(output_file) as f:
+        data = json.load(f)
+    assert data["simulation_input"]["driver"] == "opt"

--- a/tests/test_pacmof2_tools.py
+++ b/tests/test_pacmof2_tools.py
@@ -1,0 +1,100 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from chemgraph.tools.pacmof2_tools import (
+    mock_pacmof2,
+    run_pacmof2_core,
+)
+from chemgraph.schemas.pacmof2_schema import pacmof2_input_schema
+
+
+@pytest.fixture
+def mock_cif(tmp_path):
+    """Creates a dummy CIF file for testing."""
+    cif_file = tmp_path / "test_mof.cif"
+    # Minimal CIF content for ase_read to not crash.
+    cif_file.write_text(
+        "data_test\n_cell_length_a 10\n_cell_length_b 10\n_cell_length_c 10\n"
+        "_cell_angle_alpha 90\n_cell_angle_beta 90\n_cell_angle_gamma 90\n"
+        "loop_\n_atom_site_label\n_atom_site_type_symbol\n"
+        "_atom_site_fract_x\n_atom_site_fract_y\n_atom_site_fract_z\n"
+        "C C 0 0 0"
+    )
+    return cif_file
+
+
+def test_run_pacmof2_core_execution(mock_cif):
+    """run_pacmof2_core should call get_charges with resolved args and parse output."""
+    params = pacmof2_input_schema(
+        input_structure_file=str(mock_cif),
+        identifier="_pacmof",
+        adjust_charge_method="mean",
+        net_charge=0,
+    )
+
+    # Inject a fake pacmof2 module so the lazy `from pacmof2 import get_charges`
+    # inside run_pacmof2_core resolves without the real package installed.
+    fake_pacmof2 = MagicMock()
+    expected_summary = {"status": "success", "output_cif_path": "x", "sum_of_charges": 0.0}
+
+    with patch.dict(sys.modules, {"pacmof2": fake_pacmof2}), patch(
+        "chemgraph.tools.pacmof2_core._read_pacmof2_output"
+    ) as mock_parser:
+        mock_parser.return_value = expected_summary
+        result = run_pacmof2_core(params)
+
+    # get_charges called once with the resolved path and passthrough params.
+    fake_pacmof2.get_charges.assert_called_once()
+    call_kwargs = fake_pacmof2.get_charges.call_args.kwargs
+    assert call_kwargs["path_to_cif"] == str(mock_cif.resolve())
+    assert call_kwargs["identifier"] == "_pacmof"
+    assert call_kwargs["adjust_charge_method"] == "mean"
+    assert call_kwargs["net_charge"] == 0
+    assert call_kwargs["multiple_cifs"] is False
+
+    # Parser receives the derived output CIF path.
+    parser_kwargs = mock_parser.call_args.kwargs
+    assert parser_kwargs["output_cif"].endswith("test_mof_pacmof.cif")
+    assert result == expected_summary
+
+
+def test_net_charge_dict_passthrough(mock_cif):
+    """An ionic-MOF net_charge dict should reach get_charges unchanged."""
+    net = {"O": -0.5}
+    params = pacmof2_input_schema(
+        input_structure_file=str(mock_cif), net_charge=net
+    )
+    fake_pacmof2 = MagicMock()
+    with patch.dict(sys.modules, {"pacmof2": fake_pacmof2}), patch(
+        "chemgraph.tools.pacmof2_core._read_pacmof2_output",
+        return_value={"status": "success"},
+    ):
+        run_pacmof2_core(params)
+    assert fake_pacmof2.get_charges.call_args.kwargs["net_charge"] == net
+
+
+def test_mock_pacmof2(mock_cif):
+    """mock_pacmof2 returns a plausible summary without pacmof2 installed."""
+    params = pacmof2_input_schema(input_structure_file=str(mock_cif))
+    result = mock_pacmof2(params)
+    assert result["status"] == "success"
+    assert result["output_cif_path"].endswith("test_mof_pacmof.cif")
+    assert isinstance(result["per_element_mean_charge"], dict)
+
+
+def test_missing_cif_raises():
+    """A non-existent input CIF should raise FileNotFoundError."""
+    params = pacmof2_input_schema(input_structure_file="/no/such/file.cif")
+    with pytest.raises(FileNotFoundError):
+        run_pacmof2_core(params)
+
+
+def test_import_error_message(mock_cif):
+    """When pacmof2 is not importable, a clear RuntimeError is raised."""
+    params = pacmof2_input_schema(input_structure_file=str(mock_cif))
+    # Ensure importing pacmof2 fails even if it happens to be installed.
+    with patch.dict(sys.modules, {"pacmof2": None}):
+        with pytest.raises(RuntimeError, match="PACMOF2 is not installed"):
+            run_pacmof2_core(params)

--- a/tests/test_transfer_tools.py
+++ b/tests/test_transfer_tools.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from chemgraph.mcp.globus_transfer_mcp import create_globus_transfer_mcp
+from chemgraph.mcp.transfer_tools import register_transfer_tools
+
+
+@dataclass
+class _TransferResult:
+    task_id: str
+    remote_directory: str
+    file_mapping: dict[str, str]
+
+
+class _FakeTransferManager:
+    def __init__(self) -> None:
+        self.local_paths: list[str] = []
+
+    def transfer_files(self, *, local_paths, remote_subdir=None, label=None):
+        self.local_paths = local_paths
+        return _TransferResult(
+            task_id="task-1",
+            remote_directory="/destination/demo",
+            file_mapping={path: f"/destination/demo/{path.rsplit('/', 1)[-1]}" for path in local_paths},
+        )
+
+    def wait_for_transfer(self, task_id):
+        assert task_id == "task-1"
+        return {
+            "status": "SUCCEEDED",
+            "bytes_transferred": 42,
+            "files_transferred": 1,
+        }
+
+    def check_transfer_status(self, task_id):
+        return {"task_id": task_id, "status": "ACTIVE"}
+
+    def list_remote_directory(self, path):
+        return [{"name": "ethanol.xyz", "type": "file", "size": 42}]
+
+
+class _FakeMCP:
+    def __init__(self) -> None:
+        self.tools = {}
+
+    def add_tool(self, function, *, name, description):
+        self.tools[name] = function
+
+
+def test_transfer_tool_returns_destination_mapping_after_wait(tmp_path):
+    source = tmp_path / "ethanol.xyz"
+    source.write_text("1\nethanol\nH 0 0 0\n", encoding="utf-8")
+    manager = _FakeTransferManager()
+    mcp = _FakeMCP()
+    register_transfer_tools(mcp, manager)
+
+    result = mcp.tools["transfer_files"](str(source), wait=True)
+
+    resolved = str(source.resolve())
+    assert manager.local_paths == [resolved]
+    assert result["status"] == "completed"
+    assert result["file_mapping"] == {
+        resolved: "/destination/demo/ethanol.xyz"
+    }
+    assert result["files_transferred"] == 1
+
+
+def test_register_transfer_tools_exposes_complete_staging_surface():
+    mcp = _FakeMCP()
+    register_transfer_tools(mcp, _FakeTransferManager())
+
+    assert set(mcp.tools) == {
+        "transfer_files",
+        "check_transfer_status",
+        "list_remote_files",
+    }
+
+
+def test_dedicated_transfer_mcp_exposes_only_transfer_tools():
+    mcp = create_globus_transfer_mcp(_FakeTransferManager())
+
+    assert set(mcp._tool_manager._tools) == {
+        "transfer_files",
+        "check_transfer_status",
+        "list_remote_files",
+    }
+
+
+def test_dedicated_transfer_mcp_requires_configuration(monkeypatch):
+    monkeypatch.setattr(
+        "chemgraph.mcp.globus_transfer_mcp.get_transfer_manager",
+        lambda: None,
+    )
+
+    with pytest.raises(RuntimeError, match="GLOBUS_TRANSFER_SOURCE_ENDPOINT_ID"):
+        create_globus_transfer_mcp()


### PR DESCRIPTION
## Summary

Adds three new HPC / execution-layer capabilities and wires them into the demo harness:

- **PACMOF2 partial-charge tool** — ML partial atomic charges for MOFs, following the gRASPA three-layer pattern: pure core (`tools/pacmof2_core.py`), LangChain `@tool` (`tools/pacmof2_tools.py`), and a backend-agnostic `CGFastMCP` server with ensemble fanout (`mcp/pacmof2_mcp_hpc.py`, port 9009). Lazy imports; an optional dep group isolates the hard `scikit-learn==1.3.2` pin.
- **FairChem/UMA MCP server + tool** — `run_fairchem_core` delegates to `run_ase_core` (mirrors the MACE pattern) so results share `ASEOutputSchema`. A pre-submit transport hook handles local-file embedding and pre-staged remote passthrough. Uses the existing `[uma]` optional dependency.
- **Globus Transfer MCP server** — wraps the existing `GlobusTransferManager` / `transfer_tools` as a dedicated file-staging server so agents can stage inputs to a remote HPC filesystem before running ensembles.
- **Demo harness** — adds `fairchem` and `pacmof2` workloads to the `scripts/demo/` registry (builders, extractors, prompts, `run_crux_demo.sh` flags), and fixes `write_csv` to skip failed (`None`) rows so an all-failed batch writes a valid empty CSV instead of crashing.

Scope: 4 commits, 20 files, +2044 / -23.

## Related issues

_None._

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check` on all changed files — passes.
- New unit tests: `tests/test_pacmof2_tools.py` (5), `tests/test_fairchem.py` (4), `tests/test_transfer_tools.py` (4) — **10 passed, 3 skipped** (skips are the auth/HF-gated FairChem/Globus live paths). Coverage: core happy paths, schema→ASE conversion, ensemble config, and error cases.
- Full tracked suite (`pytest tests/ -k "not tblite"`): 550 passed.

## Checklist

- [x] PR is focused on a single logical change
- [x] `ruff check` passes (changed files)
- [x] `pytest tests/ -k "not tblite"` passes (new fairchem/pacmof2/transfer tests included)
- [x] Added tests for the change
- [x] Base is `dev` (not `main`) — targeting the active integration branch as requested
