### PR TITLE
Add wall-clock cap, run manifest, and chemgraph resume for long-running calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ vib*.traj
 
 # Kubernetes secrets (keep secrets.yaml.template, ignore actual secrets)
 k8s/secrets.yaml
+
+# Long-run cap / manifest run artifacts (session log dirs, test outputs)
+cg_logs/
+tests/*_output.json

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -1,7 +1,9 @@
 import asyncio
 import datetime
+import json
 import os
 import time
+from pathlib import Path
 from typing import Callable, Collection, List, Optional
 import uuid
 
@@ -66,6 +68,49 @@ from chemgraph.prompt.xanes_prompt import (
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+# Every cost-bearing tool takes a single pydantic parameter, so the LLM's
+# tool-call ``args`` nest one level under a wrapper key (``params`` for most,
+# ``graspa_input`` for gRASPA). The manifest reads ``driver`` / ``calculator`` /
+# ``input_structure_file`` at the TOP level of the recorded args, so the hook
+# must unwrap that inner dict before recording -- otherwise every field reads as
+# ``?``. Some tools name their structure field differently; ``alias`` maps that
+# field onto the canonical ``input_structure_file`` a resume reads.
+_TOOL_ARG_SPEC = {
+    "run_ase": {"wrapper": "params"},
+    "run_xanes": {"wrapper": "params"},
+    "run_mace_single": {"wrapper": "params"},
+    "run_mace_ensemble": {"wrapper": "params", "alias": "input_structure_directory"},
+    "run_graspa": {"wrapper": "graspa_input", "alias": "cif_path"},
+}
+
+
+def _unwrap_tool_args(name, args):
+    """Return a cost tool's inner args dict with the structure field normalized.
+
+    Cost tools wrap their real arguments under a single pydantic-param key; the
+    manifest reads ``driver`` / ``calculator`` / ``input_structure_file`` at the
+    top level, so return the inner dict. When the wrapper key is absent (a flat
+    direct call, or a test feeding args already unwrapped), return ``args``
+    unchanged. Any tool-specific structure-field alias is copied onto
+    ``input_structure_file`` so a resume finds it under the canonical name.
+    """
+    if not isinstance(args, dict):
+        return args
+    spec = _TOOL_ARG_SPEC.get(name)
+    if spec is None:
+        return args
+    wrapper = spec.get("wrapper")
+    inner = args.get(wrapper) if wrapper else None
+    if not isinstance(inner, dict):
+        # Already-flat args (direct call / test shape) -> use as-is.
+        inner = args
+    alias = spec.get("alias")
+    if alias and alias in inner and "input_structure_file" not in inner:
+        inner = dict(inner)
+        inner["input_structure_file"] = inner[alias]
+    return inner
 
 
 class ChemGraph:
@@ -187,6 +232,20 @@ class ChemGraph:
             self.session_store = SessionStore(db_path=memory_db_path)
         else:
             self.session_store = None
+
+        # Durable run manifest (records executed cost-bearing steps + args +
+        # result-file paths for crash-safe, cross-allocation resume). Lives in
+        # the log dir on the shared filesystem, independent of the SessionStore
+        # message layer which drops tool-call args.
+        from chemgraph.memory.manifest import RunManifest
+
+        self.run_manifest = RunManifest(
+            os.path.join(self.log_dir, "run_manifest.json")
+        )
+        # Open cost-bearing steps, keyed by tool_call_id so parallel tool calls
+        # in one AI message each close the correct manifest step. Each value is
+        # {"idx": int, "tool": str, "args": dict}.
+        self._pending_steps: dict[str, dict] = {}
 
         # Track whether session has been registered in the memory store
         self._session_created: bool = False
@@ -650,6 +709,181 @@ class ChemGraph:
         except Exception as e:
             logger.warning(f"Failed to save messages to session store: {e}")
 
+    _COST_TOOLS = {
+        "run_ase",
+        "run_mace_single",
+        "run_mace_ensemble",
+        "run_graspa",
+        "run_xanes",
+    }
+
+    def _manifest_observe(self, message) -> None:
+        """Record cost-bearing tool starts/ends into the run manifest.
+
+        Reads tool-call args from live graph state -- before
+        ``_save_messages_to_store``'s empty-content filter drops pure tool-call
+        messages -- so the durable manifest keeps the args (calculator, driver,
+        input file) a resumed agent needs. Best-effort: never breaks the run.
+        """
+        try:
+            from chemgraph.agent.turn import _message_tool_calls
+
+            # AI message issuing a cost-bearing tool call -> record a step start.
+            for call in _message_tool_calls(message) or []:
+                name = (
+                    call.get("name")
+                    if isinstance(call, dict)
+                    else getattr(call, "name", None)
+                )
+                if name in self._COST_TOOLS:
+                    raw_args = (
+                        call.get("args", {})
+                        if isinstance(call, dict)
+                        else getattr(call, "args", {})
+                    )
+                    # The LLM nests the real args under a single pydantic-param
+                    # wrapper key; unwrap so the manifest records driver /
+                    # calculator / input_structure_file at the top level.
+                    args = _unwrap_tool_args(name, raw_args)
+                    call_id = (
+                        call.get("id")
+                        if isinstance(call, dict)
+                        else getattr(call, "id", None)
+                    )
+                    idx = self.run_manifest.record_step_start(name, args)
+                    # Key by tool_call_id so the matching ToolMessage closes THIS
+                    # step even when several tool calls are open at once. A missing
+                    # id (rare) falls back to a synthetic key.
+                    key = call_id if call_id is not None else f"__noid_{idx}"
+                    self._pending_steps[key] = {
+                        "idx": idx,
+                        "tool": name,
+                        "args": args,
+                    }
+
+            # ToolMessage returning a result -> record the step end.
+            role = getattr(message, "type", None) or getattr(message, "role", None)
+            if role == "tool" and self._pending_steps:
+                # Match the ToolMessage to its open step by tool_call_id. If the
+                # id is absent or unknown, fall back to the single open step when
+                # exactly one is pending (unambiguous), else skip.
+                call_id = getattr(message, "tool_call_id", None)
+                if call_id in self._pending_steps:
+                    key = call_id
+                elif len(self._pending_steps) == 1:
+                    key = next(iter(self._pending_steps))
+                else:
+                    key = None
+                if key is None:
+                    return
+                pending = self._pending_steps.pop(key)
+                pending_step_idx = pending["idx"]
+                pending_step_tool = pending["tool"]
+                pending_step_args = pending["args"]
+                content = str(getattr(message, "content", ""))
+                # LangGraph's ToolNode serializes a non-string tool return via
+                # json.dumps, so in production `content` is the JSON of the
+                # run_ase_core result dict. Parse it and read the resume contract
+                # (wall_time_capped / result_file / restart_file /
+                # resume_input_file / wall_time) as structured fields. Scraping the
+                # human-readable message for a "saved to <path>" substring is
+                # brittle (it breaks the moment the wording changes and mis-parses
+                # a trailing '."' as part of the path), so JSON is the source of
+                # truth; the string path below is only a fallback for a plain-text
+                # ToolMessage (older tools / hand-written test content).
+                is_error = getattr(message, "status", None) == "error"
+                result_file = None
+                wall_time = None
+                wall_time_capped = False
+                restart_file = None
+                resume_input_file = None
+                try:
+                    payload = json.loads(content)
+                except (json.JSONDecodeError, TypeError):
+                    payload = None
+                if isinstance(payload, dict):
+                    is_error = is_error or payload.get("status") == "failure"
+                    if not is_error:
+                        result_file = payload.get("result_file")
+                        wall_time = payload.get("wall_time")
+                        wall_time_capped = bool(payload.get("wall_time_capped"))
+                        restart_file = payload.get("restart_file")
+                        resume_input_file = payload.get("resume_input_file")
+                else:
+                    # Plain-text fallback: recover the result-file path from the
+                    # message and read the capped flags out of that JSON on disk.
+                    is_error = (
+                        is_error
+                        or content.lstrip().startswith("Error")
+                        or '"status": "failure"' in content
+                    )
+                    if not is_error and "saved to " in content:
+                        result_file = (
+                            content.split("saved to ", 1)[1].split()[0].rstrip(".")
+                        )
+                    if result_file and os.path.isfile(result_file):
+                        try:
+                            parsed = json.loads(
+                                Path(result_file).read_text(encoding="utf-8")
+                            )
+                            wall_time = parsed.get("wall_time")
+                            wall_time_capped = bool(parsed.get("wall_time_capped"))
+                            restart_file = parsed.get("restart_file")
+                        except Exception:
+                            pass
+                if not is_error and wall_time_capped:
+                    # Wall-clock cap: record the step as "capped" (NOT done) and
+                    # queue the same step as the pending next step so a resumed
+                    # agent continues it as unfinished work.
+                    self.run_manifest.record_step_end(
+                        pending_step_idx,
+                        result_file=result_file,
+                        wall_time=wall_time,
+                        status="capped",
+                    )
+                    # For a capped opt, the durable partial geometry is a
+                    # standalone structure file; point the pending step's input at
+                    # it so a resume continues from the moved atoms and skips
+                    # recomputing from the original input.
+                    pending_args = pending_step_args
+                    if resume_input_file:
+                        pending_args = dict(pending_args)
+                        pending_args["input_structure_file"] = resume_input_file
+                        reason = (
+                            "wall-clock cap; resume from partial geometry "
+                            f"{resume_input_file}"
+                        )
+                    elif restart_file:
+                        reason = (
+                            f"wall-clock cap; resume with restart_file={restart_file}"
+                        )
+                    else:
+                        reason = (
+                            "wall-clock cap; no restart written, rerun with "
+                            "more wall-clock budget"
+                        )
+                    self.run_manifest.set_pending(
+                        pending_step_tool,
+                        pending_args,
+                        reason=reason,
+                    )
+                    self.run_manifest.set_status("capped")
+                else:
+                    self.run_manifest.record_step_end(
+                        pending_step_idx,
+                        result_file=result_file,
+                        wall_time=wall_time,
+                        status="failed" if is_error else "done",
+                    )
+                    if not is_error:
+                        # A genuinely-completed step clears any stale PENDING
+                        # marker and resets a leftover 'capped' status, so a
+                        # successful resume no longer renders the old pending
+                        # block. (A failed step leaves both untouched.)
+                        self.run_manifest.mark_running()
+        except Exception as exc:  # manifest is best-effort, never break the run
+            logger.debug("manifest observe skipped: %s", exc)
+
     def load_previous_context(
         self,
         session_id: str,
@@ -797,6 +1031,7 @@ class ChemGraph:
                         except Exception:
                             pass
                         logger.info(new_message)
+                        self._manifest_observe(new_message)
                         prev_msgs = s["messages"]
                     last_st = s
             except GraphInterrupt as gi:
@@ -846,6 +1081,28 @@ class ChemGraph:
             config["callbacks"] = callbacks
         logger.debug("validated config=%s", config)
 
+        # When resuming, adopt the prior session's log dir BEFORE anything reads
+        # it. The durable partials a resume must find ({stem}_opt.partial.xyz,
+        # {stem}_vibcache, run_manifest.json) live under that session's log_dir;
+        # a fresh auto-generated dir would hide them and force a full recompute.
+        # Also re-point self.run_manifest at the prior manifest so new steps
+        # append to it, keeping all bookkeeping in one
+        # file. This is the single choke point for every resume path.
+        if resume_from and self.session_store:
+            try:
+                prior = self.session_store.get_session(resume_from)
+            except Exception:
+                prior = None
+            prior_log_dir = getattr(prior, "log_dir", None) if prior else None
+            if prior_log_dir and os.path.isdir(prior_log_dir):
+                self.log_dir = prior_log_dir
+                os.environ["CHEMGRAPH_LOG_DIR"] = prior_log_dir
+                from chemgraph.memory.manifest import RunManifest
+
+                self.run_manifest = RunManifest(
+                    os.path.join(prior_log_dir, "run_manifest.json")
+                )
+
         # Initialize logging directory before determining inputs or running workflow
         # Check if CHEMGRAPH_LOG_DIR is already set
         if not os.environ.get("CHEMGRAPH_LOG_DIR"):
@@ -854,9 +1111,17 @@ class ChemGraph:
         # Ensure session exists in memory store
         self._ensure_session(query)
 
-        # If resuming from a previous session, prepend context
+        # If resuming from a previous session, prepend context. Augment the
+        # text summary with the run manifest (completed steps + result-file
+        # paths + pending next step) so the agent continues precisely and avoids
+        # recomputing work whose args the summary layer dropped.
         if resume_from and self.session_store:
             context = self.session_store.build_context_summary(resume_from)
+            from chemgraph.memory.manifest import RunManifest
+
+            manifest = RunManifest.for_session(self.session_store, resume_from)
+            if manifest:
+                context = f"{context}\n\n{manifest.render_for_context()}"
             if context:
                 query = (
                     f"{context}\n\n"

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -339,6 +339,64 @@ def _next_thread_id() -> int:
     return _thread_counter
 
 
+def _print_cap_handoff(console, agent) -> None:
+    """Print a copy-pasteable resume handoff when a run hit the wall-clock cap.
+
+    Display-only and fully best-effort: a missing/None run manifest, a
+    non-capped status, or any unexpected error is a silent no-op, so this never
+    crashes the CLI on the normal (uncapped) path.
+
+    Parameters
+    ----------
+    console : Any
+        Rich console to print the handoff panel to.
+    agent : Any
+        ChemGraph agent whose ``run_manifest`` and ``session_id`` are read.
+    """
+    try:
+        manifest = getattr(agent, "run_manifest", None)
+        if manifest is None:
+            return
+        if getattr(manifest, "status", None) != "capped":
+            return
+
+        data = getattr(manifest, "_data", {}) or {}
+        pending = data.get("pending_next_step") or {}
+        reason = pending.get("reason", "") if isinstance(pending, dict) else ""
+
+        # `agent.session_id` is the durable SQLite session id that
+        # `chemgraph resume <id>` / `--resume <id>` resolves via
+        # SessionStore.get_session (prefix matching supported).
+        session_id = getattr(agent, "session_id", None)
+        resume_cmd = (
+            f"chemgraph resume {session_id}"
+            if session_id
+            else "chemgraph resume <session_id>"
+        )
+
+        body_lines = [
+            "This run hit the wall-clock/allocation cap and saved a "
+            "resumable partial.",
+            "",
+            "Continue where it left off with:",
+            f"  [bold cyan]{resume_cmd}[/bold cyan]",
+        ]
+        if reason:
+            body_lines.append("")
+            body_lines.append(f"[dim]{reason}[/dim]")
+
+        console.print(
+            Panel(
+                "\n".join(body_lines),
+                title="[bold yellow]Run capped - resumable[/bold yellow]",
+                style="yellow",
+            )
+        )
+    except Exception:
+        # Best-effort handoff; never break the CLI.
+        pass
+
+
 def run_query(
     agent: Any,
     query: str,
@@ -402,6 +460,10 @@ def run_query(
             )
             progress.update(task, description="[green]Query completed!")
             time.sleep(0.3)
+            # A wall-clock-capped run completes normally (no interrupt), so this
+            # is the completion point it always reaches. Best-effort, no-op
+            # unless the run manifest reports "capped".
+            _print_cap_handoff(console, agent)
             return result
         except HumanInputRequired as hir:
             progress.update(task, description="[yellow]Agent needs your input")

--- a/src/chemgraph/cli/jobs.py
+++ b/src/chemgraph/cli/jobs.py
@@ -1,0 +1,206 @@
+"""CLI handlers for inspecting HPC job batches.
+
+Exposes the JobTracker persistence layer (previously reachable only through MCP
+tools) on the command line, so a user can answer "what did I submit last
+allocation?" and reclaim results without going through the agent.
+
+Reads the ``~/.chemgraph/*_jobs.json`` files the MCP-HPC servers persist. All
+JobTracker calls here pass ``offline=True`` so listing/inspecting batches never
+constructs a Globus Compute client or makes a network call -- the CLI must not
+trigger an interactive Globus OAuth login. As a consequence, a disk-loaded task
+whose result has not yet been cached is reported as still ``pending`` even if it
+has actually finished remotely; the MCP tools (which run ``offline=False``) are
+the path that fetches such results and writes them back to disk.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+
+from chemgraph.cli.formatting import console
+from chemgraph.execution.job_tracker import JobTracker
+
+# The MCP-HPC servers each persist to their own file under ~/.chemgraph.
+# Keep in sync with the _JOBS_FILE constants in mcp/{mace,ase,graspa,xanes}_mcp_hpc.py.
+_JOBS_DIR = Path("~/.chemgraph").expanduser()
+_JOBS_FILES = {
+    "mace": _JOBS_DIR / "mace_jobs.json",
+    "ase": _JOBS_DIR / "ase_jobs.json",
+    "graspa": _JOBS_DIR / "graspa_jobs.json",
+    "xanes": _JOBS_DIR / "xanes_jobs.json",
+}
+
+_STATUS_STYLE = {
+    "completed": "green",
+    "partial": "yellow",
+    "running": "cyan",
+    "pending": "dim",
+    "failed": "red",
+}
+
+
+def _discover_trackers() -> dict[str, JobTracker]:
+    """Return ``{backend: JobTracker}`` for every persist file that exists."""
+    trackers: dict[str, JobTracker] = {}
+    for backend, path in _JOBS_FILES.items():
+        if path.is_file():
+            trackers[backend] = JobTracker(persist_file=path)
+    return trackers
+
+
+def _find_batch(trackers: dict[str, JobTracker], batch_id: str):
+    """Locate the (backend, tracker) owning *batch_id*, or (None, None)."""
+    for backend, tracker in trackers.items():
+        status = tracker.get_status(batch_id, offline=True)
+        if "error" not in status:
+            return backend, tracker
+    return None, None
+
+
+def _fmt_status(status: str) -> str:
+    return f"[{_STATUS_STYLE.get(status, 'white')}]{status}[/]"
+
+
+_USAGE = "Usage: chemgraph jobs {list,status <batch>,results <batch>}."
+
+
+def handle_jobs(args: argparse.Namespace) -> None:
+    """Dispatch ``chemgraph jobs {list,status,results}``."""
+    command = getattr(args, "jobs_command", None)
+
+    # A bare ``chemgraph jobs`` (no subcommand) shows usage; it does not
+    # silently run ``list``. The subcommand is required and this keeps
+    # the noun/verb contract explicit.
+    if command is None:
+        console.print(_USAGE)
+        return
+    if command not in ("list", "status", "results"):
+        console.print(_USAGE)
+        return
+
+    trackers = _discover_trackers()
+    if not trackers:
+        console.print(
+            f"[dim]No job tracker files found under {_JOBS_DIR}. Nothing has "
+            "been submitted via the MCP-HPC backends yet.[/dim]"
+        )
+        return
+
+    if command == "list":
+        _jobs_list(trackers)
+    elif command == "status":
+        _jobs_status(trackers, args.batch_id)
+    elif command == "results":
+        _jobs_results(trackers, args.batch_id, include_partial=args.partial)
+
+
+def _jobs_list(trackers: dict[str, JobTracker]) -> None:
+    """Print a combined table of every batch across all backends."""
+    rows: list[tuple[str, dict]] = []
+    for backend, tracker in trackers.items():
+        for summary in tracker.list_batches(offline=True):
+            rows.append((backend, summary))
+
+    if not rows:
+        console.print("[dim]No job batches tracked.[/dim]")
+        return
+
+    console.print(Panel(f"Tracked Job Batches ({len(rows)})", style="bold cyan"))
+
+    table = Table(show_header=True, header_style="bold magenta")
+    table.add_column("Backend", style="cyan")
+    table.add_column("Batch ID", style="cyan")
+    table.add_column("Tool", style="green")
+    table.add_column("Status")
+    table.add_column("Progress", justify="right")
+    table.add_column("Done", justify="right")
+    table.add_column("Failed", justify="right")
+    table.add_column("Pending", justify="right")
+    table.add_column("Submitted", style="dim")
+
+    for backend, s in sorted(
+        rows, key=lambda r: r[1].get("submitted_at", ""), reverse=True
+    ):
+        table.add_row(
+            backend,
+            s["batch_id"],
+            s["tool_name"],
+            _fmt_status(s["status"]),
+            f"{s['progress_pct']}%",
+            str(s["completed_tasks"]),
+            str(s["failed_tasks"]),
+            str(s["pending_tasks"]),
+            s["submitted_at"].replace("T", " ")[:19],
+        )
+
+    console.print(table)
+    console.print(
+        "\n[dim]Use 'chemgraph jobs status <batch>' or "
+        "'chemgraph jobs results <batch>' for details.[/dim]"
+    )
+
+
+def _jobs_status(trackers: dict[str, JobTracker], batch_id: str) -> None:
+    backend, tracker = _find_batch(trackers, batch_id)
+    if tracker is None:
+        console.print(f"[red]Batch '{batch_id}' not found in any tracker.[/red]")
+        console.print("[dim]Use 'chemgraph jobs list' to see batches.[/dim]")
+        return
+
+    s = tracker.get_status(batch_id, offline=True)
+    meta = Table(show_header=False, box=None, padding=(0, 2))
+    meta.add_column("Key", style="bold cyan")
+    meta.add_column("Value")
+    meta.add_row("Backend", backend)
+    meta.add_row("Batch ID", s["batch_id"])
+    meta.add_row("Tool", s["tool_name"])
+    meta.add_row("Submitted", s["submitted_at"].replace("T", " ")[:19])
+    meta.add_row("Status", _fmt_status(s["status"]))
+    meta.add_row("Progress", f"{s['progress_pct']}%")
+    meta.add_row("Total tasks", str(s["total_tasks"]))
+    meta.add_row("Completed", str(s["completed_tasks"]))
+    meta.add_row("Failed", str(s["failed_tasks"]))
+    meta.add_row("Pending", str(s["pending_tasks"]))
+    console.print(Panel(meta, title="Batch Status", style="bold cyan"))
+
+
+def _jobs_results(
+    trackers: dict[str, JobTracker], batch_id: str, include_partial: bool
+) -> None:
+    backend, tracker = _find_batch(trackers, batch_id)
+    if tracker is None:
+        console.print(f"[red]Batch '{batch_id}' not found in any tracker.[/red]")
+        return
+
+    res = tracker.get_results(
+        batch_id, include_partial=include_partial, offline=True
+    )
+    if "error" in res:
+        console.print(f"[red]{res['error']}[/red]")
+        return
+    if "results" not in res:
+        # Still pending and include_partial=False. get_results supplies a
+        # "message" on this branch today; fall back defensively so a future
+        # path that returns neither "results" nor "message" cannot KeyError.
+        console.print(
+            f"[yellow]{res.get('message', 'No results available yet.')}[/yellow]"
+        )
+        return
+
+    console.print(
+        Panel(
+            f"Results for {batch_id} ({backend}) - {len(res['results'])} task(s)",
+            style="bold cyan",
+        )
+    )
+    console.print(
+        Syntax(
+            json.dumps(res["results"], indent=2, default=str), "json", theme="monokai"
+        )
+    )

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -246,6 +246,42 @@ Examples:
     # ---- "models" subcommand ---------------------------------------------
     subparsers.add_parser("models", help="List all available LLM models.")
 
+    # ---- "resume" subcommand ---------------------------------------------
+    # Sugar over the working `--resume` flag: a positional session id plus an
+    # optional query (prompted when omitted). Reuses every run option so a
+    # resumed run is configured exactly like a fresh one.
+    resume_parser = subparsers.add_parser(
+        "resume",
+        help="Resume a previous session with a follow-up query.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    resume_parser.add_argument(
+        "session_id",
+        help="Session ID to resume (prefix matching supported).",
+    )
+    _add_run_args(resume_parser)
+
+    # ---- "jobs" subcommand ----------------------------------------------
+    jobs_parser = subparsers.add_parser(
+        "jobs",
+        help="Inspect HPC job batches submitted via MCP-HPC backends.",
+    )
+    jobs_sub = jobs_parser.add_subparsers(dest="jobs_command")
+    jobs_sub.add_parser("list", help="List all tracked job batches.")
+    jobs_status_parser = jobs_sub.add_parser(
+        "status", help="Show detailed status of one batch."
+    )
+    jobs_status_parser.add_argument("batch_id", help="Batch ID to query.")
+    jobs_results_parser = jobs_sub.add_parser(
+        "results", help="Show results for a completed batch."
+    )
+    jobs_results_parser.add_argument("batch_id", help="Batch ID to query.")
+    jobs_results_parser.add_argument(
+        "--partial",
+        action="store_true",
+        help="Include results from finished tasks even if some are pending.",
+    )
+
     # ---- "dashboard" subcommands ----------------------------------------
     dashboard_parser = subparsers.add_parser(
         "dashboard",
@@ -603,6 +639,50 @@ def _run_module_main(module_name: str, argv: list[str]) -> None:
         sys.exit(code)
 
 
+def _handle_resume(args: argparse.Namespace) -> None:
+    """Handle the ``resume`` subcommand.
+
+    Thin wrapper over :func:`_handle_run`: maps the positional ``session_id``
+    onto the working ``--resume`` code path and prompts for a query when ``-q``
+    is omitted (mirrors the interactive REPL ``resume`` verb).
+    """
+    # Pre-flight: fail fast on an unresolvable session id. Without this,
+    # _handle_run prints "Resuming from: <id>", the store's build_context_summary
+    # returns "" for a missing id, and the run silently starts fresh -- the user
+    # believes they resumed when they did not. get_session resolves exact ids and
+    # unique prefixes (returns None otherwise), matching what the agent will do.
+    from chemgraph.memory.store import SessionStore
+
+    if SessionStore().get_session(args.session_id) is None:
+        console.print(
+            f"[red]No session found for '{args.session_id}'.[/red]"
+        )
+        console.print(
+            "[dim]Use 'chemgraph session list' to see resumable sessions "
+            "(exact id or a unique prefix).[/dim]"
+        )
+        sys.exit(1)
+
+    args.resume = args.session_id
+    if not args.query:
+        from rich.prompt import Prompt
+
+        args.query = Prompt.ask(
+            "[bold cyan]Enter query to continue with[/bold cyan]"
+        ).strip()
+        if not args.query:
+            console.print("[red]A query is required to resume a session.[/red]")
+            sys.exit(1)
+    _handle_run(args)
+
+
+def _handle_jobs(args: argparse.Namespace) -> None:
+    """Handle the ``jobs`` subcommand."""
+    from chemgraph.cli.jobs import handle_jobs
+
+    handle_jobs(args)
+
+
 def _handle_academy(args: argparse.Namespace) -> None:
     """Handle Academy-backed ChemGraph campaign commands."""
     command = getattr(args, "academy_command", None)
@@ -671,6 +751,12 @@ def main() -> None:
 
     elif args.command == "models":
         list_models()
+
+    elif args.command == "resume":
+        _handle_resume(args)
+
+    elif args.command == "jobs":
+        _handle_jobs(args)
 
     elif args.command == "dashboard":
         _run_module_main(

--- a/src/chemgraph/execution/job_tracker.py
+++ b/src/chemgraph/execution/job_tracker.py
@@ -153,14 +153,59 @@ class JobTracker:
             logger.warning("Could not load job tracker state: %s", exc)
             return
 
+        if not isinstance(data, dict):
+            logger.warning(
+                "Job tracker state in %s is not a JSON object (got %s); "
+                "ignoring it.",
+                self._persist_file,
+                type(data).__name__,
+            )
+            return
+
         orphaned: list[tuple[str, str]] = []  # (batch_id, task_id)
+        skipped = 0
         with self._lock:
             for bid, info in data.items():
                 if bid in self._batches:
                     continue  # don't overwrite live batches
 
+                # A persist file can be valid JSON but structurally
+                # incomplete (hand-edited, partially written, or produced by
+                # a future/older schema). Skip such a batch with a warning;
+                # raising KeyError here would lose every other batch.
+                if not isinstance(info, dict):
+                    skipped += 1
+                    continue
+                tool_name = info.get("tool_name")
+                submitted_raw = info.get("submitted_at")
+                if tool_name is None or submitted_raw is None:
+                    logger.warning(
+                        "Batch '%s' in %s is missing required fields "
+                        "(tool_name/submitted_at); skipping it.",
+                        bid,
+                        self._persist_file,
+                    )
+                    skipped += 1
+                    continue
+                try:
+                    submitted_at = datetime.fromisoformat(submitted_raw)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Batch '%s' in %s has an unparseable submitted_at "
+                        "(%r); skipping it.",
+                        bid,
+                        self._persist_file,
+                        submitted_raw,
+                    )
+                    skipped += 1
+                    continue
+
                 tasks = []
+                malformed_task = False
                 for t in info.get("tasks", []):
+                    if not isinstance(t, dict) or "task_id" not in t:
+                        malformed_task = True
+                        break
                     tracked = TrackedTask(
                         task_id=t["task_id"],
                         meta=t.get("meta", {}),
@@ -174,16 +219,28 @@ class JobTracker:
                     if tracked.globus_task_id is None and tracked.result is None:
                         orphaned.append((bid, tracked.task_id))
                     tasks.append(tracked)
+                if malformed_task:
+                    logger.warning(
+                        "Batch '%s' in %s has a malformed task entry; "
+                        "skipping the batch.",
+                        bid,
+                        self._persist_file,
+                    )
+                    skipped += 1
+                    continue
 
                 self._batches[bid] = TrackedBatch(
                     batch_id=bid,
-                    tool_name=info["tool_name"],
-                    submitted_at=datetime.fromisoformat(info["submitted_at"]),
+                    tool_name=tool_name,
+                    submitted_at=submitted_at,
                     tasks=tasks,
                 )
 
         logger.info(
-            "Loaded %d batches from %s", len(data), self._persist_file
+            "Loaded %d batches from %s (%d skipped)",
+            len(data) - skipped,
+            self._persist_file,
+            skipped,
         )
         if orphaned:
             logger.warning(
@@ -307,11 +364,23 @@ class JobTracker:
 
     # ── status ─────────────────────────────────────────────────────────
 
-    def get_status(self, batch_id: str) -> dict:
+    def get_status(self, batch_id: str, offline: bool = False) -> dict:
         """Return the current status of a batch.
 
         For tasks loaded from disk (no in-memory ``Future``), queries
         Globus Compute directly if a ``globus_task_id`` is available.
+
+        Parameters
+        ----------
+        batch_id : str
+            The batch identifier.
+        offline : bool
+            When ``True``, never construct a Globus Compute client or make a
+            network call: disk-loaded tasks with no cached result are reported
+            as still pending. Defaults to ``False`` so the MCP-HPC path is
+            unchanged. The CLI passes ``offline=True`` because it only reads
+            what is already on disk and must not trigger an interactive Globus
+            OAuth login just to list batches.
 
         Returns
         -------
@@ -363,7 +432,12 @@ class JobTracker:
                         dirty = True
 
                 # --- loaded-from-disk path (no future, use Globus client) ---
-                elif t.future is None and t.result is None and t.globus_task_id:
+                elif (
+                    not offline
+                    and t.future is None
+                    and t.result is None
+                    and t.globus_task_id
+                ):
                     gc = self._get_gc_client()
                     if gc is not None:
                         try:
@@ -437,7 +511,7 @@ class JobTracker:
     # ── results ────────────────────────────────────────────────────────
 
     def get_results(
-        self, batch_id: str, include_partial: bool = False
+        self, batch_id: str, include_partial: bool = False, offline: bool = False
     ) -> dict:
         """Collect results from a batch.
 
@@ -449,13 +523,16 @@ class JobTracker:
             If ``True``, return results for completed tasks even if some
             are still pending.  If ``False`` (default) and the batch is
             not fully resolved, return a status message instead.
+        offline : bool
+            Forwarded to :meth:`get_status`; when ``True`` no Globus client
+            is created or queried. Defaults to ``False``.
 
         Returns
         -------
         dict
             Contains ``status``, ``results`` list, and summary counts.
         """
-        status_info = self.get_status(batch_id)
+        status_info = self.get_status(batch_id, offline=offline)
         if "error" in status_info:
             return status_info
 
@@ -487,14 +564,21 @@ class JobTracker:
 
     # ── listing ────────────────────────────────────────────────────────
 
-    def list_batches(self) -> list[dict]:
-        """Return a summary of all tracked batches."""
+    def list_batches(self, offline: bool = False) -> list[dict]:
+        """Return a summary of all tracked batches.
+
+        Parameters
+        ----------
+        offline : bool
+            Forwarded to :meth:`get_status` for every batch; when ``True`` no
+            Globus client is created or queried. Defaults to ``False``.
+        """
         with self._lock:
             batch_ids = list(self._batches.keys())
 
         summaries = []
         for bid in batch_ids:
-            summaries.append(self.get_status(bid))
+            summaries.append(self.get_status(bid, offline=offline))
         return summaries
 
     # ── cancellation ───────────────────────────────────────────────────

--- a/src/chemgraph/mcp/mace_mcp_hpc.py
+++ b/src/chemgraph/mcp/mace_mcp_hpc.py
@@ -265,6 +265,7 @@ def _expand_mace_ensemble(params: mace_input_schema_ensemble) -> list[dict]:
         "pressure": params.pressure,
         "fmax": params.fmax,
         "steps": params.steps,
+        "max_wall_seconds": params.max_wall_seconds,
         "optimizer": params.optimizer,
     }
     base_output = Path(params.output_result_file)

--- a/src/chemgraph/mcp/mace_mcp_parsl.py
+++ b/src/chemgraph/mcp/mace_mcp_parsl.py
@@ -153,6 +153,7 @@ def run_mace_ensemble(params: mace_input_schema_ensemble):
             "pressure": params.pressure,
             "fmax": params.fmax,
             "steps": params.steps,
+            "max_wall_seconds": params.max_wall_seconds,
             "optimizer": params.optimizer,
         }
 

--- a/src/chemgraph/memory/manifest.py
+++ b/src/chemgraph/memory/manifest.py
@@ -1,0 +1,248 @@
+"""Durable per-session run manifest for cross-allocation resume.
+
+Records each executed cost-bearing tool call (name, args, result-file path,
+wall_time) and the pending next step on the shared filesystem under
+``CHEMGRAPH_LOG_DIR``. Written incrementally with an atomic tmp+replace (the same
+idiom as :class:`chemgraph.execution.job_tracker.JobTracker`), so a completed
+step survives a walltime kill even though the LangGraph checkpointer is in-memory
+and the SessionStore saves only at turn end.
+
+This is deliberately independent of the SessionStore message layer, which drops
+empty-content tool-call messages and has no column for tool arguments -- exactly
+the information a resumed agent needs to continue without recomputing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_SCHEMA_VERSION = 1
+
+
+class RunManifest:
+    """A durable, incrementally-written record of a session's executed steps."""
+
+    def __init__(self, path: str | Path):
+        self._path = Path(path)
+        self._data: dict[str, Any] = {
+            "schema_version": _SCHEMA_VERSION,
+            "steps": [],
+            "pending_next_step": None,
+            "status": "running",
+        }
+        if self._path.is_file():
+            try:
+                loaded = json.loads(self._path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+                # UnicodeDecodeError (a ValueError) covers a file corrupted with
+                # non-UTF-8 bytes: the writer always emits pure ASCII, so this only
+                # fires on external tampering, but the resume path must still not
+                # crash on it.
+                logger.warning("Could not load manifest %s: %s", self._path, exc)
+            else:
+                # Guard against valid-but-wrong-shape JSON (tampering, a schema
+                # drift, or a truncation that still parses): every reader assumes
+                # ``_data["steps"]`` is a list, so a bad shape must not reach
+                # them. Fall back to the fresh default so the
+                # resume this file exists to enable still proceeds.
+                if self._is_valid_shape(loaded):
+                    self._data = loaded
+                else:
+                    logger.warning(
+                        "Ignoring manifest %s: unexpected shape or schema "
+                        "version; starting fresh",
+                        self._path,
+                    )
+
+    @staticmethod
+    def _is_valid_shape(data: Any) -> bool:
+        """True if *data* is a manifest this version can safely read."""
+        return (
+            isinstance(data, dict)
+            and data.get("schema_version") == _SCHEMA_VERSION
+            and isinstance(data.get("steps"), list)
+        )
+
+    # ------------------------------------------------------------------
+    # persistence (atomic tmp + replace, mirrors JobTracker._save)
+    # ------------------------------------------------------------------
+    def _flush(self) -> None:
+        tmp = self._path.with_suffix(".tmp")
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp.write_text(
+                json.dumps(self._data, indent=2, default=str), encoding="utf-8"
+            )
+            tmp.replace(self._path)
+        except (TypeError, ValueError, OSError) as exc:
+            # Best-effort metadata, never crash the run. Widened beyond OSError to
+            # match JobTracker._save: json.dumps raises TypeError/ValueError on
+            # content default=str cannot coerce (e.g. non-str dict keys), and that
+            # must not propagate out of a write API called mid-tool-call.
+            logger.warning("Could not persist manifest %s: %s", self._path, exc)
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # write API
+    # ------------------------------------------------------------------
+    def record_step_start(self, tool: str, args: dict) -> int:
+        """Append a step in ``running`` state and return its 1-based index."""
+        idx = len(self._data["steps"]) + 1
+        self._data["steps"].append(
+            {
+                "index": idx,
+                "tool": tool,
+                "args": _jsonable(args),
+                "status": "running",
+                "result_file": None,
+                "wall_time": None,
+            }
+        )
+        self._flush()
+        return idx
+
+    def record_step_end(
+        self,
+        idx: int,
+        *,
+        result_file: Optional[str] = None,
+        wall_time: Optional[float] = None,
+        status: str = "done",
+    ) -> None:
+        """Mark step *idx* finished with its result-file path and wall time."""
+        for step in self._data["steps"]:
+            if isinstance(step, dict) and step.get("index") == idx:
+                step.update(
+                    result_file=result_file, wall_time=wall_time, status=status
+                )
+                break
+        self._flush()
+
+    def set_pending(self, tool: str, args: dict, reason: str = "") -> None:
+        """Record the un-executed next step so a resume knows where to continue."""
+        self._data["pending_next_step"] = {
+            "tool": tool,
+            "args": _jsonable(args),
+            "reason": reason,
+        }
+        self._flush()
+
+    def set_status(self, status: str) -> None:
+        self._data["status"] = status
+        self._flush()
+
+    def clear_pending(self) -> None:
+        """Drop the pending-next-step marker (one flush)."""
+        self._data["pending_next_step"] = None
+        self._flush()
+
+    def mark_running(self) -> None:
+        """Reset to a clean in-progress state: clear pending + status='running'.
+
+        Called after a genuinely-completed (non-capped, non-error) step so a
+        successful resume does not keep rendering a stale PENDING block or a
+        'capped' status left over from an earlier cap. One flush for both.
+        """
+        self._data["pending_next_step"] = None
+        self._data["status"] = "running"
+        self._flush()
+
+    # ------------------------------------------------------------------
+    # read / render
+    # ------------------------------------------------------------------
+    def render_for_context(self) -> str:
+        """Render a compact, untruncated block to append to a resume prompt.
+
+        Reads every step defensively: ``_is_valid_shape`` guarantees ``steps`` is
+        a list, but not that each element is a well-formed dict. A malformed step
+        (a null, or one missing ``status``/``index``) is skipped so it
+        cannot raise, since this method runs unguarded on the resume path and
+        a crash here would defeat the resume this manifest exists to enable.
+        """
+        done = [
+            s
+            for s in self._data["steps"]
+            if isinstance(s, dict) and s.get("status") == "done"
+        ]
+        lines = ["=== Run manifest (completed work - do NOT recompute) ==="]
+        for s in done:
+            raw = s.get("args")
+            a = raw if isinstance(raw, dict) else {}
+            lines.append(
+                f"[{s.get('index', '?')}] {s.get('tool', '?')} "
+                f"driver={a.get('driver', '?')} calc={_calc_name(a)} "
+                f"-> result={s.get('result_file', '?')} "
+                f"(wall_time={s.get('wall_time', '?')}s)"
+            )
+        pend = self._data.get("pending_next_step")
+        if isinstance(pend, dict):
+            raw = pend.get("args")
+            a = raw if isinstance(raw, dict) else {}
+            lines.append("=== PENDING NEXT STEP (start here) ===")
+            lines.append(
+                f"{pend.get('tool', '?')} driver={a.get('driver', '?')} "
+                f"input={a.get('input_structure_file', '?')}"
+                + (f"  ({pend.get('reason')})" if pend.get("reason") else "")
+            )
+        return "\n".join(lines)
+
+    @property
+    def status(self) -> str:
+        return self._data.get("status", "running")
+
+    @classmethod
+    def for_session(
+        cls, session_store, session_id: str
+    ) -> Optional["RunManifest"]:
+        """Load the manifest for a session via its stored ``log_dir``."""
+        try:
+            sess = session_store.get_session(session_id)
+        except Exception:
+            return None
+        if not sess or not getattr(sess, "log_dir", None):
+            return None
+        p = Path(sess.log_dir) / "run_manifest.json"
+        return cls(p) if p.is_file() else None
+
+
+def _calc_name(args: dict) -> str:
+    """Extract a calculator label from a run_ase args dict (dict or model)."""
+    c = args.get("calculator")
+    if isinstance(c, dict):
+        return c.get("calculator_type", "?")
+    return getattr(c, "calculator_type", "?") if c is not None else "?"
+
+
+def _jsonable(value: Any) -> Any:
+    """Normalize tool args to JSON-native types before persisting.
+
+    Tool args may nest Pydantic models (e.g. an ``ASEInputSchema`` calculator).
+    ``json.dumps(..., default=str)`` would stringify those to an unparseable repr,
+    so a resumed process would reload ``calc=?`` and lose the very args the
+    manifest exists to preserve. Convert models to dicts here so the on-disk form
+    round-trips and ``_calc_name`` still resolves after reload.
+    """
+    if hasattr(value, "model_dump"):  # pydantic v2
+        return _jsonable(value.model_dump())
+    # pydantic v1: require both a callable ``.dict`` and ``__fields__`` so a plain
+    # object that merely owns a ``.dict`` attribute (e.g. a namespace whose
+    # ``dict`` is a real mapping) is not mistaken for a model and called.
+    if (
+        not isinstance(value, dict)
+        and callable(getattr(value, "dict", None))
+        and hasattr(value, "__fields__")
+    ):
+        return _jsonable(value.dict())
+    if isinstance(value, dict):
+        return {k: _jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    return value

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -270,6 +270,16 @@ class ASEInputSchema(BaseModel):
         default=1000,
         description="Maximum number of optimization steps. Internally 'vib', 'thermo' and 'ir' run geometry optimization before performing their respective calculations.",
     )
+    max_wall_seconds: Optional[float] = Field(
+        default=None,
+        description=(
+            "Soft wall-clock budget for this calculation in seconds. When set, "
+            "geometry optimization checks the clock after each optimizer step and "
+            "returns a resumable partial result (converged=False, restart_file "
+            "set), stopping short of completion. None (default) = no cap, "
+            "current behavior."
+        ),
+    )
     temperature: Optional[float] = Field(
         default=None,
         description="Temperature for thermochemistry calculations in Kelvin (K).",
@@ -406,6 +416,14 @@ class ASEOutputSchema(BaseModel):
     wall_time: float = Field(
         default=None,
         description="Total wall time (in seconds) taken to complete the simulation.",
+    )
+    wall_time_capped: bool = Field(
+        default=False,
+        description="True if the run stopped early due to max_wall_seconds.",
+    )
+    restart_file: Optional[str] = Field(
+        default=None,
+        description="Optimizer restart-state path for resuming a capped run.",
     )
 
     @field_validator("vibrational_frequencies", "ir_data", "thermochemistry", mode="before")

--- a/src/chemgraph/schemas/mace_parsl_schema.py
+++ b/src/chemgraph/schemas/mace_parsl_schema.py
@@ -52,6 +52,16 @@ class mace_input_schema(BaseModel):
         default=1000,
         description="Maximum number of optimization steps. The optimization will terminate if this number is reached, even if forces haven't converged to fmax.",
     )
+    max_wall_seconds: float | None = Field(
+        default=None,
+        description=(
+            "Soft wall-clock cap in seconds for this calculation. When set, the "
+            "optimization/vibration self-terminates at the deadline and returns a "
+            "resumable partial short of convergence. The effective cap "
+            "is the tighter of this value and any allocation budget "
+            "(CHEMGRAPH_ALLOCATION_* env). None = no explicit cap."
+        ),
+    )
     optimizer: str = Field(
         default="lbfgs",
         description="The optimization algorithm used for geometry optimization. Options are 'bfgs', 'lbfgs', 'gpmin', 'fire', 'mdmin'",
@@ -111,6 +121,17 @@ class mace_input_schema_ensemble(BaseModel):
     steps: int = Field(
         default=1000,
         description="Maximum number of optimization steps. The optimization will terminate if this number is reached, even if forces haven't converged to fmax.",
+    )
+    max_wall_seconds: float | None = Field(
+        default=None,
+        description=(
+            "Soft wall-clock cap in seconds applied to each structure in the "
+            "ensemble. When set, a per-structure optimization/vibration self-"
+            "terminates at the deadline and returns a resumable partial instead "
+            "of running to convergence. The effective cap is the tighter of this "
+            "value and any allocation budget (CHEMGRAPH_ALLOCATION_* env). None = "
+            "no explicit cap."
+        ),
     )
     optimizer: str = Field(
         default="lbfgs",

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -8,9 +8,11 @@ simply delegate to these functions.
 
 from __future__ import annotations
 
+import contextlib
 import glob
 import json
 import logging
+import math
 import os
 import shutil
 import tempfile
@@ -24,6 +26,154 @@ from chemgraph.schemas.atomsdata import AtomsData
 from chemgraph.schemas.ase_input import ASEInputSchema, ASEOutputSchema
 
 logger = logging.getLogger(__name__)
+
+# Reference point for CHEMGRAPH_ALLOCATION_SECONDS: the moment this module is
+# imported, which is ~the moment the agent process (and thus the useful part of
+# the PBS allocation) begins. CHEMGRAPH_ALLOCATION_DEADLINE (absolute epoch) is
+# exact and takes precedence when both are set.
+_PROCESS_START = time.time()
+
+# Default seconds reserved before the allocation deadline for a clean stop:
+# the cap trips at a step boundary, then the partial state must be flushed and
+# the result file written before PBS sends SIGKILL. Overridable per run via
+# CHEMGRAPH_ALLOCATION_MARGIN.
+_DEFAULT_ALLOCATION_MARGIN = 60.0
+
+
+def _allocation_deadline() -> Optional[float]:
+    """Absolute wall-clock time (epoch seconds) when the PBS allocation ends.
+
+    Read from the environment so a batch script can advertise the allocation's
+    walltime to every calculation in the run without any per-call plumbing:
+
+    * ``CHEMGRAPH_ALLOCATION_DEADLINE`` -- absolute epoch seconds of the kill.
+      Exact, and the recommended form for real PBS jobs; e.g.
+      ``export CHEMGRAPH_ALLOCATION_DEADLINE=$(date -d "+${WALL}sec" +%s)``.
+    * ``CHEMGRAPH_ALLOCATION_SECONDS`` -- total budget in seconds, measured from
+      this process's start (module import). Convenient when a script only knows a
+      duration, but under-protects if a long setup (conda activation, model
+      downloads) runs between the PBS walltime clock starting and this module
+      being imported -- that gap is not counted, so prefer the DEADLINE form for
+      production.
+
+    Returns None when neither is set (no allocation cap; an explicit
+    ``max_wall_seconds`` still applies on its own). Non-finite values (nan/inf)
+    are rejected like non-numeric ones, so a garbage env var can never silently
+    disable the cap.
+    """
+    raw_deadline = os.environ.get("CHEMGRAPH_ALLOCATION_DEADLINE")
+    if raw_deadline:
+        try:
+            value = float(raw_deadline)
+        except ValueError:
+            logger.warning(
+                "Ignoring non-numeric CHEMGRAPH_ALLOCATION_DEADLINE=%r", raw_deadline
+            )
+        else:
+            if math.isfinite(value):
+                # A deadline already in the past when THIS process started cannot
+                # belong to the current allocation -- it is a leftover
+                # CHEMGRAPH_ALLOCATION_DEADLINE from a prior run still in the
+                # environment. Honoring it would clamp every calc to 0.001 s and
+                # cap immediately, forever (same no-progress failure class as a
+                # stale restart). Ignore it and fall through to SECONDS; a
+                # deadline after _PROCESS_START that is merely spent mid-run is
+                # still honored (and clamps in _effective_wall_seconds).
+                if value < _PROCESS_START:
+                    logger.warning(
+                        "Ignoring stale CHEMGRAPH_ALLOCATION_DEADLINE=%r (before "
+                        "this process started; leftover from a prior allocation)",
+                        raw_deadline,
+                    )
+                else:
+                    return value
+            else:
+                logger.warning(
+                    "Ignoring non-finite CHEMGRAPH_ALLOCATION_DEADLINE=%r",
+                    raw_deadline,
+                )
+    raw_seconds = os.environ.get("CHEMGRAPH_ALLOCATION_SECONDS")
+    if raw_seconds:
+        try:
+            value = float(raw_seconds)
+        except ValueError:
+            logger.warning(
+                "Ignoring non-numeric CHEMGRAPH_ALLOCATION_SECONDS=%r", raw_seconds
+            )
+        else:
+            if math.isfinite(value):
+                return _PROCESS_START + value
+            logger.warning(
+                "Ignoring non-finite CHEMGRAPH_ALLOCATION_SECONDS=%r", raw_seconds
+            )
+    return None
+
+
+def _allocation_margin() -> float:
+    """Seconds to reserve before the allocation deadline for a clean stop.
+
+    Overridable via ``CHEMGRAPH_ALLOCATION_MARGIN`` (seconds); defaults to
+    ``_DEFAULT_ALLOCATION_MARGIN``. A larger margin also absorbs one in-flight
+    step that is already running when the deadline check fires.
+    """
+    raw = os.environ.get("CHEMGRAPH_ALLOCATION_MARGIN")
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(
+                "Ignoring non-numeric CHEMGRAPH_ALLOCATION_MARGIN=%r", raw
+            )
+        else:
+            if math.isfinite(value):
+                return max(0.0, value)
+            logger.warning(
+                "Ignoring non-finite CHEMGRAPH_ALLOCATION_MARGIN=%r", raw
+            )
+    return _DEFAULT_ALLOCATION_MARGIN
+
+
+def _effective_wall_seconds(
+    explicit: Optional[float], start_time: float
+) -> Optional[float]:
+    """Combine an explicit ``max_wall_seconds`` with the PBS allocation budget.
+
+    The effective cap is the *tighter* of:
+
+    * the user's explicit ``max_wall_seconds`` (if any), and
+    * the allocation's remaining time minus a safety margin (if the allocation
+      env vars are set).
+
+    This is the enforcement side of the Layer-2 auto-continue gate: even with no
+    explicit cap, a calculation inside a PBS allocation self-terminates with a
+    resumable partial before walltime kills it, while a short calculation
+    finishes well within the budget and is never capped. The cap is *soft* -- it
+    fires only at ASE step boundaries, so the margin must exceed one step's wall
+    time (the 60 s default suits fast engines; DFT should raise it).
+
+    Returns None when neither bound is set (uncapped -- original behavior), or a
+    small positive (``0.001``) when the allocation is already spent ("cap
+    immediately").
+    """
+    bounds: list[float] = []
+    if explicit and explicit > 0:
+        bounds.append(float(explicit))
+
+    deadline = _allocation_deadline()
+    if deadline is not None:
+        alloc_remaining = deadline - _allocation_margin() - start_time
+        # Clamp to a small positive: a value <= 0 would be falsy at the gate
+        # (disabling the cap -- the opposite of intended) when we are in fact out
+        # of time. A tiny positive makes an already-exhausted allocation cap as
+        # early as possible -- typically before step 1, in which case no restart
+        # file is written and the result is a no-progress partial (see the opt/
+        # vib cap sites, which advertise restart_file only when a step actually
+        # persisted state).
+        bounds.append(max(alloc_remaining, 0.001))
+
+    if not bounds:
+        return None
+    return min(bounds)
 
 
 def _ensure_ase_core_file_log() -> None:
@@ -360,6 +510,75 @@ def create_xyz_string(atomic_numbers, positions) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
+# Vibrational-analysis wall-clock cap
+# ---------------------------------------------------------------------------
+
+def _run_vibrations_capped(vib, deadline: Optional[float]) -> tuple[bool, int, int]:
+    """Run an ASE ``Vibrations``/``Infrared`` calculation with an optional cap.
+
+    This mirrors ``ase.vibrations.Vibrations.run`` (iterate displacements, take a
+    per-displacement exclusive-create lock, compute forces, save), but adds two
+    things the stock ``run()`` lacks:
+
+    * a wall-clock deadline checked *between* displacements, so the calculation
+      stops cleanly before the scheduler SIGKILLs it mid-run;
+    * durability: because the caller uses a persistent cache directory (not a
+      ``TemporaryDirectory``), a capped run leaves its completed displacements on
+      disk and a later re-run skips them (the lock returns ``None`` for a
+      displacement whose ``cache.<name>.json`` already exists).
+
+    The deadline is checked *before* acquiring the lock, never inside it: the lock
+    exclusively creates the cache file up front, so breaking mid-lock would leave
+    an empty file that ASE would later mistake for a completed displacement. A
+    displacement already present in the cache is skipped for free (no deadline
+    check), so a complete-but-expired cache is *not* reported as capped.
+
+    Parameters
+    ----------
+    vib : ase.vibrations.Vibrations
+        A ``Vibrations`` (or ``Infrared``) instance bound to a persistent cache.
+    deadline : Optional[float]
+        Absolute ``time.time()`` value after which no new displacement starts.
+        ``None`` disables the cap (all displacements run to completion).
+
+    Returns
+    -------
+    tuple[bool, int, int]
+        ``(capped, n_done, n_total)`` where ``capped`` is True iff the run
+        stopped early with displacements still outstanding.
+    """
+    from ase.parallel import world
+
+    # An earlier interrupted run (e.g. a hard kill mid-lock) can leave empty
+    # cache files; drop them so those displacements are recomputed, not trusted.
+    with contextlib.suppress(Exception):
+        vib.cache.strip_empties()
+
+    n_total = vib.ndof * vib.nfree + 1  # 6N+1 for nfree=2
+    n_done = 0
+    capped = False
+    for disp, disp_atoms in vib.iterdisplace(inplace=False):
+        if disp.name in vib.cache:
+            # Already computed on a previous allocation -> free skip.
+            n_done += 1
+            continue
+        if deadline is not None and time.time() >= deadline:
+            capped = True
+            break
+        with vib.cache.lock(disp.name) as handle:
+            if handle is None:
+                # Won by another worker between the membership check and the
+                # lock; count it as done.
+                n_done += 1
+                continue
+            result = vib.calculate(disp_atoms, disp)
+            if world.rank == 0:
+                handle.save(result)
+            n_done += 1
+    return capped, n_done, n_total
+
+
+# ---------------------------------------------------------------------------
 # Unified ASE simulation core
 # ---------------------------------------------------------------------------
 
@@ -400,6 +619,23 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         }
 
     start_time = time.time()
+
+    # Effective wall-clock cap: the tighter of the user's explicit
+    # max_wall_seconds and the remaining PBS allocation budget (minus a safety
+    # margin), so a calculation self-terminates with a resumable partial before
+    # walltime kills it -- even when no explicit cap was requested. None =
+    # uncapped (neither an explicit cap nor an allocation deadline is set).
+    effective_wall_seconds = _effective_wall_seconds(params.max_wall_seconds, start_time)
+    if (
+        effective_wall_seconds is not None
+        and effective_wall_seconds != params.max_wall_seconds
+    ):
+        logger.info(
+            "Effective wall-clock cap: %.3fs (explicit max_wall_seconds=%s, "
+            "allocation-bounded).",
+            effective_wall_seconds,
+            params.max_wall_seconds,
+        )
 
     # Resolve a relative input path against CHEMGRAPH_LOG_DIR, matching how
     # smiles_to_coordinate_file writes it. Without this, a tool that writes
@@ -511,6 +747,9 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                 "message": f"Simulation completed. Results saved to {os.path.abspath(output_results_file)}",
                 "single_point_energy": energy,
                 "unit": "eV",
+                "result_file": os.path.abspath(output_results_file),
+                "wall_time": wall_time,
+                "wall_time_capped": False,
             }
         else:  # dipole
             return {
@@ -518,6 +757,9 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                 "message": f"Simulation completed. Results saved to {os.path.abspath(output_results_file)}",
                 "dipole_moment": dipole,
                 "dipole_unit": "e * Angstrom",
+                "result_file": os.path.abspath(output_results_file),
+                "wall_time": wall_time,
+                "wall_time_capped": False,
             }
 
     # ------------------------------------------------------------------
@@ -536,12 +778,67 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             raise ValueError(f"Unsupported optimizer: {optimizer}")
 
         logger.info("Running optimization with %s (fmax=%s, steps=%s)", optimizer, fmax, steps)
+        mol_stem = Path(input_structure_file).stem if input_structure_file else "mol"
+        opt_capped = False
+        restart_path = None
+        resume_input_file = None
         if len(atoms) > 1:
-            dyn = optimizer_class(atoms)
-            converged = dyn.run(fmax=fmax, steps=steps)
+            # Soft wall-clock cap: when an effective cap is in force (an explicit
+            # max_wall_seconds and/or a PBS allocation budget), step the optimizer
+            # via irun() and stop cleanly at the deadline, leaving a resumable
+            # partial (BFGS dumps its Hessian to restart_path and the trajectory
+            # each step). When neither is set, the path below is byte-for-byte the
+            # original dyn.run() behavior.
+            if effective_wall_seconds:
+                deadline = start_time + effective_wall_seconds
+                restart_target = _resolve_path(f"{mol_stem}_opt.restart.json")
+                traj_path = _resolve_path(f"{mol_stem}_opt.traj")
+                dyn = optimizer_class(
+                    atoms, restart=restart_target, trajectory=traj_path
+                )
+                converged = False
+                # irun() yields is_converged at each point, and BFGS dumps its
+                # restart state inside each completed step. When a step completes
+                # within the budget, the capped run has a restart file on disk and
+                # we advertise it. irun() also yields once before step 1, so a cap
+                # that fires there leaves 0 steps and no partial to resume; that
+                # case advertises no restart_file, handled by the n_done check below.
+                for converged in dyn.irun(fmax=fmax, steps=steps):
+                    # Convergence wins over the deadline: a step that reports a
+                    # converged geometry is finished, so break without capping
+                    # even when the deadline has already passed.
+                    if converged:
+                        break
+                    if time.time() >= deadline:
+                        opt_capped = True
+                        break
+                if opt_capped:
+                    n_done = dyn.get_number_of_steps()
+                    # Only claim a restart file if a step actually wrote one.
+                    if n_done > 0 and os.path.isfile(restart_target):
+                        restart_path = restart_target
+                        # Persist the moved geometry as a standalone, ASE-readable
+                        # structure so a resume continues from the partial instead
+                        # of re-reading the original input. restart_target is the
+                        # BFGS Hessian JSON (not a structure); this xyz is what a
+                        # resumed run feeds back as input_structure_file.
+                        from ase.io import write
+
+                        resume_input_file = _resolve_path(f"{mol_stem}_opt.partial.xyz")
+                        write(resume_input_file, atoms)
+                    logger.warning(
+                        "Optimization capped at effective wall-clock=%.3fs after "
+                        "%d steps (not converged); partial geometry%s saved.",
+                        effective_wall_seconds,
+                        n_done,
+                        " + restart" if restart_path else "",
+                    )
+            else:
+                dyn = optimizer_class(atoms)
+                converged = dyn.run(fmax=fmax, steps=steps)
         else:
             converged = True
-        logger.info("Optimization converged=%s", converged)
+        logger.info("Optimization converged=%s (capped=%s)", converged, opt_capped)
 
         single_point_energy = float(atoms.get_potential_energy())
         logger.info("Post-optimization energy: %s eV", single_point_energy)
@@ -554,114 +851,175 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         thermo_data: dict = {}
         vib_data: dict = {}
         ir_data: dict = {}
+        vib_capped = False
+        vib_cache_path: Optional[str] = None
+        ir_plot_path: Optional[str] = None
 
         # --------------------------------------------------------------
         # Vibrational / thermo / IR analysis
         # --------------------------------------------------------------
-        if driver in {"vib", "thermo", "ir"}:
+        # A capped optimization leaves a half-optimized geometry; running
+        # vibrations on it would produce meaningless (often imaginary) modes, so
+        # hand off for resume and skip the analysis on this non-stationary structure.
+        if driver in {"vib", "thermo", "ir"} and opt_capped:
+            logger.warning(
+                "Optimization was capped before convergence; skipping %s "
+                "analysis (needs a converged geometry). Resume to finish opt "
+                "first.",
+                driver,
+            )
+        elif driver in {"vib", "thermo", "ir"}:
             logger.info("Starting vibrational analysis (driver=%s)", driver)
             from ase.vibrations import Vibrations
             from ase import units
 
-            ir_plot_path: Optional[str] = None
             mol_stem = (
                 Path(input_structure_file).stem if input_structure_file else "mol"
             )
 
-            with tempfile.TemporaryDirectory(
-                prefix=f"chemgraph_vib_{mol_stem}_"
-            ) as tmpdir:
+            # Wall-clock cap for the 6N+1 displacement evaluations. When set, use
+            # a persistent, deterministic cache dir so a capped run is resumable:
+            # a re-run with more budget skips already-computed displacements. When
+            # unset, keep the original ephemeral TemporaryDirectory (byte-for-byte
+            # the previous behavior: no cache to leave behind, no stale reuse).
+            deadline = (
+                start_time + effective_wall_seconds
+                if effective_wall_seconds
+                else None
+            )
+            if deadline is not None:
+                vib_cache_dir = _resolve_path(f"{mol_stem}_vibcache")
+                os.makedirs(vib_cache_dir, exist_ok=True)
+                cache_ctx: object = contextlib.nullcontext(vib_cache_dir)
+            else:
+                cache_ctx = tempfile.TemporaryDirectory(
+                    prefix=f"chemgraph_vib_{mol_stem}_"
+                )
+
+            with cache_ctx as tmpdir:
                 vib_name = os.path.join(tmpdir, "vib")
                 vib = Vibrations(atoms, name=vib_name)
-                vib.clean()
-                vib.run()
-                logger.info("Vibrational analysis complete")
+                if deadline is None:
+                    # Fresh cache each uncapped run (matches original behavior).
+                    vib.clean()
+                vib_capped, n_done, n_total = _run_vibrations_capped(vib, deadline)
 
-                vib_data = {
-                    "energies": [],
-                    "energy_unit": "meV",
-                    "frequencies": [],
-                    "frequency_unit": "cm-1",
-                }
-
-                energies = vib.get_energies()
-
-                for _idx, e in enumerate(energies):
-                    is_imag = abs(e.imag) > 1e-8
-                    e_val = e.imag if is_imag else e.real
-                    energy_meV = 1e3 * e_val
-                    freq_cm1 = e_val / units.invcm
-                    suffix = "i" if is_imag else ""
-                    vib_data["energies"].append(f"{energy_meV}{suffix}")
-                    vib_data["frequencies"].append(f"{freq_cm1}{suffix}")
-
-                # Write frequencies CSV
-                freq_file_path = _resolve_path(f"frequencies_{mol_stem}.csv")
-                freq_file = Path(freq_file_path)
-                if freq_file.exists():
-                    freq_file.unlink()
-                with freq_file.open("w", encoding="utf-8") as f:
-                    for i, freq in enumerate(vib_data["frequencies"], start=0):
-                        f.write(f"{mol_stem}_vib.{i}.traj,{freq}\n")
-
-                # Write normal-mode .traj files, then copy out of tmpdir
-                for i in range(len(energies)):
-                    vib.write_mode(n=i, kT=units.kB * 300, nimages=30)
-
-                traj_dest_dir = _resolve_path("")
-                if traj_dest_dir:
-                    os.makedirs(traj_dest_dir, exist_ok=True)
-                for traj_file in glob.glob(os.path.join(tmpdir, "vib.*.traj")):
-                    dest_name = f"{mol_stem}_{Path(traj_file).name}"
-                    dest_path = (
-                        os.path.join(traj_dest_dir, dest_name)
-                        if traj_dest_dir
-                        else dest_name
+                if vib_capped:
+                    # Partial displacements are on disk in the persistent cache;
+                    # frequencies cannot be computed until all are done, so hand
+                    # off. Point restart_file at the cache dir for resume.
+                    vib_cache_path = os.path.abspath(tmpdir)
+                    logger.warning(
+                        "Vibrational analysis CAPPED at effective wall-clock=%.3fs "
+                        "after %d/%d displacements; cache kept at %s for resume.",
+                        effective_wall_seconds,
+                        n_done,
+                        n_total,
+                        vib_cache_path,
                     )
-                    shutil.copy2(traj_file, dest_path)
+                else:
+                    logger.info("Vibrational analysis complete")
 
-                # ---- IR ----
-                if driver == "ir":
-                    logger.info("Running IR calculation")
-                    from ase.vibrations import Infrared
-                    import matplotlib
+                    vib_data = {
+                        "energies": [],
+                        "energy_unit": "meV",
+                        "frequencies": [],
+                        "frequency_unit": "cm-1",
+                    }
 
-                    matplotlib.use("Agg")
-                    import matplotlib.pyplot as plt
+                    energies = vib.get_energies()
 
-                    ir_data["spectrum_frequencies"] = []
-                    ir_data["spectrum_frequencies_units"] = "cm-1"
-                    ir_data["spectrum_intensities"] = []
-                    ir_data["spectrum_intensities_units"] = "D/Å^2 amu^-1"
+                    for _idx, e in enumerate(energies):
+                        is_imag = abs(e.imag) > 1e-8
+                        e_val = e.imag if is_imag else e.real
+                        energy_meV = 1e3 * e_val
+                        freq_cm1 = e_val / units.invcm
+                        suffix = "i" if is_imag else ""
+                        vib_data["energies"].append(f"{energy_meV}{suffix}")
+                        vib_data["frequencies"].append(f"{freq_cm1}{suffix}")
 
-                    ir_name = os.path.join(tmpdir, "ir")
-                    ir = Infrared(atoms, name=ir_name)
-                    ir.clean()
-                    ir.run()
+                    # Write frequencies CSV
+                    freq_file_path = _resolve_path(f"frequencies_{mol_stem}.csv")
+                    freq_file = Path(freq_file_path)
+                    if freq_file.exists():
+                        freq_file.unlink()
+                    with freq_file.open("w", encoding="utf-8") as f:
+                        for i, freq in enumerate(vib_data["frequencies"], start=0):
+                            f.write(f"{mol_stem}_vib.{i}.traj,{freq}\n")
 
-                    IR_SPECTRUM_START = 500
-                    IR_SPECTRUM_END = 4000
-                    freq_intensity = ir.get_spectrum(
-                        start=IR_SPECTRUM_START, end=IR_SPECTRUM_END
-                    )
-                    fig, ax = plt.subplots()
-                    ax.plot(freq_intensity[0], freq_intensity[1])
-                    ax.set_xlabel("Frequency (cm⁻¹)")
-                    ax.set_ylabel("Intensity (a.u.)")
-                    ax.set_title("Infrared Spectrum")
-                    ax.grid(True)
-                    ir_plot_path = _resolve_path(f"ir_spectrum_{mol_stem}.png")
-                    fig.savefig(ir_plot_path, format="png", dpi=300)
-                    plt.close(fig)
+                    # Write normal-mode .traj files, then copy out of tmpdir
+                    for i in range(len(energies)):
+                        vib.write_mode(n=i, kT=units.kB * 300, nimages=30)
 
-                    logger.info("IR spectrum plot saved to %s", ir_plot_path)
-                    ir_data["IR Plot"] = f"Saved to {os.path.abspath(ir_plot_path)}"
-                    ir_data["Normal mode data"] = (
-                        f"Normal modes saved as individual .traj files with prefix {mol_stem}_"
-                    )
+                    traj_dest_dir = _resolve_path("")
+                    if traj_dest_dir:
+                        os.makedirs(traj_dest_dir, exist_ok=True)
+                    for traj_file in glob.glob(os.path.join(tmpdir, "vib.*.traj")):
+                        dest_name = f"{mol_stem}_{Path(traj_file).name}"
+                        dest_path = (
+                            os.path.join(traj_dest_dir, dest_name)
+                            if traj_dest_dir
+                            else dest_name
+                        )
+                        shutil.copy2(traj_file, dest_path)
+
+                    # ---- IR ----
+                    if driver == "ir":
+                        logger.info("Running IR calculation")
+                        from ase.vibrations import Infrared
+                        import matplotlib
+
+                        matplotlib.use("Agg")
+                        import matplotlib.pyplot as plt
+
+                        ir_data["spectrum_frequencies"] = []
+                        ir_data["spectrum_frequencies_units"] = "cm-1"
+                        ir_data["spectrum_intensities"] = []
+                        ir_data["spectrum_intensities_units"] = "D/Å^2 amu^-1"
+
+                        ir_name = os.path.join(tmpdir, "ir")
+                        ir = Infrared(atoms, name=ir_name)
+                        if deadline is None:
+                            ir.clean()
+                        ir_capped, _ir_done, _ir_total = _run_vibrations_capped(
+                            ir, deadline
+                        )
+                        if ir_capped:
+                            vib_capped = True
+                            vib_cache_path = os.path.abspath(tmpdir)
+                            logger.warning(
+                                "IR analysis CAPPED at effective wall-clock=%.3fs; "
+                                "cache kept at %s for resume.",
+                                effective_wall_seconds,
+                                vib_cache_path,
+                            )
+
+                    if driver == "ir" and not vib_capped:
+                        IR_SPECTRUM_START = 500
+                        IR_SPECTRUM_END = 4000
+                        freq_intensity = ir.get_spectrum(
+                            start=IR_SPECTRUM_START, end=IR_SPECTRUM_END
+                        )
+                        fig, ax = plt.subplots()
+                        ax.plot(freq_intensity[0], freq_intensity[1])
+                        ax.set_xlabel("Frequency (cm⁻¹)")
+                        ax.set_ylabel("Intensity (a.u.)")
+                        ax.set_title("Infrared Spectrum")
+                        ax.grid(True)
+                        ir_plot_path = _resolve_path(f"ir_spectrum_{mol_stem}.png")
+                        fig.savefig(ir_plot_path, format="png", dpi=300)
+                        plt.close(fig)
+
+                        logger.info("IR spectrum plot saved to %s", ir_plot_path)
+                        ir_data["IR Plot"] = (
+                            f"Saved to {os.path.abspath(ir_plot_path)}"
+                        )
+                        ir_data["Normal mode data"] = (
+                            f"Normal modes saved as individual .traj files with prefix {mol_stem}_"
+                        )
 
                 # ---- Thermochemistry ----
-                if driver == "thermo":
+                if driver == "thermo" and not vib_capped:
                     logger.info("Computing thermochemistry (T=%s K, P=%s Pa)", temperature, pressure)
                     if len(atoms) == 1:
                         thermo_data = {
@@ -726,6 +1084,10 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             ir_data=ir_data,
             single_point_energy=single_point_energy,
             wall_time=wall_time,
+            wall_time_capped=opt_capped or vib_capped,
+            restart_file=(
+                restart_path if opt_capped else vib_cache_path if vib_capped else None
+            ),
         )
         with open(output_results_file, "w", encoding="utf-8") as wf:
             wf.write(simulation_output.model_dump_json(indent=4))
@@ -733,13 +1095,69 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         # ---- minimal return payload ----
         abs_output = os.path.abspath(output_results_file)
         if driver == "opt":
+            if opt_capped:
+                if restart_path:
+                    msg = (
+                        "Optimization CAPPED at the wall-clock limit (not "
+                        f"converged). Partial geometry saved to {resume_input_file}. "
+                        "Resume by re-running opt with input_structure_file set to "
+                        "that partial geometry."
+                    )
+                else:
+                    # Capped before completing step 1 (e.g. an already-spent
+                    # allocation): no restart state was written, so there is no
+                    # partial to resume from -- rerun with more budget.
+                    msg = (
+                        "Optimization CAPPED at the wall-clock limit before any "
+                        "step completed; no restart file was written. Rerun with "
+                        f"more wall-clock budget. Results saved to {abs_output}."
+                    )
+            else:
+                msg = f"Simulation completed. Results saved to {abs_output}"
             return {
                 "status": "success",
-                "message": f"Simulation completed. Results saved to {abs_output}",
+                "message": msg,
                 "single_point_energy": single_point_energy,
                 "unit": "eV",
+                "wall_time_capped": opt_capped,
+                "result_file": abs_output,
+                "wall_time": wall_time,
+                "restart_file": restart_path,
+                "resume_input_file": resume_input_file,
             }
-        elif driver == "vib":
+
+        # vib/thermo/ir that could not finish within the wall-clock budget (the
+        # optimization capped, or the displacement sweep did): no frequencies to
+        # report, but progress is durable. Re-running the same driver on the same
+        # structure with more budget resumes from the saved cache.
+        if driver in {"vib", "thermo", "ir"} and (opt_capped or vib_capped):
+            if opt_capped:
+                reason = (
+                    "the pre-analysis optimization hit the wall-clock limit "
+                    "before converging"
+                )
+            else:
+                reason = "the displacement sweep hit the wall-clock limit"
+            return {
+                "status": "success",
+                "message": (
+                    f"{driver} analysis CAPPED: {reason}. No frequencies yet; "
+                    f"partial progress saved to {abs_output}. Resume the same "
+                    f"'{driver}' run with more wall-clock budget (a larger "
+                    "max_wall_seconds, or a fresh allocation) to continue."
+                ),
+                "wall_time_capped": True,
+                "result_file": abs_output,
+                "wall_time": wall_time,
+                # vib/thermo/ir resume from the durable cache dir by re-running the
+                # same driver on the same input; restart_file carries the cache dir
+                # (opt cap, if that is what tripped, carries its Hessian JSON). No
+                # separate partial-geometry file for the analysis sweep.
+                "restart_file": restart_path if opt_capped else vib_cache_path,
+                "resume_input_file": resume_input_file,
+            }
+
+        if driver == "vib":
             return {
                 "status": "success",
                 "result": {"vibrational_frequencies": vib_data},
@@ -747,6 +1165,9 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     "Vibrational analysis completed; frequencies returned. "
                     f"Full results (structure, vibrations and metadata) saved to {abs_output}."
                 ),
+                "result_file": abs_output,
+                "wall_time": wall_time,
+                "wall_time_capped": False,
             }
         elif driver == "thermo":
             return {
@@ -756,6 +1177,9 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     "Thermochemistry computed and returned. "
                     f"Full results (structure, vibrations, thermochemistry and metadata) saved to {abs_output}"
                 ),
+                "result_file": abs_output,
+                "wall_time": wall_time,
+                "wall_time_capped": False,
             }
         elif driver == "ir":
             return {
@@ -767,6 +1191,9 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     f"IR plot saved to {os.path.abspath(ir_plot_path) if ir_plot_path else 'N/A'}. "
                     "Normal modes saved as individual .traj files"
                 ),
+                "result_file": abs_output,
+                "wall_time": wall_time,
+                "wall_time_capped": False,
             }
 
     except Exception as e:

--- a/src/chemgraph/tools/parsl_tools.py
+++ b/src/chemgraph/tools/parsl_tools.py
@@ -56,6 +56,7 @@ def _mace_input_to_ase_input(params: mace_input_schema) -> ASEInputSchema:
         },
         fmax=params.fmax,
         steps=params.steps,
+        max_wall_seconds=params.max_wall_seconds,
         temperature=params.temperature,
         pressure=params.pressure,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,24 @@ def setup_test_env():
     pass
 
 
+@pytest.fixture(autouse=True)
+def clear_allocation_env(monkeypatch):
+    """Strip CHEMGRAPH_ALLOCATION_* from every test's environment.
+
+    ``run_ase_core`` now reads these to derive an allocation-aware wall-clock cap
+    (tests/test_allocation_cap.py). A developer with them exported in their shell
+    would otherwise see unrelated calculation tests (test_cap, test_cap_vib,
+    test_mcp, ...) silently capped. Clearing globally keeps every test hermetic;
+    the allocation tests set them explicitly via monkeypatch.
+    """
+    for var in (
+        "CHEMGRAPH_ALLOCATION_DEADLINE",
+        "CHEMGRAPH_ALLOCATION_SECONDS",
+        "CHEMGRAPH_ALLOCATION_MARGIN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.fixture
 def simple_h2_molecule():
     """Fixture providing a simple H2 molecule for testing"""

--- a/tests/test_allocation_cap.py
+++ b/tests/test_allocation_cap.py
@@ -1,0 +1,449 @@
+"""Tests for the Layer-2 allocation-aware wall-clock cap in run_ase_core.
+
+This is the enforcement side of the auto-continue gate: a calculation running
+inside a PBS allocation must self-terminate with a resumable partial *before*
+walltime kills it, even when the user set no explicit ``max_wall_seconds``. The
+allocation budget is advertised purely through the environment
+(``CHEMGRAPH_ALLOCATION_SECONDS`` / ``CHEMGRAPH_ALLOCATION_DEADLINE`` /
+``CHEMGRAPH_ALLOCATION_MARGIN``), so a batch script can set it once for the whole
+run without any per-call plumbing.
+
+Hermetic: EMT on a small metal cluster, no network/LLM/HPC. The pure-function
+tests exercise the env parsing + min() logic directly; the end-to-end tests drive
+a real (slowed) optimization and assert the partial/complete signal.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import ase.calculators.emt as emt_mod
+import pytest
+from ase.cluster import Icosahedron
+from ase.io import write
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.tools.ase_core import (
+    _allocation_deadline,
+    _allocation_margin,
+    _effective_wall_seconds,
+    run_ase_core,
+)
+
+
+@pytest.fixture
+def cu_cluster(tmp_path, monkeypatch):
+    """A rattled 13-atom Cu cluster that needs many EMT opt steps."""
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    atoms = Icosahedron("Cu", noshells=2)  # 13 atoms
+    atoms.rattle(0.2, seed=1)
+    p = tmp_path / "cu.xyz"
+    write(str(p), atoms)
+    return p
+
+
+@pytest.fixture
+def slow_emt(monkeypatch):
+    """Slow every EMT force evaluation so a wall-clock cap trips deterministically.
+
+    Bare EMT steps are sub-millisecond; ~0.1 s/step makes step *timing* dominate
+    a sub-second budget, so a handful of steps run before the cap regardless of
+    machine load (mirrors tests/test_cap.py).
+    """
+    orig = emt_mod.EMT.calculate
+
+    def _slow(self, *args, **kwargs):
+        time.sleep(0.1)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(emt_mod.EMT, "calculate", _slow)
+    return _slow
+
+
+# The ambient CHEMGRAPH_ALLOCATION_* env is stripped globally by the autouse
+# clear_allocation_env fixture in tests/conftest.py, so every test here starts
+# from a clean slate and sets only what it needs via monkeypatch.
+
+
+# ---------------------------------------------------------------------------
+# Pure-function logic: env parsing + tighter-of-two selection
+# ---------------------------------------------------------------------------
+
+
+def test_effective_none_when_nothing_set():
+    """No explicit cap and no allocation env -> uncapped (None)."""
+    assert _effective_wall_seconds(None, time.time()) is None
+
+
+def test_effective_uses_explicit_when_no_allocation():
+    """With only an explicit cap, the effective value is that cap."""
+    assert _effective_wall_seconds(42.0, time.time()) == 42.0
+
+
+def test_effective_uses_allocation_when_no_explicit(monkeypatch):
+    """With only an allocation budget, the effective value is remaining-margin."""
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    # _PROCESS_START is captured at import, arbitrarily far in the past during a
+    # full-suite run; anchor it to a known point so remaining is exact and the
+    # bound below can't flake on a slow session.
+    now = time.time()
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now)
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", "1000")
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", "60")
+    # remaining = (now + 1000) - 60 - start, and start >= now by a hair, so eff
+    # is 940 minus a tiny elapsed slack.
+    eff = _effective_wall_seconds(None, time.time())
+    assert eff is not None
+    assert 939.0 < eff <= 940.0
+
+
+def test_effective_takes_the_tighter_bound(monkeypatch):
+    """min(explicit, allocation-remaining): whichever is smaller wins."""
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    now = time.time()
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now)
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", "1000")
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", "60")
+    # Explicit 100 is tighter than ~940 remaining -> explicit wins.
+    assert _effective_wall_seconds(100.0, time.time()) == 100.0
+    # Explicit 5000 is looser than ~940 remaining -> allocation wins.
+    eff = _effective_wall_seconds(5000.0, time.time())
+    assert eff is not None and eff < 5000.0
+
+
+def test_deadline_takes_precedence_over_seconds(monkeypatch):
+    """CHEMGRAPH_ALLOCATION_DEADLINE (absolute) wins over _SECONDS when both set."""
+    target = time.time() + 500.0
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", str(target))
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", "99999")
+    assert _allocation_deadline() == pytest.approx(target)
+
+
+def test_stale_past_deadline_is_ignored(monkeypatch):
+    """A deadline BEFORE this process started is a leftover -> ignored, not honored.
+
+    A CHEMGRAPH_ALLOCATION_DEADLINE from a prior allocation still in the
+    environment would (if honored) clamp every calc to 0.001 s and cap
+    immediately, forever. _allocation_deadline must drop it (return None), so
+    with no other budget the run is uncapped.
+    """
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    now = time.time()
+    # deadline is 100 s before this process began -> stale, cannot be ours.
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now)
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", str(now - 100.0))
+    assert _allocation_deadline() is None
+    # and with nothing else set, the effective cap is None (uncapped).
+    assert _effective_wall_seconds(None, now) is None
+
+
+def test_stale_deadline_falls_through_to_seconds(monkeypatch):
+    """A stale deadline is ignored but CHEMGRAPH_ALLOCATION_SECONDS still applies.
+
+    Dropping the leftover deadline must fall through to the _SECONDS budget rather
+    than disabling the allocation cap entirely.
+    """
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    now = time.time()
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now)
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", str(now - 100.0))
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", "1000")
+    # deadline ignored -> falls through to _PROCESS_START + 1000.
+    assert _allocation_deadline() == pytest.approx(now + 1000.0)
+
+
+def test_genuinely_spent_allocation_still_clamps(monkeypatch):
+    """A deadline AFTER process start but now past is honored and clamps to tiny.
+
+    This is the genuinely-spent-mid-run case (distinct from a stale leftover): the
+    deadline belongs to this allocation, we've simply run out of time, so the cap
+    must still fire immediately (0.001) and never be ignored.
+    """
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    now = time.time()
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now)
+    # deadline 10 s after start (ours), but we check from 100 s later (spent).
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", str(now + 10.0))
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", "0")
+    assert _allocation_deadline() == pytest.approx(now + 10.0)
+    eff = _effective_wall_seconds(None, now + 100.0)
+    assert eff == 0.001
+
+
+def test_exhausted_allocation_clamps_to_tiny_positive(monkeypatch):
+    """A deadline spent mid-run yields a tiny positive, not <= 0.
+
+    A non-positive effective cap would be falsy at the gate and silently disable
+    the cap -- the opposite of intended when we are out of time. It must stay a
+    small positive so the run caps as early as cleanly possible. The deadline is
+    anchored AFTER _PROCESS_START (genuinely spent this run, not a stale leftover
+    that _allocation_deadline now ignores -- see test_stale_past_deadline).
+    """
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    now = time.time()
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now - 200.0)
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", str(now - 100.0))
+    eff = _effective_wall_seconds(None, now)
+    assert eff is not None and eff > 0.0
+
+
+def test_margin_default_and_override(monkeypatch):
+    """Margin defaults to 60 s and honors CHEMGRAPH_ALLOCATION_MARGIN."""
+    assert _allocation_margin() == 60.0
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", "120")
+    assert _allocation_margin() == 120.0
+
+
+def test_nonnumeric_env_is_ignored(monkeypatch):
+    """Garbage env values are ignored and never raise."""
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", "soon")
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", "later")
+    assert _allocation_deadline() is None
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", "lots")
+    assert _allocation_margin() == 60.0
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: allocation env alone caps run_ase_core (no explicit cap)
+# ---------------------------------------------------------------------------
+
+
+def test_allocation_seconds_caps_without_explicit(
+    cu_cluster, tmp_path, slow_emt, monkeypatch
+):
+    """CHEMGRAPH_ALLOCATION_SECONDS alone caps the opt with no max_wall_seconds.
+
+    This is the core Layer-2 behavior: a run with no explicit cap still self-
+    terminates with a resumable partial because it is inside a (nearly spent)
+    allocation.
+    """
+    # CHEMGRAPH_ALLOCATION_SECONDS is measured from process start (module
+    # import), so that one budget counts down across every calc in the run. In a
+    # long test session import time is many seconds in the past; anchor it to now
+    # so this test's budget is measured from here, not from import.
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", time.time())
+    # ~1.5 s of usable budget: total 2.0 s minus a 0.5 s margin. The budget is
+    # anchored before run_ase_core does its own setup (schema build, calculator
+    # load, read(atoms)), so it needs headroom above one 0.1 s step; a tighter
+    # budget lets setup latency starve step 1 under load and cap before any
+    # restart file is written.
+    _set_allocation_env(monkeypatch, seconds="2.0", margin="0.5")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+        # NOTE: no max_wall_seconds -- the cap comes purely from the allocation.
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    elapsed = time.time() - t0
+
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+    assert elapsed < 30
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is True
+    assert data["converged"] is False
+    assert data["restart_file"]
+    assert Path(data["restart_file"]).exists()
+
+
+def test_allocation_deadline_caps_without_explicit(
+    cu_cluster, tmp_path, slow_emt, monkeypatch
+):
+    """CHEMGRAPH_ALLOCATION_DEADLINE (absolute epoch) alone caps the opt."""
+    # ~1.5 s of usable budget (2.0 s out minus a 0.5 s margin) so setup latency
+    # cannot starve step 1 before a restart file is written; see the seconds test.
+    deadline = time.time() + 2.0
+    _set_allocation_env(monkeypatch, deadline=str(deadline), margin="0.5")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+    )
+    result = run_ase_core(params)
+    assert result["wall_time_capped"] is True
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["converged"] is False
+    assert data["restart_file"]
+
+
+def test_generous_allocation_lets_short_run_complete(
+    cu_cluster, tmp_path, monkeypatch
+):
+    """A generous allocation does NOT cap a short optimization (auto-complete).
+
+    No slow_emt here: the opt converges in well under the budget, so the run
+    finishes normally and is not marked partial -- the "short calcs auto-complete
+    within one allocation" half of the design.
+    """
+    _set_allocation_env(monkeypatch, seconds="3600", margin="60")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=0.05,
+        steps=1000,
+    )
+    result = run_ase_core(params)
+    assert result["status"] == "success"
+    assert result.get("wall_time_capped", False) is False
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is False
+    assert data["converged"] is True
+    assert data["restart_file"] is None
+
+
+def test_explicit_cap_still_wins_when_tighter(
+    cu_cluster, tmp_path, slow_emt, monkeypatch
+):
+    """A tight explicit max_wall_seconds caps even under a generous allocation."""
+    _set_allocation_env(monkeypatch, seconds="3600", margin="60")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+        max_wall_seconds=0.25,  # far tighter than the 1 h allocation
+    )
+    result = run_ase_core(params)
+    assert result["wall_time_capped"] is True
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["converged"] is False
+
+
+def test_exhausted_allocation_caps_with_no_restart_and_honest_message(
+    cu_cluster, tmp_path, slow_emt, monkeypatch
+):
+    """An already-spent allocation caps before step 1: no restart, honest message.
+
+    Guards the boundary the feature exists to protect. With the deadline already
+    in the past, the effective cap clamps to a tiny positive and the very first
+    deadline check (before any optimizer step completes) trips, so no restart
+    file is written. The result must still be coherent: wall_time_capped=True but
+    restart_file=None, and the returned message must NOT claim a restart was
+    saved.
+    """
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    # Anchor _PROCESS_START in the past so the deadline is a genuinely-spent
+    # mid-run deadline (still clamps to cap immediately), NOT a stale leftover
+    # that _allocation_deadline ignores (see test_stale_past_deadline).
+    now = time.time()
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", now - 200.0)
+    _set_allocation_env(monkeypatch, deadline=str(now - 100.0), margin="0")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+    )
+    result = run_ase_core(params)
+
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+    # No step completed -> no restart file, and the message must be honest.
+    assert "restart" not in result["message"].lower() or "no restart" in (
+        result["message"].lower()
+    )
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is True
+    assert data["converged"] is False
+    assert data["restart_file"] is None
+
+
+def test_margin_larger_than_remaining_caps_immediately(
+    cu_cluster, tmp_path, slow_emt, monkeypatch
+):
+    """A margin exceeding the remaining budget behaves like an exhausted allocation."""
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", time.time())
+    # 10 s budget but a 1000 s margin -> remaining is deeply negative -> clamp.
+    _set_allocation_env(monkeypatch, seconds="10", margin="1000")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+    )
+    result = run_ase_core(params)
+    assert result["wall_time_capped"] is True
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["converged"] is False
+
+
+def test_allocation_env_caps_vib_driver(cu_cluster, tmp_path, slow_emt, monkeypatch):
+    """The allocation env path also caps a vib displacement sweep (not just opt).
+
+    Exercises the vib deadline site, which the explicit-cap tests in
+    test_cap_vib.py cover only via max_wall_seconds, never via the allocation env.
+    """
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", time.time())
+    # ~1.5 s of usable budget (2.0 s minus a 0.5 s margin); the 6N+1 displacement
+    # sweep still cannot finish in it, but setup latency cannot starve the run.
+    _set_allocation_env(monkeypatch, seconds="2.0", margin="0.5")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="vib",
+        calculator={"calculator_type": "emt"},
+        # A converged geometry is assumed; the point is that the 6N+1 displacement
+        # sweep on a 13-atom cluster (40 evals @ ~0.1 s) cannot finish in ~1.5 s.
+    )
+    result = run_ase_core(params)
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is True
+    # vib caps point restart_file at the persistent displacement cache dir.
+    assert data["restart_file"]
+    assert Path(data["restart_file"]).exists()
+
+
+def _set_allocation_env(monkeypatch, *, seconds=None, deadline=None, margin=None):
+    """Set allocation env vars for the current test via monkeypatch.
+
+    A plain helper (not a fixture) so each end-to-end test states its own budget
+    inline; monkeypatch reverts them at teardown.
+    """
+    if seconds is not None:
+        monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", seconds)
+    if deadline is not None:
+        monkeypatch.setenv("CHEMGRAPH_ALLOCATION_DEADLINE", deadline)
+    if margin is not None:
+        monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", margin)

--- a/tests/test_cap.py
+++ b/tests/test_cap.py
@@ -1,0 +1,141 @@
+"""Tests for the calc-side wall-clock cap (max_wall_seconds) in run_ase_core.
+
+Hermetic: EMT calculator on a small metal cluster, no network, no LLM, no HPC.
+The cap lets a geometry optimization self-terminate at a deadline and return a
+resumable partial short of convergence, avoiding an external kill.
+"""
+
+import json
+import time
+from pathlib import Path
+
+import ase.calculators.emt as emt_mod
+import numpy as np
+import pytest
+from ase.cluster import Icosahedron
+from ase.io import read, write
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.tools.ase_core import run_ase_core
+
+
+@pytest.fixture
+def cu_cluster(tmp_path, monkeypatch):
+    """A rattled 13-atom Cu cluster that needs many EMT opt steps."""
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    atoms = Icosahedron("Cu", noshells=2)  # 13 atoms
+    atoms.rattle(0.2, seed=1)  # perturb so optimization has real work to do
+    p = tmp_path / "cu.xyz"
+    write(str(p), atoms)
+    return p
+
+
+@pytest.fixture
+def slow_emt(monkeypatch):
+    """Slow every EMT force evaluation so the wall-clock cap trips deterministically.
+
+    Bare EMT steps are sub-millisecond, so a fixed 50 ms budget races the first
+    optimizer step and loses under CPU load (0 steps -> no restart file). Making
+    each step ~0.1 s means step *timing* dominates the budget, so a fixed number
+    of steps run before the cap regardless of machine load.
+    """
+    orig = emt_mod.EMT.calculate
+
+    def _slow(self, *args, **kwargs):
+        time.sleep(0.1)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(emt_mod.EMT, "calculate", _slow)
+    return _slow
+
+
+def test_cap_stops_early_and_marks_partial(cu_cluster, tmp_path, slow_emt):
+    """With a tiny max_wall_seconds the opt caps, marks partial, saves restart."""
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,  # effectively unreachable -> would run many steps
+        steps=100000,
+        # With slow_emt each step takes ~0.1 s, so a 1.0 s budget lets several
+        # optimizer steps run before the cap trips, exercising the real
+        # "resumable partial" path (>=1 step, a restart file on disk). The wide
+        # budget-to-step ratio keeps a large pre-step-1 stall from starving step
+        # 1 on a loaded runner, which would leave the degenerate no-restart case.
+        max_wall_seconds=1.0,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    elapsed = time.time() - t0
+
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+    assert elapsed < 30  # capped, not run to 100000 steps
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is True
+    assert data["converged"] is False
+    # A capped run that completed >=1 step advertises a restart file that exists.
+    assert data["restart_file"]
+    assert Path(data["restart_file"]).exists()
+
+
+def test_opt_cap_writes_resumable_partial_geometry(cu_cluster, tmp_path, slow_emt):
+    """A capped opt writes a standalone, ASE-readable partial geometry to resume from.
+
+    The output schema's ``restart_file`` is the BFGS Hessian JSON (not a
+    structure). C1 adds a separate ``resume_input_file`` -- an xyz of the moved
+    atoms -- so a resumed opt continues from the partial geometry and skips
+    re-reading the original input. This asserts the file exists, reads back as a
+    real geometry (right atom count, not the Hessian JSON), and differs from the
+    input (a step actually moved the atoms).
+    """
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+        max_wall_seconds=1.0,  # slow_emt ~0.1 s/step -> a few steps then cap WITH a restart file
+    )
+    result = run_ase_core(params)
+
+    assert result["wall_time_capped"] is True
+    # The enriched return dict carries the resume contract at the top level.
+    resume_file = result["resume_input_file"]
+    assert resume_file
+    assert resume_file.endswith("_opt.partial.xyz")
+    assert Path(resume_file).exists()
+    # restart_file is still the Hessian JSON, a distinct artifact.
+    assert result["restart_file"].endswith("_opt.restart.json")
+    assert resume_file != result["restart_file"]
+
+    # It reads back as a real structure (the full cluster), not the Hessian JSON.
+    original = read(str(cu_cluster))
+    partial = read(resume_file)
+    assert len(partial) == len(original) == 13
+    # A step moved the atoms, so the partial geometry is not the input geometry.
+    assert not np.allclose(partial.get_positions(), original.get_positions())
+
+
+def test_no_cap_is_unchanged(cu_cluster, tmp_path):
+    """Without max_wall_seconds, behavior is the original path (runs to converge)."""
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=0.05,
+        steps=1000,
+        # max_wall_seconds omitted -> None -> uncapped
+    )
+    result = run_ase_core(params)
+    assert result["status"] == "success"
+    assert result.get("wall_time_capped", False) is False
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is False
+    assert data["converged"] is True
+    assert data["restart_file"] is None

--- a/tests/test_cap_manifest_integration.py
+++ b/tests/test_cap_manifest_integration.py
@@ -1,0 +1,224 @@
+"""Cross-seam integration test: ase_core's cap result <-> the manifest parser.
+
+The wall-clock-cap feature spans two files that communicate through the tool
+result. In production LangGraph's ``ToolNode`` serializes ``run_ase_core``'s
+return dict with ``json.dumps``, so the ToolMessage content the manifest hook
+sees is JSON:
+
+  * ``chemgraph.tools.ase_core.run_ase_core`` returns a dict carrying the resume
+    contract (``wall_time_capped`` / ``result_file`` / ``restart_file`` /
+    ``resume_input_file``).
+  * ``chemgraph.agent.llm_agent.ChemGraph._manifest_observe`` parses that JSON and
+    reads those structured fields to decide whether a step is "done" or "capped"
+    (pending), and what a resume should continue from.
+
+``test_real_capped_json_content_via_toolnode_is_recorded_pending`` pins the
+production path: it runs the REAL ``run_ase_core``, serializes the return with
+the REAL ``ToolNode`` serializer (``msg_content_output``) -- the exact JSON string
+production sees -- and feeds it to the REAL ``_manifest_observe``.
+``test_real_capped_message_is_recorded_as_pending`` covers the plain-text
+fallback (a ToolMessage whose content is just the message string).
+"""
+
+import time
+
+import ase.calculators.emt as emt_mod
+import pytest
+from ase.cluster import Icosahedron
+from ase.io import write
+from langchain_core.messages import AIMessage, ToolMessage
+from langgraph.prebuilt.tool_node import msg_content_output
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.tools.ase_core import run_ase_core
+
+# --- fixtures below mirror tests/test_cap.py verbatim (kept local so this cross
+# --- seam test is self-contained; see test_cap.py for the rationale comments) --
+
+
+@pytest.fixture
+def cu_cluster(tmp_path, monkeypatch):
+    """A rattled 13-atom Cu cluster that needs many EMT opt steps."""
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    atoms = Icosahedron("Cu", noshells=2)  # 13 atoms
+    atoms.rattle(0.2, seed=1)  # perturb so optimization has real work to do
+    p = tmp_path / "cu.xyz"
+    write(str(p), atoms)
+    return p
+
+
+@pytest.fixture
+def slow_emt(monkeypatch):
+    """Slow every EMT force evaluation so the wall-clock cap trips deterministically.
+
+    Bare EMT steps are sub-millisecond, so a fixed 50 ms budget races the first
+    optimizer step and loses under CPU load (0 steps -> no restart file). Making
+    each step ~0.1 s means step *timing* dominates the budget, so a fixed number
+    of steps run before the cap regardless of machine load.
+    """
+    orig = emt_mod.EMT.calculate
+
+    def _slow(self, *args, **kwargs):
+        time.sleep(0.1)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(emt_mod.EMT, "calculate", _slow)
+    return _slow
+
+
+def _fake_agent(tmp_path):
+    """A minimal object exposing the manifest + the real _manifest_observe.
+
+    Mirrors the helper in tests/test_manifest.py: ``_pending_steps`` is the
+    tool_call_id-keyed dict of open steps ``_manifest_observe`` reads on the
+    ToolMessage branch, standing in for the real ChemGraph __init__ state.
+    """
+    from chemgraph.agent.llm_agent import ChemGraph
+    from chemgraph.memory.manifest import RunManifest
+
+    class _FakeAgent:
+        # own manifest at a DIFFERENT path than the ase output so the two files
+        # cannot collide.
+        run_manifest = RunManifest(tmp_path / "run_manifest.json")
+        _pending_steps = {}
+        _COST_TOOLS = ChemGraph._COST_TOOLS
+        _manifest_observe = ChemGraph._manifest_observe
+
+        def __init__(self):
+            self._pending_steps = {}
+
+    return _FakeAgent()
+
+
+def test_real_capped_json_content_via_toolnode_is_recorded_pending(
+    cu_cluster, tmp_path, slow_emt
+):
+    """The production path: REAL cap result -> REAL ToolNode JSON -> REAL hook.
+
+    run_ase_core caps a slow EMT opt; its return dict is serialized with the exact
+    ToolNode serializer production uses (``msg_content_output``), yielding the JSON
+    string the manifest hook parses. Asserts the step is recorded 'capped', queued
+    as pending, and -- the C1<->Seam1 seam -- that the pending step's input is
+    swapped to the standalone partial geometry so a resume continues from it.
+    """
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,  # effectively unreachable -> would run many steps
+        steps=100000,
+        max_wall_seconds=1.0,  # slow_emt ~0.1 s/step -> a few steps then cap WITH a restart file
+    )
+    result = run_ase_core(params)
+
+    # sanity: a capped-with-partial run carrying the structured resume contract.
+    assert result["wall_time_capped"] is True
+    assert result["resume_input_file"].endswith("_opt.partial.xyz")
+
+    # This is the exact string production sees: ToolNode json.dumps of the return.
+    content = msg_content_output(result)
+    assert isinstance(content, str)
+
+    fa = _fake_agent(tmp_path)
+
+    # 1) the AI message issuing the cost-bearing tool call -> records a step start.
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "emt"},
+                        "input_structure_file": str(cu_cluster),
+                    },
+                }
+            ],
+        )
+    )
+
+    # 2) the ToolMessage carries the REAL serialized JSON (not a hand-written
+    #    string): this is the seam that was silently broken before the JSON parse.
+    fa._manifest_observe(ToolMessage(content=content, tool_call_id="c1"))
+
+    # --- the coupling assertions ------------------------------------------------
+    assert fa.run_manifest.status == "capped"
+
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "capped"
+
+    pending = fa.run_manifest._data["pending_next_step"]
+    assert pending is not None
+    # the C1<->Seam1 seam: resume continues from the partial geometry.
+    assert pending["args"]["input_structure_file"].endswith("_opt.partial.xyz")
+    assert "partial geometry" in pending["reason"]
+
+    assert fa._pending_steps == {}
+
+    txt = fa.run_manifest.render_for_context()
+    assert "PENDING NEXT STEP" in txt
+    # a capped step is not in the "do NOT recompute" completed list (render only
+    # lists status=="done"): its only surface is PENDING, so the input filename
+    # must not appear in the completed portion.
+    completed = txt.split("=== PENDING NEXT STEP", 1)[0]
+    assert str(cu_cluster) not in completed
+
+
+def test_real_capped_message_is_recorded_as_pending(cu_cluster, tmp_path, slow_emt):
+    """Plain-text fallback: a message-only ToolMessage still records 'capped'.
+
+    Older tools (or a tool whose return is a bare string) yield a ToolMessage
+    whose content is NOT JSON. The hook then falls back to scraping the
+    ``"saved to <path>"`` substring for the result-JSON path and reading the
+    capped flags out of that file on disk. This drives that path with a real
+    capped run's on-disk result JSON.
+    """
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,
+        steps=100000,
+        max_wall_seconds=1.0,  # slow_emt ~0.1 s/step -> a few steps then cap WITH a restart file
+    )
+    result = run_ase_core(params)
+    assert result["wall_time_capped"] is True
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "emt"},
+                        "input_structure_file": str(cu_cluster),
+                    },
+                }
+            ],
+        )
+    )
+
+    # A plain-text (non-JSON) message pointing at the real on-disk result JSON,
+    # exercising the fallback scraper along the non-structured-JSON path.
+    plain = (
+        "Optimization CAPPED at the wall-clock limit (not converged). "
+        f"Results saved to {result['result_file']}. Resume to continue."
+    )
+    fa._manifest_observe(ToolMessage(content=plain, tool_call_id="c1"))
+
+    assert fa.run_manifest.status == "capped"
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "capped"
+    pending = fa.run_manifest._data["pending_next_step"]
+    assert pending is not None
+    # the on-disk result JSON records a restart file -> restart-aware reason.
+    assert "restart_file" in pending["reason"]
+    assert fa._pending_steps == {}

--- a/tests/test_cap_vib.py
+++ b/tests/test_cap_vib.py
@@ -1,0 +1,149 @@
+"""Tests for the wall-clock cap on vibrational analysis (vib/thermo/ir).
+
+Hermetic: EMT calculator on a water molecule, no network, no LLM, no HPC.
+
+Unlike a geometry optimization -- where a capped run still yields a usable
+partial geometry -- a capped vibrational sweep cannot produce frequencies until
+every one of its 6N+1 displacements is done (ASE's ``get_energies`` needs the
+full cache). So a capped vib/thermo/ir run hands off: it keeps a persistent
+displacement cache on disk, marks ``wall_time_capped``, and a re-run of the same
+driver with more budget resumes from that cache and skips recomputing.
+
+EMT force evaluations on water are sub-millisecond, so a pure wall-clock budget
+cannot reliably trip the displacement sweep. These tests slow ``EMT.calculate``
+with a small sleep to make the cap deterministic -- the calc is built internally
+by ``run_ase_core`` from ``calculator_type`` and bound to ``atoms.calc``, which
+is exactly what ASE ``Vibrations`` reads.
+"""
+
+import glob
+import json
+import time
+from pathlib import Path
+
+import ase.calculators.emt as emt_mod
+import pytest
+from ase.build import molecule
+from ase.io import write
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.tools.ase_core import run_ase_core
+
+
+@pytest.fixture
+def water(tmp_path, monkeypatch):
+    """A water molecule written to the sandboxed log dir."""
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    p = tmp_path / "water.xyz"
+    write(str(p), molecule("H2O"))
+    return p
+
+
+@pytest.fixture
+def slow_emt(monkeypatch):
+    """Slow every EMT force evaluation so a wall-clock cap trips deterministically."""
+    orig = emt_mod.EMT.calculate
+
+    def _slow(self, *args, **kwargs):
+        time.sleep(0.03)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(emt_mod.EMT, "calculate", _slow)
+    return _slow
+
+
+def _vib_params(water, tmp_path, **extra):
+    # fmax huge -> the pre-analysis optimization converges immediately, so the
+    # wall-clock budget is spent on the displacement sweep (what we're testing),
+    # not on the optimization.
+    return ASEInputSchema(
+        input_structure_file=str(water),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="vib",
+        calculator={"calculator_type": "emt"},
+        fmax=1e3,
+        steps=200,
+        **extra,
+    )
+
+
+def test_vib_uncapped_is_unchanged(water, tmp_path):
+    """Without max_wall_seconds, vib runs to completion and returns frequencies."""
+    result = run_ase_core(_vib_params(water, tmp_path))
+    assert result["status"] == "success"
+    assert result.get("wall_time_capped", False) is False
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is False
+    assert data["restart_file"] is None
+    # H2O has 3 atoms -> 3N = 9 vibrational modes.
+    assert len(data["vibrational_frequencies"]["energies"]) == 9
+    # The uncapped path uses an ephemeral cache dir -> nothing left behind.
+    assert not glob.glob(str(tmp_path / "*_vibcache"))
+
+
+def test_vib_sweep_caps_and_keeps_cache(water, tmp_path, slow_emt):
+    """A tiny budget caps the displacement sweep, marks partial, keeps the cache."""
+    t0 = time.time()
+    result = run_ase_core(
+        _vib_params(water, tmp_path, max_wall_seconds=0.25)
+    )
+    elapsed = time.time() - t0
+
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+    assert "CAPPED" in result["message"]
+    assert elapsed < 30  # capped, not the full 19-displacement sweep at 0.03s+
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is True
+    # No frequencies on a capped sweep -- it hands off instead.
+    assert not data["vibrational_frequencies"].get("energies")
+    # restart_file points at a persistent cache dir holding partial work.
+    cache_dir = data["restart_file"]
+    assert cache_dir and Path(cache_dir).is_dir()
+    partial = glob.glob(str(Path(cache_dir) / "vib" / "cache.*.json"))
+    assert 0 < len(partial) < 19  # some done, but not the full 6N+1
+
+
+def test_vib_resume_finishes_from_cache(water, tmp_path, slow_emt):
+    """Re-running the capped driver with more budget resumes and completes."""
+    # First run caps partway through the sweep.
+    r1 = run_ase_core(_vib_params(water, tmp_path, max_wall_seconds=0.25))
+    assert r1["wall_time_capped"] is True
+    cache_dir = json.loads((tmp_path / "out.json").read_text())["restart_file"]
+    n_after_first = len(glob.glob(str(Path(cache_dir) / "vib" / "cache.*.json")))
+    assert 0 < n_after_first < 19
+
+    # Second run: same driver + structure, generous budget -> skips cached
+    # displacements and finishes.
+    r2 = run_ase_core(_vib_params(water, tmp_path, max_wall_seconds=120))
+    assert r2["status"] == "success"
+    assert r2.get("wall_time_capped", False) is False
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is False
+    assert len(data["vibrational_frequencies"]["energies"]) == 9
+
+
+def test_capped_optimization_skips_vib(water, tmp_path):
+    """If the pre-analysis opt itself caps, vib is skipped (needs a min geometry)."""
+    params = ASEInputSchema(
+        input_structure_file=str(water),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="vib",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,  # unreachable -> opt would run many steps
+        steps=100000,
+        max_wall_seconds=1e-9,  # caps the opt before it converges
+    )
+    result = run_ase_core(params)
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+    assert "optimization" in result["message"].lower()
+
+    data = json.loads((tmp_path / "out.json").read_text())
+    assert data["wall_time_capped"] is True
+    assert data["converged"] is False
+    # No vibrational analysis was attempted on the half-optimized geometry.
+    assert not data["vibrational_frequencies"].get("energies")

--- a/tests/test_cli_cap_handoff.py
+++ b/tests/test_cli_cap_handoff.py
@@ -1,0 +1,85 @@
+"""Tests for the wall-clock-cap resume handoff printed by the CLI.
+
+Hermetic: exercises the ``_print_cap_handoff`` helper directly against a fake
+agent/manifest and a captured Rich console. No LLM, no network, no CLI spin-up.
+"""
+
+import io
+
+from rich.console import Console
+
+from chemgraph.cli.commands import _print_cap_handoff
+
+
+class _FakeManifest:
+    def __init__(self, status, pending):
+        self.status = status
+        self._data = {"pending_next_step": pending}
+
+
+class _FakeAgent:
+    def __init__(self, status, pending, session_id="sess-abc123"):
+        self.run_manifest = _FakeManifest(status, pending)
+        self.session_id = session_id
+
+
+def _capture(agent) -> str:
+    console = Console(file=io.StringIO(), width=100)
+    _print_cap_handoff(console, agent)
+    return console.file.getvalue()
+
+
+def test_handoff_printed_when_capped_with_restart():
+    reason = "wall-clock cap; resume with restart_file=/x/restart_opt.json"
+    agent = _FakeAgent(
+        status="capped",
+        pending={"tool": "run_ase", "args": {}, "reason": reason},
+        session_id="sess-abc123",
+    )
+    out = _capture(agent)
+    assert "resume" in out
+    assert "sess-abc123" in out
+    assert "restart_file" in out
+    assert "chemgraph resume sess-abc123" in out
+
+
+def test_handoff_printed_when_capped_no_restart():
+    reason = (
+        "wall-clock cap; no restart written, rerun with more wall-clock budget"
+    )
+    agent = _FakeAgent(
+        status="capped",
+        pending={"tool": "run_ase", "args": {}, "reason": reason},
+        session_id="sess-def456",
+    )
+    out = _capture(agent)
+    assert "rerun with more wall-clock budget" in out
+    assert "chemgraph resume sess-def456" in out
+
+
+def test_no_handoff_when_not_capped():
+    agent = _FakeAgent(
+        status="running",
+        pending=None,
+        session_id="sess-xyz789",
+    )
+    out = _capture(agent)
+    assert "resume" not in out
+    assert out.strip() == ""
+
+
+def test_no_crash_when_no_manifest():
+    class _AgentNoManifest:
+        session_id = "sess-none"
+
+    # Agent lacking a run_manifest attribute entirely.
+    out_missing = _capture(_AgentNoManifest())
+    assert out_missing.strip() == ""
+
+    # Agent with run_manifest explicitly None.
+    class _AgentNoneManifest:
+        run_manifest = None
+        session_id = "sess-none"
+
+    out_none = _capture(_AgentNoneManifest())
+    assert out_none.strip() == ""

--- a/tests/test_cli_jobs.py
+++ b/tests/test_cli_jobs.py
@@ -1,0 +1,180 @@
+"""Tests for the `chemgraph jobs` CLI subcommand.
+
+Hermetic: writes JobTracker persist files on disk, no network, no LLM. Tasks
+carry cached results or are left pending (globus_task_id=None), so no Globus
+client is ever constructed.
+"""
+
+import argparse
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from chemgraph.cli import jobs as jobs_mod
+from chemgraph.cli.formatting import console
+
+
+def _write_jobs_file(path, batch_id, tool_name, task_results):
+    """Write a persist file matching JobTracker._save's on-disk format.
+
+    task_results: list where each element is a result dict (done) or None (pending).
+    """
+    tasks = [
+        {
+            "task_id": f"t{i}",
+            "meta": {"idx": i},
+            "globus_task_id": None,
+            "result": result,
+        }
+        for i, result in enumerate(task_results)
+    ]
+    data = {
+        batch_id: {
+            "tool_name": tool_name,
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "tasks": tasks,
+        }
+    }
+    path.write_text(json.dumps(data, indent=2))
+
+
+@pytest.fixture
+def jobs_dir(tmp_path, monkeypatch):
+    d = tmp_path / ".chemgraph"
+    d.mkdir()
+    files = {
+        "mace": d / "mace_jobs.json",
+        "ase": d / "ase_jobs.json",
+        "graspa": d / "graspa_jobs.json",
+        "xanes": d / "xanes_jobs.json",
+    }
+    monkeypatch.setattr(jobs_mod, "_JOBS_DIR", d)
+    monkeypatch.setattr(jobs_mod, "_JOBS_FILES", files)
+    return files
+
+
+def _run(**ns):
+    # Rich falls back to an 80-col width under capture(), which truncates the
+    # 12-char batch IDs (e.g. "aaaa1…"). Force a realistic terminal width so the
+    # rendered table matches what a user sees, then restore.
+    prev_width = console.width
+    console.width = 200
+    try:
+        with console.capture() as cap:
+            jobs_mod.handle_jobs(argparse.Namespace(**ns))
+        return cap.get()
+    finally:
+        console.width = prev_width
+
+
+def test_no_files_message(jobs_dir):
+    out = _run(jobs_command="list")
+    assert "No job tracker files found" in out
+
+
+def test_bare_jobs_prints_usage(jobs_dir):
+    # No subcommand -> usage, not a silent default to `list`.
+    out = _run(jobs_command=None)
+    assert "Usage: chemgraph jobs" in out
+
+
+def test_unknown_subcommand_prints_usage(jobs_dir):
+    out = _run(jobs_command="bogus")
+    assert "Usage: chemgraph jobs" in out
+
+
+def test_list_offline_never_builds_globus_client(jobs_dir, monkeypatch):
+    # A disk-loaded task with a globus_task_id but no result would trigger a
+    # Globus query if offline were not forwarded. The CLI must stay offline.
+    tasks = [
+        {
+            "task_id": "t0",
+            "meta": {"idx": 0},
+            "globus_task_id": "gc-uuid",
+            "result": None,
+        }
+    ]
+    data = {
+        "ffff00001111": {
+            "tool_name": "run_ase_opt",
+            "submitted_at": datetime.now(timezone.utc).isoformat(),
+            "tasks": tasks,
+        }
+    }
+    jobs_dir["ase"].write_text(json.dumps(data, indent=2))
+
+    from chemgraph.execution.job_tracker import JobTracker
+
+    def _boom(self):
+        raise AssertionError("CLI must not construct a Globus client")
+
+    monkeypatch.setattr(JobTracker, "_get_gc_client", _boom)
+
+    out = _run(jobs_command="list")
+    assert "ffff00001111" in out
+    assert "pending" in out
+
+
+def test_list_combines_backends(jobs_dir):
+    _write_jobs_file(
+        jobs_dir["mace"], "aaaa11112222", "run_mace_opt", [{"status": "success"}]
+    )
+    _write_jobs_file(jobs_dir["ase"], "bbbb33334444", "run_ase_opt", [None])
+    out = _run(jobs_command="list")
+    assert "aaaa11112222" in out
+    assert "bbbb33334444" in out
+    assert "mace" in out and "ase" in out
+    assert "completed" in out and "pending" in out
+
+
+def test_status_found(jobs_dir):
+    _write_jobs_file(
+        jobs_dir["mace"],
+        "aaaa11112222",
+        "run_mace_opt",
+        [{"status": "success"}, None],
+    )
+    out = _run(jobs_command="status", batch_id="aaaa11112222")
+    assert "run_mace_opt" in out
+    assert "running" in out  # 1 done, 1 pending
+    assert "50.0%" in out
+
+
+def test_status_not_found(jobs_dir):
+    _write_jobs_file(jobs_dir["mace"], "aaaa11112222", "run_mace_opt", [None])
+    out = _run(jobs_command="status", batch_id="deadbeef0000")
+    assert "not found" in out
+
+
+def test_results_completed(jobs_dir):
+    _write_jobs_file(
+        jobs_dir["ase"],
+        "cccc55556666",
+        "run_ase_opt",
+        [{"status": "success", "energy": -1.23}],
+    )
+    out = _run(jobs_command="results", batch_id="cccc55556666", partial=False)
+    assert "energy" in out and "-1.23" in out
+
+
+def test_results_pending_blocks(jobs_dir):
+    _write_jobs_file(
+        jobs_dir["ase"],
+        "dddd77778888",
+        "run_ase_opt",
+        [{"status": "success"}, None],
+    )
+    out = _run(jobs_command="results", batch_id="dddd77778888", partial=False)
+    assert "pending" in out
+
+
+def test_results_partial(jobs_dir):
+    _write_jobs_file(
+        jobs_dir["ase"],
+        "eeee9999aaaa",
+        "run_ase_opt",
+        [{"status": "success", "energy": -9.9}, None],
+    )
+    out = _run(jobs_command="results", batch_id="eeee9999aaaa", partial=True)
+    assert "energy" in out

--- a/tests/test_cli_resume.py
+++ b/tests/test_cli_resume.py
@@ -1,0 +1,109 @@
+"""Tests for the `chemgraph resume` CLI subcommand.
+
+Hermetic: parser wiring + dispatch only. `_handle_run` is monkeypatched so no
+agent/LLM is created.
+"""
+
+import importlib
+import sys
+
+# NOTE: `chemgraph.cli.__init__` does `from .main import main`, which shadows the
+# submodule name `chemgraph.cli.main` with the function. Load the real module via
+# sys.modules to reach create_argument_parser / _handle_resume.
+importlib.import_module("chemgraph.cli.main")
+cli_main = sys.modules["chemgraph.cli.main"]
+
+
+class TestResumeParser:
+    def test_parses_positional_and_query(self):
+        parser = cli_main.create_argument_parser()
+        args = parser.parse_args(["resume", "abc123", "-q", "next step"])
+        assert args.command == "resume"
+        assert args.session_id == "abc123"
+        assert args.query == "next step"
+
+    def test_query_optional(self):
+        parser = cli_main.create_argument_parser()
+        args = parser.parse_args(["resume", "abc123"])
+        assert args.session_id == "abc123"
+        assert args.query is None
+
+    def test_inherits_run_args(self):
+        parser = cli_main.create_argument_parser()
+        args = parser.parse_args(
+            ["resume", "abc123", "-q", "go", "-m", "gpt-4o", "-w", "multi_agent"]
+        )
+        assert args.model == "gpt-4o"
+        assert args.workflow == "multi_agent"
+
+
+class _FakeStore:
+    """Stand-in SessionStore whose get_session resolves only known ids."""
+
+    def __init__(self, known):
+        self._known = known
+
+    def get_session(self, session_id):
+        return object() if session_id in self._known else None
+
+
+class TestResumeDispatch:
+    def test_maps_session_id_to_resume(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            cli_main, "_handle_run", lambda args: captured.update(vars(args))
+        )
+        monkeypatch.setattr(
+            "chemgraph.memory.store.SessionStore",
+            lambda *a, **k: _FakeStore({"sess42"}),
+        )
+        parser = cli_main.create_argument_parser()
+        args = parser.parse_args(["resume", "sess42", "-q", "continue"])
+        cli_main._handle_resume(args)
+        assert captured["resume"] == "sess42"
+        assert captured["query"] == "continue"
+
+    def test_prompts_when_query_omitted(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            cli_main, "_handle_run", lambda args: captured.update(vars(args))
+        )
+        monkeypatch.setattr(
+            "rich.prompt.Prompt.ask", lambda *a, **k: "prompted query"
+        )
+        monkeypatch.setattr(
+            "chemgraph.memory.store.SessionStore",
+            lambda *a, **k: _FakeStore({"sess99"}),
+        )
+        parser = cli_main.create_argument_parser()
+        args = parser.parse_args(["resume", "sess99"])
+        cli_main._handle_resume(args)
+        assert captured["resume"] == "sess99"
+        assert captured["query"] == "prompted query"
+
+    def test_unknown_session_id_errors_and_does_not_run(self, monkeypatch):
+        import pytest
+
+        ran = {"called": False}
+        monkeypatch.setattr(
+            cli_main, "_handle_run", lambda args: ran.update(called=True)
+        )
+        monkeypatch.setattr(
+            "chemgraph.memory.store.SessionStore",
+            lambda *a, **k: _FakeStore(set()),  # nothing resolves
+        )
+        parser = cli_main.create_argument_parser()
+        args = parser.parse_args(["resume", "nope", "-q", "go"])
+        with pytest.raises(SystemExit) as exc:
+            cli_main._handle_resume(args)
+        assert exc.value.code == 1
+        assert ran["called"] is False  # never silently started a fresh run
+
+    def test_main_routes_resume(self, monkeypatch):
+        called = {}
+        monkeypatch.setattr(
+            cli_main, "_handle_resume", lambda args: called.setdefault("ok", args)
+        )
+        monkeypatch.setattr(sys, "argv", ["chemgraph", "resume", "s1", "-q", "x"])
+        cli_main.main()
+        assert called["ok"].session_id == "s1"

--- a/tests/test_job_tracker_hardening.py
+++ b/tests/test_job_tracker_hardening.py
@@ -2,12 +2,29 @@
 
 - _save must not crash on non-JSON-serializable task results (persist path).
 - register_batch must not block the full globus wait-timeout for plain futures.
+- offline=True must never construct a Globus Compute client (CLI path).
+- _load must survive structurally incomplete / wrong-shape persist files.
 """
 
+import json
 import time
 from concurrent.futures import Future
 
 from chemgraph.execution.job_tracker import JobTracker
+
+
+def _write_persist(path, data):
+    path.write_text(json.dumps(data))
+
+
+def _disk_batch(*, tool_name="run_ase", submitted_at="2026-07-28T12:00:00+00:00",
+                tasks=None):
+    """A minimal on-disk batch dict in JobTracker._save's format."""
+    return {
+        "tool_name": tool_name,
+        "submitted_at": submitted_at,
+        "tasks": tasks if tasks is not None else [],
+    }
 
 
 class _Unserializable:
@@ -42,3 +59,81 @@ def test_register_batch_does_not_block_for_plain_futures():
     # Must not wait out the 3s globus task-id deadline for a plain future.
     assert elapsed < 1.0, f"register_batch blocked for {elapsed:.2f}s"
     fut.set_result({"status": "success"})  # let the future resolve cleanly
+
+
+# ── offline=True must never touch Globus ──────────────────────────────────
+
+
+def test_offline_status_does_not_construct_globus_client(tmp_path, monkeypatch):
+    persist = tmp_path / "jobs.json"
+    # A batch loaded from disk with a globus_task_id but no cached result:
+    # this is exactly the case get_status(offline=False) would query Globus for.
+    _write_persist(
+        persist,
+        {
+            "b0": _disk_batch(
+                tasks=[{"task_id": "t0", "meta": {}, "globus_task_id": "gc-uuid",
+                        "result": None}]
+            )
+        },
+    )
+    tracker = JobTracker(persist_file=persist)
+
+    # Make any attempt to build a client an explicit test failure.
+    def _boom():
+        raise AssertionError("offline=True must not build a Globus client")
+
+    monkeypatch.setattr(tracker, "_get_gc_client", _boom)
+
+    status = tracker.get_status("b0", offline=True)
+    assert status["status"] == "pending"
+    assert status["pending_tasks"] == 1
+
+    # list_batches and get_results must forward offline too.
+    summaries = tracker.list_batches(offline=True)
+    assert summaries and summaries[0]["status"] == "pending"
+    res = tracker.get_results("b0", offline=True)
+    assert res["status"] == "pending"
+    assert "results" not in res  # blocked: still pending
+
+
+# ── _load hardening: structurally-incomplete / wrong-shape files ──────────
+
+
+def test_load_skips_batch_missing_required_fields(tmp_path):
+    persist = tmp_path / "jobs.json"
+    _write_persist(
+        persist,
+        {
+            "good": _disk_batch(tasks=[{"task_id": "t0", "result": {"status": "success"}}]),
+            "no_tool": {"submitted_at": "2026-07-28T12:00:00+00:00", "tasks": []},
+            "no_time": {"tool_name": "run_ase", "tasks": []},
+            "bad_time": _disk_batch(submitted_at="not-a-timestamp"),
+            "not_a_dict": ["oops"],
+        },
+    )
+    # Must not raise; the good batch survives, the malformed ones are skipped.
+    tracker = JobTracker(persist_file=persist)
+    assert tracker.get_status("good", offline=True)["status"] == "completed"
+    assert "error" in tracker.get_status("no_tool", offline=True)
+    assert "error" in tracker.get_status("no_time", offline=True)
+    assert "error" in tracker.get_status("bad_time", offline=True)
+    assert "error" in tracker.get_status("not_a_dict", offline=True)
+
+
+def test_load_skips_batch_with_malformed_task(tmp_path):
+    persist = tmp_path / "jobs.json"
+    _write_persist(
+        persist,
+        {"b0": _disk_batch(tasks=[{"meta": {}}])},  # task missing task_id
+    )
+    tracker = JobTracker(persist_file=persist)
+    assert "error" in tracker.get_status("b0", offline=True)
+
+
+def test_load_ignores_non_object_top_level(tmp_path):
+    persist = tmp_path / "jobs.json"
+    for payload in ([], "a string", 42):
+        _write_persist(persist, payload)
+        tracker = JobTracker(persist_file=persist)  # must not raise
+        assert tracker.list_batches(offline=True) == []

--- a/tests/test_mace_cap.py
+++ b/tests/test_mace_cap.py
@@ -1,0 +1,237 @@
+"""Tests for the wall-clock cap on the MACE/Parsl entry point.
+
+Slice D wires ``max_wall_seconds`` through the MACE path: the MACE-specific
+``mace_input_schema`` gains the input field, and ``run_mace_core`` forwards it
+into the :class:`ASEInputSchema` it builds before delegating to
+:func:`chemgraph.tools.ase_core.run_ase_core`.
+
+Two things are proven here, both hermetically (no network, no MACE weights):
+
+1. WIRING (APPROACH 1 -- spy): ``run_ase_core`` is monkeypatched with a spy that
+   captures the ``ASEInputSchema`` it receives and returns a dummy dict. This
+   proves the explicit ``max_wall_seconds`` now flows MACE -> ASE (and defaults
+   to ``None``) without running a real MACE calculation. Running ``mace_mp`` for
+   real would download foundation-model weights and is far too heavy for a unit
+   test, so we verify the plumbing at the boundary instead.
+
+2. ENV CAP (core boundary): the allocation env (``CHEMGRAPH_ALLOCATION_*``) is
+   read *inside* ``run_ase_core`` at call time, not passed as a schema field, so
+   it cannot be observed through the spy. ``run_mace_core`` delegates straight
+   into the real ``run_ase_core``, so ``test_env_allocation_would_cap_via_core``
+   drives the REAL ``run_ase_core`` (with a cheap EMT calculator standing in for
+   the MACE model) under an already-exhausted allocation and asserts the run
+   caps -- proving the env path the MACE entry point delegates into.
+"""
+
+import time
+
+import ase.calculators.emt as emt_mod
+import pytest
+from ase.cluster import Icosahedron
+from ase.io import write
+
+import chemgraph.tools.parsl_tools as parsl_tools
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.mace_parsl_schema import mace_input_schema
+from chemgraph.tools.ase_core import run_ase_core
+from chemgraph.tools.parsl_tools import run_mace_core
+
+
+@pytest.fixture
+def xyz_path(tmp_path):
+    """A trivial structure file so schema construction has a real path.
+
+    The spy tests never read it (run_ase_core is stubbed), but it keeps the
+    inputs realistic and mirrors how the other suites stage a structure.
+    """
+    p = tmp_path / "h2.xyz"
+    p.write_text("2\n\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74\n")
+    return p
+
+
+@pytest.fixture
+def ase_spy(monkeypatch):
+    """Replace run_ase_core (as seen by parsl_tools) with a capturing spy.
+
+    Returns a one-element list; after ``run_mace_core`` the captured
+    ``ASEInputSchema`` is at index 0. Patch the name bound in the
+    ``parsl_tools`` module (that is the reference ``run_mace_core`` calls).
+    """
+    captured = {}
+
+    def _spy(ase_params):
+        captured["params"] = ase_params
+        return {"status": "success", "message": "spy"}
+
+    monkeypatch.setattr(parsl_tools, "run_ase_core", _spy)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Wiring: explicit max_wall_seconds flows MACE -> ASE, defaults to None
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_max_wall_seconds_flows_through(xyz_path, ase_spy):
+    """An explicit max_wall_seconds on the MACE schema reaches ASEInputSchema."""
+    params = mace_input_schema(
+        input_structure_file=str(xyz_path),
+        driver="opt",
+        max_wall_seconds=123.0,
+    )
+    result = run_mace_core(params)
+
+    assert result["status"] == "success"  # the spy ran, not a real calc
+    ase_params = ase_spy["params"]
+    assert isinstance(ase_params, ASEInputSchema)
+    assert ase_params.max_wall_seconds == 123.0
+
+
+def test_default_max_wall_seconds_is_none(xyz_path, ase_spy):
+    """With no max_wall_seconds set, the MACE path forwards None (uncapped)."""
+    params = mace_input_schema(
+        input_structure_file=str(xyz_path),
+        driver="opt",
+    )
+    run_mace_core(params)
+
+    ase_params = ase_spy["params"]
+    assert ase_params.max_wall_seconds is None
+
+
+def test_mace_schema_has_max_wall_seconds_field():
+    """The input schema exposes max_wall_seconds (default None)."""
+    assert "max_wall_seconds" in mace_input_schema.model_fields
+    assert mace_input_schema(input_structure_file="x").max_wall_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Env cap at the boundary run_mace_core delegates into (real run_ase_core)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cu_cluster(tmp_path, monkeypatch):
+    """A rattled 13-atom Cu cluster that needs many EMT opt steps.
+
+    Copied minimally from tests/test_cap.py / tests/test_allocation_cap.py.
+    """
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    atoms = Icosahedron("Cu", noshells=2)  # 13 atoms
+    atoms.rattle(0.2, seed=1)
+    p = tmp_path / "cu.xyz"
+    write(str(p), atoms)
+    return p
+
+
+@pytest.fixture
+def slow_emt(monkeypatch):
+    """Slow every EMT force evaluation so the wall-clock cap trips deterministically.
+
+    ~0.1 s/step makes step timing dominate a sub-second budget, so a handful of
+    steps run before the cap regardless of machine load (mirrors test_cap.py).
+    """
+    orig = emt_mod.EMT.calculate
+
+    def _slow(self, *args, **kwargs):
+        time.sleep(0.1)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(emt_mod.EMT, "calculate", _slow)
+    return _slow
+
+
+def test_env_allocation_would_cap_via_core(cu_cluster, tmp_path, slow_emt, monkeypatch):
+    """CHEMGRAPH_ALLOCATION_* caps the REAL run_ase_core that run_mace_core calls.
+
+    The allocation budget is read inside ase_core at call time (not a schema
+    field), so it is invisible to the wiring spy above. run_mace_core delegates
+    unconditionally into run_ase_core, so exercising the real core under an
+    almost-spent allocation proves the env path the MACE entry point relies on.
+    A cheap EMT calculator stands in for mace_mp (whose weights we will not
+    download); the allocation gate is calculator-agnostic.
+    """
+    # CHEMGRAPH_ALLOCATION_SECONDS is measured from process start (module
+    # import); anchor _PROCESS_START to now so the tiny budget is measured from
+    # here, well after an import many seconds in the past.
+    import chemgraph.tools.ase_core as ase_core_mod
+
+    monkeypatch.setattr(ase_core_mod, "_PROCESS_START", time.time())
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_SECONDS", "0.35")
+    monkeypatch.setenv("CHEMGRAPH_ALLOCATION_MARGIN", "0.10")
+
+    params = ASEInputSchema(
+        input_structure_file=str(cu_cluster),
+        output_results_file=str(tmp_path / "out.json"),
+        driver="opt",
+        calculator={"calculator_type": "emt"},
+        fmax=1e-6,  # effectively unreachable -> would run many steps
+        steps=100000,
+        # No explicit max_wall_seconds: the cap comes purely from the env.
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    elapsed = time.time() - t0
+
+    assert result["status"] == "success"
+    assert result["wall_time_capped"] is True
+    assert elapsed < 30  # capped, not run to 100000 steps
+
+
+# ---------------------------------------------------------------------------
+# Ensemble: max_wall_seconds propagates onto every per-structure job dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def structure_dir(tmp_path):
+    """A directory of two trivial structures for ensemble expansion."""
+    d = tmp_path / "structs"
+    d.mkdir()
+    (d / "a.xyz").write_text("2\n\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74\n")
+    (d / "b.xyz").write_text("2\n\nH 0.0 0.0 0.0\nH 0.0 0.0 0.74\n")
+    return d
+
+
+def test_ensemble_schema_has_max_wall_seconds_field():
+    """The ensemble schema exposes max_wall_seconds (default None)."""
+    from chemgraph.schemas.mace_parsl_schema import mace_input_schema_ensemble
+
+    assert "max_wall_seconds" in mace_input_schema_ensemble.model_fields
+    assert mace_input_schema_ensemble().max_wall_seconds is None
+
+
+def test_ensemble_hpc_expansion_forwards_max_wall_seconds(structure_dir):
+    """_expand_mace_ensemble (HPC) puts max_wall_seconds on every job, round-trips.
+
+    The workers re-hydrate each job dict with ``mace_input_schema(**job)``, whose
+    ``_mace_input_to_ase_input`` already forwards ``max_wall_seconds`` into the
+    ASEInputSchema (proven by the single-structure wiring tests above). So proving
+    the ensemble expansion stamps the field on every per-structure job -- and that
+    it survives the schema round-trip the worker performs -- covers the cap
+    reaching each ensemble member.
+    """
+    from chemgraph.mcp.mace_mcp_hpc import _expand_mace_ensemble
+    from chemgraph.schemas.mace_parsl_schema import (
+        mace_input_schema,
+        mace_input_schema_ensemble,
+    )
+
+    params = mace_input_schema_ensemble(
+        input_structure_directory=str(structure_dir),
+        driver="opt",
+        max_wall_seconds=0.5,
+    )
+    jobs = _expand_mace_ensemble(params)
+
+    assert len(jobs) == 2
+    assert all(job["max_wall_seconds"] == 0.5 for job in jobs)
+    # the exact round-trip a worker performs before delegating to the core.
+    assert all(mace_input_schema(**job).max_wall_seconds == 0.5 for job in jobs)
+
+
+# NOTE: the legacy chemgraph.mcp.mace_mcp_parsl entry point also stamps
+# max_wall_seconds onto its per-structure job dict (kept in sync for parity), but
+# that module reads PBS_NODEFILE and builds a full Parsl Config at import time, so
+# it cannot be imported off a PBS node and has no hermetic test. It is deprecated
+# in favor of mace_mcp_hpc (exercised above), which is the current dispatch path.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,683 @@
+"""Tests for the durable run manifest (cross-allocation resume worklist).
+
+Hermetic: pure filesystem, no LLM, no network.
+"""
+
+import json
+
+from chemgraph.memory.manifest import RunManifest
+
+
+def test_records_and_renders(tmp_path):
+    m = RunManifest(tmp_path / "run_manifest.json")
+    idx = m.record_step_start(
+        "run_ase",
+        {
+            "driver": "opt",
+            "calculator": {"calculator_type": "mace_mp"},
+            "input_structure_file": "water.xyz",
+        },
+    )
+    m.record_step_end(idx, result_file="/flare/x/water_opt.json", wall_time=42.1)
+
+    # flushed atomically on every call
+    data = json.loads((tmp_path / "run_manifest.json").read_text())
+    assert data["steps"][0]["status"] == "done"
+    assert data["steps"][0]["result_file"].endswith("water_opt.json")
+
+    txt = m.render_for_context()
+    assert "do NOT recompute" in txt
+    assert "water_opt.json" in txt
+    assert "mace_mp" in txt
+
+
+def test_pending_survives_reload(tmp_path):
+    p = tmp_path / "run_manifest.json"
+    m = RunManifest(p)
+    m.set_pending(
+        "run_ase",
+        {"driver": "vib", "input_structure_file": "water_opt.json"},
+        reason="walltime cap",
+    )
+    # reload from disk (simulates a fresh process / new allocation)
+    m2 = RunManifest(p)
+    txt = m2.render_for_context()
+    assert "PENDING NEXT STEP" in txt
+    assert "vib" in txt
+    assert "walltime cap" in txt
+
+
+def test_for_session_uses_log_dir(tmp_path):
+    class FakeSess:
+        log_dir = str(tmp_path)
+
+    class FakeStore:
+        def get_session(self, sid):
+            return FakeSess()
+
+    # no manifest yet -> None
+    assert RunManifest.for_session(FakeStore(), "abc") is None
+
+    # once a manifest exists, it's found via the session's log_dir
+    RunManifest(tmp_path / "run_manifest.json").record_step_start("run_ase", {})
+    m = RunManifest.for_session(FakeStore(), "abc")
+    assert m is not None
+    assert len(m._data["steps"]) == 1
+
+
+def test_corrupt_file_does_not_crash(tmp_path):
+    p = tmp_path / "run_manifest.json"
+    p.write_text("{ not valid json")
+    m = RunManifest(p)  # should warn + start fresh, not raise
+    assert m._data["steps"] == []
+
+
+# ---------------------------------------------------------------------------
+# _manifest_observe hook (llm_agent) tested with mock messages -- no LLM.
+# Reproduces the e2e finding that a FAILED tool call must not be recorded "done".
+# ---------------------------------------------------------------------------
+
+
+def _fake_agent(tmp_path):
+    """A minimal object exposing the manifest + the real _manifest_observe."""
+    from chemgraph.agent.llm_agent import ChemGraph
+
+    class _FakeAgent:
+        run_manifest = RunManifest(tmp_path / "run_manifest.json")
+        _pending_steps = {}
+        _COST_TOOLS = ChemGraph._COST_TOOLS
+        _manifest_observe = ChemGraph._manifest_observe
+
+        def __init__(self):
+            # per-instance so parallel-call tests don't share the class dict
+            self._pending_steps = {}
+
+    return _FakeAgent()
+
+
+def test_hook_records_successful_step(tmp_path):
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    result_path = tmp_path / "water_opt.json"
+    result_path.write_text(json.dumps({"wall_time": 12.3, "converged": True}))
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "mace_mp"},
+                        "input_structure_file": "water.xyz",
+                    },
+                }
+            ],
+        )
+    )
+    assert fa._pending_steps["c1"]["idx"] == 1
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Simulation completed. Results saved to {result_path}",
+            tool_call_id="c1",
+        )
+    )
+    assert fa._pending_steps == {}
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "done"
+    assert step["result_file"] == str(result_path)
+    assert step["wall_time"] == 12.3
+
+
+def test_hook_marks_failed_tool_call(tmp_path):
+    """A validation/tool error must be recorded status='failed', not 'done'."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "run_ase", "id": "c1", "args": {"driver": "opt"}}],
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content="Error: 1 validation error for run_ase\nparams Field required",
+            tool_call_id="c1",
+            status="error",
+        )
+    )
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "failed"
+    assert step["result_file"] is None
+
+
+def test_hook_records_capped_step_as_pending(tmp_path):
+    """A wall-clock-capped step is recorded 'capped' and queued as pending."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    result_path = tmp_path / "water_opt.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "wall_time": 5.0,
+                "wall_time_capped": True,
+                "restart_file": "/some/restart_opt.json",
+                "converged": False,
+            }
+        )
+    )
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "mace_mp"},
+                        "input_structure_file": "water.xyz",
+                    },
+                }
+            ],
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content=(
+                "Optimization CAPPED at the wall-clock limit (not converged). "
+                f"Partial geometry + restart saved to {result_path}. "
+                "Resume with restart_file to continue."
+            ),
+            tool_call_id="c1",
+        )
+    )
+
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "capped"
+    assert fa.run_manifest.status == "capped"
+    assert fa._pending_steps == {}
+
+    txt = fa.run_manifest.render_for_context()
+    assert "PENDING NEXT STEP" in txt
+    assert "restart_file=/some/restart_opt.json" in txt
+    assert "opt" in txt
+    # A capped step must NOT be listed in the "do NOT recompute" completed list
+    # (render only lists status=="done"): its only surface is PENDING.
+    completed = txt.split("=== PENDING NEXT STEP", 1)[0]
+    assert "water.xyz" not in completed
+
+
+def test_hook_capped_no_restart_sets_pending_rerun(tmp_path):
+    """A cap before any step (no restart) queues a rerun-with-more-budget pending."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    result_path = tmp_path / "water_opt.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "wall_time": 0.1,
+                "wall_time_capped": True,
+                "restart_file": None,
+                "converged": False,
+            }
+        )
+    )
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "mace_mp"},
+                        "input_structure_file": "water.xyz",
+                    },
+                }
+            ],
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content=(
+                "Optimization CAPPED at the wall-clock limit before any step "
+                "completed; no restart file was written. Rerun with more "
+                f"wall-clock budget. Results saved to {result_path}."
+            ),
+            tool_call_id="c1",
+        )
+    )
+
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "capped"
+    assert fa.run_manifest.status == "capped"
+    txt = fa.run_manifest.render_for_context()
+    assert "rerun with more wall-clock budget" in txt
+
+
+def test_hook_successful_step_leaves_status_running(tmp_path):
+    """A normal (uncapped) step stays 'done' and does NOT flip status to capped."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    result_path = tmp_path / "water_opt.json"
+    result_path.write_text(
+        json.dumps(
+            {"wall_time": 12.3, "wall_time_capped": False, "converged": True}
+        )
+    )
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "mace_mp"},
+                        "input_structure_file": "water.xyz",
+                    },
+                }
+            ],
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Simulation completed. Results saved to {result_path}",
+            tool_call_id="c1",
+        )
+    )
+
+    step = fa.run_manifest._data["steps"][0]
+    assert step["status"] == "done"
+    assert fa.run_manifest.status == "running"
+    # A successful step leaves no PENDING block for a resume to re-render.
+    assert "PENDING NEXT STEP" not in fa.run_manifest.render_for_context()
+
+
+def test_success_after_cap_clears_pending(tmp_path):
+    """A cap sets PENDING+status='capped'; a later uncapped step clears both.
+
+    Models the resume happy-path: step 1 caps and queues a pending marker; the
+    resumed run completes that step, which must clear the pending block and reset
+    status to 'running' so the manifest no longer advertises stale work.
+    """
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    capped_path = tmp_path / "water_opt.json"
+    capped_path.write_text(
+        json.dumps(
+            {
+                "wall_time": 5.0,
+                "wall_time_capped": True,
+                "restart_file": "/some/restart_opt.json",
+                "converged": False,
+            }
+        )
+    )
+    done_path = tmp_path / "water_opt_done.json"
+    done_path.write_text(
+        json.dumps({"wall_time": 8.0, "wall_time_capped": False, "converged": True})
+    )
+
+    fa = _fake_agent(tmp_path)
+
+    # 1) first attempt caps -> PENDING set, status 'capped'.
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "mace_mp"},
+                        "input_structure_file": "water.xyz",
+                    },
+                }
+            ],
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Optimization CAPPED. Results saved to {capped_path}.",
+            tool_call_id="c1",
+        )
+    )
+    assert fa.run_manifest.status == "capped"
+    assert fa.run_manifest._data["pending_next_step"] is not None
+
+    # 2) resume completes the step under a NEW tool_call_id -> pending cleared.
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c2",
+                    "args": {
+                        "driver": "opt",
+                        "calculator": {"calculator_type": "mace_mp"},
+                        "input_structure_file": "water_opt.partial.xyz",
+                    },
+                }
+            ],
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Optimization complete. Results saved to {done_path}",
+            tool_call_id="c2",
+        )
+    )
+
+    assert fa.run_manifest.status == "running"
+    assert fa.run_manifest._data["pending_next_step"] is None
+    assert "PENDING NEXT STEP" not in fa.run_manifest.render_for_context()
+
+
+# ---------------------------------------------------------------------------
+# C2: cost tools take one pydantic param, so the LLM's args nest under a wrapper
+# key. The hook must unwrap it before recording, else the manifest reads every
+# field as '?'. These feed the REAL nested shape production sees.
+# ---------------------------------------------------------------------------
+
+
+def test_hook_unwraps_params_wrapper(tmp_path):
+    """run_ase args nested under ``params`` render with real driver/calc, not '?'."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    result_path = tmp_path / "water_opt.json"
+    result_path.write_text(json.dumps({"wall_time": 1.0, "converged": True}))
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    # the production shape: real args nested one level down.
+                    "args": {
+                        "params": {
+                            "driver": "opt",
+                            "calculator": {"calculator_type": "mace_mp"},
+                            "input_structure_file": "water.xyz",
+                        }
+                    },
+                }
+            ],
+        )
+    )
+
+    step = fa.run_manifest._data["steps"][0]
+    assert step["args"].get("driver") == "opt"
+
+    # close the step so it appears in the "completed work" render.
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Simulation completed. Results saved to {result_path}",
+            tool_call_id="c1",
+        )
+    )
+    txt = fa.run_manifest.render_for_context()
+    # unwrapped -> concrete fields; the pre-fix bug rendered "driver=? calc=?".
+    assert "driver=opt calc=mace_mp" in txt
+
+
+def test_hook_unwraps_graspa_wrapper_and_alias(tmp_path):
+    """run_graspa nests under ``graspa_input``; ``cif_path`` aliases the input file."""
+    from langchain_core.messages import AIMessage
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_graspa",
+                    "id": "c1",
+                    "args": {"graspa_input": {"cif_path": "mof.cif"}},
+                }
+            ],
+        )
+    )
+
+    step = fa.run_manifest._data["steps"][0]
+    # cif_path is normalized onto the canonical input_structure_file a resume reads.
+    assert step["args"].get("input_structure_file") == "mof.cif"
+
+
+def test_hook_records_run_mace_single(tmp_path):
+    """The real MACE tool name is recorded (pre-fix _COST_TOOLS had only 'run_mace')."""
+    from langchain_core.messages import AIMessage
+
+    fa = _fake_agent(tmp_path)
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_mace_single",
+                    "id": "c1",
+                    "args": {
+                        "params": {
+                            "driver": "opt",
+                            "input_structure_file": "water.xyz",
+                        }
+                    },
+                }
+            ],
+        )
+    )
+
+    assert len(fa.run_manifest._data["steps"]) == 1
+    assert fa.run_manifest._data["steps"][0]["tool"] == "run_mace_single"
+
+
+# ---------------------------------------------------------------------------
+# C3: two cost tools issued in one AI message open two steps at once. The hook
+# must close each by tool_call_id -- a single-slot tracker would close the wrong
+# one when the ToolMessages arrive out of order.
+# ---------------------------------------------------------------------------
+
+
+def test_hook_two_parallel_calls_close_correct_steps(tmp_path):
+    """Two parallel calls, results returned reversed -> each closes its own step."""
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    done_path = tmp_path / "water_opt.json"
+    done_path.write_text(
+        json.dumps({"wall_time": 3.0, "wall_time_capped": False, "converged": True})
+    )
+    capped_path = tmp_path / "water_vib.json"
+    capped_path.write_text(
+        json.dumps(
+            {
+                "wall_time": 9.0,
+                "wall_time_capped": True,
+                "restart_file": "/some/vib_restart.json",
+                "converged": False,
+            }
+        )
+    )
+
+    fa = _fake_agent(tmp_path)
+    # one AI message issuing TWO cost-bearing calls: c1 opt, c2 vib.
+    fa._manifest_observe(
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "run_ase",
+                    "id": "c1",
+                    "args": {
+                        "params": {
+                            "driver": "opt",
+                            "calculator": {"calculator_type": "mace_mp"},
+                            "input_structure_file": "water.xyz",
+                        }
+                    },
+                },
+                {
+                    "name": "run_ase",
+                    "id": "c2",
+                    "args": {
+                        "params": {
+                            "driver": "vib",
+                            "calculator": {"calculator_type": "mace_mp"},
+                            "input_structure_file": "water_opt.json",
+                        }
+                    },
+                },
+            ],
+        )
+    )
+    assert set(fa._pending_steps) == {"c1", "c2"}
+
+    # ToolMessages arrive REVERSED: c2 (vib, capped) first, then c1 (opt, done).
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Vibrations CAPPED. Results saved to {capped_path}.",
+            tool_call_id="c2",
+        )
+    )
+    fa._manifest_observe(
+        ToolMessage(
+            content=f"Optimization complete. Results saved to {done_path}",
+            tool_call_id="c1",
+        )
+    )
+
+    assert fa._pending_steps == {}
+    steps = {s["index"]: s for s in fa.run_manifest._data["steps"]}
+    # step 1 was the opt (c1) -> done despite arriving second.
+    assert steps[1]["args"]["driver"] == "opt"
+    assert steps[1]["status"] == "done"
+    # step 2 was the vib (c2) -> capped despite arriving first.
+    assert steps[2]["args"]["driver"] == "vib"
+    assert steps[2]["status"] == "capped"
+
+
+def test_model_typed_args_round_trip_across_reload(tmp_path):
+    """A Pydantic-model calculator arg must survive the reload boundary.
+
+    Regression: json.dumps(default=str) stringified models to an unparseable
+    repr, so a resumed process reloaded ``calc=?`` and lost the args.
+    """
+
+    class _Calc:
+        # minimal stand-in for a pydantic v2 model (has model_dump)
+        calculator_type = "mace_mp"
+
+        def model_dump(self):
+            return {"calculator_type": self.calculator_type, "model": "small"}
+
+    p = tmp_path / "run_manifest.json"
+    m = RunManifest(p)
+    idx = m.record_step_start(
+        "run_ase",
+        {"driver": "opt", "calculator": _Calc(), "input_structure_file": "w.xyz"},
+    )
+    m.record_step_end(idx, result_file="/x/w_opt.json", wall_time=1.0)
+
+    # on disk the model became a plain dict (not a str repr)
+    data = json.loads(p.read_text())
+    assert data["steps"][0]["args"]["calculator"] == {
+        "calculator_type": "mace_mp",
+        "model": "small",
+    }
+
+    # and a fresh process still resolves the calculator label
+    reloaded = RunManifest(p)
+    assert "calc=mace_mp" in reloaded.render_for_context()
+
+
+def test_wrong_shape_json_starts_fresh(tmp_path):
+    """Valid JSON of the wrong shape is ignored, not fed to readers that crash."""
+    for payload in ('{"unexpected": true}', "null", "[]", '{"schema_version": 999}'):
+        p = tmp_path / "run_manifest.json"
+        p.write_text(payload)
+        m = RunManifest(p)  # must not raise
+        assert m._data["steps"] == []
+        # readers stay safe on the fallback data
+        assert "do NOT recompute" in m.render_for_context()
+
+
+def test_valid_top_shape_with_malformed_step_does_not_crash_resume(tmp_path):
+    """A right-shaped manifest whose steps hold junk must still render, not crash.
+
+    ``_is_valid_shape`` accepts the top level (schema_version + steps-is-a-list),
+    so a null step or a step missing ``status``/``index`` slips past the load
+    guard. ``render_for_context`` runs unguarded on the resume path, so it must
+    tolerate such elements and never raise (a TypeError/KeyError here would kill
+    the very resume the manifest exists to enable).
+    """
+    good = {
+        "index": 1,
+        "tool": "run_ase",
+        "args": {"driver": "opt"},
+        "status": "done",
+        "result_file": "/x/opt.json",
+        "wall_time": 1.0,
+    }
+    payload = {
+        "schema_version": 1,
+        "steps": [None, {"tool": "run_ase"}, good],  # null, status-less, then good
+        "pending_next_step": None,
+        "status": "capped",
+    }
+    p = tmp_path / "run_manifest.json"
+    p.write_text(json.dumps(payload))
+
+    m = RunManifest(p)  # load must not raise
+    rendered = m.render_for_context()  # unguarded resume-path call must not raise
+    # the one well-formed done step still renders; the junk is skipped
+    assert "[1] run_ase" in rendered
+    # a malformed pending block is also tolerated (rendered as a safe placeholder)
+    p.write_text(json.dumps({**payload, "pending_next_step": {"args": None}}))
+    RunManifest(p).render_for_context()  # must not raise
+
+    # a truthy-but-non-dict ``args`` (a list or string, not just a falsy null)
+    # must also be tolerated: ``a.get(...)`` would raise AttributeError on it.
+    # This covers both a done step and the pending block.
+    bad_args_step = {**good, "args": ["driver", "opt"]}
+    p.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "steps": [bad_args_step],
+                "pending_next_step": {"tool": "run_ase", "args": "oops"},
+                "status": "capped",
+            }
+        )
+    )
+    RunManifest(p).render_for_context()  # must not raise on non-dict args
+
+    # record_step_end also tolerates malformed elements in the list
+    RunManifest(p).record_step_end(1, result_file="/x/opt.json", wall_time=1.0)
+
+
+def test_non_serializable_arg_does_not_crash_the_run(tmp_path):
+    """A non-JSON-serializable arg must be tolerated, not propagated."""
+    p = tmp_path / "run_manifest.json"
+    m = RunManifest(p)
+    # a tuple dict-key survives _jsonable (keys aren't coerced) but breaks
+    # json.dumps; _flush must swallow it and never crash the caller.
+    m.record_step_start("run_ase", {"bad": {("a", "b"): 1}})  # should not raise
+    # the tmp file must not be left behind on a failed flush
+    assert not p.with_suffix(".tmp").exists()

--- a/tests/test_resume_injection.py
+++ b/tests/test_resume_injection.py
@@ -1,0 +1,218 @@
+"""End-to-end proof that RESUME injects the run manifest's PENDING marker.
+
+``ChemGraph.run(query, resume_from=<sid>)`` loads the session's manifest and
+prepends its rendered content (completed steps + PENDING NEXT STEP) into the
+query the graph sees, so a resumed agent continues a capped step and skips
+recomputing it. Unlike ``tests/test_manifest.py`` (which exercises
+``render_for_context()`` in isolation), this drives the whole ``run()`` layer and
+asserts the PENDING block reaches the string handed to the graph.
+
+Hermetic: ``load_openai_model`` patched to a ``Mock`` (as in
+``tests/test_llm_agent.py``), a real SQLite session store in ``tmp_path``, and
+``workflow.astream`` replaced by a capturing stand-in so no graph/LLM runs.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from langchain_core.messages import AIMessage
+
+from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.memory.manifest import RunManifest
+from chemgraph.memory.store import SessionStore
+
+
+class _CapturingWorkflow:
+    """Stand-in for the compiled graph that records what ``run()`` streams into it.
+
+    ``ChemGraph.run`` calls ``self.workflow.astream(stream_input, ...)``; we
+    capture ``stream_input`` (the ``{"messages": query}`` dict) and yield a single
+    terminal state so ``run()`` completes without invoking any LLM.
+    """
+
+    def __init__(self):
+        self.captured_input = None
+        self._final_state = {
+            "messages": [AIMessage(content="ok -- resuming the capped step")]
+        }
+
+    async def astream(self, stream_input, *, stream_mode, config):
+        self.captured_input = stream_input
+        yield self._final_state
+
+    def get_state(self, config):
+        # No pending interrupts; keeps _stream_until_interrupt's post-stream and
+        # write_state's checkpoint reads from raising.
+        return SimpleNamespace(values=self._final_state, tasks=[])
+
+
+def _write_capped_manifest(manifest_dir):
+    """Write a run_manifest.json exactly as production does for a capped step.
+
+    Drives the real ``RunManifest`` write API (record a completed step, then a
+    capped step whose same args become the pending next step with a
+    restart-aware reason, then flip status to "capped") so the on-disk shape is
+    identical to what ``_manifest_observe`` writes on a wall-clock cap.
+    """
+    m = RunManifest(manifest_dir / "run_manifest.json")
+
+    # A first step that finished normally -> surfaces under "do NOT recompute".
+    done_idx = m.record_step_start(
+        "run_ase",
+        {
+            "driver": "opt",
+            "calculator": {"calculator_type": "mace_mp"},
+            "input_structure_file": "water.xyz",
+        },
+    )
+    m.record_step_end(
+        done_idx, result_file="/flare/run/water_opt.json", wall_time=42.1
+    )
+
+    # A second step capped at the wall-clock limit -> recorded "capped" (not
+    # "done") and queued as the pending next step so a resume continues it.
+    capped_args = {
+        "driver": "vib",
+        "calculator": {"calculator_type": "mace_mp"},
+        "input_structure_file": "water_opt.json",
+    }
+    capped_idx = m.record_step_start("run_ase", capped_args)
+    m.record_step_end(
+        capped_idx,
+        result_file="/flare/run/water_vib_partial.json",
+        wall_time=5.0,
+        status="capped",
+    )
+    m.set_pending(
+        "run_ase",
+        capped_args,
+        reason="wall-clock cap; resume with restart_file=/flare/run/restart_vib.json",
+    )
+    m.set_status("capped")
+    return m
+
+
+def test_resume_injects_pending_marker_into_graph_query(tmp_path):
+    """The capped manifest's PENDING block must reach the query passed to astream."""
+    # 1. A durable capped manifest on the shared filesystem, in a session's log_dir.
+    resume_log_dir = tmp_path / "resume_session_logs"
+    resume_log_dir.mkdir()
+    _write_capped_manifest(resume_log_dir)
+
+    # 2. A real session store whose prior session points get_session().log_dir at
+    #    the manifest dir, so RunManifest.for_session can discover it.
+    store = SessionStore(db_path=str(tmp_path / "sessions.db"))
+    resume_sid = "capped00"
+    store.create_session(
+        session_id=resume_sid,
+        model_name="gpt-4o-mini",
+        workflow_type="single_agent",
+        title="prior capped run",
+        log_dir=str(resume_log_dir),
+    )
+
+    # 3. Construct ChemGraph fully offline: mock the model loader (no network),
+    #    reuse the same store so both prior and resumed sessions live in tmp.
+    with patch(
+        "chemgraph.agent.llm_agent.load_openai_model", return_value=Mock()
+    ):
+        agent = ChemGraph(
+            model_name="gpt-4o-mini",
+            workflow_type="single_agent",
+            session_store=store,
+            log_dir=str(tmp_path / "agent_logs"),
+        )
+
+    # 4. Replace the compiled graph with a capturing stand-in so no LLM runs and
+    #    we can inspect exactly what run() streams into the graph.
+    capturing = _CapturingWorkflow()
+    agent.workflow = capturing
+
+    # 5. Resume.
+    original_query = "run the pending vibrational-frequency step"
+    result = asyncio.run(agent.run(original_query, resume_from=resume_sid))
+
+    # run() returned the terminal message (nothing hit an LLM).
+    assert isinstance(result, AIMessage)
+
+    # 6. Assert the manifest's PENDING block reached the graph's input query.
+    stream_input = capturing.captured_input
+    assert isinstance(stream_input, dict)
+    injected_query = stream_input["messages"]
+    assert isinstance(injected_query, str)
+
+    # The original query is still present (context is *prepended*, not replaced).
+    assert original_query in injected_query
+
+    # The PENDING NEXT STEP block and the capped step's identity are injected.
+    assert "PENDING NEXT STEP" in injected_query
+    assert "run_ase" in injected_query
+    assert "driver=vib" in injected_query
+    assert "input=water_opt.json" in injected_query
+    # The restart-aware reason (how to continue the capped work) is carried through.
+    assert "restart_file=/flare/run/restart_vib.json" in injected_query
+
+    # The completed step is injected under the "do NOT recompute" heading, and the
+    # capped step (driver=vib) is NOT listed there -- it only surfaces as PENDING,
+    # so the resumed agent continues it as unfinished work.
+    completed_section, _, pending_section = injected_query.partition(
+        "=== PENDING NEXT STEP"
+    )
+    assert "do NOT recompute" in completed_section
+    assert "driver=opt" in completed_section  # the finished step is here
+    assert "water_opt.json" in completed_section  # its result file
+    assert "driver=vib" not in completed_section  # the capped step is NOT here
+    assert "driver=vib" in pending_section  # ... only under PENDING
+
+
+def test_resume_adopts_prior_log_dir(tmp_path):
+    """Resume repoints log_dir / CHEMGRAPH_LOG_DIR / run_manifest at the prior session.
+
+    The durable partials a resume must find ({stem}_opt.partial.xyz, vib cache)
+    resolve under CHEMGRAPH_LOG_DIR. A resumed agent is built with a fresh
+    auto-generated log_dir, so run() must adopt the prior session's log_dir (and
+    re-point self.run_manifest at that session's manifest) before anything reads
+    it -- otherwise the partials are invisible and the step recomputes.
+    """
+    from pathlib import Path
+
+    resume_log_dir = tmp_path / "resume_session_logs"
+    resume_log_dir.mkdir()
+    _write_capped_manifest(resume_log_dir)
+
+    store = SessionStore(db_path=str(tmp_path / "sessions.db"))
+    resume_sid = "capped00"
+    store.create_session(
+        session_id=resume_sid,
+        model_name="gpt-4o-mini",
+        workflow_type="single_agent",
+        title="prior capped run",
+        log_dir=str(resume_log_dir),
+    )
+
+    with patch(
+        "chemgraph.agent.llm_agent.load_openai_model", return_value=Mock()
+    ):
+        agent = ChemGraph(
+            model_name="gpt-4o-mini",
+            workflow_type="single_agent",
+            session_store=store,
+            log_dir=str(tmp_path / "agent_logs"),
+        )
+
+    # sanity: before resume the agent is on its OWN fresh log dir + manifest.
+    assert agent.log_dir == str(tmp_path / "agent_logs")
+    assert Path(agent.run_manifest._path).parent != resume_log_dir
+
+    agent.workflow = _CapturingWorkflow()
+    asyncio.run(agent.run("continue", resume_from=resume_sid))
+
+    # after resume the agent adopts the prior session's log dir everywhere the
+    # durable partials are resolved.
+    assert agent.log_dir == str(resume_log_dir)
+    import os
+
+    assert os.environ["CHEMGRAPH_LOG_DIR"] == str(resume_log_dir)
+    # and new steps append to the prior manifest, not a fresh empty one.
+    assert Path(agent.run_manifest._path).parent == resume_log_dir


### PR DESCRIPTION
## Summary

Adds ChemGraph's long-running-calculation feature: a soft wall-clock cap that
stops an ASE optimization at a step boundary, a durable run manifest that records
what finished, and a `chemgraph resume` path that continues a capped run in a
later allocation without recomputing. This lets a calculation that outlasts a
single scheduler allocation finish across several of them.

The four commits are each one logical layer:

- **Wall-clock cap (`ase_core.py`).** The optimizer yields at each step boundary;
  the deadline (`CHEMGRAPH_ALLOCATION_DEADLINE`/`_SECONDS` minus a safety
  `_MARGIN`) is checked at each yield. When a step completes within the budget,
  a restart file exists and the run resumes from it; a cap that fires before
  step 1 leaves no restart and is reported as such. The cap is soft: an in-flight
  SCF is left untouched, so the margin must exceed one step's wall time.
- **Run manifest (`memory/manifest.py`).** A durable per-session JSON record of
  each executed cost-bearing tool call (name, args, result-file path, wall_time)
  and the pending next step, written incrementally with an atomic tmp-plus-replace.
  It is independent of the in-memory checkpointer and the turn-end SessionStore, so
  a completed step survives a walltime kill. Reads are defensive: a wrong-shape
  file falls back to a fresh default, and `render_for_context` tolerates malformed
  steps, because it runs unguarded on the resume path.
- **CLI (`cli/jobs.py`, `cli/commands.py`, `cli/main.py`).** `chemgraph jobs
  {list,status,results}` inspects the persisted HPC job batches offline, and
  `chemgraph resume` continues a capped session.
- **gitignore.** Ignores the per-run cap and manifest artifacts.

### When this helps

Even though starting the next allocation is still manual today, the value is
concrete: the cap preserves completed computational work that would otherwise be
discarded.

- **A single optimization that needs more than one walltime.** A geometry
  optimization of a mid-size system can run many optimizer steps at minutes to
  hours each, more than a single queue slot grants. Without the cap, the scheduler
  SIGKILLs the run partway through a step and the completed optimization progress
  is not durably handed off to the next allocation, so the next submission starts
  from zero and the run never finishes. With the cap, the run stops at a step
  boundary and saves the partial geometry; a later `chemgraph resume` continues
  from the last completed step, so the work
  finishes across a few allocations with no step recomputed.
- **Many short jobs schedule better than one long allocation.** Splitting a long
  calculation into several standard-length jobs is friendlier to the queue: short
  jobs start sooner and backfill more easily than a single special long-walltime
  allocation that may wait a long time or be denied.
- **Insurance against an underestimated walltime.** Even a run expected to fit can
  overrun when convergence is slower than planned. Without the cap that is a
  SIGKILL with total loss; with the cap the worst case is stopping at the last
  completed step, which is always resumable. This safety holds with zero
  automation layered on top.

### Part of a 3-PR series

This is the second of three PRs that together add long-running-calculation support
for subprocess DFT. They are meant to land in order:

1. feature/dft-calculators: the VASP and Quantum ESPRESSO calculators.
2. **feature/longrun-cap-resume (this PR):** the wall-clock cap, run manifest, and
   `chemgraph resume`. It overlaps with the calculators PR at the file level but
   is functionally independent, and the branches have been verified to merge
   cleanly.
3. feature/aurora-qe-example: a runnable Aurora example that validates the seam on
   real QE DFT. Depends on both earlier PRs.

The example PR opens as Draft until this one and the calculators PR merge.

## Related issues

None

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- New unit tests cover each layer on the in-process EMT/MACE calculators, with no
  HPC or DFT needed: `test_cap.py`, `test_allocation_cap.py`, `test_mace_cap.py`
  (the cap fires at a step boundary and leaves a resumable restart file),
  `test_manifest.py` and `test_job_tracker_hardening.py` (atomic write,
  wrong-shape and malformed-step tolerance), `test_cap_manifest_integration.py`
  and `test_resume_injection.py` (cap to manifest to resume end to end),
  `test_cli_jobs.py`, `test_cli_resume.py`, `test_cli_cap_handoff.py`.
- The same seam is validated against real `pw.x` DFT on ALCF Aurora in the
  companion example PR (bulk Si and a centered H2O molecule, calc layer and full
  agent stack).
- `ruff check .` passes. `pytest tests/ -k "not tblite"` passes (371 passed, 28
  skipped, 2 deselected).

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [ ] Updated docs / README for any user-facing change

The `chemgraph jobs` and `chemgraph resume` subcommands are self-documenting through
`--help`, and the end-to-end workflow documentation is provided in the companion
example PR.
