### PR TITLE
chore: upgrade the MCP integration stack

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
     - langchain-anthropic==1.5.2
     - langchain-google-genai==4.3.1
     - langchain-groq==1.1.3
-    - langchain-mcp-adapters
+    - langchain-mcp-adapters==0.3.0
     - pydantic==2.13.4
     - pubchempy==1.0.5
     - numexpr==2.11.0
@@ -38,7 +38,7 @@ dependencies:
     - stmol==0.0.9
     - ipython-genutils==0.2.0
     - langsmith==0.10.10
-    - mcp
-    - fastmcp
+    - mcp==1.28.1
+    - fastmcp==3.4.4
     - pytest-asyncio
     - grandalf==0.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "langchain-anthropic==1.5.2",
     "langchain-google-genai==4.3.1",
     "langchain-groq==1.1.3",
-    "langchain-mcp-adapters",
+    "langchain-mcp-adapters==0.3.0",
     "pydantic==2.13.4",
     "pandas==2.2.3",
     "pubchempy==1.0.5",
@@ -45,8 +45,8 @@ dependencies = [
     "langsmith==0.10.10",
     "rich==14.1.0",
     "toml==0.10.2",
-    "mcp",
-    "fastmcp",
+    "mcp==1.28.1",
+    "fastmcp==3.4.4",
     "pytest-asyncio",
     "grandalf==0.8"
     ]

--- a/src/chemgraph/academy/runtime/mcp_supervisor.py
+++ b/src/chemgraph/academy/runtime/mcp_supervisor.py
@@ -17,7 +17,7 @@ import httpx
 from langchain_core.tools import BaseTool
 from langchain_core.tools import StructuredTool
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.types import CallToolResult
 
 from chemgraph.academy.core.campaign import MCPServerSpec
@@ -122,7 +122,7 @@ class MCPServerSupervisor:
         tool_names: set[str] = set()
         matched_whitelist: set[str] = set()
         for server_name, url in connections.items():
-            async with streamablehttp_client(url) as (read, write, _):
+            async with streamable_http_client(url) as (read, write, _):
                 async with ClientSession(read, write) as session:
                     await session.initialize()
                     listed = await session.list_tools()
@@ -266,7 +266,7 @@ async def _call_mcp_tool(
     tool_name: str,
     arguments: dict[str, Any],
 ) -> Any:
-    async with streamablehttp_client(server_url) as (read, write, _):
+    async with streamable_http_client(server_url) as (read, write, _):
         async with ClientSession(read, write) as session:
             await session.initialize()
             result = await session.call_tool(tool_name, arguments)

--- a/src/chemgraph/cli/formatting.py
+++ b/src/chemgraph/cli/formatting.py
@@ -162,7 +162,28 @@ def check_api_keys_status() -> None:
 # Response formatting
 # ---------------------------------------------------------------------------
 
-def _is_atomic_json(content: str) -> bool:
+
+def _content_text(content: Any) -> str:
+    """Return display text from string or structured message content."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    text_parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            text_parts.append(block)
+        elif (
+            isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        ):
+            text_parts.append(block["text"])
+    return "".join(text_parts)
+
+
+def _is_atomic_json(content: Any) -> bool:
     """Return True if *content* is a JSON string with atomic-structure keys.
 
     This replaces the old fragile substring check (Bug 10) with a
@@ -170,14 +191,17 @@ def _is_atomic_json(content: str) -> bool:
 
     Parameters
     ----------
