### PR TITLE
chore: update numerical and data dependencies

### DIFF
--- a/.github/workflows/dependency_tests.yml
+++ b/.github/workflows/dependency_tests.yml
@@ -7,6 +7,51 @@ on:
     branches: [ main ]
 
 jobs:
+  test_data_dependency_floors:
+    name: Verify Data Floors (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install minimum supported data stack
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install \
+          "numpy==2.2.6" \
+          "pandas==2.2.3" \
+          "numexpr==2.11.0" \
+          .
+        python -m pip check
+
+    - name: Verify floor versions and focused behavior
+      run: |
+        python -c "
+        from importlib.metadata import version
+
+        expected = {
+            'numpy': '2.2.6',
+            'pandas': '2.2.3',
+            'numexpr': '2.11.0',
+        }
+        actual = {name: version(name) for name in expected}
+        assert actual == expected, actual
+        print(actual)
+        "
+        python -m pytest \
+          tests/test_data_stack.py \
+          tests/test_package_metadata.py \
+          -q
+
   test_install:
     name: Verify Install (${{ matrix.install_extras }})
     runs-on: ubuntu-latest

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.10
   - pip
   - numpy=2.2.6
-  - pandas=2.2.3
+  - pandas=2.3.3
   - pytest=8.4.1
   - rich=14.1.0
   - toml=0.10.2
@@ -29,7 +29,7 @@ dependencies:
     - langchain-mcp-adapters==0.3.0
     - pydantic==2.13.4
     - pubchempy==1.0.5
-    - numexpr==2.11.0
+    - numexpr==2.14.1
     - deepdiff==8.5.0
     - pymatgen==2025.3.10
     - mace-torch==0.3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,10 @@ dependencies = [
     "langchain-groq==1.1.3",
     "langchain-mcp-adapters==0.3.0",
     "pydantic==2.13.4",
-    "pandas==2.2.3",
+    "pandas>=2.2.3,<3",
     "pubchempy==1.0.5",
-    "numpy==2.2.6",
-    "numexpr==2.11.0",
+    "numpy>=2.2.6,<3",
+    "numexpr>=2.11.0,<3",
     "pytest==8.4.1",
     "deepdiff==8.5.0",
 

--- a/src/chemgraph/mcp/data_analysis_mcp.py
+++ b/src/chemgraph/mcp/data_analysis_mcp.py
@@ -263,7 +263,9 @@ def rank_mofs_performance(
             ]
 
             if not p_matches.empty:
-                return p_matches['uptake_in_mol_kg'].mean()
+                uptake = p_matches['uptake_in_mol_kg'].mean()
+                if not pd.isna(uptake):
+                    return uptake
             return None
 
         val_ads = get_uptake(ads_pressure, ads_temp)

--- a/tests/test_data_stack.py
+++ b/tests/test_data_stack.py
@@ -1,0 +1,192 @@
+"""Regression tests for ChemGraph's numerical and tabular data stack."""
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+from ase import Atoms
+
+from chemgraph.mcp.data_analysis_mcp import (
+    aggregate_simulation_results,
+    rank_mofs_performance,
+)
+from chemgraph.tools.ase_core import atoms_to_atomsdata, atomsdata_to_atoms
+from chemgraph.tools.generic_tools import calculator
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ("1 + 2 * 3", 7.0),
+        ("2 * pi + e", 2 * np.pi + np.e),
+        ("sin(pi / 2) + sqrt(9) + abs(-2)", 6.0),
+    ],
+)
+def test_numexpr_calculator_supported_expressions(expression, expected):
+    """The LangChain calculator tool should evaluate supported expressions."""
+    result = calculator.invoke({"expression": expression})
+
+    assert float(result) == pytest.approx(expected)
+
+
+def test_numexpr_calculator_reports_invalid_and_empty_expressions():
+    """Invalid calculator input should return an actionable error string."""
+    assert calculator.invoke({"expression": "  "}) == "Error: Empty expression"
+    assert calculator.invoke({"expression": "unknown_name + 1"}).startswith(
+        "Error evaluating expression:"
+    )
+
+
+def test_numpy_ase_round_trip_is_json_serializable():
+    """ASE's NumPy arrays should become JSON-safe AtomsData lists."""
+    atoms = Atoms(
+        numbers=np.array([8, 1, 1]),
+        positions=np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.76, 0.58, 0.0],
+                [-0.76, 0.58, 0.0],
+            ]
+        ),
+        cell=np.eye(3),
+        pbc=np.array([False, False, False]),
+    )
+
+    atoms_data = atoms_to_atomsdata(atoms)
+    payload = atoms_data.model_dump()
+    restored = atomsdata_to_atoms(atoms_data)
+
+    assert isinstance(atoms_data.numbers, list)
+    assert isinstance(atoms_data.positions, list)
+    assert isinstance(atoms_data.cell, list)
+    assert isinstance(atoms_data.pbc, list)
+    json.dumps(payload)
+    np.testing.assert_array_equal(restored.numbers, atoms.numbers)
+    np.testing.assert_allclose(restored.positions, atoms.positions)
+    np.testing.assert_allclose(restored.cell.array, atoms.cell.array)
+    np.testing.assert_array_equal(restored.pbc, atoms.pbc)
+
+
+def test_pandas_aggregation_and_ranking(monkeypatch, tmp_path):
+    """JSONL aggregation should coerce numerics and rank valid MOF records."""
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    records = [
+        {
+            "status": "success",
+            "cif_path": "/structures/low.cif",
+            "uptake_in_mol_kg": "4.0",
+            "temperature_in_K": "298.0",
+            "pressure_in_Pa": "100000",
+        },
+        {
+            "status": "success",
+            "cif_path": "/structures/low.cif",
+            "uptake_in_mol_kg": "1.0",
+            "temperature_in_K": "300.0",
+            "pressure_in_Pa": "10000",
+        },
+        {
+            "status": "success",
+            "cif_path": "/structures/high.cif",
+            "uptake_in_mol_kg": "8.0",
+            "temperature_in_K": "298.0",
+            "pressure_in_Pa": "100000",
+        },
+        {
+            "status": "success",
+            "cif_path": "/structures/high.cif",
+            "uptake_in_mol_kg": "2.0",
+            "temperature_in_K": "300.0",
+            "pressure_in_Pa": "10000",
+        },
+        {
+            "status": "success",
+            "cif_path": "/structures/incomplete.cif",
+            "uptake_in_mol_kg": None,
+            "temperature_in_K": "298.0",
+            "pressure_in_Pa": "100000",
+        },
+        {
+            "status": "failed",
+            "cif_path": "/structures/ignored.cif",
+            "uptake_in_mol_kg": 99,
+            "temperature_in_K": 298,
+            "pressure_in_Pa": 100000,
+        },
+    ]
+    input_path = tmp_path / "results.jsonl"
+    input_path.write_text(
+        "\n".join(json.dumps(record) for record in records)
+        + "\n\n{malformed json}\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "aggregated.csv"
+
+    result = aggregate_simulation_results(
+        file_paths=["results.jsonl", "", str(tmp_path / "missing.jsonl")],
+        output_csv_path=str(output_path),
+    )
+
+    assert "Success: Aggregated 5 records" in result
+    aggregated = pd.read_csv(output_path)
+    assert list(aggregated["cif_filename"]) == [
+        "low.cif",
+        "low.cif",
+        "high.cif",
+        "high.cif",
+        "incomplete.cif",
+    ]
+    assert pd.api.types.is_numeric_dtype(aggregated["uptake_in_mol_kg"])
+    assert pd.api.types.is_numeric_dtype(aggregated["temperature"])
+    assert pd.api.types.is_numeric_dtype(aggregated["pressure"])
+    assert pd.isna(
+        aggregated.loc[
+            aggregated["cif_filename"] == "incomplete.cif",
+            "uptake_in_mol_kg",
+        ].iloc[0]
+    )
+
+    absolute = rank_mofs_performance(
+        input_csv_path=str(output_path),
+        ads_pressure=100000,
+        ads_temp=298,
+        top_percentile=1.0,
+    )
+    assert "Found 2 candidates (out of 2 valid MOFs)" in absolute
+    assert absolute.index("high.cif") < absolute.index("low.cif")
+    assert "8.0" in absolute
+    assert "4.0" in absolute
+
+    working_capacity = rank_mofs_performance(
+        input_csv_path=str(output_path),
+        ads_pressure=100000,
+        ads_temp=298,
+        des_pressure=10000,
+        des_temp=300,
+        top_percentile=1.0,
+    )
+    assert "Found 2 candidates (out of 2 valid MOFs)" in working_capacity
+    assert working_capacity.index("high.cif") < working_capacity.index("low.cif")
+    assert "6.0" in working_capacity
+    assert "3.0" in working_capacity
+
+
+def test_pandas_aggregation_rejects_files_without_success_records(tmp_path):
+    """Malformed, failed, and missing inputs should not produce an empty CSV."""
+    input_path = tmp_path / "invalid.jsonl"
+    input_path.write_text(
+        "\n{malformed json}\n"
+        + json.dumps({"status": "failed", "cif_path": "/structures/failed.cif"})
+        + "\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "aggregated.csv"
+
+    result = aggregate_simulation_results(
+        file_paths=[str(input_path), str(tmp_path / "missing.jsonl")],
+        output_csv_path=str(output_path),
+    )
+
+    assert result == "Error: No valid success data found in the provided file list."
+    assert not output_path.exists()

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -44,3 +44,15 @@ def test_pyproject_version_fallback_matches_project_metadata() -> None:
     project_version = _load_toml(pyproject)["project"]["version"]
 
     assert chemgraph._version_from_pyproject() == project_version
+
+
+def test_data_dependencies_use_bounded_compatible_ranges() -> None:
+    """Published data dependencies should allow compatible 2.x releases."""
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    dependencies = set(_load_toml(pyproject)["project"]["dependencies"])
+
+    assert {
+        "numpy>=2.2.6,<3",
+        "pandas>=2.2.3,<3",
+        "numexpr>=2.11.0,<3",
+    }.issubset(dependencies)


### PR DESCRIPTION
## Summary

- Replace exact NumPy, pandas, and NumExpr package pins with compatible major-bounded ranges: NumPy >=2.2.6,<3, pandas >=2.2.3,<3, and NumExpr >=2.11.0,<3.
- Update the reproducible environment snapshot to pandas 2.3.3 and NumExpr 2.14.1 while retaining NumPy 2.2.6 for Python 3.10 compatibility.
- Add Python 3.10-3.13 CI coverage for the minimum supported data-stack versions.
- Add hermetic NumExpr, pandas, and NumPy/ASE regression tests and ignore missing uptake values during MOF ranking.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [x] Chore / refactor / CI

## How was this tested?

- Python 3.10-3.13 full dependency resolver dry runs
- Minimum versions: NumPy 2.2.6, pandas 2.2.3, NumExpr 2.11.0; focused tests: 10 passed; pip check passed
- Newest compatible versions on Python 3.12: NumPy 2.5.1, pandas 2.3.3, NumExpr 2.14.2; focused tests: 10 passed; pip check passed
- Core suite: 301 passed, 28 skipped, 2 deselected
- Academy/Parsl/Globus Compute extras suite: 349 passed, 19 skipped, 2 deselected
- ruff check .
- Source distribution and wheel build
- Clean wheel install, metadata/import assertions, and pip check

No live LLM, Globus Compute endpoint, or external model-download tests were enabled.

## Checklist

- [x] Branched off the latest main and targets main
- [x] PR is focused on a single logical change
- [x] ruff check . passes
- [x] pytest tests/ -k "not tblite" passes, including the extras suite
- [x] Added/updated tests for the change
- [x] Docs / README reviewed; no documentation change is needed for this packaging-only migration