### PR TITLE
Add an Aurora Quantum ESPRESSO long-run cap-to-resume example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,11 @@ nwchem.nwi
 nwchem.nwo
 vib*.traj
 
+# Aurora QE example run outputs (drivers/PBS/README are tracked; run dirs are not)
+examples/aurora_qe_longrun/*_run/
+examples/aurora_qe_longrun/agent_e2e_*/
+examples/aurora_qe_longrun/agent_mol_*/
+examples/aurora_qe_longrun/*.o[0-9]*
+
 # Kubernetes secrets (keep secrets.yaml.template, ignore actual secrets)
 k8s/secrets.yaml

--- a/examples/aurora_qe_longrun/IRI_INTEGRATION.md
+++ b/examples/aurora_qe_longrun/IRI_INTEGRATION.md
@@ -1,0 +1,169 @@
+# Future direction: auto-resubmit via the IRI Facility API
+
+This is a design note, not shipped code. It records how the cap-to-resume
+mechanism validated in this example would extend into unattended, cross-allocation
+auto-resubmission through the DOE IRI Facility API, and it explains why that
+extension is purely additive on top of what already exists.
+
+Nothing here is implemented. The goal is to give a reviewer the forward map so the
+current PRs read as a deliberate first layer, complete in their own scope.
+
+## Where auto-resubmit sits in the layering
+
+The shipped feature is **Layer 1: enforcement**, and it runs entirely inside one
+scheduler allocation (one `qsub` window on the compute node). A calculation that
+would exceed the allocation's wall clock self-terminates at an ASE optimizer-step
+boundary, writes a durable partial geometry plus a `run_manifest.json` with
+`status="capped"` and a `pending_next_step`, and `chemgraph resume <session_id>`
+continues from that partial. Within a single allocation this continuation is
+automatic: the agent adopts the prior session's `log_dir`, clears the pending
+step, and resumes from the partial with no human action. The examples here drive
+that path either as one agent run that resumes itself or as a PBS script that runs
+run1 then resume as two processes in the same allocation.
+
+The step that stays manual today is starting the **next** allocation. When a whole
+`qsub` window is exhausted, the compute node is released, so continuing the
+calculation means submitting a fresh `qsub`. Nothing in ChemGraph submits a
+scheduler job, so that next submission is done by a human running `qsub` again.
+
+Auto-resubmit is **Layer 2: continuation across allocations**. A long-lived
+service watches for capped manifests and submits the next allocation's resume job
+itself, so a calculation that needs more wall time than any single allocation
+grants runs to completion across many allocations with no human in the loop. This
+maps directly to the IRI "Long-Term Campaign" science pattern, which names the
+short-allocation / long-calculation mismatch as a target case.
+
+Layer 2 consumes Layer 1's outputs. It adds no requirement back onto Layer 1.
+
+## What the IRI Facility API provides
+
+The IRI Facility API (ALCF reference implementation:
+`github.com/argonne-lcf/alcf-facility-api`, forked from
+`doe-iri/iri-facility-api-python`) is a REST service that standardizes job
+submission and status across DOE facilities. A live instance runs at
+`api.alcf.anl.gov`; NERSC and ESnet run their own. Each facility maps the standard
+endpoints onto its local scheduler through a `FacilityAdapter` implementation.
+
+The compute endpoints relevant to Layer 2:
+
+| Purpose | HTTP | Path | operation_id |
+|---------|------|------|--------------|
+| Submit a job | POST | `/job/{resource_id}` | `launchJob` |
+| Update a job | PUT | `/job/{resource_id}/{job_id}` | `updateJob` |
+| Get one job's status | GET | `/status/{resource_id}/{job_id}` | `getJob` |
+| List jobs | POST | `/status/{resource_id}` | `getJobs` |
+| Cancel a job | DELETE | `/cancel/{resource_id}/{job_id}` | `cancelJob` |
+
+A submission carries a scheduler-agnostic `JobSpec`. The fields that matter for a
+resume job, and their source in this example's PBS scripts:
+
+| JobSpec field | Meaning | Source in our PBS script |
+|---------------|---------|--------------------------|
+| `executable` + `arguments` | what to run | `chemgraph resume <session_id>` |
+| `environment` (dict) | env vars for the job | the `export` block (`ESPRESSO_PSEUDO`, proxy vars, the LLM model) |
+| `directory` | working directory | the per-job work dir |
+| `stdout_path` / `stderr_path` | output capture | `#PBS -j oe` target |
+| `launcher` | `mpirun` / `srun` | the `mpiexec` in `ASE_ESPRESSO_COMMAND` |
+| `resources.node_count` / `process_count` | node/rank counts | `#PBS -l select`, `NRANKS` |
+| `attributes.duration` | wall time in seconds | `#PBS -l walltime` |
+| `attributes.queue_name` | queue / partition | `#PBS -q debug` |
+| `attributes.account` | project to charge | `#PBS -A ChemGraph` |
+
+Status comes back as a `JobStatus` with a PSI-J-derived `state` enum
+(`new` / `queued` / `held` / `active` / `completed` / `failed` / `canceled`), a
+single `time` timestamp (seconds since epoch), and an `exit_code`.
+
+## How Layer 2 would use it
+
+A login-node service (the compute node is gone once a job caps, so submission has
+to originate somewhere persistent) would:
+
+1. Poll for `run_manifest.json` files whose `status` is `capped`.
+2. Read the `session_id` and the `pending_next_step` (whose `input_structure_file`
+   is the saved partial geometry).
+3. Build a `JobSpec` with `executable="chemgraph"`,
+   `arguments=["resume", session_id]`, the environment and resource fields copied
+   from the original submission, and `attributes.duration` set to a fresh
+   allocation window.
+4. POST it to `launchJob`.
+5. Poll `getJob` until the state is terminal, then repeat from step 1 if the new
+   run capped again.
+
+The `chemgraph resume <session_id>` path already exists and is validated in this
+example. Layer 2 only chooses when and where to invoke it.
+
+### How the two layers fit together
+
+It may help to state the division of labour, since the within-allocation half is
+already in place. The agent layer (validated here on real QE) handles everything
+inside a single allocation: it caps at a step boundary, writes the partial and
+manifest, and on resume adopts the prior `log_dir`, clears the pending step, and
+continues. The launcher layer described above would handle only the transition to
+the next allocation: notice a capped manifest and submit the follow-on job. The
+two communicate through three seams that already exist, so the launcher would not
+need to touch the agent or calculator code:
+
+- **detection**: the manifest's `status="capped"` field tells the launcher a
+  follow-on is due;
+- **continuation key**: `session_id` is all the launcher needs to pass on, since
+  resume resolves the `log_dir`, partial geometry, and pending step from it;
+- **time authority**: each allocation sets its own
+  `CHEMGRAPH_ALLOCATION_DEADLINE`, so the launcher supplies a fresh window per
+  submission and the agent enforces it.
+
+The IRI Facility API is one way to implement the launcher, and a convenient one
+where portability across facilities matters. A simpler login-node loop that calls
+`qsub` directly would use the same three seams. Either way, the choice is confined
+to the launcher layer and leaves the shipped enforcement path unchanged.
+
+## Why this is additive, with no breaking change to the current PRs
+
+Three properties keep Layer 2 outside the scope of the shipped work:
+
+1. **The manifest is forward-compatible by construction.** `run_manifest.json`
+   carries a `schema_version` (currently 1) and is read with a permissive JSON
+   loader that tolerates unknown keys. Any field Layer 2 might want later (a
+   facility job id, a submission timestamp, an `iri_*` block) can be added without
+   breaking an older reader. None of those fields are needed now.
+
+2. **Our deadline stays authoritative.** `JobStatus` reports a state and one
+   timestamp; it exposes no live "seconds remaining". The cap already computes its
+   own deadline from `CHEMGRAPH_ALLOCATION_DEADLINE` (absolute epoch) minus
+   `CHEMGRAPH_ALLOCATION_MARGIN`, read fresh from the environment on each run. That
+   self-computed deadline remains the single source of truth whether or not a
+   Facility API sits above it, so adopting IRI changes nothing in the enforcement
+   path.
+
+3. **The join key is already `session_id`.** Resume finds the prior run's
+   `log_dir` (and thus its manifest and partial geometry) through the session
+   store, keyed by `session_id`. The facility's own `Job.id` is bookkeeping for
+   the resubmitter, so it belongs to Layer 2 and never has to enter the manifest.
+
+## What Layer 2 additionally requires (and why it is deferred)
+
+These are the reasons Layer 2 is a separate future effort held apart from the
+current validation:
+
+- **A non-demo facility adapter.** The reference implementation ships a demo
+  adapter that returns fake data; a real submission needs the facility's adapter
+  wired to the live scheduler behind `api.alcf.anl.gov`.
+- **A separate Globus scope.** The Facility API authorizes through Globus and
+  needs an `iri-api` scope. That is distinct from the inference scope this
+  example's LLM calls already use, and it requires the account to be registered
+  with the IRI resource server.
+- **A persistent login-node service.** Submission has to run somewhere that
+  outlives the capped compute-node process.
+
+Because none of these can be exercised without live facility access, Layer 2 would
+be developed the same way VASP support is: written against the documented
+interface and unit-tested hermetically, with a clear label that it has not been
+run against the live API. The validated real-DFT results in this example stay
+scoped to Layer 1 (the cap-to-resume mechanism on real Quantum ESPRESSO).
+
+## Relationship to other layers already in the codebase
+
+Layer 2 is also distinct from the Parsl / Academy launcher path. That launcher is
+the natural place to export `CHEMGRAPH_ALLOCATION_DEADLINE` into each worker so the
+cap knows its window; the Facility API is the transport that resubmits a fresh
+allocation after a cap. They compose (a launcher sets the deadline; the Facility
+API submits the next allocation) and neither one changes the enforcement code.

--- a/examples/aurora_qe_longrun/README.md
+++ b/examples/aurora_qe_longrun/README.md
@@ -1,0 +1,254 @@
+# Aurora QE long-run cap to resume validation
+
+This example validates ChemGraph's **long-running-calculation** support on **real
+Quantum ESPRESSO DFT** on ALCF Aurora: a calculation that would exceed the job's
+wall-clock allocation self-terminates at an ASE optimizer-step boundary, writes a
+durable *partial geometry* plus manifest, and a later `chemgraph resume` continues
+from that partial and skips recomputing from scratch.
+
+The core principle is **enforcement by deadline**. The run makes no attempt to
+guess whether the next step will fit in the remaining time. It runs steps until a
+wall-clock deadline (`CHEMGRAPH_ALLOCATION_DEADLINE` / `_SECONDS`, minus a safety
+`_MARGIN`) is crossed at a step boundary, then stops cleanly with a resumable
+artifact. The cap is *soft*: it is checked only between optimizer steps and leaves
+an in-flight SCF untouched, so the margin must exceed one SCF step's wall time.
+
+> The fast, portable, CI-run version of these checks lives in the repo's unit
+> tests (`tests/test_cap*.py`, `tests/test_manifest.py`,
+> `tests/test_allocation_cap.py`, `tests/test_resume_injection.py`,
+> `tests/test_mace_cap.py`) using the in-process EMT/MACE calculators. This
+> directory is the **real-DFT, HPC counterpart**. It needs Aurora plus QE plus an
+> LLM endpoint and therefore cannot run in CI, yet it proves the same seam
+> end-to-end on a subprocess DFT engine, which is the ultimate target.
+
+## What each route exercises
+
+| File | Route | Stack exercised |
+|------|-------|-----------------|
+| `qe_cap_driver.py` | **Route 1, calc layer** | `run_ase_core` calls QE directly, with no LLM/agent. Proves the cap fires at a step boundary, writes a resumable partial, and a resume continues to the same energy. |
+| `qe_agent_e2e.py` | **Route 2, full agent** | real LLM to LangGraph `single_agent` to `run_ase` ToolNode (JSON-serialized return) to `run_ase_core` to QE, plus the manifest hook and `chemgraph resume`. Proves the layers Route 1 bypasses: tool-arg unwrapping, JSON tool-message parsing, `tool_call_id` correlation, clear-pending-on-success (M2), and log_dir adoption on resume (M3). |
+
+Route 2 is the real production path. Route 1 is the isolation check you run first
+to confirm QE plus pseudopotentials plus the cap seam work before adding LLM
+variance.
+
+### Periodic and non-periodic: two systems, two code paths
+
+Route 1 covers **both** DFT k-point regimes, because they run different code:
+
+- **Bulk Si (`smoke`/`cap`/`resume`)** is fully periodic (`pbc=[T,T,T]`), so the
+  configured Monkhorst-Pack mesh is used verbatim. This is the original seam check.
+- **H2O molecule (`mol_smoke`/`mol_cap`/`mol_resume`)** is non-periodic
+  (`pbc=[F,F,F]`, no cell), so it exercises the molecule path added on this branch:
+  `is_nonperiodic(atoms)` then `atoms.center(vacuum=…)` (a finite box for the
+  plane-wave basis) then **`K_POINTS gamma`** (a Monkhorst-Pack mesh is
+  meaningless for an isolated molecule). Bulk Si leaves this path untouched, so the
+  H2O stages are what validate the molecule fix on live `pw.x`. `mol_smoke` and
+  `mol_cap` grep the generated `espresso.pwi` for `K_POINTS gamma` plus a finite
+  cell, and `mol_resume` asserts the relaxed geometry lands in the cross-code
+  plane-wave-PBE water band (see *Validated results*).
+
+## Files
+
+- `qe_cap_driver.py`: Route 1 driver. Bulk-Si stages `smoke` | `cap` | `resume`;
+  H2O-molecule stages `mol_smoke` | `mol_cap` | `mol_resume`.
+- `qe_agent_e2e.py`: Route 2 driver, stages `run1` | `resume`.
+- `run_qe_cap.pbs`: PBS batch script for Route 1 bulk-Si (runs all three bulk-Si
+  stages `smoke` | `cap` | `resume` in one allocation).
+- `run_qe_mol.pbs`: PBS batch script for Route 1 H2O molecule (runs all three
+  `mol_*` stages in one allocation, covering the non-periodic gamma/centering path).
+- `run_agent_e2e.pbs`: PBS batch script for Route 2 bulk Si (run1 **then** resume
+  in one allocation, as two separate processes so the resume genuinely re-adopts
+  state).
+- `run_agent_mol.pbs`: PBS batch script for Route 2 H2O molecule (same run1
+  **then** resume flow with `QE_SYSTEM=h2o`, driving the non-periodic
+  gamma/centering path through the full agent stack).
+
+## Prerequisites (Aurora)
+
+1. **ChemGraph installed** in a Python environment; point `PY` in the PBS script
+   at it.
+2. **Quantum ESPRESSO `pw.x`**. Aurora ships a prebuilt binary at
+   `/soft/applications/quantum_espresso/…/bin/pw.x` (see `QE_BIN` in the scripts).
+3. **Pseudopotentials**: a directory pointed to by `ESPRESSO_PSEUDO` (default
+   `$HOME/qe_pseudo`) holding, for the bulk-Si stages, `Si.UPF` (PBE), and for the
+   H2O molecule stages the matching pslibrary USPP PBE H/O pseudos
+   `H.pbe-rrkjus_psl.1.0.0.UPF` and `O.pbe-n-rrkjus_psl.1.0.0.UPF`. Fetch the H/O
+   pair (same family, functional, and type as the Si pseudo: pslibrary 1.0.0
+   ultrasoft PBE) from the QE pseudopotential library:
+   ```bash
+   cd "$ESPRESSO_PSEUDO"
+   base=https://pseudopotentials.quantum-espresso.org/upf_files
+   curl -sSLO $base/H.pbe-rrkjus_psl.1.0.0.UPF
+   curl -sSLO $base/O.pbe-n-rrkjus_psl.1.0.0.UPF
+   ```
+4. **An LLM endpoint** (Route 2 only). These scripts use the ALCF inference API
+   (`openai/gpt-oss-120b`) reached through the ALCF HTTP proxy. Put a valid ALCF
+   access token at `~/.alcf_token` (the driver reads it into `ALCF_ACCESS_TOKEN`;
+   see the repo's ALCF auth notes). Aurora compute nodes have no direct outbound
+   network, hence the `*_PROXY` block in `run_agent_e2e.pbs`.
+
+## Run it
+
+```bash
+cd examples/aurora_qe_longrun
+
+# Route 1, bulk Si (no LLM): prove the cap seam on real QE in isolation.
+qsub run_qe_cap.pbs
+
+# Route 1, H2O molecule (no LLM): prove the non-periodic gamma/centering path.
+qsub run_qe_mol.pbs
+
+# Route 2, bulk Si (full agent): run1 (capped) then resume, in one allocation.
+qsub run_agent_e2e.pbs
+
+# Route 2, H2O molecule (full agent): the non-periodic path through the agent stack.
+qsub run_agent_mol.pbs
+```
+
+The Route 2 scripts write each job to a fresh per-job work dir under the submit
+directory (`agent_e2e_<jobid>` / `agent_mol_<jobid>`), so a resubmission stays
+clean of a prior attempt. The Route 1 scripts reuse a fixed run dir (`cap_run` /
+`mol_run`) across resubmissions; the cap stage overwrites the partial-path
+pointer each time. Each script echoes `RUN1 OK` / `RESUME OK` (Route 2) or
+`CAP OK` / `RESUME OK` (Route 1) plus the manifest JSON. The drivers `assert` every invariant, so a
+non-zero exit signals a real regression.
+
+## Validated results
+
+> ### Scope: these runs validate the mechanism
+>
+> The runs below validate the **flow**: the cap-to-resume seam, and for H2O the
+> non-periodic Gamma/centering code path on live `pw.x`. They make no claim about
+> the physical accuracy of the numbers. Cutoffs, vacuum padding, and convergence
+> thresholds are sized for a fast validation run that fits one debug allocation,
+> well short of a converged production calculation. The geometry band is a coarse
+> sanity guard that catches a broken run (a blown-up geometry from a wrong k-mesh
+> or a zero cell); read it as a coarse pass/fail guard; a converged accuracy figure is a separate goal. A
+> physically-rigorous convergence study is a planned future update of this example.
+
+### Route 1 and Route 2, bulk Si
+
+Measured on the Aurora `debug` queue (account `ChemGraph`), 2026-07-28. System:
+rattled 2-atom Si diamond, `ecutwfc=25 Ry`, `2×2×2` k-mesh, PBE, ~1 s/SCF at 8 MPI
+ranks.
+
+- **Route 1 (calc layer):** cap fired at an optimizer step boundary, left
+  `*_opt.partial.xyz` plus `*_opt.restart.json` plus `*_opt.traj`, and exited
+  cleanly with no walltime kill. Resume from the partial converged to the **same**
+  energy as a single uncapped opt, **-308.187965 eV**, so the cap preserves the
+  result.
+- **Route 2 (full agent):** run1 capped mid-opt (24.2 s), manifest
+  `status=capped` with a PENDING step whose `input_structure_file` is the partial;
+  resume (fresh process, new default log_dir) adopted run1's log_dir
+  from the session DB (**M3**), cleared pending and reset status to
+  `running` (**M2**), continued from the partial, and converged to
+  **-308.18796684 eV**.
+- **Route 2 under langgraph 1.x:** the same flow re-run after the
+  upstream dependency major-bump (langgraph 1.2.9 / langchain 1.x) behaves
+  identically and converges to **-308.18796440 eV** (about 1e-6 eV of BFGS noise
+  away from the other runs).
+
+### Route 1, H2O molecule (non-periodic Gamma path), 2026-07-30
+
+System: ASE `molecule("H2O")` (`pbc=[F,F,F]`, cell-less) centered into a 6 Å
+vacuum box by `ase_core`; `ecutwfc=50`, `ecutrho=400 Ry`, PBE, pslibrary USPP H/O
+pseudos, 8 MPI ranks, about 14 s/SCF. All three `mol_*` stages passed (`rc=0`):
+
+- **`mol_smoke`:** single-point **-473.2192 eV**. The generated `espresso.pwi`
+  carries `K_POINTS gamma` plus a finite `CELL_PARAMETERS`, so the centering
+  reached the writer and the new `is_nonperiodic` to `center(vacuum)` to gamma path
+  drove real pw.x.
+- **`mol_cap`:** BFGS capped at a step boundary after 2 steps (49.9 s of an
+  about 50 s effective window), leaving `h2o_cap_opt.partial.xyz` plus
+  `.restart.json` plus `.traj`; the `.pwi` again shows `K_POINTS gamma` plus a
+  finite cell.
+- **`mol_resume`:** uncapped resume from the partial converged in 7 BFGS steps
+  (fmax 2.71 down to 0.006) to **-473.2196 eV**. Relaxed geometry
+  **r(O-H) = 0.9709 / 0.9710 Å, ∠(H-O-H) = 104.40°**, inside the cross-code
+  plane-wave-PBE band (0.96-1.00 Å, 102-106°; compare JDFTx PBE about 0.98 Å /
+  103.7°, experiment 0.9572 Å / 104.52°).
+
+The cap left a resumable partial and the resume continued to a converged,
+physically-sensible water geometry, so the molecule cap-to-resume flow works
+end-to-end on real DFT.
+
+### Route 2, H2O molecule (full agent stack), 2026-07-30
+
+The same non-periodic Gamma/centering path as the Route 1 H2O run, driven this
+time through the whole agent stack (real LLM to `single_agent` to `run_ase` to
+`run_ase_core` to QE, plus the manifest hook and `chemgraph resume`), so it
+covers the molecule fix and the layers Route 1 bypasses at once. Same system and
+settings as the Route 1 H2O run (`molecule("H2O")` centered into a 6 Å vacuum
+box, `ecutwfc=50`, `ecutrho=400 Ry`, PBE, pslibrary USPP H/O pseudos, 8 MPI
+ranks). Both stages passed (`rc=0`):
+
+- **run1 (capped):** the agent called `run_ase` once, BFGS capped at a step
+  boundary after 4 steps (66.6 s effective wall-clock), single-point
+  **-473.2142 eV** for the partial. The manifest recorded `status=capped` with a
+  PENDING step whose `input_structure_file` is the partial geometry, and the
+  generated `espresso.pwi` carries `K_POINTS gamma` plus a `CELL_PARAMETERS`
+  block (the agent path asserts the block is present; the finite-volume cell
+  check is done by the Route 1 driver).
+- **resume (fresh process):** adopted run1's `log_dir` from the session DB
+  (**M3**), cleared the pending step and reset `status` (**M2**), continued from
+  the partial, and converged to **-473.2196 eV** (matching the Route 1 H2O
+  resume). The resume `espresso.pwi` again shows `K_POINTS gamma` plus a
+  `CELL_PARAMETERS` block, and the relaxed geometry is **r(O-H) = 0.9709 / 0.9710 Å,
+  ∠(H-O-H) = 104.43°**, inside the cross-code plane-wave-PBE band (0.96-1.00 Å,
+  102-106°).
+
+So the full agent stack reproduces the calc-layer physics on the molecule path:
+the same converged energy and a water geometry that matches the Route 1 result to
+within BFGS noise, with the cap and resume driven entirely through the LLM tool
+layer.
+
+### Resume-prompt hardening (a real lesson, baked into `qe_agent_e2e.py`)
+
+An early Route 2 resume attempt failed because the prompt asked the LLM to echo
+the **full absolute** partial-geometry path. `gpt-oss-120b` then (a) dropped the
+required single `params` wrapper and (b) mistyped the path, burning every
+recursion with zero successful tool calls, so the clear-on-success (M2) path never
+even ran. The state machine behaved correctly (nothing succeeded, so nothing was
+cleared); the failure was in the *prompt*.
+
+The fix lives on the prompt side:
+
+- Hand the model only the **bare basename** (`si_agent_opt.partial.xyz`), which
+  leaves no long path to mistype. It still resolves because resume adopts the prior
+  session's `log_dir` into `CHEMGRAPH_LOG_DIR` (M3) and `run_ase`'s input path is
+  resolved against that dir. (This rescues a bare name; a mistyped absolute path is
+  still on the model to get right.)
+- Spell out the single-`params`-argument tool contract explicitly.
+
+A healthy Route 2 log still shows a benign `Error invoking tool 'run_ase' … params:
+Field required` line. That is the model's **own** self-correcting retry: the first
+call omitted the `params` wrapper and the next message re-sent it correctly. It is
+expected, and it is separate from any framework error.
+
+## Porting to another HPC
+
+The cap-to-manifest-to-resume machinery itself is fully portable (that is what the
+in-process unit tests prove on any laptop). Only this HPC *harness* is
+Aurora-specific. To run it elsewhere, edit the marked sections of the PBS scripts:
+
+- **Scheduler directives:** the `#PBS -A/-q/-l …` lines. On a Slurm site, rewrite
+  them as `#SBATCH …` and submit with `sbatch`.
+- **Environment modules:** the `module load oneapi/… mpich/… hdf5/…` lines become
+  whatever provides an MPI plus QE toolchain on your machine.
+- **`QE_BIN`:** path to your `pw.x`.
+
+> **Note on version pins.** The exact QE build path in `QE_BIN`
+> (`.../quantum_espresso/7.5-oneapi2025.0.5/...`) and the `mpich/opt/develop-git.<hash>`
+> snapshot module are point-in-time Aurora values and will drift as the facility
+> updates its software stack. They are pinned deliberately so a run is reproducible,
+> and `set -euo pipefail` makes a stale path fail loudly at launch. Refresh both
+> against the current `module avail` / `/soft/applications` on the day you run.
+- **`ESPRESSO_PSEUDO`:** your pseudopotential directory (needs `Si.UPF`, plus the
+  H/O pseudos for the molecule stages).
+- **`PY`:** a Python with ChemGraph installed.
+- **LLM plus proxy** (Route 2): the `*_PROXY` block is only needed on networks that
+  firewall compute nodes (like Aurora). If your LLM endpoint is directly reachable,
+  drop it. To use a different model or endpoint, change `QE_LLM_MODEL` and the auth
+  the driver loads (for example `OPENAI_API_KEY` plus an `api.openai.com` model in
+  place of the ALCF token).

--- a/examples/aurora_qe_longrun/README.md
+++ b/examples/aurora_qe_longrun/README.md
@@ -252,3 +252,19 @@ Aurora-specific. To run it elsewhere, edit the marked sections of the PBS script
   drop it. To use a different model or endpoint, change `QE_LLM_MODEL` and the auth
   the driver loads (for example `OPENAI_API_KEY` plus an `api.openai.com` model in
   place of the ALCF token).
+
+## Future direction: unattended auto-resubmit
+
+Within one allocation (one `qsub` window), resume is already automatic: when the
+cap fires, the agent continues from the saved partial on its own, and the example
+PBS scripts also show resume as a fresh process in the same allocation. The step
+that is still manual is starting the *next* allocation: once a `qsub` window is
+exhausted the compute node is released, and ChemGraph does not submit scheduler
+jobs, so continuing across a fresh allocation means running `qsub` again by hand.
+A later layer would submit that next allocation automatically, so a calculation
+longer than any single allocation runs to completion across many allocations with
+no human in the loop. The design for that layer, built on the DOE IRI Facility
+API, is written up in [`IRI_INTEGRATION.md`](IRI_INTEGRATION.md), including the
+endpoint and field mapping, why it is additive on top of the current manifest (no
+schema break), and what live-facility access it would need. It is a design note;
+none of it is implemented here.

--- a/examples/aurora_qe_longrun/qe_agent_e2e.py
+++ b/examples/aurora_qe_longrun/qe_agent_e2e.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python
+"""Route 2: full ChemGraph AGENT end-to-end validation of the cap->manifest->
+resume seam on real Quantum ESPRESSO DFT.
+
+Unlike qe_cap_driver.py (which calls run_ase_core directly), this drives the
+WHOLE stack: real LLM -> LangGraph single_agent -> run_ase tool (ToolNode,
+JSON-serialized return) -> run_ase_core -> QE, plus the manifest hook that
+records the capped step and the `chemgraph resume` log_dir adoption. It exercises
+exactly the layers the cap commits touched (C2 arg-unwrap, Seam1 JSON parse,
+C3 id-correlation, M2 clear-on-success, M3 log_dir adoption) which the calc-layer
+route (run_ase_core direct) bypasses.
+
+The physical system is selected by the QE_SYSTEM env var:
+
+  si   (default) -- a rattled 2-atom Si diamond cell, fully periodic (pbc all
+                    True). The original agent-seam check; the configured k-mesh is
+                    used verbatim.
+  h2o            -- an ASE molecule("H2O"), non-periodic (pbc all False, cell-less).
+                    This routes the WHOLE agent stack through the branch's molecule
+                    code path (is_nonperiodic -> atoms.center(vacuum) -> K_POINTS
+                    gamma), so it proves that path drives real pw.x end to end
+                    through the LLM/tool/manifest/resume layers as well, extending
+                    the calc-layer coverage in qe_cap_driver.py. For h2o, both
+                    stages also grep the generated espresso.pwi for K_POINTS
+                    gamma plus a CELL_PARAMETERS block (a presence check; the
+                    finite-volume cell check is done by the Route 1 driver).
+
+Two stages, selected by argv[1]:
+
+  run1    -- LLM optimizes the rattled system with QE under a wall-clock cap set
+             so the opt is capped mid-flight. Verify the manifest (in the agent's
+             OWN auto-generated log_dir) records status='capped', a step with
+             status='capped', and a PENDING NEXT STEP whose input_structure_file
+             is the readable *_opt.partial.xyz. The session_id + its log_dir are
+             printed and the session is persisted to ~/.chemgraph/sessions.db.
+  resume  -- `chemgraph resume`-equivalent: a FRESH agent (new uuid, new default
+             log_dir) with resume_from=<sid> and NO cap. Verify M3 adopts the
+             prior session's log_dir from the DB, the manifest is re-pointed at
+             the prior file, the LLM continues from the partial to convergence,
+             and M2 clears pending / resets status.
+
+CAP TIMING (the subtle part): the env cap is measured from module import, but the
+agent path adds a variable LLM round-trip before the tool runs. A fixed small
+SECONDS budget would be spent by the LLM latency and cap at step 0 (no partial).
+So run1 sets an ABSOLUTE CHEMGRAPH_ALLOCATION_DEADLINE *right before* cg.run(),
+after the LLM+agent are built, and uses an unreachable fmax so the opt can never
+converge inside the window -- the cap then fires at a step boundary regardless of
+how long the LLM took. NOTE: this makes CHEMGRAPH_ALLOCATION_* effective per the
+env read at tool-exec time; run_ase_core reads them live, so setting them after
+import is fine (they are not cached at import).
+
+M3 (log_dir adoption) is only genuinely tested if the resume stage does NOT
+pre-set CHEMGRAPH_LOG_DIR to the run1 dir -- otherwise the fresh agent would land
+in the same dir for the trivial reason. So the resume stage explicitly UNSETS it
+and relies on the DB lookup to bring the agent home.
+"""
+import asyncio
+import json
+import os
+import sys
+import time
+
+STAGE = sys.argv[1] if len(sys.argv) > 1 else "run1"
+WORK = os.environ["WORK_DIR"]  # parent dir that holds session_id.txt across stages
+os.makedirs(WORK, exist_ok=True)
+os.chdir(WORK)
+
+# LLM auth: load the ALCF token into the env var ChemGraph reads. Never echo it.
+os.environ["ALCF_ACCESS_TOKEN"] = open(os.path.expanduser("~/.alcf_token")).read().strip()
+
+MODEL = os.environ.get("QE_LLM_MODEL", "openai/gpt-oss-120b")
+SESSION_FILE = os.path.join(WORK, "session_id.txt")
+
+# Which physical system the agent drives. "si" keeps the original periodic seam
+# check; "h2o" routes the same agent stack through the non-periodic Gamma path.
+SYSTEM = os.environ.get("QE_SYSTEM", "si").lower()
+STRUCT = os.path.join(WORK, f"{SYSTEM}_agent.xyz")
+
+# Effective-window controls (seconds). Budget must comfortably exceed the LLM
+# round-trip + a couple SCF steps; the unreachable fmax guarantees the cap, not
+# convergence, ends run1. Margin must exceed one SCF step (~2s here).
+# window is deliberately generous: effective budget = window - margin - T_llm,
+# and T_llm (LLM round-trip, incl. any self-correct retries) is variable. An
+# unreachable fmax means a larger window only runs a few more steps before the
+# cap (the opt can never converge before the cap fires), so we size the
+# window so even a slow LLM leaves >= 1 completed SCF step (a real partial).
+CAP_WINDOW = float(os.environ.get("QE_CAP_WINDOW", "40"))   # deadline = now + this
+CAP_MARGIN = float(os.environ.get("QE_CAP_MARGIN", "8"))    # > one SCF step
+
+# The calculator config the LLM must marshal into run_ase(params=...). Given
+# verbatim in the prompt so the model drives the calc and does not invent
+# chemistry. One config per system; the h2o config carries no kpts, so the
+# non-periodic branch emits K_POINTS gamma, and a vacuum for the plane-wave box.
+CALC_BY_SYSTEM = {
+    "si": {
+        "calculator_type": "espresso",
+        "pseudopotentials": {"Si": "Si.UPF"},
+        "pseudo_dir": os.environ["ESPRESSO_PSEUDO"],
+        "ecutwfc": 25.0,
+        "kpts": [2, 2, 2],
+        "xc": "PBE",
+        "input_data": {
+            "conv_thr": 1e-6, "mixing_beta": 0.3, "electron_maxstep": 80,
+        },
+    },
+    "h2o": {
+        "calculator_type": "espresso",
+        "pseudopotentials": {
+            "H": "H.pbe-rrkjus_psl.1.0.0.UPF",
+            "O": "O.pbe-n-rrkjus_psl.1.0.0.UPF",
+        },
+        "pseudo_dir": os.environ["ESPRESSO_PSEUDO"],
+        "ecutwfc": 50.0,
+        "ecutrho": 400.0,  # 8*ecutwfc; ultrasoft O needs a dense charge grid
+        "xc": "PBE",
+        "vacuum": 6.0,
+        "input_data": {
+            "conv_thr": 1e-7, "mixing_beta": 0.3, "electron_maxstep": 120,
+        },
+    },
+}
+if SYSTEM not in CALC_BY_SYSTEM:
+    sys.exit(f"unknown QE_SYSTEM={SYSTEM!r}; expected one of {list(CALC_BY_SYSTEM)}")
+CALC = CALC_BY_SYSTEM[SYSTEM]
+CALC_JSON = json.dumps(CALC)
+
+# Per-system nouns for the prompts: Si is a periodic "crystal structure", H2O is
+# an isolated "molecule". Keeps each prompt physically honest.
+NOUN = "molecule" if SYSTEM == "h2o" else "crystal structure"
+
+
+def _banner(m):
+    print(f"\n{'=' * 70}\n{m}\n{'=' * 70}", flush=True)
+
+
+def build_struct():
+    """Write the starting geometry for the selected system.
+
+    Si: rattled diamond cell (periodic). H2O: an ASE molecule, left cell-less and
+    non-periodic so the agent stack exercises the center(vacuum) -> Gamma path.
+    """
+    from ase.build import bulk, molecule
+    from ase.io import write
+    if SYSTEM == "h2o":
+        atoms = molecule("H2O")
+        atoms.rattle(stdev=0.08, seed=1)  # perturb so the opt has real work to do
+    else:
+        atoms = bulk("Si", "diamond", a=5.43)
+        atoms.rattle(stdev=0.05, seed=1)
+    write(STRUCT, atoms)
+    return STRUCT
+
+
+def water_geometry(numbers, positions):
+    """Return (r1, r2, angle_deg) for the O,H,H atoms, for the h2o band check."""
+    import numpy as np
+    numbers = list(numbers)
+    positions = np.asarray(positions, dtype=float)
+    o = numbers.index(8)
+    hs = [i for i, z in enumerate(numbers) if z == 1]
+    v1, v2 = positions[hs[0]] - positions[o], positions[hs[1]] - positions[o]
+    r1, r2 = float(np.linalg.norm(v1)), float(np.linalg.norm(v2))
+    cos = float(np.dot(v1, v2) / (r1 * r2))
+    ang = float(np.degrees(np.arccos(max(-1.0, min(1.0, cos)))))
+    return r1, r2, ang
+
+
+def _newest_matching(pattern, *roots):
+    """Newest file matching pattern under any of roots (recursive), or None.
+
+    The agent path splits its outputs across two dirs: the BFGS .traj and manifest
+    follow CHEMGRAPH_LOG_DIR (the adopted log_dir), while EspressoCalc writes its
+    .pwi into its own `directory` field, which defaults to '.' (the process cwd =
+    WORK). Searching both roots finds the file wherever it landed.
+    """
+    import glob
+    hits = []
+    for root in roots:
+        if root and os.path.isdir(root):
+            hits += glob.glob(os.path.join(root, "**", pattern), recursive=True)
+    hits = sorted(set(hits), key=os.path.getmtime)
+    return hits[-1] if hits else None
+
+
+def assert_gamma_pwi(log_dir, tag):
+    """For h2o only: the newest espresso.pwi must carry K_POINTS gamma plus a
+    CELL_PARAMETERS block (a substring presence check). This confirms the agent
+    path drove the non-periodic centering/Gamma code and ruled out a stray
+    k-mesh. The rigorous non-degenerate/finite-volume cell check is done by the
+    Route 1 driver (qe_cap_driver.py)."""
+    if SYSTEM != "h2o":
+        return
+    pwi = _newest_matching("*.pwi", log_dir, WORK)
+    assert pwi, f"{tag}: no .pwi written under {log_dir} or {WORK}"
+    low = open(pwi).read().lower()
+    assert "k_points gamma" in low, (
+        f"{tag}: espresso.pwi missing 'K_POINTS gamma' (non-periodic path did not "
+        f"drive the writer): {pwi}"
+    )
+    assert "cell_parameters" in low, f"{tag}: .pwi has no CELL_PARAMETERS: {pwi}"
+    print(f"{tag}: gamma+cell-block OK in {os.path.basename(pwi)}", flush=True)
+
+
+def show_manifest(log_dir, tag):
+    path = os.path.join(log_dir, "run_manifest.json")
+    _banner(f"MANIFEST ({tag}) @ {path}")
+    if not os.path.isfile(path):
+        print("  <no manifest file>")
+        return None
+    data = json.load(open(path))
+    print(json.dumps(data, indent=2, default=str)[:3000], flush=True)
+    return data
+
+
+# Import chemgraph AFTER env setup (token, pseudo). Allocation env is set later,
+# per-stage, and read live by run_ase_core at tool-exec time.
+from chemgraph.agent.llm_agent import ChemGraph  # noqa: E402
+
+
+if STAGE == "run1":
+    build_struct()
+    # Hardening (see the resume stage and README): handing the LLM a long ABSOLUTE
+    # path invites two failures we actually observed here: the model drops the
+    # required single `params` wrapper AND abbreviates the path (e.g. to
+    # "/home/rez.../h2o_agent.xyz"), which then fails to resolve. Give it just the
+    # basename: build_struct writes the file into WORK, the driver's cwd, so
+    # run_ase's `_resolve_existing_path` finds a bare name against cwd. Also spell
+    # out the single-`params`-argument contract explicitly.
+    struct_name = os.path.basename(STRUCT)
+    prompt = (
+        f"Optimize the geometry of the {NOUN} saved in the file named "
+        f"'{struct_name}' using Quantum ESPRESSO. Call the run_ase tool exactly "
+        f"ONCE. The run_ase tool takes a SINGLE argument named 'params' whose "
+        f"value is an object; put ALL of the following inside params: "
+        f"driver='opt', optimizer='bfgs', fmax=0.0001, steps=200, "
+        f"input_structure_file='{struct_name}' (use exactly that filename, do not "
+        f"add any directory path and do not alter a single character), and this "
+        f"exact calculator configuration: {CALC_JSON}. Then report the final "
+        f"energy."
+    )
+    cg = ChemGraph(
+        model_name=MODEL, workflow_type="single_agent",
+        return_option="last_message", recursion_limit=25,
+    )
+    sid = cg.session_id
+    log_dir = cg.log_dir
+    with open(SESSION_FILE, "w") as fh:
+        fh.write(sid + "\n")
+    print(f"session_id={sid}\nlog_dir={log_dir}", flush=True)
+
+    # Set the ABSOLUTE deadline now, after the agent is built and just before the
+    # run, so the LLM round-trip does not eat the budget (see module docstring).
+    os.environ["CHEMGRAPH_ALLOCATION_DEADLINE"] = str(time.time() + CAP_WINDOW)
+    os.environ["CHEMGRAPH_ALLOCATION_MARGIN"] = str(CAP_MARGIN)
+    os.environ.pop("CHEMGRAPH_ALLOCATION_SECONDS", None)
+    print(f"cap: deadline=now+{CAP_WINDOW}s  margin={CAP_MARGIN}s", flush=True)
+
+    t0 = time.time()
+    out = asyncio.run(cg.run(prompt))
+    _banner(f"RUN1 FINAL MESSAGE (agent wall={time.time() - t0:.1f}s)")
+    print(str(getattr(out, "content", out))[:1500], flush=True)
+
+    data = show_manifest(log_dir, "after run1")
+    assert data is not None, "no manifest written -- did the LLM call run_ase?"
+    status = data.get("status")
+    pending = data.get("pending_next_step")
+    steps = data.get("steps", [])
+    capped = [s for s in steps if s.get("status") == "capped"]
+    print(
+        f"\nstatus={status}  pending={bool(pending)}  n_steps={len(steps)}  "
+        f"capped_steps={len(capped)}",
+        flush=True,
+    )
+    assert status == "capped", f"expected manifest status 'capped', got {status!r}"
+    assert capped, "expected >=1 step with status='capped'"
+    assert pending, "expected a PENDING NEXT STEP block"
+    pin = (pending.get("args") or {}).get("input_structure_file", "")
+    print(f"pending input_structure_file={pin}", flush=True)
+    assert pin.endswith("_opt.partial.xyz"), (
+        f"pending input should be the partial geometry, got {pin!r}"
+    )
+    assert os.path.isfile(pin), f"partial geometry not on disk: {pin}"
+    # C2 check: the recorded step args must be UNWRAPPED (driver/calc visible,
+    # not buried under a 'params' key).
+    s0 = capped[0].get("args", {})
+    assert s0.get("driver") == "opt", f"C2 unwrap failed: step args={s0}"
+    # For h2o: the agent path must have driven the non-periodic Gamma/centering
+    # code, so the .pwi it generated must carry K_POINTS gamma + a finite cell.
+    assert_gamma_pwi(log_dir, "run1")
+    print("RUN1 OK: agent recorded a capped step + pending partial-geometry.",
+          flush=True)
+
+elif STAGE == "resume":
+    sid = open(SESSION_FILE).read().strip()
+    print(f"resuming session_id={sid}", flush=True)
+    # M3 is only tested if we do NOT pre-point the fresh agent at the run1 dir.
+    os.environ.pop("CHEMGRAPH_LOG_DIR", None)
+    # No cap this time -> let it converge. Clear any leftover deadline too.
+    for k in ("CHEMGRAPH_ALLOCATION_SECONDS", "CHEMGRAPH_ALLOCATION_DEADLINE"):
+        os.environ.pop(k, None)
+
+    # Look up run1's log_dir from the DB (sid -> log_dir), read its manifest, and
+    # pull the partial-geometry path the cap left behind. This both pre-checks
+    # that run1 really left a resumable pending step and lets us build a concrete,
+    # non-flaky resume prompt (render_for_context injects driver+input but NOT the
+    # calculator config, so a bare "continue" would leave the LLM without the QE
+    # settings and the resume tool call would fail -- never exercising M2).
+    from chemgraph.memory.store import SessionStore  # noqa: E402
+    prior_sess = SessionStore().get_session(sid)
+    prior_log_dir = getattr(prior_sess, "log_dir", None)
+    assert prior_log_dir and os.path.isdir(prior_log_dir), (
+        f"cannot find run1 log_dir for session {sid}: {prior_log_dir!r}"
+    )
+    prior_manifest = json.load(
+        open(os.path.join(prior_log_dir, "run_manifest.json"))
+    )
+    assert prior_manifest.get("status") == "capped", (
+        "run1 manifest is not 'capped' -- run the run1 stage first"
+    )
+    partial = (prior_manifest.get("pending_next_step") or {}).get("args", {}).get(
+        "input_structure_file", ""
+    )
+    assert partial.endswith("_opt.partial.xyz") and os.path.isfile(partial), (
+        f"run1 left no readable partial geometry: {partial!r}"
+    )
+    # Hardening (see the failure documented in README): asking the LLM to echo the
+    # full absolute partial path made it (a) drop the required `params` wrapper and
+    # (b) mistype the path. Both are avoidable:
+    #   - The agent adopts run1's log_dir on resume (M3), and run_ase's input goes
+    #     through `_resolve_existing_path`, which resolves a BARE filename against
+    #     CHEMGRAPH_LOG_DIR. So we hand the model just the basename -- there is no
+    #     long path left to mistype, and it still resolves to the partial.
+    #   - Spell out the single-`params`-argument tool contract explicitly.
+    partial_name = os.path.basename(partial)
+    print(f"run1 log_dir={prior_log_dir}\nrun1 partial={partial}"
+          f"\nresume input (bare name)={partial_name}", flush=True)
+
+    # Loose fmax: from the near-minimum partial this converges in a couple steps,
+    # so the resume completes (uncapped) and M2's clear-on-success fires.
+    resume_prompt = (
+        f"The previous run was capped mid-optimization; a partial {NOUN} geometry "
+        f"was saved to the file named '{partial_name}'. "
+        f"Continue the geometry optimization from that partial geometry using "
+        f"Quantum ESPRESSO. Call the run_ase tool exactly ONCE. The run_ase tool "
+        f"takes a SINGLE argument named 'params' whose value is an object; put ALL "
+        f"of the following inside params: driver='opt', optimizer='bfgs', "
+        f"fmax=0.05, steps=200, input_structure_file='{partial_name}' (use exactly "
+        f"that filename, do not add any directory path and do not alter a single "
+        f"character), and this exact calculator configuration: {CALC_JSON}. "
+        f"Then report the final energy."
+    )
+
+    cg = ChemGraph(
+        model_name=MODEL, workflow_type="single_agent",
+        return_option="last_message", recursion_limit=25,
+    )
+    fresh_default = cg.log_dir  # the auto-generated dir before adoption
+    print(f"fresh agent default log_dir={fresh_default}", flush=True)
+
+    t0 = time.time()
+    out = asyncio.run(cg.run(resume_prompt, resume_from=sid))
+    _banner(f"RESUME FINAL MESSAGE (agent wall={time.time() - t0:.1f}s)")
+    print(str(getattr(out, "content", out))[:1500], flush=True)
+
+    adopted = cg.log_dir
+    print(f"adopted log_dir={adopted}", flush=True)
+    assert adopted != fresh_default, (
+        "M3 FAILED: agent did not adopt the prior log_dir (still on the fresh "
+        f"default {fresh_default})"
+    )
+    assert os.path.realpath(adopted) == os.path.realpath(prior_log_dir), (
+        f"M3 FAILED: adopted {adopted!r} is not run1's log_dir {prior_log_dir!r}"
+    )
+    # The manifest the agent now writes to must be the prior session's file.
+    assert os.path.dirname(str(cg.run_manifest._path)) == adopted, \
+        "M3 FAILED: run_manifest not re-pointed at the adopted log_dir"
+
+    data = show_manifest(adopted, "after resume")
+    assert data is not None
+    status = data.get("status")
+    pending = data.get("pending_next_step")
+    print(f"\nstatus={status}  pending={bool(pending)}", flush=True)
+    assert status in ("running", "done", "completed"), \
+        f"M2 FAILED: expected pending cleared / running-or-done, got {status!r}"
+    assert not pending, "M2 FAILED: PENDING NEXT STEP not cleared after resume"
+
+    # For h2o: the resumed opt must land in the coarse cross-code plane-wave-PBE
+    # water band. Read this as a coarse pass/fail guard against a broken run; a converged
+    # accuracy claim is a separate goal (see the README scope note). Also re-confirm the resume
+    # tool call itself ran through the Gamma/centering path. run_ase writes the
+    # converged geometry as `final_structure` into its output JSON (default
+    # output.json, resolved into the adopted log_dir), which is the reliable
+    # source: an uncapped opt writes no trajectory, so read the JSON, matching how
+    # qe_cap_driver.py's mol_resume stage reads it.
+    if SYSTEM == "h2o":
+        assert_gamma_pwi(adopted, "resume")
+        out_json = _newest_matching("output.json", adopted, WORK)
+        assert out_json, f"resume: no output.json written under {adopted} or {WORK}"
+        fs = json.load(open(out_json)).get("final_structure")
+        assert fs and fs.get("numbers") and fs.get("positions"), (
+            f"resume: output.json has no usable final_structure: {out_json}"
+        )
+        r1, r2, ang = water_geometry(fs["numbers"], fs["positions"])
+        print(f"resume geometry: r(O-H)={r1:.4f}/{r2:.4f} A  angle={ang:.2f} deg",
+              flush=True)
+        assert 0.96 <= r1 <= 1.00 and 0.96 <= r2 <= 1.00, (
+            f"O-H length out of band: {r1:.4f}/{r2:.4f} A (expected 0.96-1.00)"
+        )
+        assert 102.0 <= ang <= 106.0, (
+            f"H-O-H angle out of band: {ang:.2f} deg (expected 102-106)"
+        )
+        print("resume geometry in cross-code plane-wave-PBE water band.", flush=True)
+
+    print("RESUME OK: log_dir adopted (M3), pending cleared (M2), run continued.",
+          flush=True)
+
+else:
+    sys.exit(f"unknown stage: {STAGE}")

--- a/examples/aurora_qe_longrun/qe_cap_driver.py
+++ b/examples/aurora_qe_longrun/qe_cap_driver.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python
+"""Drive ChemGraph's run_ase_core with a real Quantum ESPRESSO calculator to
+validate the wall-clock cap -> partial-geometry seam on Aurora.
+
+This is the CALC-LAYER route (Route 1): it calls run_ase_core directly, bypassing
+the LLM agent / tool wrapper / resume CLI. Use it to prove the cap+resume seam on
+real DFT in isolation before running the full agent stack (qe_agent_e2e.py).
+
+Stages, selected by argv[1]:
+
+  Bulk Si (fully periodic -> keeps the configured Monkhorst-Pack mesh):
+  smoke   -- single-point SCF on bulk Si (no cap). Proves pw.x + pseudo + MPI
+             actually produce an energy through the ChemGraph Espresso seam.
+  cap     -- geometry opt on a rattled Si cell with an allocation deadline set
+             a few SCF steps out. Proves the soft cap fires at an optimizer-step
+             boundary and leaves a resumable partial (.traj + restart + xyz).
+  resume  -- re-run opt from the partial geometry written by the cap stage,
+             uncapped, and confirm it makes progress / converges.
+
+  H2O molecule (non-periodic -> exercises the NEW DFT code path added in this
+  branch: is_nonperiodic -> atoms.center(vacuum) -> K_POINTS gamma). Bulk Si
+  never touches that path, so these stages are what actually validate the fix
+  on real pw.x:
+  mol_smoke  -- single-point SCF on an isolated H2O. Proves the molecule is
+                centered into a finite box and pw.x runs at the Gamma point
+                (grep the generated espresso.pwi for "K_POINTS gamma").
+  mol_cap    -- geometry opt on a rattled H2O with a short allocation deadline;
+                proves the cap fires at an optimizer-step boundary on the
+                molecule path and leaves a resumable partial.
+  mol_resume -- resume the H2O opt uncapped and confirm it relaxes into the
+                cross-code plane-wave-PBE water band (0.96-1.00 Ang, 102-106 deg).
+
+All output goes under $RUN_DIR (default: cwd). Structures are built in-process
+with ASE so no external structure file is needed for the first run.
+"""
+import json
+import math
+import os
+import sys
+import time
+
+import numpy as np
+from ase.build import bulk, molecule
+from ase.io import write
+
+STAGE = sys.argv[1] if len(sys.argv) > 1 else "smoke"
+RUN_DIR = os.environ.get("RUN_DIR", os.getcwd())
+os.chdir(RUN_DIR)
+
+# run_ase_core resolves relative paths against CHEMGRAPH_LOG_DIR when set; keep
+# every artifact for this run together so the manifest/resume logic has one home.
+os.environ.setdefault("CHEMGRAPH_LOG_DIR", RUN_DIR)
+
+from chemgraph.tools.ase_core import run_ase_core  # noqa: E402
+from chemgraph.schemas.ase_input import ASEInputSchema  # noqa: E402
+from chemgraph.schemas.ase_input import get_available_calculator_names  # noqa: E402
+
+
+def _banner(msg):
+    print(f"\n{'=' * 70}\n{msg}\n{'=' * 70}", flush=True)
+
+
+_banner(f"STAGE={STAGE}  RUN_DIR={RUN_DIR}")
+print("available calculators:", get_available_calculator_names(), flush=True)
+assert "EspressoCalc" in get_available_calculator_names(), (
+    "EspressoCalc not available -- check pw.x on PATH / ASE_ESPRESSO_COMMAND and "
+    "ESPRESSO_PSEUDO are exported BEFORE importing chemgraph."
+)
+
+# A small, cheap cell: 2-atom Si diamond primitive. Low cutoff + coarse k-mesh
+# keep one SCF to a few seconds so the cap has clean step boundaries to fire on.
+CALC = {
+    "calculator_type": "espresso",
+    "pseudopotentials": {"Si": "Si.UPF"},
+    "pseudo_dir": os.environ["ESPRESSO_PSEUDO"],
+    "ecutwfc": 25.0,
+    "kpts": [2, 2, 2],
+    "xc": "PBE",
+    "input_data": {
+        # keep each SCF short and robust for a validation run
+        "conv_thr": 1e-6,
+        "mixing_beta": 0.3,
+        "electron_maxstep": 80,
+    },
+}
+
+
+def build_si(rattle=0.0, path="si.xyz"):
+    atoms = bulk("Si", "diamond", a=5.43)
+    if rattle:
+        atoms.rattle(stdev=rattle, seed=1)
+    write(path, atoms)
+    return os.path.abspath(path)
+
+
+# H2O molecule config. Non-periodic (pbc=[F,F,F], cell.rank==0), so this is what
+# drives the new is_nonperiodic -> center(vacuum) -> K_POINTS gamma path. kpts is
+# left at the schema default on purpose: the molecule branch discards it and emits
+# a single Gamma point, so keeping a stray mesh here exercises the fix
+# (the branch must drop it). Cutoffs suit the pslibrary USPP PBE H/O pseudos (RRKJUS is soft, but
+# O needs a healthy density cutoff; ecutrho=8*ecutwfc for ultrasoft).
+MOL_CALC = {
+    "calculator_type": "espresso",
+    "pseudopotentials": {
+        "H": "H.pbe-rrkjus_psl.1.0.0.UPF",
+        "O": "O.pbe-n-rrkjus_psl.1.0.0.UPF",
+    },
+    "pseudo_dir": os.environ["ESPRESSO_PSEUDO"],
+    "ecutwfc": 50.0,
+    "ecutrho": 400.0,  # 8*ecutwfc -- ultrasoft O needs a dense charge grid
+    "xc": "PBE",
+    "vacuum": 6.0,  # padding added around the molecule by ase_core before the run
+    "input_data": {
+        "conv_thr": 1e-7,
+        "mixing_beta": 0.3,
+        "electron_maxstep": 120,
+        # An isolated neutral molecule at Gamma: no smearing (fixed occupations).
+    },
+}
+
+
+def build_h2o(rattle=0.0, path="h2o.xyz"):
+    """ASE's built-in H2O: O,H,H, cell-less, pbc all False -> the molecule path.
+
+    Writing it to .xyz and reading it back through run_ase_core is what the real
+    agent does, and it is where the cell-less structure originates -- ase_core
+    then centers it into a vacuum box before handing it to pw.x.
+    """
+    atoms = molecule("H2O")
+    if rattle:
+        atoms.rattle(stdev=rattle, seed=1)
+    write(path, atoms)
+    return os.path.abspath(path)
+
+
+def water_geometry(numbers, positions):
+    """Return (r1, r2, angle_deg) for an O,H,H structure (any atom order)."""
+    numbers = list(numbers)
+    o_idx = numbers.index(8)
+    h_idx = [i for i, z in enumerate(numbers) if z == 1]
+    pos = np.asarray(positions, dtype=float)
+    o = pos[o_idx]
+    v1 = pos[h_idx[0]] - o
+    v2 = pos[h_idx[1]] - o
+    r1 = float(np.linalg.norm(v1))
+    r2 = float(np.linalg.norm(v2))
+    angle = math.degrees(math.acos(np.dot(v1, v2) / (r1 * r2)))
+    return r1, r2, angle
+
+
+def _assert_gamma_in_pwi(run_dir):
+    """Grep the pw.x input ase_core wrote for proof of the molecule path.
+
+    The new code path is only truly validated if the *written* input pw.x
+    consumed carried K_POINTS gamma and a non-zero cell. A parameter-only check
+    can pass while the writer still emits a spurious mesh or a zero cell.
+    """
+    hits = []
+    for root, _dirs, files in os.walk(run_dir):
+        for fn in files:
+            if fn.endswith(".pwi"):
+                hits.append(os.path.join(root, fn))
+    assert hits, f"no .pwi input found under {run_dir} to verify the gamma path"
+    newest = max(hits, key=os.path.getmtime)
+    txt = open(newest).read()
+    print(f"verifying generated input: {newest}", flush=True)
+    assert "K_POINTS gamma" in txt, (
+        f"molecule path did NOT emit 'K_POINTS gamma' in {newest}:\n{txt}"
+    )
+    assert "CELL_PARAMETERS" in txt, (
+        f"no CELL_PARAMETERS in {newest} -- centering did not reach the writer"
+    )
+    # A zero/near-zero cell means centering never happened; guard against it by
+    # parsing the CELL_PARAMETERS block itself (the three lattice vectors on the
+    # lines right after the header). Scanning for the first 3-float
+    # line could match an atomic position. A finite cell has a non-zero
+    # volume, so require |det| above a small threshold.
+    lines = txt.splitlines()
+    header = next(
+        i for i, ln in enumerate(lines) if ln.split()[:1] == ["CELL_PARAMETERS"]
+    )
+    vectors = []
+    for ln in lines[header + 1 : header + 4]:
+        parts = ln.split()
+        assert len(parts) == 3, (
+            f"malformed CELL_PARAMETERS row in {newest}: {ln!r}"
+        )
+        vectors.append([float(p) for p in parts])
+    volume = abs(float(np.linalg.det(np.asarray(vectors, dtype=float))))
+    assert volume > 1.0, (
+        f"cell in {newest} looks degenerate (volume={volume:.3g} Ang^3)"
+    )
+    print(f"OK: {os.path.basename(newest)} has K_POINTS gamma + a finite cell "
+          f"(volume={volume:.1f} Ang^3).", flush=True)
+
+
+if STAGE == "smoke":
+    struct = build_si(rattle=0.0, path="si_smoke.xyz")
+    params = ASEInputSchema(
+        input_structure_file=struct,
+        output_results_file="si_smoke_out.json",
+        driver="energy",  # single-point: one SCF, no optimizer, no cap
+        calculator=CALC,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    dt = time.time() - t0
+    _banner("SMOKE RESULT")
+    print(json.dumps(result, indent=2, default=str), flush=True)
+    print(f"\none single-point SCF wall_time ~= {dt:.1f}s", flush=True)
+    assert result.get("status") == "success", "QE single-point failed"
+    assert result.get("single_point_energy") is not None
+    print("SMOKE OK: QE produced an energy through the ChemGraph seam.", flush=True)
+
+elif STAGE == "cap":
+    rattle = float(os.environ.get("QE_CAP_RATTLE", "0.05"))
+    struct = build_si(rattle=rattle, path="si_cap.xyz")
+    # Deadline: give it enough for >=1 step but force a cap before convergence.
+    # SECONDS is measured from process start; the cap fires at the first
+    # step-boundary past the budget. Tune via QE_CAP_SECONDS (default 60s).
+    budget = float(os.environ.get("QE_CAP_SECONDS", "60"))
+    os.environ["CHEMGRAPH_ALLOCATION_SECONDS"] = str(budget)
+    # Margin must exceed one SCF step so the cap never breaches walltime mid-SCF.
+    os.environ.setdefault("CHEMGRAPH_ALLOCATION_MARGIN", "30")
+    print(
+        f"cap budget={budget}s  margin={os.environ['CHEMGRAPH_ALLOCATION_MARGIN']}s",
+        flush=True,
+    )
+    params = ASEInputSchema(
+        input_structure_file=struct,
+        output_results_file="si_cap_out.json",
+        driver="opt",
+        optimizer="bfgs",
+        calculator=CALC,
+        fmax=0.001,  # tight target the short budget can't reach -> guaranteed cap
+        steps=100,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    dt = time.time() - t0
+    _banner("CAP RESULT")
+    print(json.dumps(result, indent=2, default=str), flush=True)
+    print(f"\ntotal wall_time ~= {dt:.1f}s", flush=True)
+    assert result.get("wall_time_capped") is True, "expected wall_time_capped=True"
+    assert result.get("resume_input_file"), "expected a partial geometry for resume"
+    assert os.path.isfile(result["resume_input_file"]), "partial xyz not on disk"
+    # Hand the partial path to the resume stage.
+    with open(os.path.join(RUN_DIR, "partial_path.txt"), "w") as fh:
+        fh.write(result["resume_input_file"] + "\n")
+    print("CAP OK: soft cap fired at a step boundary; partial saved.", flush=True)
+
+elif STAGE == "resume":
+    partial = os.environ.get("QE_RESUME_INPUT")
+    if not partial:
+        # Fall back to the path the cap stage recorded in this RUN_DIR.
+        rec = os.path.join(RUN_DIR, "partial_path.txt")
+        if os.path.isfile(rec):
+            partial = open(rec).read().strip()
+    assert partial and os.path.isfile(partial), (
+        "set QE_RESUME_INPUT to the partial xyz written by the cap stage "
+        f"(looked for {os.path.join(RUN_DIR, 'partial_path.txt')})"
+    )
+    # Uncapped this time: let it run to convergence (or the step cap).
+    for k in ("CHEMGRAPH_ALLOCATION_SECONDS", "CHEMGRAPH_ALLOCATION_DEADLINE"):
+        os.environ.pop(k, None)
+    params = ASEInputSchema(
+        input_structure_file=partial,
+        output_results_file="si_resume_out.json",
+        driver="opt",
+        optimizer="bfgs",
+        calculator=CALC,
+        fmax=0.05,
+        steps=100,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    dt = time.time() - t0
+    _banner("RESUME RESULT")
+    print(json.dumps(result, indent=2, default=str), flush=True)
+    print(f"\nresume wall_time ~= {dt:.1f}s", flush=True)
+    assert result.get("status") == "success"
+    assert result.get("wall_time_capped") is not True, "resume unexpectedly capped"
+    print("RESUME OK: continued from partial to completion.", flush=True)
+
+elif STAGE == "mol_smoke":
+    # Single-point on an isolated H2O -- the minimal proof that the molecule path
+    # (center into a box + Gamma point) runs on real pw.x.
+    struct = build_h2o(rattle=0.0, path="h2o_smoke.xyz")
+    params = ASEInputSchema(
+        input_structure_file=struct,
+        output_results_file="h2o_smoke_out.json",
+        driver="energy",  # single-point: one SCF, no optimizer, no cap
+        calculator=MOL_CALC,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    dt = time.time() - t0
+    _banner("MOL_SMOKE RESULT")
+    print(json.dumps(result, indent=2, default=str), flush=True)
+    print(f"\none single-point SCF wall_time ~= {dt:.1f}s", flush=True)
+    assert result.get("status") == "success", "QE H2O single-point failed"
+    assert result.get("single_point_energy") is not None
+    _assert_gamma_in_pwi(RUN_DIR)
+    print("MOL_SMOKE OK: isolated H2O ran at Gamma through the molecule path.",
+          flush=True)
+
+elif STAGE == "mol_cap":
+    # Rattle the water so the optimizer has real work, then cap it a few SCF
+    # steps in. Proves the soft cap fires at an optimizer-step boundary on the
+    # non-periodic molecule path and leaves a resumable partial.
+    rattle = float(os.environ.get("QE_CAP_RATTLE", "0.08"))
+    struct = build_h2o(rattle=rattle, path="h2o_cap.xyz")
+    budget = float(os.environ.get("QE_CAP_SECONDS", "60"))
+    os.environ["CHEMGRAPH_ALLOCATION_SECONDS"] = str(budget)
+    os.environ.setdefault("CHEMGRAPH_ALLOCATION_MARGIN", "30")
+    print(
+        f"cap budget={budget}s  margin={os.environ['CHEMGRAPH_ALLOCATION_MARGIN']}s",
+        flush=True,
+    )
+    params = ASEInputSchema(
+        input_structure_file=struct,
+        output_results_file="h2o_cap_out.json",
+        driver="opt",
+        optimizer="bfgs",
+        calculator=MOL_CALC,
+        fmax=0.01,  # tight enough that the short budget caps before convergence
+        steps=100,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    dt = time.time() - t0
+    _banner("MOL_CAP RESULT")
+    print(json.dumps(result, indent=2, default=str), flush=True)
+    print(f"\ntotal wall_time ~= {dt:.1f}s", flush=True)
+    _assert_gamma_in_pwi(RUN_DIR)
+    assert result.get("wall_time_capped") is True, "expected wall_time_capped=True"
+    assert result.get("resume_input_file"), "expected a partial geometry for resume"
+    assert os.path.isfile(result["resume_input_file"]), "partial xyz not on disk"
+    with open(os.path.join(RUN_DIR, "mol_partial_path.txt"), "w") as fh:
+        fh.write(result["resume_input_file"] + "\n")
+    print("MOL_CAP OK: cap fired on the molecule path; partial saved.", flush=True)
+
+elif STAGE == "mol_resume":
+    partial = os.environ.get("QE_RESUME_INPUT")
+    if not partial:
+        rec = os.path.join(RUN_DIR, "mol_partial_path.txt")
+        if os.path.isfile(rec):
+            partial = open(rec).read().strip()
+    assert partial and os.path.isfile(partial), (
+        "set QE_RESUME_INPUT to the partial xyz written by the mol_cap stage "
+        f"(looked for {os.path.join(RUN_DIR, 'mol_partial_path.txt')})"
+    )
+    for k in ("CHEMGRAPH_ALLOCATION_SECONDS", "CHEMGRAPH_ALLOCATION_DEADLINE"):
+        os.environ.pop(k, None)
+    params = ASEInputSchema(
+        input_structure_file=partial,
+        output_results_file="h2o_resume_out.json",
+        driver="opt",
+        optimizer="bfgs",
+        calculator=MOL_CALC,
+        fmax=0.03,
+        steps=200,
+    )
+    t0 = time.time()
+    result = run_ase_core(params)
+    dt = time.time() - t0
+    _banner("MOL_RESUME RESULT")
+    print(json.dumps(result, indent=2, default=str), flush=True)
+    print(f"\nresume wall_time ~= {dt:.1f}s", flush=True)
+    assert result.get("status") == "success"
+    assert result.get("wall_time_capped") is not True, "resume unexpectedly capped"
+    # Physical class-C check: a correct plane-wave-PBE water optimization lands in
+    # this cross-code band. A broken run (non-gamma mesh / zero cell) blows the
+    # geometry up and falls outside it.
+    out = json.load(open(os.path.join(RUN_DIR, "h2o_resume_out.json")))
+    fs = out["final_structure"]
+    r1, r2, angle = water_geometry(fs["numbers"], fs["positions"])
+    _banner("MOL_RESUME GEOMETRY")
+    print(f"r(O-H) = {r1:.4f}, {r2:.4f} Ang", flush=True)
+    print(f"angle(H-O-H) = {angle:.2f} deg", flush=True)
+    print("reference band: 0.96-1.00 Ang, 102-106 deg "
+          "(JDFTx PBE ~0.98 Ang/103.7 deg; expt 0.9572 Ang/104.52 deg)",
+          flush=True)
+    assert 0.96 <= r1 <= 1.00 and 0.96 <= r2 <= 1.00, (
+        f"O-H bond {r1:.4f}/{r2:.4f} Ang outside plane-wave-PBE band [0.96,1.00]"
+    )
+    assert 102.0 <= angle <= 106.0, (
+        f"H-O-H angle {angle:.2f} deg outside plane-wave-PBE band [102,106]"
+    )
+    print("MOL_RESUME OK: resumed to a water geometry inside the cross-code "
+          "plane-wave-PBE band.",
+          flush=True)
+
+else:
+    sys.exit(f"unknown stage: {STAGE}")

--- a/examples/aurora_qe_longrun/run_agent_e2e.pbs
+++ b/examples/aurora_qe_longrun/run_agent_e2e.pbs
@@ -1,0 +1,90 @@
+#!/bin/bash
+#PBS -A ChemGraph
+#PBS -q debug
+#PBS -l select=1:ncpus=208
+#PBS -l walltime=00:30:00
+#PBS -l filesystems=home:flare
+#PBS -N qe_agent_e2e
+#PBS -j oe
+
+# Route 2 (full agent stack) end-to-end validation of cap -> manifest -> resume on
+# real Quantum ESPRESSO DFT. Runs run1 (capped) THEN resume, as two SEPARATE python
+# processes in one allocation, in a FRESH work dir so the manifest is clean. The two
+# stages being separate processes is what makes M3 a real test: resume must adopt
+# run1's log_dir from the persisted session DB, not inherit run1's in-memory state.
+#
+# Submit from this directory:  qsub run_agent_e2e.pbs
+#
+# ====================== EDIT ME (site-specific) ==============================
+# These defaults are for ALCF Aurora (PBS + oneAPI + the ALCF LLM inference API).
+# To port to another HPC, change: the #PBS directives above (account/queue; use
+# #SBATCH on a Slurm site), the `module load` lines, QE_BIN, ESPRESSO_PSEUDO, PY,
+# and the LLM/proxy block. See README.md "Porting to another HPC".
+set -euo pipefail
+cd "$PBS_O_WORKDIR"
+
+echo "Jobid: $PBS_JOBID"
+echo "Host:  $(hostname)"
+
+for m in oneapi/release oneapi/eng-compiler; do
+  module is-loaded "$m" 2>/dev/null && module unload "$m" 2>/dev/null || true
+done
+module load oneapi/release/2025.3.1 mpich/opt/develop-git.6037a7a
+module load hdf5/1.14.6
+module list 2>&1 | tail -6
+
+export MPIR_CVAR_CH4_XPMEM_ENABLE=0
+export MPIR_CVAR_ENABLE_GPU=0
+export FI_CXI_DEFAULT_CQ_SIZE=131072
+export FI_CXI_CQ_FILL_PERCENT=20
+export OMP_NUM_THREADS=1
+
+# Aurora compute nodes have NO direct outbound network -- the agent's LLM call to
+# inference-api.alcf.anl.gov must go through the ALCF HTTP proxy (httpx/openai read
+# *_PROXY from the env). Keep localhost + the HSN fabric off the proxy so MPI/pw.x
+# sockets stay local. (Not needed if your LLM endpoint is directly reachable.)
+export HTTPS_PROXY="http://proxy.alcf.anl.gov:3128"
+export HTTP_PROXY="http://proxy.alcf.anl.gov:3128"
+export https_proxy="http://proxy.alcf.anl.gov:3128"
+export http_proxy="http://proxy.alcf.anl.gov:3128"
+export no_proxy="localhost,127.0.0.1,.hsn.cm.aurora.alcf.anl.gov"
+export NO_PROXY="$no_proxy"
+
+QE_BIN=/soft/applications/quantum_espresso/7.5-oneapi2025.0.5/cpu/bin/pw.x
+NRANKS=8
+export ASE_ESPRESSO_COMMAND="mpiexec -np ${NRANKS} -ppn ${NRANKS} -d 1 ${QE_BIN}"
+export ESPRESSO_PSEUDO="${ESPRESSO_PSEUDO:-$HOME/qe_pseudo}"
+
+export QE_CAP_WINDOW="${QE_CAP_WINDOW:-40}"
+export QE_CAP_MARGIN="${QE_CAP_MARGIN:-8}"
+export QE_LLM_MODEL="${QE_LLM_MODEL:-openai/gpt-oss-120b}"
+
+# Python that has chemgraph installed. Point PY at your environment.
+PY="${PY:-$HOME/chemgraph-env/bin/python}"
+
+# FRESH per-job work dir keeps run1's manifest uncontaminated by prior attempts.
+# Both stages share it so resume finds session_id.txt; neither pins
+# CHEMGRAPH_LOG_DIR, so the agent picks its own dir (M3 must bring resume home).
+export WORK_DIR="$PBS_O_WORKDIR/agent_e2e_${PBS_JOBID%%.*}"
+mkdir -p "$WORK_DIR"
+
+echo "--- proxy probe: inference-api.alcf.anl.gov via $HTTPS_PROXY ---"
+if curl -sS -o /dev/null -w "probe HTTP %{http_code} in %{time_total}s\n" \
+     --max-time 20 https://inference-api.alcf.anl.gov/ ; then
+  echo "proxy probe reached the endpoint (any HTTP code = TCP+TLS OK)"
+else
+  echo "PROXY PROBE FAILED (rc=$?) -- compute node cannot reach the LLM endpoint"
+  exit 1
+fi
+
+echo "WORK_DIR=$WORK_DIR  window=$QE_CAP_WINDOW margin=$QE_CAP_MARGIN model=$QE_LLM_MODEL"
+
+echo "########## STAGE 1: run1 (capped) ##########"
+"$PY" "$PBS_O_WORKDIR/qe_agent_e2e.py" run1
+echo "=== run1 done ==="
+
+echo "########## STAGE 2: resume (uncapped, fresh process) ##########"
+"$PY" "$PBS_O_WORKDIR/qe_agent_e2e.py" resume
+echo "=== resume done ==="
+
+echo "=== agent e2e (run1+resume) done ==="

--- a/examples/aurora_qe_longrun/run_agent_mol.pbs
+++ b/examples/aurora_qe_longrun/run_agent_mol.pbs
@@ -1,0 +1,106 @@
+#!/bin/bash
+#PBS -A ChemGraph
+#PBS -q debug
+#PBS -l select=1:ncpus=208
+#PBS -l walltime=00:30:00
+#PBS -l filesystems=home:flare
+#PBS -N qe_agent_mol
+#PBS -j oe
+
+# Route 2 (full agent stack) end-to-end validation on a NON-PERIODIC molecule
+# (H2O). Same run1 (capped) THEN resume flow as run_agent_e2e.pbs, but with
+# QE_SYSTEM=h2o so the WHOLE agent stack (LLM -> tool -> ase_core -> QE) drives
+# the branch's molecule code path: is_nonperiodic -> atoms.center(vacuum) ->
+# K_POINTS gamma. run_agent_e2e.pbs covers periodic Si; this covers the molecule
+# path through the same LLM/tool/manifest/resume layers. The driver greps the
+# generated espresso.pwi for the Gamma + finite-cell signature in both stages,
+# and asserts the resumed geometry lands in the cross-code plane-wave-PBE water
+# band.
+#
+# Requires the pslibrary USPP PBE H/O pseudos in $ESPRESSO_PSEUDO alongside Si.UPF:
+#   H.pbe-rrkjus_psl.1.0.0.UPF, O.pbe-n-rrkjus_psl.1.0.0.UPF
+#
+# Submit from this directory:  qsub run_agent_mol.pbs
+#
+# ====================== EDIT ME (site-specific) ==============================
+# These defaults are for ALCF Aurora (PBS + oneAPI + the ALCF LLM inference API).
+# To port to another HPC, change: the #PBS directives above (account/queue; use
+# #SBATCH on a Slurm site), the `module load` lines, QE_BIN, ESPRESSO_PSEUDO, PY,
+# and the LLM/proxy block. See README.md "Porting to another HPC".
+set -euo pipefail
+cd "$PBS_O_WORKDIR"
+
+echo "Jobid: $PBS_JOBID"
+echo "Host:  $(hostname)"
+
+for m in oneapi/release oneapi/eng-compiler; do
+  module is-loaded "$m" 2>/dev/null && module unload "$m" 2>/dev/null || true
+done
+module load oneapi/release/2025.3.1 mpich/opt/develop-git.6037a7a
+module load hdf5/1.14.6
+module list 2>&1 | tail -6
+
+export MPIR_CVAR_CH4_XPMEM_ENABLE=0
+export MPIR_CVAR_ENABLE_GPU=0
+export FI_CXI_DEFAULT_CQ_SIZE=131072
+export FI_CXI_CQ_FILL_PERCENT=20
+export OMP_NUM_THREADS=1
+
+# Aurora compute nodes have NO direct outbound network, so the agent's LLM call
+# to inference-api.alcf.anl.gov must go through the ALCF HTTP proxy (httpx/openai
+# read *_PROXY from the env). Keep localhost + the HSN fabric off the proxy so
+# MPI/pw.x sockets stay local. (Drop this block if your LLM is directly reachable.)
+export HTTPS_PROXY="http://proxy.alcf.anl.gov:3128"
+export HTTP_PROXY="http://proxy.alcf.anl.gov:3128"
+export https_proxy="http://proxy.alcf.anl.gov:3128"
+export http_proxy="http://proxy.alcf.anl.gov:3128"
+export no_proxy="localhost,127.0.0.1,.hsn.cm.aurora.alcf.anl.gov"
+export NO_PROXY="$no_proxy"
+
+QE_BIN=/soft/applications/quantum_espresso/7.5-oneapi2025.0.5/cpu/bin/pw.x
+NRANKS=8
+export ASE_ESPRESSO_COMMAND="mpiexec -np ${NRANKS} -ppn ${NRANKS} -d 1 ${QE_BIN}"
+export ESPRESSO_PSEUDO="${ESPRESSO_PSEUDO:-$HOME/qe_pseudo}"
+
+# Drive the molecule (non-periodic Gamma path) through the agent stack.
+export QE_SYSTEM=h2o
+
+# H2O SCF is much heavier than the 2-atom Si cell (~14 s/SCF vs ~1 s), so give the
+# cap a wider window and a margin that comfortably exceeds one SCF step. Effective
+# opt budget = window - margin - T_llm; the driver uses an unreachable fmax in
+# run1, so a wider window only runs a few more steps before capping (it can never
+# let the opt converge instead). Tune from the run1 SCF time if the cap fires at
+# step 0 (raise the window) or never (lower it).
+export QE_CAP_WINDOW="${QE_CAP_WINDOW:-100}"
+export QE_CAP_MARGIN="${QE_CAP_MARGIN:-25}"
+export QE_LLM_MODEL="${QE_LLM_MODEL:-openai/gpt-oss-120b}"
+
+# Python that has chemgraph installed. Point PY at your environment.
+PY="${PY:-$HOME/chemgraph-env/bin/python}"
+
+# FRESH per-job work dir keeps run1's manifest uncontaminated by prior attempts.
+# Both stages share it so resume finds session_id.txt; neither pins
+# CHEMGRAPH_LOG_DIR, so the agent picks its own dir (M3 must bring resume home).
+export WORK_DIR="$PBS_O_WORKDIR/agent_mol_${PBS_JOBID%%.*}"
+mkdir -p "$WORK_DIR"
+
+echo "--- proxy probe: inference-api.alcf.anl.gov via $HTTPS_PROXY ---"
+if curl -sS -o /dev/null -w "probe HTTP %{http_code} in %{time_total}s\n" \
+     --max-time 20 https://inference-api.alcf.anl.gov/ ; then
+  echo "proxy probe reached the endpoint (any HTTP code = TCP+TLS OK)"
+else
+  echo "PROXY PROBE FAILED (rc=$?): compute node cannot reach the LLM endpoint"
+  exit 1
+fi
+
+echo "WORK_DIR=$WORK_DIR system=$QE_SYSTEM window=$QE_CAP_WINDOW margin=$QE_CAP_MARGIN model=$QE_LLM_MODEL"
+
+echo "########## STAGE 1: run1 (capped) ##########"
+"$PY" "$PBS_O_WORKDIR/qe_agent_e2e.py" run1
+echo "=== run1 done ==="
+
+echo "########## STAGE 2: resume (uncapped, fresh process) ##########"
+"$PY" "$PBS_O_WORKDIR/qe_agent_e2e.py" resume
+echo "=== resume done ==="
+
+echo "=== agent mol e2e (run1+resume) done ==="

--- a/examples/aurora_qe_longrun/run_qe_cap.pbs
+++ b/examples/aurora_qe_longrun/run_qe_cap.pbs
@@ -1,0 +1,67 @@
+#!/bin/bash
+#PBS -A ChemGraph
+#PBS -q debug
+#PBS -l select=1:ncpus=208
+#PBS -l walltime=00:30:00
+#PBS -l filesystems=home:flare
+#PBS -N qe_cap_run
+#PBS -j oe
+
+# Route 1 (calc-layer) validation: drives run_ase_core directly (no LLM agent) to
+# prove the wall-clock cap -> partial-geometry seam on real QE in isolation. Runs
+# all three bulk-Si stages in one allocation (mirroring run_qe_mol.pbs):
+#   smoke  -> single-point SCF (sanity: QE produces an energy through the seam)
+#   cap    -> capped opt, leaves a resumable partial in RUN_DIR
+#   resume -> uncapped resume from that partial
+# No LLM => no proxy/token needed here.
+#
+# Submit from this directory:  qsub run_qe_cap.pbs
+#
+# ====================== EDIT ME (site-specific) ==============================
+# ALCF Aurora defaults. To port: change the #PBS directives, module loads, QE_BIN,
+# ESPRESSO_PSEUDO, PY. See README.md "Porting to another HPC".
+set -euo pipefail
+cd "$PBS_O_WORKDIR"
+
+echo "Jobid: $PBS_JOBID"
+echo "Host:  $(hostname)"
+
+for m in oneapi/release oneapi/eng-compiler; do
+  module is-loaded "$m" 2>/dev/null && module unload "$m" 2>/dev/null || true
+done
+module load oneapi/release/2025.3.1 mpich/opt/develop-git.6037a7a
+module load hdf5/1.14.6
+module list 2>&1 | tail -6
+
+export MPIR_CVAR_CH4_XPMEM_ENABLE=0
+export MPIR_CVAR_ENABLE_GPU=0
+export FI_CXI_DEFAULT_CQ_SIZE=131072
+export FI_CXI_CQ_FILL_PERCENT=20
+export OMP_NUM_THREADS=1
+
+QE_BIN=/soft/applications/quantum_espresso/7.5-oneapi2025.0.5/cpu/bin/pw.x
+NRANKS=8
+export ASE_ESPRESSO_COMMAND="mpiexec -np ${NRANKS} -ppn ${NRANKS} -d 1 ${QE_BIN}"
+export ESPRESSO_PSEUDO="${ESPRESSO_PSEUDO:-$HOME/qe_pseudo}"
+
+# Cap tuning: budget just a few SCF steps; margin > one SCF step wall time.
+# Tune QE_CAP_SECONDS from the measured smoke SCF time before submit.
+export QE_CAP_SECONDS="${QE_CAP_SECONDS:-60}"
+export CHEMGRAPH_ALLOCATION_MARGIN="${CHEMGRAPH_ALLOCATION_MARGIN:-30}"
+
+PY="${PY:-$HOME/chemgraph-env/bin/python}"
+export RUN_DIR="$PBS_O_WORKDIR/cap_run"
+mkdir -p "$RUN_DIR"
+
+echo "QE_CAP_SECONDS=$QE_CAP_SECONDS  MARGIN=$CHEMGRAPH_ALLOCATION_MARGIN"
+
+echo "########## STAGE smoke ##########"
+"$PY" "$PBS_O_WORKDIR/qe_cap_driver.py" smoke
+
+echo "########## STAGE cap ##########"
+"$PY" "$PBS_O_WORKDIR/qe_cap_driver.py" cap
+
+echo "########## STAGE resume ##########"
+"$PY" "$PBS_O_WORKDIR/qe_cap_driver.py" resume
+
+echo "=== cap job done ==="

--- a/examples/aurora_qe_longrun/run_qe_mol.pbs
+++ b/examples/aurora_qe_longrun/run_qe_mol.pbs
@@ -1,0 +1,70 @@
+#!/bin/bash
+#PBS -A ChemGraph
+#PBS -q debug
+#PBS -l select=1:ncpus=208
+#PBS -l walltime=00:30:00
+#PBS -l filesystems=home:flare
+#PBS -N qe_mol_run
+#PBS -j oe
+
+# Route 1 (calc-layer) validation on a NON-PERIODIC molecule (H2O). This is the
+# stage that actually exercises the new DFT code path added on this branch:
+#   is_nonperiodic(atoms) -> atoms.center(vacuum) -> K_POINTS gamma
+# Bulk Si (run_qe_cap.pbs) is fully periodic and never touches that path, so this
+# script is the real proof the molecule fix works on live pw.x. No LLM here, so no
+# proxy/token needed. Runs all three molecule stages in one allocation:
+#   mol_smoke  -> single-point at Gamma (grep espresso.pwi for K_POINTS gamma)
+#   mol_cap    -> capped opt, leaves a resumable partial
+#   mol_resume -> uncapped resume; asserts the class-C water geometry band
+#
+# Requires the pslibrary USPP PBE H/O pseudos in $ESPRESSO_PSEUDO alongside Si.UPF:
+#   H.pbe-rrkjus_psl.1.0.0.UPF, O.pbe-n-rrkjus_psl.1.0.0.UPF
+#
+# Submit from this directory:  qsub run_qe_mol.pbs
+#
+# ====================== EDIT ME (site-specific) ==============================
+set -euo pipefail
+cd "$PBS_O_WORKDIR"
+
+echo "Jobid: $PBS_JOBID"
+echo "Host:  $(hostname)"
+
+for m in oneapi/release oneapi/eng-compiler; do
+  module is-loaded "$m" 2>/dev/null && module unload "$m" 2>/dev/null || true
+done
+module load oneapi/release/2025.3.1 mpich/opt/develop-git.6037a7a
+module load hdf5/1.14.6
+module list 2>&1 | tail -6
+
+export MPIR_CVAR_CH4_XPMEM_ENABLE=0
+export MPIR_CVAR_ENABLE_GPU=0
+export FI_CXI_DEFAULT_CQ_SIZE=131072
+export FI_CXI_CQ_FILL_PERCENT=20
+export OMP_NUM_THREADS=1
+
+QE_BIN=/soft/applications/quantum_espresso/7.5-oneapi2025.0.5/cpu/bin/pw.x
+NRANKS=8
+export ASE_ESPRESSO_COMMAND="mpiexec -np ${NRANKS} -ppn ${NRANKS} -d 1 ${QE_BIN}"
+export ESPRESSO_PSEUDO="${ESPRESSO_PSEUDO:-$HOME/qe_pseudo}"
+
+# H2O SCF is heavier than the 2-atom Si cell; give the cap a bit more room so it
+# fires cleanly a few steps in. Tune from the mol_smoke SCF time if needed.
+export QE_CAP_SECONDS="${QE_CAP_SECONDS:-90}"
+export CHEMGRAPH_ALLOCATION_MARGIN="${CHEMGRAPH_ALLOCATION_MARGIN:-40}"
+
+PY="${PY:-$HOME/chemgraph-env/bin/python}"
+export RUN_DIR="$PBS_O_WORKDIR/mol_run"
+mkdir -p "$RUN_DIR"
+
+echo "QE_CAP_SECONDS=$QE_CAP_SECONDS  MARGIN=$CHEMGRAPH_ALLOCATION_MARGIN"
+
+echo "########## STAGE mol_smoke ##########"
+"$PY" "$PBS_O_WORKDIR/qe_cap_driver.py" mol_smoke
+
+echo "########## STAGE mol_cap ##########"
+"$PY" "$PBS_O_WORKDIR/qe_cap_driver.py" mol_cap
+
+echo "########## STAGE mol_resume ##########"
+"$PY" "$PBS_O_WORKDIR/qe_cap_driver.py" mol_resume
+
+echo "=== mol job done ==="


### PR DESCRIPTION
## Summary

Adds a runnable example under `examples/aurora_qe_longrun/` that exercises
ChemGraph's long-running-calculation support using **real Quantum ESPRESSO DFT**
on ALCF Aurora. A calculation that would exceed the job's wall-clock allocation
self-terminates at an ASE optimizer-step boundary, writes a durable partial
geometry and run manifest, and a later `chemgraph resume` continues from that
partial. This is the real-DFT, HPC counterpart to the in-process EMT/MACE unit
tests: it proves the same cap-to-resume seam end to end on a subprocess DFT engine.

This PR is example and documentation only. It adds no library code and changes no
shipped behavior; it is the validation harness for the calculator and
cap-to-resume PRs.

The example drives the seam at two layers, each over a periodic and a
non-periodic system:

- **Route 1 (calc layer), `qe_cap_driver.py`.** `run_ase_core` calls QE directly
  with no LLM. Proves the cap fires at a step boundary, writes a resumable partial,
  and a resume continues to the same final energy.
- **Route 2 (full agent), `qe_agent_e2e.py`.** A real LLM drives LangGraph
  `single_agent` to `run_ase` to `run_ase_core` to QE, plus the manifest hook and
  `chemgraph resume`. Covers the layers Route 1 bypasses: tool-arg unwrapping, JSON
  tool-message parsing, `tool_call_id` correlation, clear-pending-on-success (M2),
  and log_dir adoption on resume (M3).
- Bulk Si (`pbc=[T,T,T]`) uses the configured mesh verbatim; an H2O molecule
  (cell-less) exercises the molecule path (`is_nonperiodic` then `center(vacuum)`
  then `K_POINTS gamma`), validating the calculator PR's molecule fix on live
  `pw.x`.

`IRI_INTEGRATION.md` is a design note for a future cross-allocation auto-resubmit
layer built on the DOE IRI Facility API. It is additive on top of the shipped
manifest and is not implemented here. Three properties keep it additive: the
manifest carries a `schema_version` and is read permissively, so older readers can
continue to parse manifests that contain new fields; the cap's self-computed
deadline stays authoritative because the Facility API exposes no live
seconds-remaining; and the join key is already `session_id`, which resume uses to
adopt the prior `log_dir`.

### Part of a 3-PR series

This is the third of three PRs that together add long-running-calculation support
for subprocess DFT. They are meant to land in order:

1. feature/dft-calculators: the VASP and Quantum ESPRESSO calculators.
2. feature/longrun-cap-resume: the wall-clock cap, run manifest, and `chemgraph
   resume`.
3. **feature/aurora-qe-example (this PR):** a runnable Aurora example that
   validates the seam on real QE DFT. Depends on both earlier PRs, so it opens as
   Draft until they merge.

## Related issues

None

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

The portable CI coverage of this seam lives in the repo unit tests
(`tests/test_cap*.py`, `tests/test_manifest.py`, `tests/test_allocation_cap.py`,
`tests/test_resume_injection.py`, `tests/test_mace_cap.py`) on the in-process
EMT/MACE calculators and stays green. This directory is the HPC counterpart and
cannot run in CI (it needs Aurora plus QE plus an LLM endpoint); the drivers
`assert` every invariant, so a non-zero exit signals a real regression.

Live-run scope: these runs validate the flow (the cap-to-resume seam, and for H2O
the non-periodic Gamma/centering path on live `pw.x`), not physical accuracy. The
geometry band is a coarse pass/fail guard against a broken run.

- **Bulk Si, Route 1 and Route 2:** cap fired at a step boundary, left a resumable
  partial, and every resume converged to the same energy as a single uncapped opt
  (`-308.187965 eV`), including a re-run under the langgraph 1.x dependency bump.
- **H2O molecule, Route 1 and Route 2:** all molecule
  stages passed. The generated `espresso.pwi` carries `K_POINTS gamma` plus a
  finite `CELL_PARAMETERS`, and the resume converged to `-473.2196 eV` with a
  relaxed geometry of `r(O-H) = 0.971 A, angle(H-O-H) = 104.4 deg`, within the
  reference range observed across plane-wave PBE codes (0.96-1.00 A, 102-106 deg).

Full per-job numbers and porting notes are in the example README.

- `ruff check .` passes. `pytest tests/ -k "not tblite"` passes (293 passed, 28
  skipped, 2 deselected).

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [ ] Added/updated tests for the change (n/a: example only; the CI unit tests for this seam ship in the cap-to-resume PR. The drivers self-check via `assert`.)
- [x] Updated docs / README for any user-facing change