-    content : str
-        Candidate JSON text.
+    content : Any
+        Candidate string or structured message content.
 
     Returns
     -------
     bool
         ``True`` when the parsed object contains atomic-structure keys.
     """
+    content = _content_text(content)
+    if not content:
+        return False
     try:
         data = json.loads(content.strip())
     except (json.JSONDecodeError, ValueError):
@@ -215,14 +239,14 @@ def format_response(result: Any, verbose: bool = False) -> None:
     final_answer = ""
     for message in reversed(messages):
         if hasattr(message, "content") and hasattr(message, "type"):
-            if message.type == "ai" and message.content.strip():
-                content = message.content.strip()
+            content = _content_text(message.content).strip()
+            if message.type == "ai" and content:
                 if not _is_atomic_json(content):
                     final_answer = content
                     break
         elif isinstance(message, dict):
-            if message.get("type") == "ai" and message.get("content", "").strip():
-                content = message["content"].strip()
+            content = _content_text(message.get("content", "")).strip()
+            if message.get("type") == "ai" and content:
                 if not _is_atomic_json(content):
                     final_answer = content
                     break
@@ -241,9 +265,9 @@ def format_response(result: Any, verbose: bool = False) -> None:
     for message in messages:
         content = ""
         if hasattr(message, "content"):
-            content = message.content
+            content = _content_text(message.content).strip()
         elif isinstance(message, dict):
-            content = message.get("content", "")
+            content = _content_text(message.get("content", "")).strip()
 
         if content and _is_atomic_json(content):
             console.print(

--- a/tests/test_academy_mcp_supervisor.py
+++ b/tests/test_academy_mcp_supervisor.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from langchain_mcp_adapters.client import MultiServerMCPClient
 
 # Skip when the optional 'academy' extra is absent; mcp_supervisor
 # imports httpx (also in the extra) at module level.
@@ -12,6 +13,10 @@ pytest.importorskip("academy")
 
 from chemgraph.academy.core.campaign import MCPServerSpec
 from chemgraph.academy.runtime.mcp_supervisor import MCPServerSupervisor
+
+pytestmark = pytest.mark.filterwarnings(
+    "error:Use `streamable_http_client` instead.:DeprecationWarning"
+)
 
 
 def _pythonpath(tmp_path: Path) -> str:
@@ -89,6 +94,19 @@ async def test_mcp_supervisor_starts_server_and_gets_tools(tmp_path) -> None:
         tools = await supervisor.get_tools(("tiny",))
         echo = next(tool for tool in tools if tool.name == "echo")
         result = await echo.ainvoke({"text": "hello"})
+        adapter = MultiServerMCPClient(
+            {
+                "tiny": {
+                    "transport": "streamable_http",
+                    "url": urls["tiny"],
+                }
+            }
+        )
+        adapter_tools = await adapter.get_tools()
+        adapter_echo = next(
+            tool for tool in adapter_tools if tool.name == "echo"
+        )
+        adapter_result = await adapter_echo.ainvoke({"text": "adapter"})
     finally:
         await supervisor.shutdown()
 
@@ -96,6 +114,7 @@ async def test_mcp_supervisor_starts_server_and_gets_tools(tmp_path) -> None:
     assert "echo" in {tool.name for tool in tools}
     assert result["status"] == "ok"
     assert "hello" in repr(result)
+    assert "adapter" in repr(adapter_result)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_formatting.py
+++ b/tests/test_cli_formatting.py
@@ -1,0 +1,60 @@
+import json
+
+from langchain_core.messages import AIMessage
+
+from chemgraph.cli.formatting import _content_text, console, format_response
+
+
+def test_content_text_normalizes_structured_blocks():
+    content = [
+        {"type": "reasoning", "reasoning": "internal"},
+        {"type": "text", "text": "Optimization complete"},
+        "!",
+        {"type": "tool_call", "name": "run_ase"},
+    ]
+
+    assert _content_text(content) == "Optimization complete!"
+
+
+def test_format_response_renders_structured_ai_content():
+    result = {
+        "messages": [
+            {
+                "type": "ai",
+                "content": [{"type": "text", "text": "Dictionary response"}],
+            },
+            AIMessage(
+                content=[{"type": "text", "text": "Optimization complete"}]
+            ),
+        ]
+    }
+
+    with console.capture() as capture:
+        format_response(result)
+
+    output = capture.get()
+    assert "ChemGraph Response" in output
+    assert "Optimization complete" in output
+
+
+def test_format_response_detects_atomic_json_in_structured_content():
+    structure = json.dumps(
+        {
+            "numbers": [8, 1, 1],
+            "positions": [[0, 0, 0], [0, 1, 0], [0, -1, 0]],
+        }
+    )
+    result = {
+        "messages": [
+            AIMessage(content=[{"type": "text", "text": structure}]),
+            AIMessage(content=[{"type": "text", "text": "Water optimized"}]),
+        ]
+    }
+
+    with console.capture() as capture:
+        format_response(result)
+
+    output = capture.get()
+    assert "ChemGraph Response" in output
+    assert "Water optimized" in output
+    assert "Molecular Structure Data" in output

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -136,7 +136,7 @@ def test_cli_mcp_adapter_loads_stdio_tools(monkeypatch, tmp_path):
 
     monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
     tools = load_mcp_tools_from_config(
-        command=f"{sys.executable} -m chemgraph.mcp.mcp_tools",
+        command=f'"{sys.executable}" -m chemgraph.mcp.mcp_tools',
     )
 
     assert tools is not None

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,18 +1,22 @@
 """Test suite for MCP servers."""
 
+from concurrent.futures import Future
 import inspect
 import json
 from pathlib import Path
+import sys
 from typing import Any
 
 import pytest
 
 try:
-    from mcp.types import TextContent
-    from fastmcp import Client
+    from fastmcp import Client, FastMCP as StandaloneFastMCP
+    from mcp.server.fastmcp import FastMCP as SDKFastMCP
+    from mcp.types import TextContent, ToolAnnotations
+
     from chemgraph.mcp.cg_fastmcp import CGFastMCP
-    from chemgraph.mcp.mcp_tools import mcp
     from chemgraph.mcp.data_analysis_mcp import mcp as data_mcp
+    from chemgraph.mcp.mcp_tools import mcp
 except ModuleNotFoundError:
     pytest.skip("MCP test dependencies are not installed", allow_module_level=True)
 
@@ -21,6 +25,19 @@ TEST_DIR = Path(__file__).parent
 
 def _fanout_worker(item: dict) -> dict:
     return item
+
+
+class _ImmediateBackend:
+    is_async_remote = False
+
+    def __init__(self):
+        self.submitted = []
+
+    def submit(self, task):
+        self.submitted.append(task)
+        future = Future()
+        future.set_result(task.callable(**task.kwargs))
+        return future
 
 
 def test_schema_fanout_tool_advertises_batch_result_signature(monkeypatch):
@@ -45,14 +62,100 @@ def test_schema_fanout_tool_advertises_batch_result_signature(monkeypatch):
     assert sig.return_annotation == dict[str, Any]
 
 
-def test_mace_worker_creates_inline_output_parent(monkeypatch):
+@pytest.mark.asyncio
+async def test_cg_fastmcp_preserves_sdk_schema_and_backend_contract():
+    """CGFastMCP stays on the SDK server while FastMCP Client drives it."""
+    local_mcp = CGFastMCP(name="test")
+    backend = _ImmediateBackend()
+    local_mcp._backend = backend
+
+    @local_mcp.tool(
+        name="increment",
+        title="Increment",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        structured_output=True,
+    )
+    def increment(value: int) -> dict[str, int]:
+        return {"result": value + 1}
+
+    assert isinstance(local_mcp, SDKFastMCP)
+    assert not isinstance(local_mcp, StandaloneFastMCP)
+
+    async with Client(local_mcp) as client:
+        listed = await client.list_tools()
+        tool = next(item for item in listed if item.name == "increment")
+        result = await client.call_tool("increment", {"value": 4})
+
+    assert tool.title == "Increment"
+    assert tool.inputSchema["properties"]["value"]["type"] == "integer"
+    assert tool.outputSchema["additionalProperties"]["type"] == "integer"
+    assert tool.annotations.readOnlyHint is True
+    assert result.data == {"result": 5}
+    assert result.structured_content == {"result": 5}
+    assert len(backend.submitted) == 1
+    assert backend.submitted[0].task_type == "python"
+    assert backend.submitted[0].kwargs == {"value": 4}
+
+
+def test_streamable_http_server_disables_websockets(monkeypatch):
+    """The HTTP transport keeps Uvicorn's unused WebSocket stack disabled."""
+    from chemgraph.mcp import server_utils
+
+    local_mcp = SDKFastMCP("test")
+    app = object()
+    captured = {}
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["mcp-server", "--transport", "streamable_http"],
+    )
+    monkeypatch.setattr(local_mcp, "streamable_http_app", lambda: app)
+
+    def capture_run(actual_app, **kwargs):
+        captured["app"] = actual_app
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(server_utils.uvicorn, "run", capture_run)
+
+    server_utils.run_mcp_server(
+        local_mcp,
+        default_host="127.0.0.1",
+        default_port=8765,
+    )
+
+    assert captured == {
+        "app": app,
+        "kwargs": {"host": "127.0.0.1", "port": 8765, "ws": "none"},
+    }
+
+
+def test_cli_mcp_adapter_loads_stdio_tools(monkeypatch, tmp_path):
+    """The LangChain MCP adapter loads the general server over stdio."""
+    from chemgraph.cli.mcp_utils import load_mcp_tools_from_config
+
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    tools = load_mcp_tools_from_config(
+        command=f"{sys.executable} -m chemgraph.mcp.mcp_tools",
+    )
+
+    assert tools is not None
+    assert {tool.name for tool in tools} == {
+        "extract_output_json",
+        "molecule_name_to_smiles",
+        "run_ase",
+        "smiles_to_coordinate_file",
+    }
+
+
+def test_mace_worker_creates_inline_output_parent(monkeypatch, tmp_path):
     from ase import Atoms
 
     from chemgraph.mcp import mace_mcp_hpc
     from chemgraph.tools.ase_core import atoms_to_atomsdata
 
     atoms = Atoms(numbers=[1, 1], positions=[[0, 0, 0], [0, 0, 0.74]])
