### PR TITLE
Add VASP and Quantum ESPRESSO plane-wave DFT calculators

### DIFF
--- a/examples/plane_wave_tools/README.md
+++ b/examples/plane_wave_tools/README.md
@@ -1,0 +1,147 @@
+# Plane-wave DFT tools: run_qe and run_vasp
+
+ChemGraph exposes two calculator-pinned tools for plane-wave DFT:
+
+- **`run_qe`** - Quantum ESPRESSO (`pw.x`)
+- **`run_vasp`** - VASP
+
+Both are thin variants of `run_ase` with the calculator fixed to one engine, so
+the LLM sees only that engine's parameters. They are registered automatically in
+the `single_agent` workflow, and each is offered **only when its engine is
+detected on the host** (binary + pseudopotentials), so an uninstalled engine is
+never shown to the model.
+
+[`run_plane_wave.py`](run_plane_wave.py) drives them end to end: an Argo-hosted
+LLM reads a natural-language prompt, chooses the tool, fills in the input, and
+the tool launches the real DFT engine through ASE.
+
+> Scope note: this example proves the ChemGraph -> tool -> engine flow and the
+> code path. The Quantum ESPRESSO path is runnable on Aurora (real `pw.x`); the
+> VASP path is documented for a VASP-equipped host and has **not** been run on
+> real VASP here (Aurora has no VASP binary). Treat the VASP section as the
+> setup a VASP user would follow, not a validated run.
+
+---
+
+## Prerequisites
+
+Assumes the DFT packages are already installed on your machine. You need three
+things: (1) the DFT engine reachable by ASE, (2) a pseudopotential library, and
+(3) an LLM endpoint (this example uses Argo via `argo-shim`).
+
+### 1. Quantum ESPRESSO (`run_qe`)
+
+ChemGraph builds `EspressoProfile(command=$ASE_ESPRESSO_COMMAND)` and ASE
+appends `-in <input>` itself, so `ASE_ESPRESSO_COMMAND` must be the launch
+**prefix only** (executable + launcher flags), with no `-in` / redirection.
+
+**On Aurora** `pw.x` is prebuilt (no module file; add the bin dir to PATH):
+
+```bash
+# Vendor build + its runtime modules (see the build's own job.sub):
+module load oneapi/release/2025.3.1 mpich/opt/develop-git.6037a7a hdf5/1.14.6
+
+QE_BIN=/soft/applications/quantum_espresso/7.5-oneapi2025.0.5/cpu/bin/pw.x
+
+# MPI launch prefix (102 ranks/node on Aurora CPU, 1 OpenMP thread each).
+# ASE appends "-in <file>"; do NOT add -in / > here.
+export ASE_ESPRESSO_COMMAND="mpiexec -np 102 -ppn 102 -d 1 $QE_BIN"
+export OMP_NUM_THREADS=1
+
+# Pseudopotentials: none are bundled. Point ESPRESSO_PSEUDO at your own set
+# (e.g. SSSP). This gate must be set for run_qe to be offered.
+export ESPRESSO_PSEUDO=$HOME/pseudo/sssp_efficiency
+```
+
+**On a generic cluster**: put `pw.x` on `PATH` (or set `ASE_ESPRESSO_COMMAND`)
+and export `ESPRESSO_PSEUDO`.
+
+```bash
+export ASE_ESPRESSO_COMMAND="mpirun -np 4 pw.x"
+export ESPRESSO_PSEUDO=/path/to/pseudopotentials
+```
+
+Download pseudopotentials matching your elements and XC functional. For the
+bulk-Si default prompt you need a Si UPF in `$ESPRESSO_PSEUDO` (the SSSP PBE
+efficiency set covers it).
+
+### 2. VASP (`run_vasp`)
+
+VASP is licensed. ASE accepts several launch mechanisms; set one, plus the
+pseudopotential path:
+
+```bash
+# Launch command (any one of these ASE-recognized forms):
+export ASE_VASP_COMMAND="mpirun -np 4 vasp_std"    # or:
+# export VASP_COMMAND="srun vasp_std"
+# ...or put vasp_std / vasp_gam on PATH
+
+# POTCAR library root (contains potpaw_PBE/, potpaw_LDA/, ...).
+export VASP_PP_PATH=/path/to/vasp/potcars
+```
+
+`run_vasp` is offered only when a VASP binary/command **and** `VASP_PP_PATH` are
+both set. Aurora has no VASP binary, so this step is for a VASP-licensed host.
+
+### 3. Argo LLM endpoint
+
+`run_plane_wave.py` calls an LLM through Argo via `argo-shim`. Follow
+[`../connecting_to_argo/README.md`](../connecting_to_argo/README.md) to bring up
+the tunnel so ChemGraph can POST to `http://127.0.0.1:18085/argoapi/v1` from a
+compute node. Then:
+
+```bash
+export ARGO_USER=<your.cels.login>          # required
+# optional overrides:
+# export ARGO_MODEL=argo:gpt-4.1-mini
+# export ARGO_BASE=http://127.0.0.1:18085/argoapi/v1
+```
+
+You can point `ARGO_BASE` at any OpenAI-compatible endpoint; the Argo shim is
+just what we validated on ALCF hardware.
+
+---
+
+## Running
+
+From the repo root, inside your ChemGraph environment:
+
+```bash
+# Quantum ESPRESSO (runnable on Aurora):
+python examples/plane_wave_tools/run_plane_wave.py --engine qe
+
+# VASP (on a VASP-equipped host):
+python examples/plane_wave_tools/run_plane_wave.py --engine vasp
+```
+
+Override the prompt to try your own chemistry:
+
+```bash
+QE_PROMPT="Compute the total energy of an isolated water molecule with Quantum ESPRESSO." \
+  python examples/plane_wave_tools/run_plane_wave.py --engine qe
+```
+
+Expected: an `INFO` line showing the Argo model mapping, then the LLM calling
+`run_qe` (or `run_vasp`), the DFT engine running through ASE, and ChemGraph
+reporting the result. If the requested engine is not registered on the host, the
+script exits early and prints exactly which environment variables are missing.
+
+---
+
+## How it fits together
+
+```
+prompt --> ChemGraph (single_agent) --> LLM picks run_qe / run_vasp
+                                              |
+                                     QEInputSchema / VaspInputSchema
+                                     (calculator pinned to one engine)
+                                              |
+                                         run_ase_core --> ASE --> pw.x / VASP
+```
+
+`run_qe` / `run_vasp` are defined in
+[`src/chemgraph/tools/ase_tools.py`](../../src/chemgraph/tools/ase_tools.py) and
+their pinned input schemas in
+[`src/chemgraph/schemas/plane_wave_input.py`](../../src/chemgraph/schemas/plane_wave_input.py).
+Availability gating (which engines are offered) lives in
+[`src/chemgraph/schemas/ase_input.py`](../../src/chemgraph/schemas/ase_input.py).

--- a/examples/plane_wave_tools/README.md
+++ b/examples/plane_wave_tools/README.md
@@ -16,10 +16,10 @@ LLM reads a natural-language prompt, chooses the tool, fills in the input, and
 the tool launches the real DFT engine through ASE.
 
 > Scope note: this example proves the ChemGraph -> tool -> engine flow and the
-> code path. The Quantum ESPRESSO path is runnable on Aurora (real `pw.x`); the
-> VASP path is documented for a VASP-equipped host and has **not** been run on
-> real VASP here (Aurora has no VASP binary). Treat the VASP section as the
-> setup a VASP user would follow, not a validated run.
+> code path. The Quantum ESPRESSO path is runnable on Aurora (real `pw.x`). The
+> VASP path has been run against real `vasp_std` (VASP 6.5.1, 8 MPI ranks, PBE
+> PAW) on a VASP-licensed cluster: the agent chose `run_vasp` unprompted and
+> bulk Si returned -10.8379 eV at ENCUT=325, 4x4x4.
 
 ---
 
