### PR TITLE
fix: report physical ASE vibrational modes

### DIFF
--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -177,6 +177,40 @@ def is_linear_molecule(atomsdata: AtomsData, tol: float = 1e-3) -> bool:
     return (s[1] / s[0]) < tol
 
 
+def _vibrational_mode_indices(atomsdata: AtomsData, total_modes: int) -> list[int]:
+    """Return ASE mode indices corresponding to molecular vibrations.
+
+    ASE returns all ``3N`` normal modes in ascending order.  The leading
+    translational and rotational modes are excluded from reported vibration
+    data: five modes for a linear molecule and six for a nonlinear molecule.
+
+    Parameters
+    ----------
+    atomsdata : AtomsData
+        Optimized molecular structure.
+    total_modes : int
+        Number of modes returned by ASE.
+
+    Returns
+    -------
+    list[int]
+        Indices of the modes to report.
+    """
+    num_atoms = len(atomsdata.numbers)
+    expected_modes = 3 * num_atoms
+    if total_modes != expected_modes:
+        raise ValueError(
+            f"Expected {expected_modes} normal modes for {num_atoms} atoms, "
+            f"got {total_modes}."
+        )
+
+    if num_atoms == 1:
+        return []
+
+    num_nonvibrational = 5 if is_linear_molecule(atomsdata) else 6
+    return list(range(num_nonvibrational, total_modes))
+
+
 def get_symmetry_number(atomsdata: AtomsData) -> int:
     """Return the rotational symmetry number using Pymatgen.
 
@@ -584,9 +618,13 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     "frequency_unit": "cm-1",
                 }
 
-                energies = vib.get_energies()
+                all_energies = vib.get_energies()
+                mode_indices = _vibrational_mode_indices(
+                    final_structure, len(all_energies)
+                )
 
-                for _idx, e in enumerate(energies):
+                for mode_index in mode_indices:
+                    e = all_energies[mode_index]
                     is_imag = abs(e.imag) > 1e-8
                     e_val = e.imag if is_imag else e.real
                     energy_meV = 1e3 * e_val
@@ -601,17 +639,27 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                 if freq_file.exists():
                     freq_file.unlink()
                 with freq_file.open("w", encoding="utf-8") as f:
-                    for i, freq in enumerate(vib_data["frequencies"], start=0):
-                        f.write(f"{mol_stem}_vib.{i}.traj,{freq}\n")
+                    for mode_index, freq in zip(
+                        mode_indices, vib_data["frequencies"]
+                    ):
+                        f.write(f"{mol_stem}_vib.{mode_index}.traj,{freq}\n")
 
                 # Write normal-mode .traj files, then copy out of tmpdir
-                for i in range(len(energies)):
-                    vib.write_mode(n=i, kT=units.kB * 300, nimages=30)
+                for mode_index in mode_indices:
+                    vib.write_mode(
+                        n=mode_index, kT=units.kB * 300, nimages=30
+                    )
 
                 traj_dest_dir = _resolve_path("")
                 if traj_dest_dir:
                     os.makedirs(traj_dest_dir, exist_ok=True)
-                for traj_file in glob.glob(os.path.join(tmpdir, "vib.*.traj")):
+                stale_traj_pattern = os.path.join(
+                    traj_dest_dir, f"{mol_stem}_vib.*.traj"
+                )
+                for stale_traj_file in glob.glob(stale_traj_pattern):
+                    os.unlink(stale_traj_file)
+                for mode_index in mode_indices:
+                    traj_file = os.path.join(tmpdir, f"vib.{mode_index}.traj")
                     dest_name = f"{mol_stem}_{Path(traj_file).name}"
                     dest_path = (
                         os.path.join(traj_dest_dir, dest_name)
@@ -686,7 +734,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                         spin_S = (multiplicity - 1) / 2.0
 
                         thermo = IdealGasThermo(
-                            vib_energies=energies,
+                            vib_energies=all_energies,
                             potentialenergy=single_point_energy,
                             atoms=atoms,
                             geometry=geometry,

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -505,10 +505,20 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         freq_unit = ase_output.vibrational_frequencies.get("frequency_unit", "cm-1")
         energy_unit = ase_output.vibrational_frequencies.get("energy_unit", "meV")
 
-        # Check if molecule is linear
-        is_linear = is_linear_molecule.invoke({"atomsdata": ase_output.final_structure})
         num_atoms = len(ase_output.final_structure.numbers)
-        trans_rot_modes = 5 if is_linear else 6  # Number of translation/rotation modes
+        if num_atoms == 1:
+            molecule_type = "Monatomic"
+            trans_rot_modes = 3
+        else:
+            is_linear = is_linear_molecule.invoke(
+                {"atomsdata": ase_output.final_structure}
+            )
+            molecule_type = "Linear" if is_linear else "Non-linear"
+            trans_rot_modes = 5 if is_linear else 6
+
+        frequencies = ase_output.vibrational_frequencies["frequencies"]
+        includes_nonvibrational_modes = len(frequencies) == 3 * num_atoms
+        num_vibrational_modes = max(3 * num_atoms - trans_rot_modes, 0)
 
         # Create table header
         freq_table = f"""