-    output_file = "nested/family/output.json"
+    output_file = str(tmp_path / "nested" / "family" / "output.json")
 
     def fake_run_mace_core(params):
         output_path = Path(params.output_result_file)
@@ -157,14 +260,14 @@ async def test_split_cif_dataset(tmp_path):
 
 
 @pytest.fixture(name="base_ase_input_dict")
-def fixture_base_ase_input_dict():
+def fixture_base_ase_input_dict(tmp_path):
     """Fixture providing base ASE input parameters."""
     return {
         "input_structure_file": str(TEST_DIR / "water.xyz"),
-        "output_results_file": str(TEST_DIR / "water_output.json"),
+        "output_results_file": str(tmp_path / "water_output.json"),
         "optimizer": "bfgs",
         "calculator": {
-            "calculator_type": "mace_mp",
+            "calculator_type": "emt",
         },
     }
 


### PR DESCRIPTION
## Summary

- Pin `mcp==1.28.1`, `fastmcp==3.4.4`, and `langchain-mcp-adapters==0.3.0` in both supported manifests.
- Adopt the canonical MCP streamable HTTP client name while preserving the SDK `FastMCP` server and Uvicorn `ws="none"` behavior.
- Add regression coverage for SDK/standalone FastMCP interoperability, schemas, backend submission, stdio adapters, Academy HTTP adapters, and WebSocket disabling.
- Make existing MCP tests hermetic by using EMT and pytest temporary output paths.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [x] Chore / refactor / CI

## How was this tested?

- `ruff check .`
- `pytest tests/ -k "not tblite"` with core install: 290 passed, 28 skipped, 2 deselected
- `pytest tests/ -k "not tblite"` with Academy, Parsl, and Globus Compute extras: 338 passed, 19 skipped, 2 deselected
- `python -m pip check` in clean editable and clean wheel environments
- Built sdist and wheel; installed/imported the wheel under Python 3.14
- Resolver dry-runs for Python 3.10, 3.11, 3.12, and 3.13

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change (not user-facing)