@@ -114,17 +114,44 @@ python examples/plane_wave_tools/run_plane_wave.py --engine qe
 python examples/plane_wave_tools/run_plane_wave.py --engine vasp
 ```
 
-Override the prompt to try your own chemistry:
-
-```bash
-QE_PROMPT="Compute the total energy of an isolated water molecule with Quantum ESPRESSO." \
-  python examples/plane_wave_tools/run_plane_wave.py --engine qe
-```
-
 Expected: an `INFO` line showing the Argo model mapping, then the LLM calling
 `run_qe` (or `run_vasp`), the DFT engine running through ASE, and ChemGraph
 reporting the result. If the requested engine is not registered on the host, the
 script exits early and prints exactly which environment variables are missing.
+
+### Where the structure comes from
+
+The example writes the bulk-Si cell itself, into `$PLANE_WAVE_WORKDIR`
+(default `./plane_wave_example`), and names that file in the prompt. Set
+`MP_API_KEY` and it fetches the relaxed [mp-149](https://materialsproject.org/materials/mp-149)
+cell from Materials Project; without a key it falls back to an idealized
+`ase.build.bulk("Si", "diamond", a=5.43)` lattice. Either way you get a real
+periodic rank-3 cell, and any fetch failure falls back rather than aborting.
+
+This is deliberate, not a shortcut. **No tool in the `single_agent` set can
+build a crystal.** The only structure source is `smiles_to_coordinate_file`,
+which is RDKit-backed and returns an isolated molecule with no cell. A prompt
+that just says "bulk silicon" makes the model reach for it and get one lone Si
+atom at `pbc=[F,F,F]`: VASP rejects that outright, and pw.x accepts it and
+quietly reports the energy of the wrong system. The LLM still chooses the tool
+and fills in every plane-wave parameter; only the lattice is supplied.
+
+### Overriding the prompt
+
+`QE_PROMPT` / `VASP_PROMPT` replace the default outright, so they must name a
+structure file themselves. The example's own file is a good starting point:
+
+```bash
+VASP_PROMPT="Relax the crystal in '$PWD/plane_wave_example/si_bulk.xyz' with VASP \
+using input_structure_file='$PWD/plane_wave_example/si_bulk.xyz', driver='opt', \
+a 4x4x4 k-point mesh and a 300 eV cutoff." \
+  python examples/plane_wave_tools/run_plane_wave.py --engine vasp
+```
+
+For QE, `QE_SI_PSEUDO` sets the Si UPF filename looked up inside
+`$ESPRESSO_PSEUDO` (default `Si.pbe-n-rrkjus_psl.1.0.0.UPF`); pw.x needs an
+explicit per-element pseudopotential, whereas ASE derives VASP's POTCAR path
+from `$VASP_PP_PATH` and the element symbol.
 
 ---
 

--- a/examples/plane_wave_tools/run_plane_wave.py
+++ b/examples/plane_wave_tools/run_plane_wave.py
@@ -21,6 +21,13 @@ Override defaults via env vars (same names as connecting_to_argo/test_run.py):
     ARGO_BASE   -- shim URL (default: http://127.0.0.1:18085/argoapi/v1)
     QE_PROMPT   -- override the Quantum ESPRESSO prompt
     VASP_PROMPT -- override the VASP prompt
+    MP_API_KEY  -- Materials Project key; when set, the bulk Si cell is the
+                   DFT-relaxed mp-149 structure in place of an idealized
+                   ase.build lattice
+    PLANE_WAVE_WORKDIR -- where the structure file is written
+                   (default: <cwd>/plane_wave_example)
+    QE_SI_PSEUDO -- Si UPF filename inside $ESPRESSO_PSEUDO
+                   (default: Si.pbe-n-rrkjus_psl.1.0.0.UPF)
 """
 
 from __future__ import annotations
@@ -37,19 +44,130 @@ import sys
 os.environ.setdefault("CHEMGRAPH_ARGO_MODEL_FORMAT", "wire")
 
 
-# A realistic default prompt per engine. Bulk Si is the canonical periodic
-# plane-wave smoke test: a few atoms, a real k-mesh, converges fast.
+# Bulk Si is the canonical periodic plane-wave smoke test: 2 atoms, a real
+# k-mesh, converges in seconds.
+#
+# The prompt has to name a structure FILE rather than just say "bulk silicon".
+# No tool in the single_agent set can build a crystal. The only structure
+# source is smiles_to_coordinate_file, which is RDKit-backed and returns an
+# isolated molecule with no cell. Asked for "bulk silicon" with no file, the
+# model reaches for it, gets one lone Si atom at pbc=[F,F,F], and the run is a
+# vacuum-box atom rather than a crystal. VASP rejects that outright; pw.x
+# accepts it and quietly reports the energy of the wrong system. So the example
+# supplies the cell itself. The LLM still chooses the tool and fills in every
+# plane-wave parameter.
+# 325 eV is 1.3 * the Si PAW POTCAR's ENMAX (245.3 eV), rounded up to the
+# nearest 25. The 1.3 margin is VASP's guidance for variable-cell relaxation;
+# applying it to these fixed-cell runs too keeps one stated rule across the
+# example and leaves every element well above its own ENMAX. A different
+# element needs its own value: oxygen's ENMAX alone is 400 eV.
 _DEFAULT_PROMPTS = {
     "qe": (
-        "Relax the geometry of bulk silicon with Quantum ESPRESSO using a "
-        "4x4x4 k-point mesh and a 40 Ry wavefunction cutoff, then report the "
-        "final total energy."
+        "Relax the geometry of the periodic crystal in the file '{structure}' "
+        "with Quantum ESPRESSO. Call run_qe with "
+        "input_structure_file='{structure}', a 4x4x4 k-point mesh, a 40 Ry "
+        "wavefunction cutoff and pseudopotentials={{'Si': '{si_pseudo}'}}, "
+        "then report the final total energy."
     ),
     "vasp": (
-        "Compute the total energy of bulk silicon with VASP using a 4x4x4 "
-        "k-point mesh and a 400 eV plane-wave cutoff."
+        "Compute the total energy of the periodic crystal in the file "
+        "'{structure}' with VASP. Call run_vasp with "
+        "input_structure_file='{structure}', a 4x4x4 k-point mesh and a "
+        "325 eV plane-wave cutoff."
     ),
 }
+
+
+# pw.x needs an explicit per-element UPF filename (ASE raises KeyError on an
+# empty pseudopotentials map) and the name depends on which library is installed
+# under $ESPRESSO_PSEUDO. Default to the PSLibrary PBE name; override if yours
+# differs. VASP needs no equivalent: ASE derives the POTCAR path from
+# $VASP_PP_PATH and the element symbol.
+_DEFAULT_SI_PSEUDO = "Si.pbe-n-rrkjus_psl.1.0.0.UPF"
+
+# Materials Project entry for diamond silicon.
+_MP_SILICON = "mp-149"
+
+
+def _bulk_si_from_mp(api_key: str):
+    """Fetch the mp-149 silicon cell from Materials Project, or None on failure.
+
+    Prefers a DFT-relaxed structure over an idealized textbook lattice, so the
+    example exercises the same kind of input a user would really calculate on.
+    Returns None on any failure (missing mp-api package, bad key, no network,
+    empty result) in place of raising, so an unreachable structure source
+    leaves the demo runnable.
+
+    Parameters
+    ----------
+    api_key : str
+        Materials Project API key.
+
+    Returns
+    -------
+    ase.Atoms or None
+        The relaxed conventional cell, or None if it could not be fetched.
+    """
+    try:
+        from mp_api.client import MPRester
+        from pymatgen.io.ase import AseAtomsAdaptor
+
+        with MPRester(api_key) as mpr:
+            doc = mpr.materials.summary.search(
+                material_ids=[_MP_SILICON], fields=["material_id", "structure"]
+            )
+            if not doc:
+                return None
+            atoms = AseAtomsAdaptor.get_atoms(doc[0].structure)
+            atoms.info["MP-id"] = str(doc[0].material_id)
+            return atoms
+    except Exception as exc:  # noqa: BLE001 - any failure falls back
+        print(f"Materials Project fetch failed ({exc}); using ase.build.bulk.")
+        return None
+
+
+def _write_bulk_si(directory: str) -> tuple[str, str]:
+    """Write a bulk-Si cell and return ``(path, provenance)``.
+
+    Uses the Materials Project structure when ``MP_API_KEY`` is set and
+    reachable, otherwise an idealized diamond lattice from ``ase.build``. Either
+    way the result is a genuine periodic rank-3 cell, which is the property the
+    plane-wave run depends on. Overwritten on every run so a stale file cannot
+    silently change the result.
+
+    Parameters
+    ----------
+    directory : str
+        Directory to write ``si_bulk.xyz`` into; created if missing.
+
+    Returns
+    -------
+    tuple of (str, str)
+        Absolute path to the structure file, and a human-readable description
+        of where the cell came from.
+    """
+    from ase.build import bulk
+    from ase.io import write
+
+    atoms = None
+    provenance = ""
+    api_key = os.environ.get("MP_API_KEY")
+    if api_key:
+        atoms = _bulk_si_from_mp(api_key)
+        if atoms is not None:
+            provenance = f"Materials Project {_MP_SILICON}, {len(atoms)} atoms"
+    if atoms is None:
+        atoms = bulk("Si", "diamond", a=5.43)
+        provenance = f"ase.build.bulk diamond a=5.43 A, {len(atoms)} atoms"
+        if not api_key:
+            provenance += " (set MP_API_KEY for the Materials Project cell)"
+
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.abspath(os.path.join(directory, "si_bulk.xyz"))
+    # extxyz keeps Lattice= and pbc="T T T", so ASE reads it back as a periodic
+    # rank-3 cell, which is what makes this a bulk plane-wave run.
+    write(path, atoms)
+    return path, provenance
 
 
 def _engine_available(engine: str) -> bool:
@@ -96,11 +214,24 @@ def main() -> int:
 
     model = os.environ.get("ARGO_MODEL", "argo:gpt-4.1-mini")
     base_url = os.environ.get("ARGO_BASE", "http://127.0.0.1:18085/argoapi/v1")
-    prompt = os.environ.get(
-        f"{engine.upper()}_PROMPT", _DEFAULT_PROMPTS[engine]
+
+    # Written after the engine gate so an unsupported host leaves no stray dir.
+    workdir = os.environ.get(
+        "PLANE_WAVE_WORKDIR", os.path.join(os.getcwd(), "plane_wave_example")
+    )
+    structure, provenance = _write_bulk_si(workdir)
+    # `or` rather than a two-arg get: .format() must not run on a user-supplied
+    # prompt, whose literal braces would blow up or be silently substituted.
+    prompt = os.environ.get(f"{engine.upper()}_PROMPT") or _DEFAULT_PROMPTS[
+        engine
+    ].format(
+        structure=structure,
+        si_pseudo=os.environ.get("QE_SI_PSEUDO", _DEFAULT_SI_PSEUDO),
     )
 
     print(f"Engine:    {engine}")
+    print(f"Structure: {structure}")
+    print(f"           ({provenance})")
     print(f"Model:     {model}")
     print(f"Base URL:  {base_url}")
     print(f"Argo user: {argo_user}")

--- a/examples/plane_wave_tools/run_plane_wave.py
+++ b/examples/plane_wave_tools/run_plane_wave.py
@@ -1,0 +1,131 @@
+"""Run ChemGraph's plane-wave DFT tools (run_qe / run_vasp) via an LLM.
+
+This drives the calculator-pinned tools ``run_qe`` (Quantum ESPRESSO / pw.x)
+and ``run_vasp`` (VASP) end to end: an Argo-hosted LLM reads a natural-language
+prompt, picks the plane-wave tool, fills in a physically sensible input, and the
+tool launches the real DFT engine through ASE.
+
+Only the engines detected on this host are offered to the model (same gate as
+ChemGraph's calculator union), so on a machine with pw.x + pseudopotentials but
+no VASP binary, the QE prompt runs for real and the VASP prompt is skipped with
+a clear message. See README.md for the full end-to-end setup (DFT binaries,
+pseudopotentials, and the Argo tunnel).
+
+Run:
+    python examples/plane_wave_tools/run_plane_wave.py          # QE prompt
+    python examples/plane_wave_tools/run_plane_wave.py --engine vasp
+
+Override defaults via env vars (same names as connecting_to_argo/test_run.py):
+    ARGO_USER   -- your CELS login (required), e.g. jane.doe
+    ARGO_MODEL  -- argo model name (default: argo:gpt-4.1-mini)
+    ARGO_BASE   -- shim URL (default: http://127.0.0.1:18085/argoapi/v1)
+    QE_PROMPT   -- override the Quantum ESPRESSO prompt
+    VASP_PROMPT -- override the VASP prompt
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+# argo-shim rejects the stripped lowercase-hyphenated model name (e.g.
+# "gpt-4.1-mini") with 400 Invalid model. Tell ChemGraph's normalizer to send
+# the wire form (e.g. "gpt41mini"), which the shim accepts. Set BEFORE importing
+# chemgraph so the normalizer picks it up. (Same shim quirk as the argo example.)
+os.environ.setdefault("CHEMGRAPH_ARGO_MODEL_FORMAT", "wire")
+
+
+# A realistic default prompt per engine. Bulk Si is the canonical periodic
+# plane-wave smoke test: a few atoms, a real k-mesh, converges fast.
+_DEFAULT_PROMPTS = {
+    "qe": (
+        "Relax the geometry of bulk silicon with Quantum ESPRESSO using a "
+        "4x4x4 k-point mesh and a 40 Ry wavefunction cutoff, then report the "
+        "final total energy."
+    ),
+    "vasp": (
+        "Compute the total energy of bulk silicon with VASP using a 4x4x4 "
+        "k-point mesh and a 400 eV plane-wave cutoff."
+    ),
+}
+
+
+def _engine_available(engine: str) -> bool:
+    """Return whether the pinned calculator for ``engine`` is registered here."""
+    from chemgraph.schemas.ase_input import get_available_calculator_names
+
+    names = get_available_calculator_names()
+    return {"qe": "EspressoCalc", "vasp": "VaspCalc"}[engine] in names
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--engine",
+        choices=["qe", "vasp"],
+        default="qe",
+        help="Which plane-wave engine to prompt for (default: qe).",
+    )
+    args = parser.parse_args()
+    engine = args.engine
+
+    argo_user = os.environ.get("ARGO_USER")
+    if not argo_user:
+        print(
+            "ERROR: set ARGO_USER to your CELS login "
+            "(e.g. `export ARGO_USER=jane.doe`).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not _engine_available(engine):
+        need = {
+            "qe": "pw.x on PATH (or ASE_ESPRESSO_COMMAND) AND ESPRESSO_PSEUDO",
+            "vasp": "a VASP binary (or VASP_COMMAND) AND VASP_PP_PATH",
+        }[engine]
+        print(
+            f"ERROR: the {engine.upper()} engine is not registered on this host.\n"
+            f"       run_{engine} is only offered when {need} is set.\n"
+            "       See README.md for the setup. QE is runnable on Aurora; VASP\n"
+            "       needs a licensed binary this machine may not have.",
+            file=sys.stderr,
+        )
+        return 2
+
+    model = os.environ.get("ARGO_MODEL", "argo:gpt-4.1-mini")
+    base_url = os.environ.get("ARGO_BASE", "http://127.0.0.1:18085/argoapi/v1")
+    prompt = os.environ.get(
+        f"{engine.upper()}_PROMPT", _DEFAULT_PROMPTS[engine]
+    )
+
+    print(f"Engine:    {engine}")
+    print(f"Model:     {model}")
+    print(f"Base URL:  {base_url}")
+    print(f"Argo user: {argo_user}")
+    print(f"Prompt:    {prompt}")
+    print()
+
+    from chemgraph.agent.llm_agent import ChemGraph
+
+    # run_qe / run_vasp are in the single_agent default tool set, gated on the
+    # engines detected above, so a plain single_agent already exposes them.
+    cg = ChemGraph(
+        model_name=model,
+        workflow_type="single_agent",
+        base_url=base_url,
+        api_key="dummy",  # argo-shim doesn't check
+        argo_user=argo_user,
+    )
+    result = asyncio.run(cg.run(prompt))
+    print()
+    print("=" * 60)
+    print("ChemGraph response:")
+    print("=" * 60)
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chemgraph/graphs/single_agent.py
+++ b/src/chemgraph/graphs/single_agent.py
@@ -7,8 +7,11 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import ToolNode
 from chemgraph.tools.ase_tools import (
     run_ase,
+    run_qe,
+    run_vasp,
     extract_output_json,
 )
+from chemgraph.schemas.ase_input import get_available_calculator_names
 from chemgraph.tools.cheminformatics_tools import (
     molecule_name_to_smiles,
     smiles_to_coordinate_file,
@@ -25,6 +28,30 @@ from chemgraph.utils.parsing import parse_response_formatter
 from chemgraph.state.state import State
 
 logger = setup_logger(__name__)
+
+
+def _plane_wave_tools() -> list:
+    """Return the plane-wave DFT tools whose engine is detected on this host.
+
+    ``run_qe`` / ``run_vasp`` are calculator-pinned wrappers over ``run_ase``.
+    Each is only useful when its engine (pw.x / VASP binary + pseudopotentials)
+    is installed, so we offer it only when the corresponding calculator survived
+    the availability gate in ``chemgraph.schemas.ase_input`` -- mirroring how the
+    ``CalculatorUnion`` itself is filtered. This keeps them out of the prompt on
+    hosts that cannot run them (and off the token budget there).
+
+    Returns
+    -------
+    list
+        The subset of ``[run_qe, run_vasp]`` whose engine is available.
+    """
+    available = set(get_available_calculator_names())
+    tools = []
+    if "EspressoCalc" in available:
+        tools.append(run_qe)
+    if "VaspCalc" in available:
+        tools.append(run_vasp)
+    return tools
 
 
 def _tool_call_signature(tool_calls) -> tuple:
@@ -307,6 +334,7 @@ def ChemGraphAgent(
             extract_output_json,
             calculator,
         ]
+        tools.extend(_plane_wave_tools())
         if human_supervised:
             tools.append(ask_human)
     elif human_supervised and ask_human not in tools:
@@ -499,6 +527,7 @@ def construct_single_agent_graph(
                 extract_output_json,
                 calculator,
             ]
+            tools.extend(_plane_wave_tools())
             if human_supervised:
                 tools.append(ask_human)
         elif human_supervised and ask_human not in tools:

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -13,6 +13,8 @@ from chemgraph.schemas.calculators.fairchem_calc import FAIRChemCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
 from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
 from chemgraph.schemas.calculators.aimnet2_calc import AIMNET2Calc
+from chemgraph.schemas.calculators.vasp_calc import VaspCalc
+from chemgraph.schemas.calculators.espresso_calc import EspressoCalc
 
 # Gate optional calculators on whether their engine package is installed.
 # Schema classes are always importable (internal to ChemGraph), so we must
@@ -75,11 +77,38 @@ if not _command_available("nwchem", "ASE_NWCHEM_COMMAND"):
 if not _command_available("orca", "ASE_ORCA_COMMAND"):
     OrcaCalc = None
 
+# VASP needs a licensed binary AND a pseudopotential library at VASP_PP_PATH,
+# both present. ASE accepts several launch mechanisms: ASE_VASP_COMMAND /
+# VASP_COMMAND / VASP_SCRIPT env vars, or a vasp_std/vasp_gam binary on PATH.
+_vasp_binary = (
+    _command_available("vasp_std", "ASE_VASP_COMMAND")
+    or shutil.which("vasp_gam") is not None
+    or bool(os.environ.get("VASP_COMMAND"))
+    or bool(os.environ.get("VASP_SCRIPT"))
+)
+if not (_vasp_binary and bool(os.environ.get("VASP_PP_PATH"))):
+    VaspCalc = None
+
+# Quantum ESPRESSO needs pw.x (or ASE_ESPRESSO_COMMAND) AND a pseudopotential
+# directory. The gate checks ESPRESSO_PSEUDO only: it deliberately ignores the
+# per-call ``pseudo_dir`` field so registration proves pseudos exist somewhere on
+# this host before offering the calculator (mirroring the VASP_PP_PATH gate).
+# Export ESPRESSO_PSEUDO to register even when you pass pseudo_dir per call.
+if not (
+    _command_available("pw.x", "ASE_ESPRESSO_COMMAND")
+    and bool(os.environ.get("ESPRESSO_PSEUDO"))
+):
+    EspressoCalc = None
+
 
 _CALCULATOR_ALIASES = {
     "xtb": "tbli",
     "gfn1xtb": "tbli",
     "gfn2xtb": "tbli",
+    "qe": "espr",
+    "quantumespresso": "espr",
+    "pwscf": "espr",
+    "pw": "espr",
 }
 
 
@@ -109,6 +138,8 @@ _all_calculator_classes: List[Optional[Type[BaseModel]]] = [
     EMTCalc,
     NWChemCalc,
     OrcaCalc,
+    VaspCalc,
+    EspressoCalc,
 ]
 
 # Filter out unavailable calculators
@@ -228,10 +259,12 @@ class ASEInputSchema(BaseModel):
     optimizer : str
         Optimization algorithm for geometry optimization. Options:
         - 'bfgs', 'lbfgs', 'gpmin', 'fire', 'mdmin'.
-    calculator : Union[FAIRChemCalc, MaceCalc, NWChemCalc, OrcaCalc, TBLiteCalc, EMTCalc, AIMNET2Calc]
+    calculator : Union[FAIRChemCalc, MaceCalc, NWChemCalc, OrcaCalc, TBLiteCalc, EMTCalc, AIMNET2Calc, VaspCalc, EspressoCalc]
         ASE-compatible calculator used for the simulation. Supported types are determined
         by installed packages and may include:
-        - FAIRChem, MACE, NWChem, Orca, TBLite and EMT. The order determines the priority of the calculators.
+        - FAIRChem, MACE, NWChem, Orca, TBLite, EMT, AIMNet2, and the plane-wave
+          DFT calculators VASP and Quantum ESPRESSO. The order determines the
+          priority of the calculators.
         - Use MACE or FAIRChem if the calculator is not specified.
     fmax : float
         Force convergence criterion in eV/Å. Optimization stops when all force components fall below this threshold.

--- a/src/chemgraph/schemas/calculators/_plane_wave.py
+++ b/src/chemgraph/schemas/calculators/_plane_wave.py
@@ -1,0 +1,50 @@
+# Shared helpers for the subprocess plane-wave DFT calculators (Quantum
+# ESPRESSO and VASP). Both launch an external executable via ASE and need the
+# same periodicity-aware k-mesh handling, so the logic lives here once instead
+# of being duplicated in each calculator schema.
+
+
+def is_nonperiodic(atoms) -> bool:
+    """Return True when ``atoms`` is a fully non-periodic (isolated) structure.
+
+    An isolated molecule has ``pbc`` False on every axis, so it takes the
+    Gamma-only / molecule branch in both plane-wave schemas. ``atoms=None``
+    (construction / unit-test time, before any structure is read) is treated as
+    *not* known-nonperiodic so callers fall back to their configured mesh.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms or None
+        The structure, or None when no structure is available yet.
+
+    Returns
+    -------
+    bool
+        True only when ``atoms`` exists and no axis is periodic.
+    """
+    return atoms is not None and not atoms.pbc.any()
+
+
+def mask_kmesh_by_pbc(kpts, pbc) -> tuple:
+    """Collapse the k-mesh to a single point on every non-periodic axis.
+
+    A Monkhorst-Pack mesh is only meaningful along a periodic direction; a slab
+    (``pbc=[T,T,F]``) or wire (``pbc=[T,F,F]``) must use a single k-point in its
+    vacuum direction(s). This keeps the user's requested subdivisions on the
+    periodic axes and forces ``1`` on the rest -- unlike ASE's
+    ``kptdensity2monkhorstpack`` it does NOT recompute the mesh from a density,
+    so an explicit ``kpts`` is honored exactly as configured.
+
+    Parameters
+    ----------
+    kpts : sequence of int
+        The configured 3-axis Monkhorst-Pack subdivisions.
+    pbc : sequence of bool
+        ``atoms.pbc`` -- periodicity per axis.
+
+    Returns
+    -------
+    tuple of int
+        The per-axis masked mesh (``1`` on non-periodic axes).
+    """
+    return tuple(int(k) if p else 1 for k, p in zip(kpts, pbc))

--- a/src/chemgraph/schemas/calculators/espresso_calc.py
+++ b/src/chemgraph/schemas/calculators/espresso_calc.py
@@ -1,0 +1,309 @@
+# Keywords and parameters obtained from
+# https://wiki.fysik.dtu.dk/ase/ase/calculators/espresso.html
+# Quantum ESPRESSO (pw.x) parameters for ChemGraph. Periodic plane-wave DFT;
+# same subprocess model as NWChem/ORCA/VASP (an external executable ASE
+# launches), so the ChemGraph wall-clock cap applies at optimizer-step /
+# displacement boundaries while an ASE optimizer drives the geometry. A single
+# internal pw.x 'relax'/'vc-relax' run stays outside the cap, since it runs to
+# completion inside one subprocess.
+
+import shlex
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from chemgraph.schemas.calculators._plane_wave import mask_kmesh_by_pbc
+
+# Tokens that mark the start of ASE's own input/redirection handling. A legacy
+# ASE_ESPRESSO_COMMAND may bake in the full pw.x command line
+# ("mpirun -np 4 pw.x -in PREFIX.pwi > PREFIX.pwo"), but the modern
+# EspressoProfile only wants the executable (+ any launcher/runtime flags) and
+# appends "-in <file>" itself. Anything from the first of these tokens onward is
+# ASE's job, so it must be stripped to avoid a duplicated "-in", a literal ">"
+# token, and the wrong input file on a real run.
+_ESPRESSO_CMD_STOP_TOKENS = frozenset(
+    {"-in", "-inp", "-input", "-i", "<", ">", ">>", "|", "&>", "1>", "2>"}
+)
+
+
+def _sanitize_espresso_command(raw: str) -> str:
+    """Reduce a (possibly legacy) pw.x command line to just its launch prefix.
+
+    Keeps the executable and any launcher/runtime flags (e.g. ``mpirun -np 4``,
+    ``srun``, ``-npool 4``) but drops ASE-owned input/redirection tokens and the
+    input-file operand, so the result is safe to hand to
+    ``EspressoProfile(command=...)`` (which appends ``-in <file>`` itself).
+
+    Parameters
+    ----------
+    raw : str
+        The raw command string, typically from ``$ASE_ESPRESSO_COMMAND``.
+
+    Returns
+    -------
+    str
+        The sanitized launch prefix. Falls back to ``raw`` (stripped) when the
+        string cannot be parsed or nothing would remain.
+    """
+    try:
+        tokens = shlex.split(raw)
+    except ValueError:
+        return raw.strip()
+
+    kept: List[str] = []
+    for tok in tokens:
+        if tok in _ESPRESSO_CMD_STOP_TOKENS or tok.endswith((".pwi", ".pwo")):
+            break
+        kept.append(tok)
+
+    if not kept:
+        return raw.strip()
+    return shlex.join(kept)
+
+
+class EspressoCalc(BaseModel):
+    """Quantum ESPRESSO (pw.x) periodic plane-wave DFT calculator configuration.
+
+    Quantum ESPRESSO is an external executable that ASE launches as a subprocess
+    (like NWChem, ORCA, and VASP). It requires ``pw.x`` on ``PATH`` (or via
+    ``ASE_ESPRESSO_COMMAND``) and a pseudopotential directory (``ESPRESSO_PSEUDO``
+    or the ``pseudo_dir`` field). This machine has neither, so the class is
+    written to be constructed and unit-tested (kwargs -> ASE ``Espresso``)
+    without a real run.
+
+    Parameters
+    ----------
+    calculator_type : str, optional
+        Calculator type. Currently supports only 'espresso', by default
+        'espresso'. Aliases 'qe', 'pwscf', 'quantum-espresso' resolve to this.
+    pseudopotentials : dict, optional
+        Per-element pseudopotential filename map, e.g. {'Si': 'Si.UPF'}. Required
+        for a real run; may be omitted when only constructing the calculator, by
+        default None.
+    pseudo_dir : str, optional
+        Directory holding the .UPF pseudopotential files. Falls back to the
+        ESPRESSO_PSEUDO environment variable when None, by default None.
+    ecutwfc : float, optional
+        Plane-wave wavefunction cutoff in Ry, by default 50.0.
+    ecutrho : float, optional
+        Charge-density cutoff in Ry; defaults to QE's 4*ecutwfc when None, by
+        default None.
+    kpts : list of int, optional
+        Monkhorst-Pack k-point mesh, by default [4, 4, 4]. Mutually exclusive
+        with ``kspacing``.
+    kspacing : float, optional
+        k-point spacing in 1/Angstrom; an alternative to ``kpts``, by default
+        None.
+    xc : str, optional
+        Exchange-correlation functional written to the pw.x ``input_dft``
+        keyword, by default 'PBE'.
+    smearing : str, optional
+        Occupation smearing type for metals (e.g. 'gaussian', 'mp', 'mv'); None
+        uses fixed occupations, by default None.
+    degauss : float, optional
+        Smearing width in Ry (used with ``smearing``), by default None.
+    nspin : int, optional
+        1 = non-spin-polarized, 2 = spin-polarized, by default 1.
+    tot_charge : float, optional
+        Net charge of the cell, by default None.
+    input_data : dict, optional
+        Extra raw pw.x namelist parameters merged into the input (advanced;
+        overrides the convenience fields above where they overlap), by default
+        None.
+    directory : str, optional
+        Working directory for pw.x I/O, by default '.'.
+    vacuum : float, optional
+        Padding in Angstrom added around a non-periodic molecule that has no
+        cell, so plane-wave pw.x has a finite box to run in. Applied by the
+        ChemGraph runner (``ase_core``) via ``atoms.center(vacuum=...)`` before
+        the run; ignored for structures that already carry a cell, by default
+        6.0. For a *charged* isolated molecule also set
+        ``input_data={'assume_isolated': 'mt'}`` (Martyna-Tuckerman) so the
+        periodic images do not interact spuriously.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    calculator_type: str = Field(
+        default="espresso",
+        description="Calculator type. Supports 'espresso' (aliases: qe, pwscf, quantum-espresso).",
+    )
+    pseudopotentials: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Per-element pseudopotential filename map, e.g. {'Si': 'Si.UPF'}.",
+    )
+    pseudo_dir: Optional[str] = Field(
+        default=None,
+        description="Directory of .UPF files; falls back to $ESPRESSO_PSEUDO when None.",
+    )
+    ecutwfc: float = Field(
+        default=50.0, description="Plane-wave wavefunction cutoff in Ry."
+    )
+    ecutrho: Optional[float] = Field(
+        default=None,
+        description="Charge-density cutoff in Ry; QE default is 4*ecutwfc when None.",
+    )
+    kpts: Optional[List[int]] = Field(
+        default=[4, 4, 4],
+        min_length=3,
+        max_length=3,
+        description="Monkhorst-Pack k-point mesh (exactly 3 axes). Mutually exclusive with kspacing.",
+    )
+    kspacing: Optional[float] = Field(
+        default=None,
+        description="k-point spacing in 1/Angstrom; alternative to kpts.",
+    )
+    xc: str = Field(
+        default="PBE",
+        description="Exchange-correlation functional (pw.x input_dft keyword).",
+    )
+    smearing: Optional[str] = Field(
+        default=None,
+        description="Occupation smearing for metals ('gaussian', 'mp', 'mv'); None = fixed.",
+    )
+    degauss: Optional[float] = Field(
+        default=None, description="Smearing width in Ry (used with smearing)."
+    )
+    nspin: int = Field(
+        default=1,
+        description="1 = non-spin-polarized, 2 = spin-polarized.",
+        ge=1,
+        le=2,
+    )
+    tot_charge: Optional[float] = Field(
+        default=None, description="Net charge of the cell."
+    )
+    input_data: Optional[Dict[str, Union[str, int, float, bool, dict]]] = Field(
+        default=None,
+        description="Extra raw pw.x namelist parameters merged into the input (advanced).",
+    )
+    directory: str = Field(
+        default=".", description="Working directory for Quantum ESPRESSO calculations."
+    )
+    vacuum: float = Field(
+        default=6.0,
+        description=(
+            "Padding (Angstrom) added around a cell-less non-periodic molecule "
+            "so plane-wave pw.x has a finite box; applied by ase_core."
+        ),
+    )
+
+    def _build_input_data(self) -> dict:
+        """Assemble the pw.x ``input_data`` namelist from the convenience fields.
+
+        Returns
+        -------
+        dict
+            A flat pw.x parameter dict; ASE routes keys into their namelists.
+            Any keys in ``self.input_data`` override the convenience defaults.
+        """
+        data: dict = {
+            "ecutwfc": self.ecutwfc,
+            "input_dft": self.xc,
+            "nspin": self.nspin,
+            # ChemGraph drives geometry with an ASE optimizer, so pw.x is used as
+            # a force engine and must print forces after every SCF. ASE 3.29's
+            # espresso writer does NOT translate properties=['forces'] into the
+            # pw.x 'tprnfor' control flag, so without this the first optimizer
+            # step raises PropertyNotImplementedError('forces not present'). Set
+            # it explicitly; overridable via the input_data field below.
+            "tprnfor": True,
+        }
+        if self.ecutrho is not None:
+            data["ecutrho"] = self.ecutrho
+        if self.smearing is not None:
+            data["occupations"] = "smearing"
+            data["smearing"] = self.smearing
+            if self.degauss is not None:
+                data["degauss"] = self.degauss
+        if self.tot_charge is not None:
+            data["tot_charge"] = self.tot_charge
+        if self.input_data:
+            data.update(self.input_data)
+        return data
+
+    def get_calculator(self, atoms=None):
+        """Get an ASE-compatible Quantum ESPRESSO calculator instance.
+
+        Parameters
+        ----------
+        atoms : ase.Atoms, optional
+            The structure the calculator will run on. When provided and fully
+            non-periodic (``atoms.pbc.any()`` is False), the k-point mesh is
+            dropped so ASE writes ``K_POINTS gamma`` -- a Monkhorst-Pack mesh is
+            meaningless for an isolated molecule. For a partially periodic
+            structure (slab ``[T,T,F]`` / wire ``[T,F,F]``) the configured mesh
+            is masked per axis so the non-periodic (vacuum) directions collapse
+            to a single k-point. When None (construction / unit-test time), the
+            configured ``kpts``/``kspacing`` is kept unchanged for backward
+            compatibility.
+
+        Returns
+        -------
+        Espresso
+            An ASE-compatible Espresso calculator instance.
+
+        Raises
+        ------
+        ValueError
+            If an invalid calculator_type is specified.
+        """
+        if self.calculator_type != "espresso":
+            raise ValueError(
+                "Invalid calculator_type. The only valid option is 'espresso'."
+            )
+
+        import os
+
+        from ase.calculators.espresso import Espresso, EspressoProfile
+
+        pseudo_dir = self.pseudo_dir or os.environ.get("ESPRESSO_PSEUDO")
+        # EspressoProfile.command must be the executable (or an mpi wrapper
+        # around it), e.g. "pw.x" or "mpirun -np 4 pw.x". ASE appends
+        # "-in <input>" itself, so the legacy full-command-line form of
+        # ASE_ESPRESSO_COMMAND (with "-in PREFIX.pwi > PREFIX.pwo") is sanitized
+        # down to just the launch prefix -- otherwise a real run gets a
+        # duplicated "-in", a literal ">" token, and the wrong input file.
+        profile = EspressoProfile(
+            command=_sanitize_espresso_command(
+                os.environ.get("ASE_ESPRESSO_COMMAND", "pw.x")
+            ),
+            pseudo_dir=pseudo_dir or ".",
+        )
+
+        kwargs: dict = dict(
+            profile=profile,
+            input_data=self._build_input_data(),
+            pseudopotentials=self.pseudopotentials or {},
+            directory=self.directory,
+        )
+        # k-mesh follows atoms.pbc:
+        #   * fully non-periodic molecule -> pass neither kpts nor kspacing, so
+        #     ASE emits "K_POINTS gamma" (a Monkhorst-Pack mesh is meaningless);
+        #   * slab/wire -> mask the configured mesh per axis so vacuum
+        #     directions collapse to a single k-point (a mesh there is wasted
+        #     and unphysical);
+        #   * fully periodic solid -> keep the configured mesh verbatim.
+        # kspacing is left to ASE, whose own mesh generation is already
+        # pbc-aware. atoms=None (construction time) keeps the configured mesh so
+        # existing no-arg callers are unaffected.
+        if atoms is None:
+            if self.kspacing is not None:
+                kwargs["kspacing"] = self.kspacing
+            elif self.kpts is not None:
+                kwargs["kpts"] = tuple(self.kpts)
+        elif atoms.pbc.any():
+            if self.kspacing is not None:
+                kwargs["kspacing"] = self.kspacing
+            elif self.kpts is not None:
+                kwargs["kpts"] = mask_kmesh_by_pbc(self.kpts, atoms.pbc)
+
+        return Espresso(**kwargs)
+
+    def get_multiplicity(self) -> Optional[int]:
+        """Return spin multiplicity for thermochemistry.
+
+        Quantum ESPRESSO expresses spin through ``nspin``/``tot_magnetization``,
+        so it reports no 2S+1 molecular multiplicity.
+        """
+        return None

--- a/src/chemgraph/schemas/calculators/vasp_calc.py
+++ b/src/chemgraph/schemas/calculators/vasp_calc.py
@@ -1,0 +1,282 @@
+# Keywords and parameters obtained from
+# https://wiki.fysik.dtu.dk/ase/ase/calculators/vasp.html
+# VASP parameters for ChemGraph. Periodic plane-wave DFT; same subprocess model
+# as NWChem/ORCA (an external executable ASE launches), so the ChemGraph
+# wall-clock cap applies at optimizer-step / displacement boundaries while an
+# ASE optimizer drives the geometry. A single internal VASP relax (NSW>0) stays
+# outside the cap, since it runs to completion inside one subprocess.
+
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, Field
+
+from chemgraph.schemas.calculators._plane_wave import (
+    is_nonperiodic,
+    mask_kmesh_by_pbc,
+)
+
+
+class VaspCalc(BaseModel):
+    """VASP periodic plane-wave DFT calculator configuration.
+
+    VASP is an external executable that ASE launches as a subprocess (like
+    NWChem and ORCA). It requires a licensed ``vasp_std``/``vasp_gam`` binary on
+    ``PATH`` (or via ``ASE_VASP_COMMAND``) and a pseudopotential library pointed
+    to by ``VASP_PP_PATH``. This machine has neither, so the class is written to
+    be constructed and unit-tested (kwargs -> ASE ``Vasp``) without a real run.
+
+    Parameters
+    ----------
+    calculator_type : str, optional
+        Calculator type. Currently supports only 'vasp', by default 'vasp'.
+    xc : str, optional
+        Exchange-correlation functional, by default 'PBE'.
+    encut : float, optional
+        Plane-wave kinetic-energy cutoff in eV, by default 520.0.
+    kpts : list of int, optional
+        Monkhorst-Pack k-point mesh, by default [3, 3, 3]. Mutually exclusive
+        with ``kspacing`` (set one; if both are given ``kspacing`` wins in VASP).
+    kspacing : float, optional
+        k-point spacing in 2*pi/Angstrom, VASP's own KSPACING convention (ASE
+        writes this value straight to the INCAR KSPACING tag, so the same number
+        means a denser mesh here than QE's Angstrom^-1 kspacing). An alternative
+        to ``kpts``, by default None.
+    ispin : int, optional
+        Spin polarization: 1 = non-spin-polarized, 2 = spin-polarized, by
+        default 1.
+    nsw : int, optional
+        Number of ionic steps for VASP's own internal relaxation. Leave None (or
+        0) to let an ASE optimizer drive the geometry instead -- required for the
+        ChemGraph wall-clock cap to see ionic-step boundaries, by default None.
+    ediff : float, optional
+        Electronic SCF convergence threshold in eV, by default None (VASP
+        default).
+    ediffg : float, optional
+        Ionic relaxation convergence threshold; eV for energy or, if negative,
+        eV/Angstrom for forces, by default None.
+    prec : str, optional
+        VASP precision mode ('Normal', 'Accurate', 'Single', ...), by default
+        'Accurate'.
+    setups : str or dict, optional
+        Pseudopotential setup selection (e.g. 'recommended' or a per-element
+        map), by default None.
+    charge : int, optional
+        Net charge of the cell (VASP ``nelect`` is derived from this by ASE), by
+        default None.
+    directory : str, optional
+        Working directory for VASP I/O, by default '.'.
+    gamma : bool, optional
+        Use a Gamma-centered k-mesh; the default (False) uses Monkhorst-Pack.
+        Forced True for a non-periodic molecule (single Gamma point).
+    vacuum : float, optional
+        Padding in Angstrom added around a non-periodic molecule that has no
+        cell, so plane-wave VASP has a finite box to run in. Applied by the
+        ChemGraph runner (``ase_core``) via ``atoms.center(vacuum=...)`` before
+        the run; ignored for structures that already carry a cell, by default
+        6.0.
+    input_data : dict, optional
+        Extra raw INCAR tags merged into the ASE ``Vasp`` kwargs (advanced
+        escape hatch, the VASP analogue of ``EspressoCalc.input_data``): e.g.
+        ``{'ismear': 0, 'sigma': 0.05, 'algo': 'Fast', 'lreal': 'Auto'}``. Keys
+        are lowercased before merging: ASE routes a canonical lowercase name to
+        its typed parameter slot, but a raw uppercase key lands in a stray slot
+        and, on a conflict with a convenience field, writes a *duplicate* INCAR
+        tag (e.g. both ``ISMEAR = 0`` and ``ISMEAR = 1``). Lowercasing collapses
+        that so ``{'ISMEAR': 0}`` cleanly overrides. Merged **last**, so these
+        win over the convenience fields (and even the molecule k-mesh / molecule
+        smearing) on conflict. Unlike QE, VASP keys are case-normalized here;
+        ``EspressoCalc.input_data`` passes its namelist keys through untouched.
+        ASE does not validate these keys, so an unrecognized tag (a typo such as
+        ``ismaer``) is accepted silently and never reaches INCAR; check spelling
+        against the VASP tag list. By default None.
+    """
+
+    calculator_type: str = Field(
+        default="vasp",
+        description="Calculator type. Currently supports only 'vasp'.",
+    )
+    xc: str = Field(
+        default="PBE", description="Exchange-correlation functional."
+    )
+    encut: float = Field(
+        default=520.0, description="Plane-wave kinetic-energy cutoff in eV."
+    )
+    kpts: Optional[List[int]] = Field(
+        default=[3, 3, 3],
+        min_length=3,
+        max_length=3,
+        description="Monkhorst-Pack k-point mesh (exactly 3 axes). Mutually exclusive with kspacing.",
+    )
+    kspacing: Optional[float] = Field(
+        default=None,
+        description=(
+            "k-point spacing in 2*pi/Angstrom (VASP KSPACING convention, denser "
+            "than QE's Angstrom^-1 kspacing for the same value); alternative to kpts."
+        ),
+    )
+    ispin: int = Field(
+        default=1,
+        description="Spin polarization: 1 = non-spin-polarized, 2 = spin-polarized.",
+        ge=1,
+        le=2,
+    )
+    nsw: Optional[int] = Field(
+        default=None,
+        description=(
+            "Ionic steps for VASP's internal relaxation. Leave None/0 to let an "
+            "ASE optimizer drive the geometry (needed for the wall-clock cap)."
+        ),
+    )
+    ediff: Optional[float] = Field(
+        default=None, description="Electronic SCF convergence threshold in eV."
+    )
+    ediffg: Optional[float] = Field(
+        default=None,
+        description=(
+            "Ionic convergence threshold; eV for energy, or eV/Angstrom (forces) "
+            "if negative."
+        ),
+    )
+    prec: str = Field(
+        default="Accurate",
+        description="VASP precision mode ('Normal', 'Accurate', 'Single', ...).",
+    )
+    setups: Optional[Union[str, dict]] = Field(
+        default=None,
+        description="Pseudopotential setup selection (e.g. 'recommended' or a per-element map).",
+    )
+    charge: Optional[int] = Field(
+        default=None, description="Net charge of the cell."
+    )
+    directory: str = Field(
+        default=".", description="Working directory for VASP calculations."
+    )
+    gamma: bool = Field(
+        default=False,
+        description="Use a Gamma-centered k-mesh (forced True for a non-periodic molecule).",
+    )
+    vacuum: float = Field(
+        default=6.0,
+        description=(
+            "Padding (Angstrom) added around a cell-less non-periodic molecule "
+            "so plane-wave VASP has a finite box; applied by ase_core."
+        ),
+    )
+    input_data: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Extra raw INCAR tags (keys lowercased) merged last into the ASE "
+            "Vasp kwargs (advanced escape hatch mirroring EspressoCalc.input_data; "
+            "overrides convenience fields on conflict). ASE does not validate "
+            "these keys, so a misspelled tag is accepted silently and dropped."
+        ),
+    )
+
+    def get_calculator(self, atoms=None):
+        """Get an ASE-compatible VASP calculator instance.
+
+        Parameters
+        ----------
+        atoms : ase.Atoms, optional
+            The structure the calculator will run on. When provided and fully
+            non-periodic (``atoms.pbc.any()`` is False), the k-mesh is pinned to
+            a single Gamma point (``kpts=[1,1,1]``, ``gamma=True``), any
+            ``kspacing`` is dropped -- a real VASP run still needs a KPOINTS
+            file (unlike QE's gamma shortcut), and an INCAR ``KSPACING`` would
+            silently override that single Gamma point -- and ``ismear=0`` with a
+            small ``sigma`` is defaulted so an isolated molecule does not inherit
+            VASP's metallic default (``ISMEAR=1``, which gives spurious partial
+            occupancies for discrete molecular levels). For a partially periodic
+            structure (slab ``[T,T,F]`` / wire ``[T,F,F]``) the configured mesh
+            is masked per axis so the vacuum directions collapse to a single
+            k-point. When None (construction / unit-test time), the configured
+            mesh is kept unchanged for backward compatibility.
+
+        Returns
+        -------
+        Vasp
+            An ASE-compatible VASP calculator instance.
+
+        Raises
+        ------
+        ValueError
+            If an invalid calculator_type is specified.
+        """
+        if self.calculator_type != "vasp":
+            raise ValueError(
+                "Invalid calculator_type. The only valid option is 'vasp'."
+            )
+
+        from ase.calculators.vasp import Vasp
+
+        # Only pass keys the user actually set, so ASE/VASP defaults stand in for
+        # the rest. kpts is dropped when kspacing is given (VASP uses kspacing).
+        kwargs: dict = dict(
+            xc=self.xc,
+            encut=self.encut,
+            ispin=self.ispin,
+            prec=self.prec,
+            directory=self.directory,
+        )
+        nonperiodic = is_nonperiodic(atoms)
+        if nonperiodic:
+            # A single Gamma point for the isolated molecule. Pin kpts (real VASP
+            # needs a KPOINTS file -- None writes none) and force gamma; do NOT
+            # pass kspacing (an INCAR KSPACING silently overrides KPOINTS).
+            kwargs["kpts"] = [1, 1, 1]
+            kwargs["gamma"] = True
+            # A discrete molecule has sharp, well-separated levels, so use the
+            # Gaussian smearing that suits an insulator/molecule. Without this
+            # VASP falls back to its metallic default (ISMEAR=1, Methfessel-
+            # Paxton), which produces spurious partial/negative occupancies for
+            # a molecule. Overridable via input_data (merged last, below).
+            kwargs["ismear"] = 0
+            kwargs["sigma"] = 0.03
+        else:
+            # Periodic (or atoms=None at construction time). Keep the configured
+            # mesh, but for a periodic structure mask it per axis so a slab/wire
+            # uses a single k-point in its vacuum direction(s); atoms=None keeps
+            # the mesh verbatim for backward compatibility.
+            if self.kspacing is not None:
+                kwargs["kspacing"] = self.kspacing
+            elif self.kpts is not None:
+                if atoms is None:
+                    kwargs["kpts"] = self.kpts
+                else:
+                    kwargs["kpts"] = list(
+                        mask_kmesh_by_pbc(self.kpts, atoms.pbc)
+                    )
+            if self.gamma:
+                kwargs["gamma"] = self.gamma
+        if self.nsw is not None:
+            kwargs["nsw"] = self.nsw
+        if self.ediff is not None:
+            kwargs["ediff"] = self.ediff
+        if self.ediffg is not None:
+            kwargs["ediffg"] = self.ediffg
+        if self.setups is not None:
+            kwargs["setups"] = self.setups
+        if self.charge is not None:
+            kwargs["charge"] = self.charge
+
+        # Advanced escape hatch: raw INCAR tags win over the convenience fields
+        # above (and over the molecule k-mesh / smearing) on any key collision.
+        # Keys are lowercased because ASE routes a canonical lowercase name to
+        # its typed parameter slot; a raw uppercase key lands in a stray slot and
+        # (on a collision with a convenience field we set above) writes a
+        # DUPLICATE INCAR tag -- e.g. both "ISMEAR = 0" and "ISMEAR = 1".
+        # Lowercasing collapses the two so the escape-hatch value cleanly wins.
+        if self.input_data:
+            kwargs.update(
+                {k.lower(): v for k, v in self.input_data.items()}
+            )
+
+        return Vasp(**kwargs)
+
+    def get_multiplicity(self) -> Optional[int]:
+        """Return spin multiplicity for thermochemistry.
+
+        VASP expresses spin through ``ispin``/``nupdown``, so it reports no
+        2S+1 molecular multiplicity.
+        """
+        return None

--- a/src/chemgraph/schemas/plane_wave_input.py
+++ b/src/chemgraph/schemas/plane_wave_input.py
@@ -1,0 +1,121 @@
+"""Calculator-pinned input schemas for the plane-wave DFT tools.
+
+``run_ase`` accepts any installed calculator through the ``CalculatorUnion`` on
+:class:`~chemgraph.schemas.ase_input.ASEInputSchema`, so its whole tool schema
+(every calculator's fields) is serialized into every LLM request. The dedicated
+``run_qe`` / ``run_vasp`` tools instead each pin a single engine, so the model
+sees only that engine's parameters. These subclasses reuse every common ASE
+input field (``input_structure_file``, ``driver``, ``optimizer``, ``fmax``,
+``steps`` ...) from :class:`ASEInputSchema` and override only ``calculator`` to
+the concrete plane-wave type.
+
+The parent's ``_validate_calculator_type`` coerces + availability-gates the
+calculator against ``available_calculator_classes`` (engines detected at import
+time). That gate is right for ``run_ase`` (the union only offers installed
+engines) but wrong here: these schemas are also constructed in hermetic tests
+and by ``tool_call_eval`` on machines with no pw.x / VASP binary. So each
+subclass replaces the validator with a narrow coercion that instantiates its own
+calculator type WITHOUT the availability probe. Registration of the *tools*
+themselves still gates on availability (see ``graphs/single_agent.py``), so an
+engine that is not installed is never offered to the model on a real run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field, model_validator
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.calculators.espresso_calc import EspressoCalc
+from chemgraph.schemas.calculators.vasp_calc import VaspCalc
+
+
+def _coerce_pinned_calculator(data: Any, calc_cls: type, canonical_type: str) -> Any:
+    """Coerce ``data['calculator']`` into ``calc_cls`` without the availability gate.
+
+    Mirrors the accept-dict-or-instance behavior of
+    :func:`chemgraph.schemas.ase_input._coerce_calculator_payload`, but pins the
+    single calculator type and skips the installed-engine check so the schema is
+    constructible in hermetic tests / eval on a host lacking the binary.
+
+    Parameters
+    ----------
+    data : Any
+        Raw payload before Pydantic validation (dict when it carries a
+        ``calculator`` key; passed through unchanged otherwise).
+    calc_cls : type
+        The concrete calculator model to instantiate (``EspressoCalc`` /
+        ``VaspCalc``).
+    canonical_type : str
+        The canonical ``calculator_type`` string forced onto the result so it
+        routes correctly in ``ase_core`` dispatch even if the caller passed an
+        alias (``qe``, ``pw``, ...).
+
+    Returns
+    -------
+    Any
+        The payload with ``calculator`` set to a ``calc_cls`` instance.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    calc = data.get("calculator")
+    if calc is None:
+        data["calculator"] = calc_cls()
+    elif isinstance(calc, dict):
+        init_args = {k: v for k, v in calc.items() if k != "calculator_type"}
+        data["calculator"] = calc_cls(**init_args)
+    elif not isinstance(calc, calc_cls):
+        # A pre-built instance of the wrong type is a caller error worth surfacing.
+        raise ValueError(
+            f"{calc_cls.__name__} tool received a "
+            f"{type(calc).__name__} calculator; expected {calc_cls.__name__}."
+        )
+    # Normalize the type tag so ase_core dispatch always sees the canonical name.
+    data["calculator"].calculator_type = canonical_type
+    return data
+
+
+class QEInputSchema(ASEInputSchema):
+    """ASE input pinned to the Quantum ESPRESSO (pw.x) calculator.
+
+    Identical to :class:`ASEInputSchema` for every non-calculator field; the
+    ``calculator`` is fixed to :class:`EspressoCalc` so ``run_qe`` exposes only
+    QE parameters to the model.
+    """
+
+    calculator: EspressoCalc = Field(
+        default_factory=EspressoCalc,
+        description=(
+            "Quantum ESPRESSO (pw.x) plane-wave DFT configuration: plane-wave "
+            "cutoffs, k-point mesh, pseudopotentials, smearing, etc."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_calculator_type(cls, data: Any):
+        return _coerce_pinned_calculator(data, EspressoCalc, "espresso")
+
+
+class VaspInputSchema(ASEInputSchema):
+    """ASE input pinned to the VASP calculator.
+
+    Identical to :class:`ASEInputSchema` for every non-calculator field; the
+    ``calculator`` is fixed to :class:`VaspCalc` so ``run_vasp`` exposes only
+    VASP parameters to the model.
+    """
+
+    calculator: VaspCalc = Field(
+        default_factory=VaspCalc,
+        description=(
+            "VASP plane-wave DFT configuration: ENCUT, k-point mesh, spin, "
+            "smearing, INCAR overrides, etc."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_calculator_type(cls, data: Any):
+        return _coerce_pinned_calculator(data, VaspCalc, "vasp")

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -240,6 +240,23 @@ def load_calculator(calculator: dict) -> tuple[object, dict, object]:
     elif "nwchem" in calc_type:
         from chemgraph.schemas.calculators.nwchem_calc import NWChemCalc
         calc = NWChemCalc(**calculator)
+    elif "vasp" in calc_type:
+        from chemgraph.schemas.calculators.vasp_calc import VaspCalc
+        # Normalize aliases (e.g. "VASP", "vasp_std") to the canonical type so
+        # VaspCalc.get_calculator's strict check passes (mirrors espresso below).
+        vasp_args = {**calculator, "calculator_type": "vasp"}
+        calc = VaspCalc(**vasp_args)
+    elif (
+        "espresso" in calc_type
+        or "qe" in calc_type
+        or "pwscf" in calc_type
+        or calc_type == "pw"
+    ):
+        from chemgraph.schemas.calculators.espresso_calc import EspressoCalc
+        # Normalize aliases (qe/pwscf/pw/quantum-espresso) to the canonical type
+        # so EspressoCalc.get_calculator's strict check passes.
+        espresso_args = {**calculator, "calculator_type": "espresso"}
+        calc = EspressoCalc(**espresso_args)
     elif "fairchem" in calc_type:
         from chemgraph.schemas.calculators.fairchem_calc import FAIRChemCalc
         calc = FAIRChemCalc(**calculator)
@@ -253,7 +270,7 @@ def load_calculator(calculator: dict) -> tuple[object, dict, object]:
         raise ValueError(
             f"Unsupported calculator: {calculator}. "
             "Available calculators are EMT, TBLite (GFN2-xTB, GFN1-xTB), "
-            "Orca, NWChem, FAIRChem, MACE, or AIMNET2."
+            "Orca, NWChem, FAIRChem, MACE, AIMNET2, VASP, or Quantum ESPRESSO."
         )
 
     extra_info: dict = {}
@@ -272,6 +289,59 @@ def load_calculator(calculator: dict) -> tuple[object, dict, object]:
         ase_calculator = calc.get_calculator()
 
     return ase_calculator, extra_info, calc
+
+
+def prepare_dft_calculator(atoms, calc, calc_model):
+    """Finalize a subprocess plane-wave DFT calculator once the atoms are known.
+
+    ``load_calculator`` builds every calculator before the structure is read, so
+    a plane-wave engine (Quantum ESPRESSO / VASP) cannot yet know the cell or
+    periodicity it must run under. This bridges that gap, and is a no-op for
+    every other calculator type:
+
+      * a non-periodic structure without a full 3D cell (``pbc`` all False and
+        ``cell.rank < 3`` -- a bare molecule at rank 0, or a degenerate
+        zero-volume cell at rank 1/2) is given a vacuum box in place (so pw.x/
+        VASP have a finite, non-singular cell and the writer sees the moved
+        cell); a non-periodic structure that already carries a full rank-3 cell
+        is left untouched so a user-supplied box is not clobbered;
+      * the DFT calculator is rebuilt WITH the atoms so its k-mesh follows
+        ``atoms.pbc`` (Gamma for a molecule, per-axis masked mesh for a
+        slab/wire, the configured mesh for a bulk solid).
+
+    The ``isinstance`` guard is mandatory: every other calculator's
+    ``get_calculator()`` is zero-arg and would raise ``TypeError`` on ``atoms=``.
+
+    Parameters
+    ----------
+    atoms : ase.Atoms
+        The structure just read from disk. Mutated in place when centering.
+    calc : object
+        The ASE calculator already built by ``load_calculator``.
+    calc_model : object
+        The ChemGraph calculator schema instance from ``load_calculator``.
+
+    Returns
+    -------
+    object
+        The calculator to attach to ``atoms`` -- rebuilt for QE/VASP, otherwise
+        the ``calc`` passed in unchanged.
+    """
+    from chemgraph.schemas.calculators._plane_wave import is_nonperiodic
+    from chemgraph.schemas.calculators.espresso_calc import EspressoCalc
+    from chemgraph.schemas.calculators.vasp_calc import VaspCalc
+
+    if isinstance(calc_model, (EspressoCalc, VaspCalc)):
+        # A non-periodic structure with no full 3D cell (rank < 3) has no finite
+        # box for a plane-wave run: rank 0 is a bare xyz molecule, rank 1/2 is a
+        # degenerate cell with a zero-volume (singular) lattice vector that would
+        # make pw.x/VASP emit garbage. Give both a clean vacuum box. A structure
+        # that already carries a full rank-3 cell is left untouched so a
+        # user-supplied box is never clobbered.
+        if is_nonperiodic(atoms) and atoms.cell.rank < 3:
+            atoms.center(vacuum=calc_model.vacuum)
+        return calc_model.get_calculator(atoms=atoms)
+    return calc
 
 
 # ---------------------------------------------------------------------------
@@ -453,7 +523,8 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             "error_type": "ValueError",
             "message": (
                 f"Unsupported calculator: {calculator}. Available calculators are "
-                "MACE (mace_mp, mace_off, mace_anicc), EMT, TBLite (GFN2-xTB, GFN1-xTB), NWChem and Orca"
+                "MACE (mace_mp, mace_off, mace_anicc), EMT, TBLite (GFN2-xTB, GFN1-xTB), "
+                "NWChem, Orca, VASP and Quantum ESPRESSO"
             ),
         }
     logger.info("Calculator loaded successfully: %s", type(calc).__name__)
@@ -470,6 +541,14 @@ def run_ase_core(params: ASEInputSchema) -> dict:
 
     logger.info("Read %d atoms from %s", len(atoms), input_structure_file)
     atoms.info.update(system_info)
+
+    # Subprocess plane-wave DFT (QE/VASP) needs a finite cell and a
+    # periodicity-aware k-mesh, neither of which get_calculator could know at
+    # load_calculator time (the atoms were not read yet). Now that atoms exist,
+    # center a cell-less molecule and rebuild the calculator with the atoms; a
+    # no-op for every other calculator type (see prepare_dft_calculator).
+    calc = prepare_dft_calculator(atoms, calc, calc_model)
+
     atoms.calc = calc
 
     # ------------------------------------------------------------------

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -307,7 +307,13 @@ def prepare_dft_calculator(atoms, calc, calc_model):
         is left untouched so a user-supplied box is not clobbered;
       * the DFT calculator is rebuilt WITH the atoms so its k-mesh follows
         ``atoms.pbc`` (Gamma for a molecule, per-axis masked mesh for a
-        slab/wire, the configured mesh for a bulk solid).
+        slab/wire, the configured mesh for a bulk solid);
+      * a structure that was just given a vacuum box is then marked periodic.
+        ``atoms.center()`` supplies the cell but leaves ``pbc`` all False, and
+        ASE's VASP calculator refuses to run on anything not fully periodic
+        (``check_pbc``), so without this a molecule never reaches VASP. This
+        happens AFTER the rebuild above, because ``get_calculator`` reads
+        ``atoms.pbc`` to choose the molecule branch.
 
     The ``isinstance`` guard is mandatory: every other calculator's
     ``get_calculator()`` is zero-arg and would raise ``TypeError`` on ``atoms=``.
@@ -340,7 +346,29 @@ def prepare_dft_calculator(atoms, calc, calc_model):
         # user-supplied box is never clobbered.
         if is_nonperiodic(atoms) and atoms.cell.rank < 3:
             atoms.center(vacuum=calc_model.vacuum)
-        return calc_model.get_calculator(atoms=atoms)
+        # Build the calculator BEFORE touching pbc below: get_calculator reads
+        # atoms.pbc to choose the k-mesh: a single Gamma point for a molecule,
+        # a per-axis masked mesh for a slab/wire, the configured mesh for bulk.
+        # Flipping pbc first would send a molecule down the bulk branch (full
+        # k-mesh + VASP's metallic smearing) and un-mask a slab's vacuum axis.
+        dft_calc = calc_model.get_calculator(atoms=atoms)
+        # ASE's VASP calculator refuses anything not FULLY periodic
+        # (check_pbc: ``if not atoms.pbc.all(): raise``). That rejects three
+        # cases the code otherwise supports: a centered molecule (pbc all
+        # False), a molecule the user supplied their own rank-3 box for, and
+        # (despite mask_kmesh_by_pbc existing precisely for them) every slab
+        # ([T,T,F]) and wire ([T,F,F]). A plane-wave code has no aperiodic
+        # mode, so in VASP's model all of these ARE fully periodic cells and
+        # marking them so states what VASP will do anyway. Enough vacuum is
+        # what makes the residual image interaction small; it never removes it,
+        # and no dipole or monopole correction is applied here, so a polar or
+        # charged species needs a bigger box or an explicit IDIPOL/LDIPOL via
+        # input_data. The masked k-mesh computed above keeps the vacuum axes
+        # from being sampled as if they dispersed. QE needs none of this: pw.x
+        # has no equivalent check and write_espresso_in ignores pbc.
+        if isinstance(calc_model, VaspCalc) and not atoms.pbc.all():
+            atoms.pbc = True
+        return dft_calc
     return calc
 
 
@@ -541,6 +569,12 @@ def run_ase_core(params: ASEInputSchema) -> dict:
 
     logger.info("Read %d atoms from %s", len(atoms), input_structure_file)
     atoms.info.update(system_info)
+
+    # Remember how the structure was written before the plane-wave preparation
+    # below can mark it periodic. Gas-phase thermochemistry keys off this: an
+    # aperiodic input stays eligible even after being given a box, while a real
+    # crystal keeps its periodicity and is refused.
+    was_periodic_on_input = bool(atoms.pbc.any())
 
     # Subprocess plane-wave DFT (QE/VASP) needs a finite cell and a
     # periodicity-aware k-mesh, neither of which get_calculator could know at
@@ -764,10 +798,25 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                         )
                         spin_S = (multiplicity - 1) / 2.0
 
+                        # IdealGasThermo rejects periodic atoms outright
+                        # (ase.thermochemistry: "should not have periodic
+                        # boundary conditions"), and that guard is the only
+                        # thing stopping a crystal from being handed
+                        # rigid-rotor gas statistics, which are meaningless for
+                        # a solid. Keep it for anything periodic on input, and
+                        # sidestep it only for a structure the plane-wave path
+                        # boxed on our behalf: that is still one isolated
+                        # molecule, whose partition functions need nothing but
+                        # its masses and positions. `atoms` stays untouched.
+                        thermo_atoms = atoms
+                        if atoms.pbc.any() and not was_periodic_on_input:
+                            thermo_atoms = atoms.copy()
+                            thermo_atoms.pbc = False
+
                         thermo = IdealGasThermo(
                             vib_energies=energies,
                             potentialenergy=single_point_energy,
-                            atoms=atoms,
+                            atoms=thermo_atoms,
                             geometry=geometry,
                             symmetrynumber=symmetrynumber,
                             spin=spin_S,

--- a/src/chemgraph/tools/ase_tools.py
+++ b/src/chemgraph/tools/ase_tools.py
@@ -13,6 +13,7 @@ from langchain_core.tools import tool
 
 from chemgraph.schemas.atomsdata import AtomsData
 from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.plane_wave_input import QEInputSchema, VaspInputSchema
 from chemgraph.tools.ase_core import (
     _resolve_path,
     _resolve_existing_path,
@@ -171,4 +172,60 @@ def run_ase(params: ASEInputSchema) -> dict:
     """
     # MACE thread/process serialization now lives in run_ase_core ->
     # load_calculator, so this wrapper just delegates.
+    return run_ase_core(params)
+
+
+@tool
+def run_qe(params: QEInputSchema) -> dict:
+    """Run a Quantum ESPRESSO (pw.x) plane-wave DFT calculation.
+
+    A calculator-pinned variant of ``run_ase`` for Quantum ESPRESSO: the
+    ``calculator`` is fixed to the QE (pw.x) engine, so only QE parameters
+    (plane-wave cutoffs, k-point mesh, pseudopotentials, smearing) are exposed.
+    Use this when the user asks for a plane-wave DFT calculation with Quantum
+    ESPRESSO / pw.x. Same drivers as ``run_ase`` (energy, opt, vib, thermo, ir).
+
+    Parameters
+    ----------
+    params : QEInputSchema
+        Input parameters with the calculator pinned to Quantum ESPRESSO.
+
+    Returns
+    -------
+    dict
+        Output containing calculation results and status.
+
+    Raises
+    ------
+    ValueError
+        If the calculation fails.
+    """
+    return run_ase_core(params)
+
+
+@tool
+def run_vasp(params: VaspInputSchema) -> dict:
+    """Run a VASP plane-wave DFT calculation.
+
+    A calculator-pinned variant of ``run_ase`` for VASP: the ``calculator`` is
+    fixed to the VASP engine, so only VASP parameters (ENCUT, k-point mesh,
+    spin, smearing, INCAR overrides) are exposed. Use this when the user asks
+    for a plane-wave DFT calculation with VASP. Same drivers as ``run_ase``
+    (energy, opt, vib, thermo, ir).
+
+    Parameters
+    ----------
+    params : VaspInputSchema
+        Input parameters with the calculator pinned to VASP.
+
+    Returns
+    -------
+    dict
+        Output containing calculation results and status.
+
+    Raises
+    ------
+    ValueError
+        If the calculation fails.
+    """
     return run_ase_core(params)

--- a/src/chemgraph/utils/tool_call_eval.py
+++ b/src/chemgraph/utils/tool_call_eval.py
@@ -2,6 +2,7 @@
 
 from deepdiff import DeepDiff
 from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.plane_wave_input import QEInputSchema, VaspInputSchema
 
 
 def remove_ignored_fields(obj, ignored_keys=("cell", "pbc")):
@@ -132,11 +133,19 @@ def single_function_checker(
         result = {"valid": False, "error": error}
         return result
 
-    # Have a special case for run_ase due to complex input schema
-    if tool_name_model == "run_ase":
+    # Special-case the ASE tools due to their complex input schema. run_qe /
+    # run_vasp are calculator-pinned variants of run_ase, each validated through
+    # its own pinned schema.
+    _ase_tool_schemas = {
+        "run_ase": ASEInputSchema,
+        "run_qe": QEInputSchema,
+        "run_vasp": VaspInputSchema,
+    }
+    if tool_name_model in _ase_tool_schemas:
+        schema_cls = _ase_tool_schemas[tool_name_model]
         try:
-            model_args = ASEInputSchema(**model_args_raw["params"]).model_dump()
-            answer_args = ASEInputSchema(**answer_args_raw["params"]).model_dump()
+            model_args = schema_cls(**model_args_raw["params"]).model_dump()
+            answer_args = schema_cls(**answer_args_raw["params"]).model_dump()
         except Exception as e:
             result = {"valid": False, "error": e}
             return result

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -372,6 +372,18 @@ def _cu_wire():
     return wire
 
 
+def _h2o_in_box():
+    """A molecule the user already boxed: pbc all False but a full rank-3 cell.
+
+    Skips the centering branch (which requires ``cell.rank < 3``), so it is the
+    case where a box exists but the periodicity flag still does not.
+    """
+    atoms = _h2o_molecule()
+    atoms.cell = [[12.0, 0, 0], [0, 12.0, 0], [0, 0, 12.0]]
+    atoms.pbc = [False, False, False]
+    return atoms
+
+
 # --- Fix 1: pbc-aware k-mesh --------------------------------------------------
 
 
@@ -581,7 +593,10 @@ def test_prepare_dft_calculator_centers_cell_less_molecule_and_writes_gamma(
     )
     ase_calc = prepare_dft_calculator(atoms, calc, model)
 
-    # The helper centered the molecule in place but must NOT turn on periodicity.
+    # The helper centered the molecule in place. For QE it must NOT turn on
+    # periodicity: pw.x has no check_pbc to satisfy, and a spurious periodic
+    # flag would leak into the results and into gas-phase thermochemistry.
+    # (The VASP-only pbc flip is covered separately below.)
     assert atoms.cell.rank == 3
     assert not atoms.pbc.any()
 
@@ -669,7 +684,127 @@ def test_prepare_dft_calculator_centers_degenerate_partial_cell():
     prepare_dft_calculator(atoms, calc, model)
 
     assert atoms.cell.rank == 3  # centered into a finite, non-singular box
-    assert not atoms.pbc.any()
+    assert not atoms.pbc.any()  # QE keeps its periodicity; only VASP is flipped
+
+
+def test_prepare_dft_calculator_molecule_passes_ase_vasp_pbc_check():
+    """A cell-less molecule prepared for VASP must survive ASE's own pbc check.
+
+    ASE's Vasp calculator hard-rejects any structure that is not fully periodic
+    (``ase.calculators.vasp.vasp.check_atoms`` -> ``check_pbc``), and it does so
+    before writing a single input file. Centering alone does not satisfy it,
+    because ``atoms.center()`` supplies a cell but leaves ``pbc`` all False, so
+    without the pbc flag every molecule routed through ``run_vasp`` dies with
+    ``CalculatorSetupError`` and real VASP is never launched.
+
+    This asserts against ASE's real validator rather than re-stating the flag,
+    so it stays honest if ASE's rule changes. It needs no VASP binary and no
+    POTCARs: check_atoms runs purely on the Atoms object. The QE-only tests
+    above cannot catch this, because pw.x has no equivalent check.
+    """
+    from ase.calculators.vasp.vasp import check_atoms
+
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = _h2o_molecule()
+    assert atoms.cell.rank == 0 and not atoms.pbc.any()
+
+    calc, _extra, model = load_calculator({"calculator_type": "vasp"})
+    ase_calc = prepare_dft_calculator(atoms, calc, model)
+
+    check_atoms(atoms)  # raises CalculatorSetupError if pbc is not all True
+
+    # The molecule branch must survive the pbc flip: a single Gamma point and
+    # Gaussian smearing, not the configured bulk mesh with metallic smearing.
+    assert list(ase_calc.input_params["kpts"]) == [1, 1, 1]
+    assert ase_calc.input_params["gamma"] is True
+    assert ase_calc.parameters["ismear"] == 0
+
+
+@pytest.mark.parametrize(
+    "name, build, kpts, expected_kpts",
+    [
+        # A slab and a wire are the cases mask_kmesh_by_pbc exists for. They are
+        # NOT caught by is_nonperiodic (pbc.any() is True), yet check_pbc rejects
+        # them all the same because it tests pbc.all(), so before the fix no
+        # slab or wire could ever reach vasp_std and the masking was dead code.
+        ("slab", lambda: _cu_slab(), [3, 3, 3], [3, 3, 1]),
+        ("wire", lambda: _cu_wire(), [3, 3, 3], [3, 1, 1]),
+        # A molecule the user supplied their own rank-3 box for skips centering
+        # (the docstring explicitly invites this), so it needs the pbc flag too.
+        ("boxed molecule", lambda: _h2o_in_box(), [3, 3, 3], [1, 1, 1]),
+    ],
+)
+def test_prepare_dft_calculator_partial_periodicity_passes_vasp_check(
+    name, build, kpts, expected_kpts
+):
+    """Slabs, wires and pre-boxed molecules must reach VASP with a masked mesh.
+
+    ASE's check_pbc is ``not atoms.pbc.all()``, a conjunction, so partial
+    periodicity is rejected exactly like a bare molecule. Marking the cell fully
+    periodic is what VASP expects: a plane-wave code has no aperiodic mode, so
+    enough vacuum is what makes the residual image interaction small. The
+    per-axis masked k-mesh computed BEFORE the flip keeps the vacuum axes from
+    being sampled as if they dispersed. Asserting both together is the point:
+    a fix that set pbc before building the calculator would pass check_pbc and
+    silently un-mask the vacuum axis.
+    """
+    from ase.calculators.vasp.vasp import check_atoms
+
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = build()
+    calc, _extra, model = load_calculator(
+        {"calculator_type": "vasp", "kpts": kpts}
+    )
+    ase_calc = prepare_dft_calculator(atoms, calc, model)
+
+    check_atoms(atoms)  # raises CalculatorSetupError if pbc is not all True
+    assert list(ase_calc.input_params["kpts"]) == expected_kpts
+
+
+@pytest.mark.parametrize(
+    "build", [lambda: _h2o_molecule(), lambda: _cu_slab()]
+)
+def test_prepare_dft_calculator_does_not_touch_pbc_for_qe(build):
+    """The pbc flip is VASP-only: QE's periodicity must be left as the user set.
+
+    pw.x has no check_pbc and ``write_espresso_in`` ignores pbc entirely, so QE
+    gains nothing from the flip, and mutating it would leak a periodic flag
+    into QE results and into gas-phase thermochemistry, which rejects periodic
+    atoms.
+    """
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = build()
+    pbc_before = atoms.pbc.copy()
+
+    calc, _extra, model = load_calculator({"calculator_type": "espresso"})
+    prepare_dft_calculator(atoms, calc, model)
+
+    assert (atoms.pbc == pbc_before).all()
+
+
+def test_prepare_dft_calculator_leaves_bulk_pbc_and_mesh_alone():
+    """A real periodic crystal is untouched: the pbc fix must not disturb it.
+
+    Guards the ``needs_box`` condition on the high side: a bulk solid already
+    has pbc all True and a rank-3 cell, so it must keep its configured k-mesh
+    (no collapse to Gamma) and its cell must not be re-centered.
+    """
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = _si_bulk()
+    cell_before = atoms.cell.array.copy()
+
+    calc, _extra, model = load_calculator(
+        {"calculator_type": "vasp", "kpts": [4, 4, 4]}
+    )
+    ase_calc = prepare_dft_calculator(atoms, calc, model)
+
+    assert atoms.pbc.all()
+    assert np.allclose(atoms.cell.array, cell_before)  # not re-boxed
+    assert list(ase_calc.input_params["kpts"]) == [4, 4, 4]
 
 
 # --- Fix follow-ups: kpts length validation ----------------------------------
@@ -921,3 +1056,94 @@ def test_espresso_command_sanitizer_edge_branches(raw, expected):
     )
 
     assert _sanitize_espresso_command(raw) == expected
+
+
+def test_plane_wave_thermo_survives_a_periodic_box(tmp_path, monkeypatch):
+    """The thermo driver must still work for a molecule given a vacuum box.
+
+    ASE's IdealGasThermo refuses periodic atoms outright ("Atoms object should
+    not have periodic boundary conditions"), but a plane-wave molecule is
+    periodic only as a computational device: a vacuum box holding one
+    isolated molecule. run_ase_core must therefore hand the gas-phase thermo a
+    non-periodic copy. Without that, marking the VASP box periodic silently
+    breaks a driver that previously worked.
+
+    The molecule is written aperiodic, exactly as ASE reads an .xyz from disk,
+    so the box and the pbc flag come from prepare_dft_calculator itself rather
+    than from the test. EMT stands in for the calculator (no DFT binary, no
+    pseudopotentials, no POTCARs); prepare_dft_calculator is driven directly
+    with the VaspCalc schema so the boxing under test is the real one.
+    """
+    from ase.io import write
+
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.tools.ase_core import (
+        load_calculator,
+        prepare_dft_calculator,
+        run_ase_core,
+    )
+
+    atoms = _h2o_molecule()
+    assert atoms.cell.rank == 0 and not atoms.pbc.any()
+
+    # The VASP path boxes it and marks it periodic; confirm that is what lands
+    # on disk, so the thermo run below starts from a genuinely boxed molecule.
+    vasp_calc, _extra, vasp_model = load_calculator({"calculator_type": "vasp"})
+    prepare_dft_calculator(atoms, vasp_calc, vasp_model)
+    assert atoms.pbc.all() and atoms.cell.rank == 3
+
+    xyz = tmp_path / "h2o_boxed.xyz"
+    write(str(xyz), _h2o_molecule())  # aperiodic on disk, as ASE would read it
+
+    monkeypatch.chdir(tmp_path)
+    result = run_ase_core(
+        ASEInputSchema(
+            input_structure_file=str(xyz),
+            output_results_file=str(tmp_path / "out.json"),
+            driver="thermo",
+            calculator={"calculator_type": "emt"},
+            temperature=298.15,
+        )
+    )
+
+    assert result["status"] == "success", result
+    thermo = result["result"]["thermochemistry"]
+    assert "gibbs_free_energy" in thermo
+    # A real gas-phase entropy, not the len(atoms)==1 shortcut that returns 0.
+    assert thermo["entropy"] > 0.0
+
+
+def test_thermo_still_refuses_a_real_crystal(tmp_path, monkeypatch):
+    """Sidestepping the IdealGasThermo pbc guard must not let a crystal through.
+
+    That guard is the only thing stopping a periodic solid from being handed
+    rigid-rotor, ideal-gas statistics, which are meaningless for a crystal (a
+    solid needs a phonon treatment). The plane-wave path clears pbc only for a
+    structure that arrived aperiodic and was boxed on its behalf, so a genuine
+    crystal keeps its periodicity and is still refused.
+    """
+    from ase.build import bulk
+    from ase.io import write
+
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.tools.ase_core import run_ase_core
+
+    # repeat() avoids the len(atoms) == 1 shortcut, which skips IdealGasThermo.
+    atoms = bulk("Cu").repeat((2, 1, 1))
+    assert atoms.pbc.all() and len(atoms) > 1
+    xyz = tmp_path / "cu2.xyz"
+    write(str(xyz), atoms)
+
+    monkeypatch.chdir(tmp_path)
+    result = run_ase_core(
+        ASEInputSchema(
+            input_structure_file=str(xyz),
+            output_results_file=str(tmp_path / "out.json"),
+            driver="thermo",
+            calculator={"calculator_type": "emt"},
+            temperature=298.15,
+        )
+    )
+
+    assert result["status"] == "failure", result
+    assert "periodic" in str(result.get("message", "")).lower()

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -708,6 +708,194 @@ def test_espresso_molecule_drops_kspacing():
     assert "kpts" not in ase_calc.parameters
 
 
+# ---------------------------------------------------------------------------
+# run_qe / run_vasp: calculator-pinned wrappers over run_ase.
+#
+# These are hermetic: they exercise the pinned schemas + the dispatch parity
+# with run_ase, never invoking a pw.x / VASP binary. The pinned schemas
+# deliberately skip the availability gate so they construct on this machine.
+# ---------------------------------------------------------------------------
+
+
+def test_qe_input_schema_pins_espresso_calculator():
+    """QEInputSchema coerces a bare dict into EspressoCalc (canonical type),
+    constructible even though pw.x is not installed here."""
+    from chemgraph.schemas.plane_wave_input import QEInputSchema
+
+    params = QEInputSchema(
+        input_structure_file="si.cif",
+        calculator={"ecutwfc": 40.0, "kpts": [2, 2, 2]},
+    )
+    assert type(params.calculator).__name__ == "EspressoCalc"
+    assert params.calculator.calculator_type == "espresso"
+    assert params.calculator.ecutwfc == 40.0
+
+
+def test_qe_input_schema_default_calculator():
+    """With no calculator payload QEInputSchema defaults to a plain EspressoCalc."""
+    from chemgraph.schemas.plane_wave_input import QEInputSchema
+
+    params = QEInputSchema(input_structure_file="si.cif")
+    assert type(params.calculator).__name__ == "EspressoCalc"
+    assert params.calculator.calculator_type == "espresso"
+
+
+def test_qe_input_schema_accepts_qe_alias():
+    """A QE alias in calculator_type is dropped in favor of the canonical tag,
+    so ase_core dispatch always sees 'espresso'."""
+    from chemgraph.schemas.plane_wave_input import QEInputSchema
+
+    params = QEInputSchema(
+        input_structure_file="si.cif",
+        calculator={"calculator_type": "qe", "ecutwfc": 30.0},
+    )
+    assert params.calculator.calculator_type == "espresso"
+
+
+def test_vasp_input_schema_pins_vasp_calculator():
+    """VaspInputSchema coerces a bare dict into VaspCalc (canonical type)."""
+    from chemgraph.schemas.plane_wave_input import VaspInputSchema
+
+    params = VaspInputSchema(
+        input_structure_file="si.cif",
+        calculator={"encut": 400.0, "kpts": [2, 2, 2]},
+    )
+    assert type(params.calculator).__name__ == "VaspCalc"
+    assert params.calculator.calculator_type == "vasp"
+    assert params.calculator.encut == 400.0
+
+
+def test_vasp_input_schema_rejects_wrong_instance():
+    """A pre-built calculator of the wrong type is a caller error."""
+    from chemgraph.schemas.plane_wave_input import VaspInputSchema
+
+    with pytest.raises(ValueError):
+        VaspInputSchema(
+            input_structure_file="si.cif", calculator=EspressoCalc()
+        )
+
+
+def test_qe_input_schema_rejects_wrong_instance():
+    """The mirror of the VASP case: a VaspCalc handed to QEInputSchema raises."""
+    from chemgraph.schemas.plane_wave_input import QEInputSchema
+
+    with pytest.raises(ValueError):
+        QEInputSchema(input_structure_file="si.cif", calculator=VaspCalc())
+
+
+def test_run_qe_tool_schema_excludes_vasp_fields():
+    """run_qe's tool schema exposes only QE parameters, not the full calculator
+    union -- the whole point of the pinned tool (smaller per-call prompt)."""
+    import json
+
+    from langchain_core.utils.function_calling import convert_to_openai_tool
+
+    from chemgraph.tools.ase_tools import run_qe
+
+    blob = json.dumps(convert_to_openai_tool(run_qe))
+    assert "ecutwfc" in blob  # QE field present
+    assert "encut" not in blob  # VASP-only field absent
+
+
+def test_run_vasp_tool_schema_excludes_qe_fields():
+    """The mirror of the QE case: run_vasp's schema exposes only VASP
+    parameters, not QE-only fields."""
+    import json
+
+    from langchain_core.utils.function_calling import convert_to_openai_tool
+
+    from chemgraph.tools.ase_tools import run_vasp
+
+    blob = json.dumps(convert_to_openai_tool(run_vasp))
+    assert "encut" in blob  # VASP field present
+    assert "ecutwfc" not in blob  # QE-only field absent
+
+
+def test_run_qe_delegates_espresso_payload_to_core(tmp_path, monkeypatch):
+    """run_qe hands run_ase_core an EspressoCalc payload with calculator_type
+    'espresso', the same shape run_ase produces for an espresso calculator on a
+    host where QE is installed. We stub run_ase_core (no pw.x) and inspect the
+    params it receives. Dispatch routing of that payload is covered separately by
+    test_espresso_aliases_route_to_espresso_calc."""
+    import chemgraph.tools.ase_tools as ase_tools
+
+    captured = {}
+
+    def _capture(params):
+        captured["type"] = type(params).__name__
+        captured["calc"] = params.calculator.model_dump()
+        captured["driver"] = params.driver
+        return {"success": True}
+
+    monkeypatch.setattr(ase_tools, "run_ase_core", _capture)
+
+    ase_tools.run_qe.func(
+        ase_tools.QEInputSchema(
+            input_structure_file=str(tmp_path / "si.cif"),
+            driver="energy",
+            calculator={"ecutwfc": 35.0},
+        )
+    )
+
+    assert captured["type"] == "QEInputSchema"
+    assert captured["calc"]["calculator_type"] == "espresso"
+    assert captured["calc"]["ecutwfc"] == 35.0
+    assert captured["driver"] == "energy"
+
+
+def test_run_vasp_delegates_vasp_payload_to_core(tmp_path, monkeypatch):
+    """run_vasp hands run_ase_core a VaspCalc payload with calculator_type
+    'vasp' (stubbed core, no VASP binary). Dispatch routing is covered by
+    test_vasp_aliases_route_to_vasp_calc."""
+    import chemgraph.tools.ase_tools as ase_tools
+
+    captured = {}
+
+    def _capture(params):
+        captured["type"] = type(params).__name__
+        captured["calc"] = params.calculator.model_dump()
+        captured["driver"] = params.driver
+        return {"success": True}
+
+    monkeypatch.setattr(ase_tools, "run_ase_core", _capture)
+
+    ase_tools.run_vasp.func(
+        ase_tools.VaspInputSchema(
+            input_structure_file=str(tmp_path / "si.cif"),
+            driver="energy",
+            calculator={"encut": 500.0},
+        )
+    )
+
+    assert captured["type"] == "VaspInputSchema"
+    assert captured["calc"]["calculator_type"] == "vasp"
+    assert captured["calc"]["encut"] == 500.0
+    assert captured["driver"] == "energy"
+
+
+def test_plane_wave_tools_registered_only_when_engine_available(monkeypatch):
+    """_plane_wave_tools offers run_qe/run_vasp only for detected engines, so an
+    uninstalled engine is never bound into the agent (nor its token cost paid)."""
+    import chemgraph.graphs.single_agent as sa
+
+    monkeypatch.setattr(
+        sa, "get_available_calculator_names", lambda: ["EMTCalc", "EspressoCalc"]
+    )
+    names = {t.name for t in sa._plane_wave_tools()}
+    assert names == {"run_qe"}
+
+    monkeypatch.setattr(
+        sa,
+        "get_available_calculator_names",
+        lambda: ["EMTCalc", "EspressoCalc", "VaspCalc"],
+    )
+    names = {t.name for t in sa._plane_wave_tools()}
+    assert names == {"run_qe", "run_vasp"}
+
+    monkeypatch.setattr(sa, "get_available_calculator_names", lambda: ["EMTCalc"])
+    assert sa._plane_wave_tools() == []
+
+
 # --- Fix follow-ups: sanitizer edge branches ---------------------------------
 
 

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -1,10 +1,14 @@
 import importlib.util
+import sys
+
 import pytest
 import numpy as np
 from chemgraph.schemas.calculators.emt_calc import EMTCalc
+from chemgraph.schemas.calculators.espresso_calc import EspressoCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
-from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
 from chemgraph.schemas.calculators.orca_calc import OrcaCalc
+from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
+from chemgraph.schemas.calculators.vasp_calc import VaspCalc
 from ase import Atoms
 
 
@@ -124,3 +128,608 @@ def test_orca_calculator():
 
     # Test basic calculator properties
     assert hasattr(ase_calc, "calculate")
+
+
+# ---------------------------------------------------------------------------
+# VASP + Quantum ESPRESSO (subprocess DFT)
+#
+# These need a licensed/installed binary + pseudopotentials to *run*, which this
+# machine lacks. But the ASE calculator objects *construct* without a binary, so
+# we mock-test the schema -> ASE-object kwarg plumbing unconditionally, and gate
+# only the availability-registration test on a monkeypatched environment.
+# ---------------------------------------------------------------------------
+
+_DFT_ENV_VARS = (
+    "ASE_VASP_COMMAND",
+    "VASP_COMMAND",
+    "VASP_PP_PATH",
+    "ASE_ESPRESSO_COMMAND",
+    "ESPRESSO_PSEUDO",
+)
+
+
+def _available_calculators_in_subprocess(env_overrides):
+    """Return get_available_calculator_names() from a fresh interpreter.
+
+    The availability gating in ``chemgraph.schemas.ase_input`` runs once at
+    import time, so testing it requires a pristine import under a controlled
+    environment. We do that in a subprocess. Using ``importlib.reload`` would
+    rebind ASEInputSchema/ASEOutputSchema to new class objects while
+    ``chemgraph.tools.ase_core`` keeps its original references, which breaks
+    pydantic identity checks for the rest of the session (cross-test leak).
+    """
+    import json
+    import os
+    import subprocess
+
+    env = {k: v for k, v in os.environ.items() if k not in _DFT_ENV_VARS}
+    env.update(env_overrides)
+    script = (
+        "import json;"
+        "from chemgraph.schemas.ase_input import get_available_calculator_names;"
+        "print(json.dumps(get_available_calculator_names()))"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_vasp_calculator_builds_ase_object_with_kwargs():
+    """VaspCalc maps its fields onto the ASE Vasp object's parameter stores."""
+    calc = VaspCalc(
+        encut=400.0,
+        kpts=[2, 2, 2],
+        ispin=2,
+        nsw=5,
+        ediffg=-0.02,
+        prec="Accurate",
+    )
+    assert calc.get_multiplicity() is None  # VASP uses ispin, not 2S+1
+
+    ase_calc = calc.get_calculator()
+    assert type(ase_calc).__name__ == "Vasp"
+    assert ase_calc.float_params["encut"] == 400.0
+    assert ase_calc.int_params["ispin"] == 2
+    assert ase_calc.int_params["nsw"] == 5
+    assert ase_calc.exp_params["ediffg"] == -0.02
+    assert ase_calc.string_params["prec"] == "Accurate"
+    assert ase_calc.input_params["kpts"] == [2, 2, 2]
+
+
+def test_vasp_charge_and_setups_reach_ase():
+    """charge and setups land in the ASE Vasp input_params store."""
+    ase_calc = VaspCalc(charge=-1, setups="recommended").get_calculator()
+    assert ase_calc.input_params["charge"] == -1
+    assert ase_calc.input_params["setups"] == "recommended"
+
+
+def test_vasp_kspacing_replaces_kpts():
+    """When kspacing is given it wins and kpts is not passed through."""
+    ase_calc = VaspCalc(kspacing=0.25, kpts=[4, 4, 4]).get_calculator()
+    assert ase_calc.float_params["kspacing"] == 0.25
+    # kpts falls back to the ASE default (not the schema's [4,4,4]).
+    assert ase_calc.input_params["kpts"] != [4, 4, 4]
+
+
+def test_vasp_rejects_wrong_calculator_type():
+    with pytest.raises(ValueError):
+        VaspCalc(calculator_type="notvasp").get_calculator()
+
+
+def test_espresso_calculator_builds_ase_object_with_kwargs():
+    """EspressoCalc assembles the pw.x input_data namelist + passes k-points."""
+    calc = EspressoCalc(
+        ecutwfc=40.0,
+        ecutrho=320.0,
+        kpts=[2, 2, 2],
+        xc="PBE",
+        smearing="mv",
+        degauss=0.01,
+        pseudopotentials={"Si": "Si.UPF"},
+        pseudo_dir="/tmp/pseudo",
+    )
+    assert calc.get_multiplicity() is None  # QE uses nspin, not 2S+1
+
+    ase_calc = calc.get_calculator()
+    assert type(ase_calc).__name__ == "Espresso"
+    input_data = ase_calc.parameters["input_data"]
+    assert input_data["ecutwfc"] == 40.0
+    assert input_data["ecutrho"] == 320.0
+    assert input_data["input_dft"] == "PBE"
+    assert input_data["occupations"] == "smearing"
+    assert input_data["smearing"] == "mv"
+    assert input_data["degauss"] == 0.01
+    assert ase_calc.parameters["kpts"] == (2, 2, 2)
+    assert ase_calc.parameters["pseudopotentials"] == {"Si": "Si.UPF"}
+
+
+def test_espresso_input_data_override_wins():
+    """Raw input_data keys override the convenience-field defaults."""
+    calc = EspressoCalc(ecutwfc=40.0, input_data={"ecutwfc": 80.0, "nbnd": 20})
+    data = calc._build_input_data()
+    assert data["ecutwfc"] == 80.0  # override wins over the field
+    assert data["nbnd"] == 20
+
+
+def test_espresso_requests_forces_by_default():
+    """pw.x must print forces every SCF: ChemGraph drives geometry with an ASE
+    optimizer, so QE is a force engine. ASE 3.29 does not translate
+    properties=['forces'] into the 'tprnfor' control flag, so EspressoCalc must
+    set it or the first optimizer step raises 'forces not present'."""
+    data = EspressoCalc(ecutwfc=25.0)._build_input_data()
+    assert data["tprnfor"] is True
+
+
+def test_espresso_tprnfor_is_overridable():
+    """A user can still turn force printing off via raw input_data."""
+    calc = EspressoCalc(ecutwfc=25.0, input_data={"tprnfor": False})
+    assert calc._build_input_data()["tprnfor"] is False
+
+
+def test_espresso_rejects_wrong_calculator_type():
+    with pytest.raises(ValueError):
+        EspressoCalc(calculator_type="notqe").get_calculator()
+
+
+@pytest.mark.parametrize(
+    "env, expected",
+    [
+        (
+            {
+                "ASE_VASP_COMMAND": "vasp_std",
+                "VASP_PP_PATH": "/tmp/pp",
+                "ASE_ESPRESSO_COMMAND": "pw.x",
+                "ESPRESSO_PSEUDO": "/tmp/pseudo",
+            },
+            True,
+        ),
+        ({}, False),  # nothing configured -> both gated off
+    ],
+)
+def test_subprocess_dft_availability_gating(env, expected):
+    """VaspCalc/EspressoCalc register only when their binary + pseudos are set."""
+    names = _available_calculators_in_subprocess(env)
+    assert ("VaspCalc" in names) is expected
+    assert ("EspressoCalc" in names) is expected
+
+
+@pytest.mark.parametrize("alias", ["espresso", "qe", "pwscf", "pw"])
+def test_espresso_aliases_route_to_espresso_calc(alias):
+    """load_calculator routes espresso/qe/pwscf/pw to EspressoCalc + ASE Espresso.
+
+    This exercises the dispatch + alias normalization directly (no binary, no
+    module reload), so it stays hermetic and isolated.
+    """
+    from chemgraph.tools.ase_core import load_calculator
+
+    ase_calc, _extra, model = load_calculator(
+        {"calculator_type": alias, "ecutwfc": 30.0, "pseudo_dir": "/tmp/pseudo"}
+    )
+    assert type(model).__name__ == "EspressoCalc"
+    assert type(ase_calc).__name__ == "Espresso"
+    # Alias is normalized to the canonical type so get_calculator's check passes.
+    assert model.calculator_type == "espresso"
+    assert model.ecutwfc == 30.0
+
+
+@pytest.mark.parametrize("alias", ["vasp", "VASP", "Vasp", "vasp_std"])
+def test_vasp_aliases_route_to_vasp_calc(alias):
+    """load_calculator routes vasp/VASP/Vasp/vasp_std to VaspCalc + ASE Vasp.
+
+    Guards against the normalization asymmetry where a non-canonical
+    calculator_type reached VaspCalc.get_calculator's strict check and raised.
+    """
+    from chemgraph.tools.ase_core import load_calculator
+
+    ase_calc, _extra, model = load_calculator(
+        {"calculator_type": alias, "encut": 300.0, "kpts": [1, 1, 1]}
+    )
+    assert type(model).__name__ == "VaspCalc"
+    assert type(ase_calc).__name__ == "Vasp"
+    assert model.calculator_type == "vasp"  # normalized to canonical
+    assert model.encut == 300.0
+
+
+# ---------------------------------------------------------------------------
+# PR1 DFT-correctness fixes: pbc-aware k-mesh, QE command sanitization,
+# VASP INCAR escape hatch, and molecule centering. All hermetic (kwargs -> ASE
+# object / written file); no pw.x or VASP binary is invoked.
+# ---------------------------------------------------------------------------
+
+
+def _h2o_molecule():
+    """A non-periodic water molecule (pbc all False, no cell)."""
+    from ase.build import molecule
+
+    return molecule("H2O")
+
+
+def _si_bulk():
+    """A periodic silicon crystal (pbc all True, finite cell)."""
+    from ase.build import bulk
+
+    return bulk("Si")
+
+
+def _cu_slab():
+    """A metal slab, periodic in x/y and vacuum in z (pbc=[T,T,F])."""
+    from ase.build import fcc111
+
+    return fcc111("Cu", size=(1, 1, 3), vacuum=8.0)
+
+
+def _cu_wire():
+    """A 1D wire, periodic in x only (pbc=[T,F,F])."""
+    from ase.build import bulk
+
+    wire = bulk("Cu")
+    wire.pbc = [True, False, False]
+    return wire
+
+
+# --- Fix 1: pbc-aware k-mesh --------------------------------------------------
+
+
+def test_espresso_molecule_drops_kmesh_for_gamma():
+    """A non-periodic molecule must get NO k-mesh so ASE writes K_POINTS gamma;
+    a Monkhorst-Pack mesh is meaningless for an isolated molecule."""
+    ase_calc = EspressoCalc(
+        pseudopotentials={"O": "O.UPF", "H": "H.UPF"}
+    ).get_calculator(atoms=_h2o_molecule())
+    assert "kpts" not in ase_calc.parameters
+    assert "kspacing" not in ase_calc.parameters
+
+
+def test_espresso_periodic_keeps_configured_mesh():
+    """A periodic solid keeps its configured Monkhorst-Pack mesh."""
+    ase_calc = EspressoCalc().get_calculator(atoms=_si_bulk())
+    assert ase_calc.parameters["kpts"] == (4, 4, 4)
+
+
+def test_espresso_atoms_none_keeps_mesh_backward_compat():
+    """atoms=None (construction / existing no-arg callers) keeps the mesh."""
+    ase_calc = EspressoCalc().get_calculator()
+    assert ase_calc.parameters["kpts"] == (4, 4, 4)
+
+
+def test_vasp_molecule_pins_single_gamma_point():
+    """A non-periodic molecule pins kpts=[1,1,1]+gamma (real VASP needs a
+    KPOINTS file, so None is wrong) and drops kspacing (an INCAR KSPACING would
+    silently override the single Gamma point)."""
+    ase_calc = VaspCalc(kspacing=0.25).get_calculator(atoms=_h2o_molecule())
+    assert ase_calc.input_params["kpts"] == [1, 1, 1]
+    assert ase_calc.input_params["gamma"] is True
+    assert ase_calc.float_params["kspacing"] is None
+
+
+def test_vasp_periodic_keeps_configured_mesh():
+    """A periodic solid keeps its configured Monkhorst-Pack mesh."""
+    ase_calc = VaspCalc().get_calculator(atoms=_si_bulk())
+    assert ase_calc.input_params["kpts"] == [3, 3, 3]
+
+
+def test_vasp_atoms_none_keeps_mesh_backward_compat():
+    """atoms=None keeps the configured mesh (backward compatible)."""
+    ase_calc = VaspCalc().get_calculator()
+    assert ase_calc.input_params["kpts"] == [3, 3, 3]
+
+
+def test_vasp_gamma_field_threads_for_periodic():
+    """The gamma field requests a Gamma-centered mesh for a periodic solid."""
+    ase_calc = VaspCalc(gamma=True).get_calculator(atoms=_si_bulk())
+    assert ase_calc.input_params["gamma"] is True
+
+
+def test_vasp_molecule_defaults_gaussian_smearing():
+    """A non-periodic molecule defaults to ismear=0 (+small sigma) so it does not
+    inherit VASP's metallic default ISMEAR=1 (spurious partial occupancies)."""
+    ase_calc = VaspCalc().get_calculator(atoms=_h2o_molecule())
+    assert ase_calc.int_params["ismear"] == 0
+    assert ase_calc.float_params["sigma"] == 0.03
+
+
+def test_vasp_molecule_smearing_overridable_via_input_data():
+    """The molecule ismear default is a convenience, still overridable by the
+    input_data escape hatch (merged last)."""
+    ase_calc = VaspCalc(
+        input_data={"ismear": -1, "sigma": 0.2}
+    ).get_calculator(atoms=_h2o_molecule())
+    assert ase_calc.int_params["ismear"] == -1
+    assert ase_calc.float_params["sigma"] == 0.2
+
+
+# --- Fix D: per-axis k-mesh for slabs / wires ---------------------------------
+
+
+def test_espresso_slab_masks_vacuum_axis():
+    """A slab (pbc=[T,T,F]) keeps its in-plane mesh but collapses the vacuum
+    axis to a single k-point."""
+    ase_calc = EspressoCalc(kpts=[6, 6, 6]).get_calculator(atoms=_cu_slab())
+    assert ase_calc.parameters["kpts"] == (6, 6, 1)
+
+
+def test_espresso_wire_masks_two_vacuum_axes():
+    """A wire (pbc=[T,F,F]) keeps only its periodic axis subdivided."""
+    ase_calc = EspressoCalc(kpts=[8, 8, 8]).get_calculator(atoms=_cu_wire())
+    assert ase_calc.parameters["kpts"] == (8, 1, 1)
+
+
+def test_vasp_slab_masks_vacuum_axis():
+    """VASP slab (pbc=[T,T,F]) collapses the vacuum axis to one k-point."""
+    ase_calc = VaspCalc(kpts=[6, 6, 6]).get_calculator(atoms=_cu_slab())
+    assert ase_calc.input_params["kpts"] == [6, 6, 1]
+
+
+def test_vasp_wire_masks_two_vacuum_axes():
+    """VASP wire (pbc=[T,F,F]) keeps only the periodic axis subdivided."""
+    ase_calc = VaspCalc(kpts=[8, 8, 8]).get_calculator(atoms=_cu_wire())
+    assert ase_calc.input_params["kpts"] == [8, 1, 1]
+
+
+def test_mask_kmesh_by_pbc_helper():
+    """The shared per-axis mask helper is exercised directly."""
+    from chemgraph.schemas.calculators._plane_wave import mask_kmesh_by_pbc
+
+    assert mask_kmesh_by_pbc([4, 4, 4], [True, True, True]) == (4, 4, 4)
+    assert mask_kmesh_by_pbc([4, 4, 4], [True, True, False]) == (4, 4, 1)
+    assert mask_kmesh_by_pbc([4, 4, 4], [True, False, False]) == (4, 1, 1)
+    assert mask_kmesh_by_pbc([4, 4, 4], [False, False, False]) == (1, 1, 1)
+
+
+# --- Fix 2: QE command sanitization ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("pw.x", "pw.x"),
+        ("mpirun -np 4 pw.x -in PREFIX.pwi > PREFIX.pwo", "mpirun -np 4 pw.x"),
+        ("srun pw.x -inp foo.pwi", "srun pw.x"),
+        ("mpirun -np 8 pw.x < in.pwi", "mpirun -np 8 pw.x"),
+        ("pw.x -in a.pwi >> log", "pw.x"),
+        # runtime flags (npool/ndiag) are launch args, not ASE's -in -> kept
+        ("pw.x -npool 4 -ndiag 1", "pw.x -npool 4 -ndiag 1"),
+    ],
+)
+def test_espresso_command_sanitizer(raw, expected):
+    """Legacy full-command ASE_ESPRESSO_COMMAND is reduced to its launch prefix;
+    ASE appends '-in <file>' itself so the input/redirection tail must be cut."""
+    from chemgraph.schemas.calculators.espresso_calc import (
+        _sanitize_espresso_command,
+    )
+
+    assert _sanitize_espresso_command(raw) == expected
+
+
+def test_espresso_profile_command_is_sanitized(monkeypatch):
+    """The EspressoProfile built from a legacy env value carries only the clean
+    launch prefix, not the duplicated -in / redirection tokens."""
+    monkeypatch.setenv(
+        "ASE_ESPRESSO_COMMAND", "mpirun -np 4 pw.x -in PREFIX.pwi > PREFIX.pwo"
+    )
+    ase_calc = EspressoCalc(pseudopotentials={"O": "O.UPF"}).get_calculator()
+    assert ase_calc.profile.command == "mpirun -np 4 pw.x"
+
+
+# --- Fix 3: VASP INCAR escape hatch ------------------------------------------
+
+
+def test_vasp_input_data_reach_ase_param_stores():
+    """Advanced INCAR tags land in their correct ASE parameter groups. Note
+    lreal routes to special_params (NOT string_params)."""
+    ase_calc = VaspCalc(
+        input_data={
+            "ismear": 0,
+            "sigma": 0.05,
+            "algo": "Fast",
+            "lreal": "Auto",
+        }
+    ).get_calculator(atoms=_si_bulk())
+    assert ase_calc.int_params["ismear"] == 0
+    assert ase_calc.float_params["sigma"] == 0.05
+    assert ase_calc.string_params["algo"] == "Fast"
+    assert ase_calc.special_params["lreal"] == "Auto"
+
+
+def test_vasp_input_data_override_convenience_field():
+    """input_data is merged last, so it wins over a convenience field."""
+    ase_calc = VaspCalc(
+        encut=400.0, input_data={"encut": 650.0}
+    ).get_calculator(atoms=_si_bulk())
+    assert ase_calc.float_params["encut"] == 650.0
+
+
+def test_vasp_input_data_uppercase_keys_are_lowercased():
+    """A user pasting canonical UPPERCASE INCAR names (as they appear in a real
+    INCAR file) must still reach ASE -- keys are lowercased on merge, so
+    {'ISMEAR': 0} is not silently dropped."""
+    ase_calc = VaspCalc(
+        input_data={"ISMEAR": 0, "SIGMA": 0.05}
+    ).get_calculator(atoms=_si_bulk())
+    assert ase_calc.int_params["ismear"] == 0
+    assert ase_calc.float_params["sigma"] == 0.05
+
+
+# --- Fix 0: molecule centering (via the ase_core runner seam) -----------------
+
+
+def test_prepare_dft_calculator_centers_cell_less_molecule_and_writes_gamma(
+    tmp_path,
+):
+    """The real ase_core seam (prepare_dft_calculator) centers a cell-less
+    non-periodic molecule (so the plane-wave writer has a finite box) while
+    leaving pbc False (so it stays on the Gamma path), and the written QE input
+    carries K_POINTS gamma + a real non-zero cell. Exercises the shipped helper,
+    not a re-implementation -- reverting the seam turns this red."""
+    from ase.io.espresso import write_espresso_in
+
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = _h2o_molecule()
+    assert atoms.cell.rank == 0 and not atoms.pbc.any()
+
+    calc, _extra, model = load_calculator(
+        {
+            "calculator_type": "espresso",
+            "pseudopotentials": {"O": "O.UPF", "H": "H.UPF"},
+        }
+    )
+    ase_calc = prepare_dft_calculator(atoms, calc, model)
+
+    # The helper centered the molecule in place but must NOT turn on periodicity.
+    assert atoms.cell.rank == 3
+    assert not atoms.pbc.any()
+
+    out = tmp_path / "espresso.pwi"
+    with open(out, "w") as fh:
+        write_espresso_in(
+            fh,
+            atoms,
+            input_data=ase_calc.parameters["input_data"],
+            pseudopotentials={"O": "O.UPF", "H": "H.UPF"},
+        )
+    text = out.read_text()
+    assert "K_POINTS gamma" in text
+    # A real box: the centered cell diagonal must be non-zero, proving the
+    # centering reached the writer (a param-only test can miss a zero cell).
+    assert "CELL_PARAMETERS" in text
+    cell_lines = text.split("CELL_PARAMETERS", 1)[1].splitlines()[1:4]
+    diag = [float(cell_lines[i].split()[i]) for i in range(3)]
+    assert all(d > 1.0 for d in diag)
+
+
+def test_prepare_dft_calculator_rebuilds_qe_gamma_only(tmp_path):
+    """prepare_dft_calculator rebuilds the QE calculator Gamma-only for a
+    cell-less molecule read from disk (the run_ase_core code path)."""
+    from ase.io import read, write
+
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    xyz = tmp_path / "h2o.xyz"
+    write(str(xyz), _h2o_molecule())
+
+    calc, _extra, model = load_calculator(
+        {"calculator_type": "espresso", "pseudo_dir": "/tmp/pseudo"}
+    )
+    assert type(model).__name__ == "EspressoCalc"
+
+    atoms = read(str(xyz))
+    rebuilt = prepare_dft_calculator(atoms, calc, model)
+    assert "kpts" not in rebuilt.parameters  # Gamma-only for the molecule
+
+
+def test_prepare_dft_calculator_is_noop_for_non_dft(tmp_path):
+    """The isinstance guard leaves a non-DFT calculator (EMT) untouched: the
+    same object is returned and a cell-less molecule is NOT centered."""
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    calc, _extra, model = load_calculator({"calculator_type": "emt"})
+    atoms = _h2o_molecule()
+    result = prepare_dft_calculator(atoms, calc, model)
+    assert result is calc
+    assert atoms.cell.rank == 0  # not centered -- EMT needs no cell
+
+
+def test_prepare_dft_calculator_keeps_user_supplied_full_cell():
+    """A non-periodic molecule that ALREADY carries a full rank-3 cell must not
+    be re-centered -- a user-supplied box is preserved. Guards the ``rank < 3``
+    condition: dropping it would clobber the box with a fresh vacuum cell."""
+    import numpy as np
+
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = _h2o_molecule()
+    atoms.center(vacuum=9.0)  # rank-3 cell, pbc still all False
+    assert atoms.cell.rank == 3 and not atoms.pbc.any()
+    preset = atoms.cell.array.copy()
+
+    calc, _extra, model = load_calculator({"calculator_type": "espresso"})
+    prepare_dft_calculator(atoms, calc, model)
+
+    assert np.allclose(atoms.cell.array, preset)  # untouched
+
+
+def test_prepare_dft_calculator_centers_degenerate_partial_cell():
+    """A non-periodic molecule with a degenerate (rank 1/2, zero-volume) cell is
+    still given a clean vacuum box -- a singular lattice vector would make pw.x/
+    VASP emit garbage. Guards the ``rank < 3`` condition on the low side."""
+    from chemgraph.tools.ase_core import load_calculator, prepare_dft_calculator
+
+    atoms = _h2o_molecule()
+    atoms.cell = [[10.0, 0, 0], [0, 10.0, 0], [0, 0, 0]]  # rank-2, one zero vector
+    atoms.pbc = [False, False, False]
+    assert atoms.cell.rank == 2
+
+    calc, _extra, model = load_calculator({"calculator_type": "espresso"})
+    prepare_dft_calculator(atoms, calc, model)
+
+    assert atoms.cell.rank == 3  # centered into a finite, non-singular box
+    assert not atoms.pbc.any()
+
+
+# --- Fix follow-ups: kpts length validation ----------------------------------
+
+
+@pytest.mark.parametrize("Calc", [EspressoCalc, VaspCalc])
+@pytest.mark.parametrize("bad_kpts", [[4, 4], [4, 4, 4, 4], []])
+def test_plane_wave_kpts_must_have_three_axes(Calc, bad_kpts):
+    """kpts must be exactly 3 axes; a 2- or 4-element mesh is rejected at
+    construction, so it cannot crash later in the ASE writer (IndexError)."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        Calc(kpts=bad_kpts)
+
+
+def test_is_nonperiodic_helper():
+    """is_nonperiodic: True only for a real, fully non-periodic structure."""
+    from chemgraph.schemas.calculators._plane_wave import is_nonperiodic
+
+    assert is_nonperiodic(_h2o_molecule()) is True
+    assert is_nonperiodic(_si_bulk()) is False
+    assert is_nonperiodic(_cu_slab()) is False
+    assert is_nonperiodic(None) is False  # construction time -> use configured mesh
+
+
+# --- Fix follow-ups: QE kspacing dropped for a molecule ----------------------
+
+
+def test_espresso_molecule_drops_kspacing():
+    """A fully non-periodic molecule must not carry a kspacing (which would make
+    ASE build a Monkhorst-Pack mesh); it stays on the K_POINTS gamma path.
+    Parallels the VASP kspacing-drop coverage."""
+    ase_calc = EspressoCalc(kspacing=0.25).get_calculator(atoms=_h2o_molecule())
+    assert "kspacing" not in ase_calc.parameters
+    assert "kpts" not in ase_calc.parameters
+
+
+# --- Fix follow-ups: sanitizer edge branches ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        # positional input-file operand with no preceding -in flag
+        ("pw.x in.pwi", "pw.x"),
+        ("mpirun -np 4 pw.x job.pwo", "mpirun -np 4 pw.x"),
+        # unbalanced quote -> shlex.split raises -> raw (stripped) fallback
+        ('pw.x "unterminated', 'pw.x "unterminated'),
+        # command that is nothing but a stop token -> raw (stripped) fallback
+        ("-in only.pwi", "-in only.pwi"),
+        # whitespace-only -> empty
+        ("   ", ""),
+    ],
+)
+def test_espresso_command_sanitizer_edge_branches(raw, expected):
+    """The fallback branches: a bare positional operand is cut, an unparseable
+    string or an all-stripped result falls back to the raw (stripped) input."""
+    from chemgraph.schemas.calculators.espresso_calc import (
+        _sanitize_espresso_command,
+    )
+
+    assert _sanitize_espresso_command(raw) == expected


### PR DESCRIPTION
## Summary

Adds two subprocess-based DFT calculators to ChemGraph, VASP and Quantum ESPRESSO, so the agent can run plane-wave DFT through the same `run_ase` path already used for EMT, MACE, and other calculators. These are the primary target engines for long-running calculations.

The calculators are periodicity-aware, which is the core correctness feature of this PR:

* **PBC-aware k-point mesh.** A non-periodic molecule, with all `pbc` values set to False, no longer receives a spurious Monkhorst-Pack mesh. QE emits `K_POINTS gamma`; VASP pins the mesh to `[1, 1, 1]`, enables `gamma`, and removes `kspacing`. Otherwise, a stray `KSPACING` entry in the INCAR could override the gamma point specified by KPOINTS. Periodic systems retain their configured meshes. Constructing a calculator without atoms also preserves the configured mesh for backward compatibility. Slabs and wires use a per-axis mesh: periodic axes retain their configured subdivisions, while non-periodic vacuum axes are forced to a single point.
* **Non-periodic cell handling.** A molecule without a cell is centered inside a finite vacuum box, controlled by the `vacuum` field, before it reaches the input writer. Plane-wave QE and VASP calculations cannot run with a zero cell. The molecule's `pbc` values are still False when the calculator is built, so it follows the gamma-point branch above.
* **QE command sanitization.** A legacy full `ASE_ESPRESSO_COMMAND`, such as `mpirun -np 4 pw.x -in PREFIX.pwi > PREFIX.pwo`, is reduced to only the launcher and executable before being passed to `EspressoProfile`. This prevents ASE's own `-in` handling from being duplicated and ensures that no `>` token leaks into the argument vector. Runtime flags such as `-npool` and `-ndiag` are preserved.
* **VASP INCAR escape hatch.** An `input_data` field passes advanced INCAR parameters, including ISMEAR, SIGMA, ALGO, LREAL, MAGMOM, and others, through to ASE. Keys are converted to lowercase during the merge, with documented last-value-wins precedence. VASP also gains a `gamma` field. Molecular calculations default to Gaussian smearing with `ismear=0`, which is appropriate for isolated systems.
* **Fully periodic cells for VASP.** ASE refuses any structure whose `pbc` is not all True (`check_pbc`) before writing a single input file, so a centered molecule, a slab `[T,T,F]`, and a wire `[T,F,F]` all failed setup and only a bulk solid reached `vasp_std`. The cell is now marked fully periodic for VASP, after the calculator is built so the k-mesh above still follows the input periodicity. A plane-wave code has no aperiodic mode, so this states what VASP was always going to do; the vacuum is what keeps the residual image interaction small. No dipole or monopole correction is applied, so a polar or charged species needs a larger box or an explicit `IDIPOL` / `LDIPOL` through `input_data`. QE keeps its `pbc` untouched: `pw.x` has no equivalent check and `write_espresso_in` ignores `pbc`, so the flip would only leak a spurious periodic flag into QE results.

Because all existing calculators expose a zero-argument `get_calculator()` method, `ase_core.py` passes `atoms` only to `EspressoCalc` and `VaspCalc`, selected through an `isinstance` check.

Gas-phase thermochemistry keys off the input's periodicity, recorded before that flip. A molecule this code boxed stays eligible for `IdealGasThermo`; a structure that arrived periodic keeps its periodicity and is still refused, so a crystal never collects rigid-rotor statistics.

### Plane-wave tools: `run_qe` and `run_vasp`

Two calculator-pinned tools plus a runnable example.

* **Thin wrappers.** `run_qe` and `run_vasp` are `@tool` wrappers that build an `ASEInputSchema` with a fixed calculator and call `run_ase_core`; dispatch already routes the `espresso` and `vasp` aliases, so the core is reused directly. `QEInputSchema` / `VaspInputSchema` (new `schemas/plane_wave_input.py`) subclass `ASEInputSchema` and pin the calculator field, so the model sees a focused single-engine tool and inherits the common fields for free.
* **Registration.** `single_agent.py` adds each tool to the default set gated on engine availability; `tool_call_eval.py` extends the `run_ase` special-case to both for schema-aware argument comparison.
* **Token cost.** The two schemas add ~3248 tokens (tiktoken `cl100k_base`: `run_qe` 1621 + `run_vasp` 1627), about half of `run_ase` (3184) each because the calculator type is fixed.

The example in `examples/plane_wave_tools/` binds the tools to a `single_agent` ChemGraph over Argo and runs a bulk-Si relaxation prompt, with a `README.md` covering the full setup (`ASE_ESPRESSO_COMMAND`, `ESPRESSO_PSEUDO`, the VASP equivalents, and the Argo tunnel).

The example writes the Si cell itself, from Materials Project `mp-149` when `MP_API_KEY` is set and from `ase.build.bulk` otherwise, and names that file in the prompt. No tool in the `single_agent` set can build a crystal: the only structure source is `smiles_to_coordinate_file`, which is RDKit-backed and returns an isolated molecule with no cell, so a bare "bulk silicon" prompt yielded one lone Si atom. The LLM still chooses the tool and fills in the driver, cutoff, k-mesh, and pseudopotentials; only the lattice is supplied. A crystal-building tool would remove even that, and belongs in its own PR.

### Part of a 3-PR series

This is the first of three PRs that together add long-running-calculation support for subprocess DFT. They are intended to land in the following order:

1. **`feature/dft-calculators` (this PR):** adds the VASP and Quantum ESPRESSO calculators.
2. `feature/longrun-cap-resume`: adds the wall-clock cap, run manifest, and `chemgraph resume`. It overlaps with this PR at the file level but is functionally independent, and the branches have been verified to merge cleanly.
3. `feature/aurora-qe-example`: adds a long-running cap-to-resume example on Aurora that validates the full workflow using real QE DFT. It depends on both earlier PRs.

The example PR will remain in Draft until the calculators and cap PRs merge.

## Related issues

None

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Docs
* [ ] Chore / refactor / CI

## How was this tested?

* Hermetic unit tests in `tests/test_calculators.py` assert against both the parameter dictionaries of the constructed ASE calculators and the actual input files written to disk. These checks cover QE's `K_POINTS gamma` and finite `CELL_PARAMETERS`, as well as VASP's `kpts`, `gamma`, and INCAR parameters, and add dispatch-parity tests proving `run_qe` / `run_vasp` drive the same `run_ase_core` path as `run_ase`. The tests therefore validate the generated inputs, not only the schema. No DFT calculations run in CI.
* The QE path is validated against real `pw.x` DFT on ALCF Aurora. The full agent stack was run with a prompt that named Quantum ESPRESSO but named no tool; the LLM autonomously selected `run_qe`, and real `pw.x` relaxed bulk Si with BFGS to convergence at approximately -308.189 eV. This was confirmed on both LLM backends independently: the ALCF inference endpoint (gpt-oss-120b) and Argo (gpt-4.1-mini).
* The VASP path is validated against real `vasp_std` (VASP 6.5.1, 8 MPI ranks, PBE PAW) on a VASP-licensed cluster reached through Argo, with the agent again choosing `run_vasp` unprompted. ENCUT follows one rule throughout: 1.3 times the hardest element's POTCAR ENMAX, rounded up to the nearest 25. Energies in eV: an H2O molecule at -14.21983871 on a 1x1x1 gamma mesh with `ISMEAR=0`, an Al slab at -10.65570601 on a 4x4x1 mesh with the vacuum axis correctly collapsed, and bulk Si at -10.83792607, matching a direct ASE run of the same cell. The molecule and the slab were hard failures before the periodicity fix above. Running the example end to end gave -10.83792607 eV from the `ase.build` cell and -10.84103139 eV from `mp-149`; a lattice scan at these settings puts the minimum near a=5.47, so the 3 meV gap reflects `mp-149` sitting closer to it.
* Both real-engine runs exercise the code path and flow on real hardware. Neither is a physical-accuracy benchmark.
* `ruff check .` passes.
* `pytest tests/ -k "not tblite"` passes with 374 passed, 28 skipped, and 2 deselected. Each new periodicity and thermochemistry test was confirmed to fail with its fix reverted.

## Checklist

* [x] Branched off the latest `main` and targets `main`
* [x] PR is focused on a single logical change and was split where necessary
* [x] `ruff check .` passes
* [x] `pytest tests/ -k "not tblite"` passes, including additional tests if Academy or backend code was touched
* [x] Added or updated tests for the change
* [x] Updated docs or README for any user-facing change