@@ -533,11 +543,15 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
             ),
             1,
         ):
-            # First 5 (linear) or 6 (non-linear) modes are translation/rotation
-            mode_type = (
-                "Translation/Rotation" if i <= trans_rot_modes else "Vibrational"
+            is_nonvibrational = (
+                includes_nonvibrational_modes and i <= trans_rot_modes
             )
-            row_class = "trans-rot-mode" if i <= trans_rot_modes else "vibrational-mode"
+            mode_type = (
+                "Translation/Rotation" if is_nonvibrational else "Vibrational"
+            )
+            row_class = (
+                "trans-rot-mode" if is_nonvibrational else "vibrational-mode"
+            )
 
             freq_table += f"""
                     <tr class="{row_class}">
@@ -554,12 +568,22 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         </div>
         """
 
-        # Add explanation about the modes
+        if includes_nonvibrational_modes:
+            mode_note = (
+                f"This legacy result includes the first {trans_rot_modes} "
+                "translation/rotation modes."
+            )
+        else:
+            mode_note = (
+                f"The {trans_rot_modes} translation/rotation modes are excluded "
+                "from the reported frequencies."
+            )
+
         mode_explanation = f"""
         <div class="mode-explanation">
-            <p><strong>Molecule Type:</strong> {'Linear' if is_linear else 'Non-linear'}</p>
-            <p><strong>Mode Breakdown:</strong> {trans_rot_modes} translation/rotation modes + {3 * num_atoms - trans_rot_modes} vibrational modes</p>
-            <p><em>Note: The first {trans_rot_modes} modes (highlighted in orange) are translation/rotation modes. The remaining modes (highlighted in green) are vibrational modes.</em></p>
+            <p><strong>Molecule Type:</strong> {molecule_type}</p>
+            <p><strong>Mode Breakdown:</strong> {trans_rot_modes} translation/rotation modes + {num_vibrational_modes} vibrational modes</p>
+            <p><em>Note: {mode_note}</em></p>
         </div>
         """
 

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -946,16 +946,16 @@ def _is_linear_geometry(atoms) -> bool:
 
 
 def _num_nonvibrational_modes(total_modes: int, log_dir: Optional[str]) -> int:
-    """Return how many leading translational/rotational modes to skip.
+    """Return how many legacy translational/rotational rows to skip.
 
-    Non-linear molecules have 6 (3 translations + 3 rotations); linear
-    molecules have only 5.  Hardcoding 6 silently dropped a genuine
-    vibration for linear species (CO2, HCN, diatomics).
+    Current frequency CSV files contain only molecular vibrations.  Legacy
+    files contain all ``3N`` modes, so their leading translation/rotation rows
+    are removed when the corresponding structure is available.
 
     Parameters
     ----------
     total_modes : int
-        Total number of rows in the frequency table (``3N``).
+        Total number of rows in the frequency table.
     log_dir : str, optional
         Directory to search for a structure file used to test linearity.
 
@@ -964,20 +964,34 @@ def _num_nonvibrational_modes(total_modes: int, log_dir: Optional[str]) -> int:
     int
         Number of leading modes to discard.
     """
-    n_atoms = total_modes // 3
-    if n_atoms <= 2:
-        # Single atom -> no vibrations; diatomic -> always linear (5 modes).
-        return min(total_modes, 5)
-    if log_dir:
-        xyz = find_latest_xyz_file_in_dir(log_dir)
-        if xyz:
-            try:
-                atoms = ase_read(xyz)
-                if _is_linear_geometry(atoms):
-                    return 5
-            except Exception:
-                pass
+    if not log_dir:
+        return 0
+
+    xyz = find_latest_xyz_file_in_dir(log_dir)
+    if not xyz:
+        return 0
+
+    try:
+        atoms = ase_read(xyz)
+    except Exception:
+        return 0
+
+    n_atoms = len(atoms)
+    if total_modes != 3 * n_atoms:
+        return 0
+    if n_atoms == 1:
+        return 3
+    if n_atoms == 2 or _is_linear_geometry(atoms):
+        return 5
     return 6
+
+
+def _trajectory_mode_index(filename: str, fallback: int) -> int:
+    """Return the original ASE mode index encoded in a trajectory filename."""
+    try:
+        return int(Path(filename).stem.rsplit(".", 1)[1])
+    except (IndexError, ValueError):
+        return fallback
 
 
 def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
@@ -1030,12 +1044,17 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
             freq_options = {}
             for mode_idx, row in modes.iterrows():
                 freq_text = str(row["frequency"]).strip()
+                ase_mode_idx = _trajectory_mode_index(
+                    str(row["filename"]), mode_idx
+                )
                 suffix = "i" if freq_text.endswith("i") else ""
                 try:
                     freq_value = float(freq_text.rstrip("i"))
-                    label = f"Mode {mode_idx}: {freq_value:.2f}{suffix} cm\u207b\u00b9"
+                    label = (
+                        f"Mode {ase_mode_idx}: {freq_value:.2f}{suffix} cm\u207b\u00b9"
+                    )
                 except ValueError:
-                    label = f"Mode {mode_idx}: {freq_text} cm\u207b\u00b9"
+                    label = f"Mode {ase_mode_idx}: {freq_text} cm\u207b\u00b9"
                 freq_options[label] = mode_idx
 
             selected_freq = st.selectbox(

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -29,14 +29,8 @@ sample_ase_output = {
         "driver": "thermo",
         "optimizer": "bfgs",
         "calculator": {
-            "calculator_type": "mace_mp",
-            "model": None,
-            "device": "cpu",
-            "default_dtype": "float64",
-            "dispersion": False,
-            "damping": "bj",
-            "dispersion_xc": "pbe",
-            "dispersion_cutoff": 21.167088422553647,
+            "calculator_type": "emt",
+            "asap_cutoff": False,
         },
         "fmax": 0.01,
         "steps": 1000,
@@ -104,6 +98,40 @@ def create_xyz_content_from_final_structure(final_structure):
 def sample_ase_output_schema():
     """Create a valid ASEOutputSchema object from the sample data."""
     return ASEOutputSchema(**sample_ase_output)
+
+
+def test_generate_html_distinguishes_filtered_and_legacy_modes(tmp_path):
+    filtered_output = json.loads(json.dumps(sample_ase_output))
+    vibration_data = filtered_output["vibrational_frequencies"]
+    vibration_data["energies"] = vibration_data["energies"][-3:]
+    vibration_data["frequencies"] = vibration_data["frequencies"][-3:]
+
+    filtered_json = tmp_path / "filtered.json"
+    filtered_html = tmp_path / "filtered.html"
+    filtered_json.write_text(json.dumps(filtered_output), encoding="utf-8")
+    generate_html.invoke(
+        {
+            "results_json_path": str(filtered_json),
+            "output_path": str(filtered_html),
+        }
+    )
+    filtered_content = filtered_html.read_text(encoding="utf-8")
+    assert filtered_content.count("<td>Vibrational</td>") == 3
+    assert "<td>Translation/Rotation</td>" not in filtered_content
+    assert "6 translation/rotation modes are excluded" in filtered_content
+
+    legacy_json = tmp_path / "legacy.json"
+    legacy_html = tmp_path / "legacy.html"
+    legacy_json.write_text(json.dumps(sample_ase_output), encoding="utf-8")
+    generate_html.invoke(
+        {
+            "results_json_path": str(legacy_json),
+            "output_path": str(legacy_html),
+        }
+    )
+    legacy_content = legacy_html.read_text(encoding="utf-8")
+    assert legacy_content.count("<td>Translation/Rotation</td>") == 6
+    assert "This legacy result includes the first 6" in legacy_content
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -185,13 +185,33 @@ def test_parenthetical_prose_is_not_mangled_into_math():
     )
 
 
-def test_num_nonvibrational_modes_handles_linear_and_small_systems():
-    # No geometry available -> conservative default of 6 for polyatomics.
-    assert main_ui._num_nonvibrational_modes(9, None) == 6
-    # Diatomic is always linear (5 non-vibrational modes).
-    assert main_ui._num_nonvibrational_modes(6, None) == 5
-    # Single atom has no vibrations.
-    assert main_ui._num_nonvibrational_modes(3, None) == 3
+def test_num_nonvibrational_modes_handles_filtered_and_legacy_data(monkeypatch):
+    from ase import Atoms
+
+    water = Atoms(
+        "H2O", positions=[[0, 0.76, 0.59], [0, -0.76, 0.59], [0, 0, 0]]
+    )
+    monkeypatch.setattr(main_ui, "find_latest_xyz_file_in_dir", lambda _path: "x")
+    monkeypatch.setattr(main_ui, "ase_read", lambda _path: water)
+
+    assert main_ui._num_nonvibrational_modes(9, "/logs") == 6
+    assert main_ui._num_nonvibrational_modes(3, "/logs") == 0
+    assert main_ui._num_nonvibrational_modes(9, None) == 0
+
+    co2 = Atoms("CO2", positions=[[0, 0, 0], [0, 0, 1.16], [0, 0, -1.16]])
+    monkeypatch.setattr(main_ui, "ase_read", lambda _path: co2)
+    assert main_ui._num_nonvibrational_modes(9, "/logs") == 5
+    assert main_ui._num_nonvibrational_modes(4, "/logs") == 0
+
+    hydrogen = Atoms("H2", positions=[[0, 0, 0], [0, 0, 0.74]])
+    monkeypatch.setattr(main_ui, "ase_read", lambda _path: hydrogen)
+    assert main_ui._num_nonvibrational_modes(6, "/logs") == 5
+    assert main_ui._num_nonvibrational_modes(1, "/logs") == 0
+
+    atom = Atoms("He", positions=[[0, 0, 0]])
+    monkeypatch.setattr(main_ui, "ase_read", lambda _path: atom)
+    assert main_ui._num_nonvibrational_modes(3, "/logs") == 3
+    assert main_ui._num_nonvibrational_modes(0, "/logs") == 0
 
 
 def test_is_linear_geometry_detects_linear_molecules():
@@ -201,6 +221,11 @@ def test_is_linear_geometry_detects_linear_molecules():
     h2o = Atoms("H2O", positions=[[0, 0, 0], [0, 0.76, 0.59], [0, -0.76, 0.59]])
     assert main_ui._is_linear_geometry(co2) is True
     assert main_ui._is_linear_geometry(h2o) is False
+
+
+def test_trajectory_mode_index_uses_exported_ase_index():
+    assert main_ui._trajectory_mode_index("water_vib.6.traj", 0) == 6
+    assert main_ui._trajectory_mode_index("legacy-name.traj", 4) == 4
 
 
 def test_latex_delimiters_are_normalized_for_streamlit_markdown():


### PR DESCRIPTION
## Summary

- Report only physical molecular vibrations from ASE: 3N-5 modes for linear molecules, 3N-6 for nonlinear molecules, and zero for monatomic systems.
- Preserve the complete raw 3N energy array for IdealGasThermo so ASE continues to perform its own geometry-aware selection.
- Limit frequency CSV and normal-mode trajectory artifacts to reported modes, while keeping HTML and Streamlit consumers compatible with legacy 3N outputs.

## Related issues

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check src tests`
- `pytest -q tests/test_report.py tests/test_ui_main_interface.py` (26 passed)
- Full core-suite audit outside the sandbox: 292 passed, 29 skipped, 2 deselected; eight pre-existing MACE fixture setup errors remained because MACE is not installed in the current post-stash interpreter.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change
- [ ] `ruff check .` passes (workspace contains unrelated embedded environments and existing notebook lint findings; `ruff check src tests` passes)
- [ ] `pytest tests/ -k "not tblite"` passes (292 passed; eight MACE setup errors because MACE is unavailable locally)
- [x] Added/updated tests for the change
- [x] Docs / README reviewed; no documentation change is needed