### PR TITLE
fix: handle model-specific LLM parameters

### DIFF
--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -15,6 +15,8 @@ from chemgraph.models.anthropic import load_anthropic_model
 from chemgraph.models.gemini import load_gemini_model
 from chemgraph.models.groq import load_groq_model
 from chemgraph.models.supported_models import (
+    MODELS_WITH_REASONING_EFFORT,
+    SUPPORTED_REASONING_EFFORTS,
     supported_openai_models,
     supported_ollama_models,
     supported_anthropic_models,
@@ -68,6 +70,29 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _resolve_reasoning_effort(
+    model_name: str, reasoning_effort: Optional[str]
+) -> Optional[str]:
+    """Validate and resolve reasoning effort for manually verified models."""
+    if model_name not in MODELS_WITH_REASONING_EFFORT:
+        if reasoning_effort is not None:
+            supported_models = ", ".join(sorted(MODELS_WITH_REASONING_EFFORT))
+            raise ValueError(
+                f"Model '{model_name}' does not have verified reasoning-effort "
+                f"support. Supported models: {supported_models}."
+            )
+        return None
+
+    effective_effort = "none" if reasoning_effort is None else reasoning_effort
+    if effective_effort not in SUPPORTED_REASONING_EFFORTS:
+        supported_efforts = ", ".join(sorted(SUPPORTED_REASONING_EFFORTS))
+        raise ValueError(
+            f"Unsupported reasoning effort '{effective_effort}'. "
+            f"Choose one of: {supported_efforts}."
+        )
+    return effective_effort
+
+
 class ChemGraph:
     """A graph-based workflow for LLM-powered computational chemistry tasks.
 
@@ -89,6 +114,10 @@ class ChemGraph:
         Base URL for API calls, by default None
     api_key : str, optional
         API key for authentication, by default None
+    reasoning_effort : str, optional
+        Reasoning effort for manually verified GPT-5.6 models, which default to
+        ``"none"``. Supported values are ``none``, ``low``, ``medium``,
+        ``high``, ``xhigh``, and ``max``.
     system_prompt : str, optional
         System prompt for the language model, by default single_agent_prompt
     formatter_prompt : str, optional
@@ -161,7 +190,10 @@ class ChemGraph:
         human_supervised: bool = False,
         terminal_tool_names: Collection[str] = (),
         on_event: Optional[EventCallback] = None,
+        reasoning_effort: Optional[str] = None,
     ):
+        reasoning_effort = _resolve_reasoning_effort(model_name, reasoning_effort)
+
         # Always generate a unique identifier for this instance
         self.uuid = str(uuid.uuid4())[:8]
 
@@ -211,6 +243,8 @@ class ChemGraph:
                 }
                 if argo_user is not None:
                     openai_load_kwargs["argo_user"] = argo_user
+                if reasoning_effort is not None:
+                    openai_load_kwargs["reasoning_effort"] = reasoning_effort
                 llm = load_openai_model(
                     **openai_load_kwargs,
                 )
@@ -275,6 +309,7 @@ class ChemGraph:
 
         self.workflow_type = workflow_type
         self.model_name = model_name
+        self.reasoning_effort = reasoning_effort
         self.system_prompt = system_prompt
         self.formatter_prompt = formatter_prompt
         self.structured_output = structured_output

--- a/src/chemgraph/models/openai.py
+++ b/src/chemgraph/models/openai.py
@@ -8,6 +8,9 @@ from langchain_openai import ChatOpenAI
 
 from chemgraph.models.supported_models import (
     ARGO_DEFAULT_BASE_URL,
+    MODELS_WITHOUT_TEMPERATURE,
+    MODELS_WITH_REASONING_EFFORT,
+    SUPPORTED_REASONING_EFFORTS,
     supported_openai_models,
     supported_argo_models,
 )
@@ -39,6 +42,9 @@ ARGO_MODEL_MAP = {
     "argo:gpt-5.1": "gpt51",
     "argo:gpt-5.2": "gpt52",
     "argo:gpt-5.4": "gpt54",
+    "argo:gpt-5.6-luna": "gpt56luna",
+    "argo:gpt-5.6-sol": "gpt56sol",
+    "argo:gpt-5.6-terra": "gpt56terra",
 
     # Reasoning / o-series
     "argo:o1-preview": "gpto1preview",
@@ -56,6 +62,7 @@ ARGO_MODEL_MAP = {
     "argo:claude-opus-4.1": "claudeopus41",
     "argo:claude-opus-4": "claudeopus4",
     "argo:claude-haiku-4.5": "claudehaiku45",
+    "argo:claude-sonnet-5": "claudesonnet5",
     "argo:claude-sonnet-4.5": "claudesonnet45",
     "argo:claude-sonnet-4": "claudesonnet4",
     "argo:claude-sonnet-3.5-v2": "claudesonnet35v2",
@@ -164,6 +171,7 @@ def load_openai_model(
     prompt: str = None,
     base_url: str = None,
     argo_user: str = None,
+    reasoning_effort: str = None,
 ) -> ChatOpenAI:
     """Load an OpenAI chat model into LangChain.
 
@@ -185,6 +193,8 @@ def load_openai_model(
         from the environment variable `OPENAI_API_KEY`.
     prompt : str, optional
         Custom prompt to use when requesting the API key from the user.
+    reasoning_effort : str, optional
+        Reasoning effort for manually verified models that support it.
 
     Returns
     -------
@@ -208,7 +218,21 @@ def load_openai_model(
     5. Handle any authentication errors by prompting for a new key
     """
 
+    requested_model_name = model_name
     base_url = normalize_openai_base_url(base_url)
+
+    if reasoning_effort is not None:
+        if requested_model_name not in MODELS_WITH_REASONING_EFFORT:
+            raise ValueError(
+                f"Model '{requested_model_name}' does not have verified "
+                "reasoning-effort support."
+            )
+        if reasoning_effort not in SUPPORTED_REASONING_EFFORTS:
+            supported = ", ".join(sorted(SUPPORTED_REASONING_EFFORTS))
+            raise ValueError(
+                f"Unsupported reasoning effort '{reasoning_effort}'. "
+                f"Choose one of: {supported}."
+            )
 
     # Apply default Argo base URL for argo: models when none is specified.
     if model_name.startswith("argo:") and not base_url:
@@ -251,14 +275,24 @@ def load_openai_model(
             model_name = _normalize_argo_model(model_name, base_url)
             llm_kwargs = dict(
                 model=model_name,
-                temperature=temperature,
                 api_key=api_key,
                 base_url=base_url,
                 max_tokens=4000,
-                top_p=1.0,
-                frequency_penalty=0.0,
-                presence_penalty=0.0,
             )
+            if requested_model_name in MODELS_WITHOUT_TEMPERATURE:
+                logger.info(
+                    "Using minimal request parameters for model '%s'",
+                    requested_model_name,
+                )
+            else:
+                llm_kwargs.update(
+                    temperature=temperature,
+                    top_p=1.0,
+                    frequency_penalty=0.0,
+                    presence_penalty=0.0,
+                )
+            if reasoning_effort is not None:
+                llm_kwargs["reasoning_effort"] = reasoning_effort
             # Anthropic requires streaming for requests that may exceed its
             # non-streaming duration limit. LangChain still aggregates the
             # chunks into one response for callers using ``invoke``.
@@ -273,12 +307,21 @@ def load_openai_model(
             llm = ChatOpenAI(**llm_kwargs)
         else:
             logger.info(f"Loading OpenAI model: {model_name}")
-            llm = ChatOpenAI(
+            openai_kwargs = dict(
                 model=model_name,
-                temperature=temperature,
                 api_key=api_key,
                 max_tokens=6000,
             )
+            if requested_model_name in MODELS_WITHOUT_TEMPERATURE:
+                logger.info(
+                    "Using minimal request parameters for model '%s'",
+                    requested_model_name,
+                )
+            else:
+                openai_kwargs["temperature"] = temperature
+            if reasoning_effort is not None:
+                openai_kwargs["reasoning_effort"] = reasoning_effort
+            llm = ChatOpenAI(**openai_kwargs)
         # Authentication happens only during invocation.
         logger.info(f"Requested model: {model_name}")
         logger.info("OpenAI model loaded successfully")
@@ -292,7 +335,13 @@ def load_openai_model(
             os.environ["OPENAI_API_KEY"] = api_key
             # Retry with new API key
             return load_openai_model(
-                model_name, temperature, api_key, prompt, base_url, argo_user
+                requested_model_name,
+                temperature,
+                api_key,
+                prompt,
+                base_url,
+                argo_user,
+                reasoning_effort,
             )
         else:
             logger.error(f"Error loading OpenAI model: {str(e)}")

--- a/src/chemgraph/models/openai.py
+++ b/src/chemgraph/models/openai.py
@@ -25,14 +25,7 @@ logger = setup_logger(__name__)
 # prefix is stripped instead and the remainder is sent as-is.
 ARGO_MODEL_MAP = {
     # GPT family
-    "argo:gpt-3.5-turbo": "gpt35",
-    "argo:gpt-3.5-turbo-16k": "gpt35turbo16k",
-    "argo:gpt-4": "gpt4",
-    "argo:gpt-4-32k": "gpt432k",
-    "argo:gpt-4-turbo": "gpt4turbo",
     "argo:gpt-4o": "gpt4o",
-    "argo:gpt-4o-latest": "gpt4olatest",
-    "argo:gpt-4o-mini": "gpt4omini",
     "argo:gpt-4.1": "gpt41",
     "argo:gpt-4.1-mini": "gpt41mini",
     "argo:gpt-4.1-nano": "gpt41nano",
@@ -42,13 +35,14 @@ ARGO_MODEL_MAP = {
     "argo:gpt-5.1": "gpt51",
     "argo:gpt-5.2": "gpt52",
     "argo:gpt-5.4": "gpt54",
+    "argo:gpt-5.4-mini": "gpt54mini",
+    "argo:gpt-5.4-nano": "gpt54nano",
+    "argo:gpt-5.5": "gpt55",
     "argo:gpt-5.6-luna": "gpt56luna",
     "argo:gpt-5.6-sol": "gpt56sol",
     "argo:gpt-5.6-terra": "gpt56terra",
 
     # Reasoning / o-series
-    "argo:o1-preview": "gpto1preview",
-    "argo:o1-mini": "gpto1mini",
     "argo:o1": "gpto1",
     "argo:o3-mini": "gpto3mini",
     "argo:o3": "gpto3",
@@ -56,17 +50,16 @@ ARGO_MODEL_MAP = {
     # Gemini via Argo
     "argo:gemini-2.5-pro": "gemini25pro",
     "argo:gemini-2.5-flash": "gemini25flash",
+    "argo:gemini-3.1-flash-lite": "gemini31flashlite",
+    "argo:gemini-3.5-flash": "gemini35flash",
     # Claude via Argo
     "argo:claude-opus-4.6": "claudeopus46",
     "argo:claude-opus-4.5": "claudeopus45",
     "argo:claude-opus-4.1": "claudeopus41",
-    "argo:claude-opus-4": "claudeopus4",
     "argo:claude-haiku-4.5": "claudehaiku45",
     "argo:claude-sonnet-5": "claudesonnet5",
+    "argo:claude-sonnet-4.6": "claudesonnet46",
     "argo:claude-sonnet-4.5": "claudesonnet45",
-    "argo:claude-sonnet-4": "claudesonnet4",
-    "argo:claude-sonnet-3.5-v2": "claudesonnet35v2",
-    "argo:claude-haiku-3.5": "claudehaiku35",
 }
 
 

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -90,14 +90,7 @@ ARGO_DEFAULT_BASE_URL = "https://apps.inside.anl.gov/argoapi/v1"
 # Default: ARGO_DEFAULT_BASE_URL (Argo API).
 supported_argo_models = [
     # GPT family
-    "argo:gpt-3.5-turbo",
-    "argo:gpt-3.5-turbo-16k",
-    "argo:gpt-4",
-    "argo:gpt-4-32k",
-    "argo:gpt-4-turbo",
     "argo:gpt-4o",
-    "argo:gpt-4o-latest",
-    "argo:gpt-4o-mini",
     "argo:gpt-4.1",
     "argo:gpt-4.1-mini",
     "argo:gpt-4.1-nano",
@@ -107,13 +100,13 @@ supported_argo_models = [
     "argo:gpt-5.1",
     "argo:gpt-5.2",
     "argo:gpt-5.4",
+    "argo:gpt-5.4-mini",
+    "argo:gpt-5.4-nano",  
     "argo:gpt-5.5",
     "argo:gpt-5.6-sol",
     "argo:gpt-5.6-terra",
     "argo:gpt-5.6-luna",
     # Reasoning / o-series
-    "argo:o1-preview",
-    "argo:o1-mini",
     "argo:o1",
     "argo:o3-mini",
     "argo:o3",
@@ -121,19 +114,18 @@ supported_argo_models = [
     # Gemini via Argo
     "argo:gemini-2.5-pro",
     "argo:gemini-2.5-flash",
+    "argo:gemini-3.1-flash-lite",
+    "argo:gemini-3.5-flash",
     # Claude via Argo
     "argo:claude-opus-4.8",
     "argo:claude-opus-4.7",
     "argo:claude-opus-4.6",
     "argo:claude-opus-4.5",
     "argo:claude-opus-4.1",
-    "argo:claude-opus-4",
     "argo:claude-haiku-4.5",
     "argo:claude-sonnet-5",
+    "argo:claude-sonnet-4.6",
     "argo:claude-sonnet-4.5",
-    "argo:claude-sonnet-4",
-    "argo:claude-sonnet-3.5-v2",
-    "argo:claude-haiku-3.5",
 ]
 
 # Exact Argo model routes that require minimal ChatOpenAI construction.

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -108,6 +108,9 @@ supported_argo_models = [
     "argo:gpt-5.2",
     "argo:gpt-5.4",
     "argo:gpt-5.5",
+    "argo:gpt-5.6-sol",
+    "argo:gpt-5.6-terra",
+    "argo:gpt-5.6-luna",
     # Reasoning / o-series
     "argo:o1-preview",
     "argo:o1-mini",
@@ -126,11 +129,34 @@ supported_argo_models = [
     "argo:claude-opus-4.1",
     "argo:claude-opus-4",
     "argo:claude-haiku-4.5",
+    "argo:claude-sonnet-5",
     "argo:claude-sonnet-4.5",
     "argo:claude-sonnet-4",
     "argo:claude-sonnet-3.5-v2",
     "argo:claude-haiku-3.5",
 ]
+
+# Exact Argo model routes that require minimal ChatOpenAI construction.
+# Optional sampling parameters are omitted for every entry in this set. Add
+# entries only after validating them against the deployed endpoint.
+MODELS_WITHOUT_TEMPERATURE = frozenset(
+    {
+        "argo:claude-sonnet-5",
+        "argo:gpt-5.6-luna",
+        "argo:gpt-5.6-sol",
+        "argo:gpt-5.6-terra",
+    }
+)
+MODELS_WITH_REASONING_EFFORT = frozenset(
+    {
+        "argo:gpt-5.6-luna",
+        "argo:gpt-5.6-sol",
+        "argo:gpt-5.6-terra",
+    }
+)
+SUPPORTED_REASONING_EFFORTS = frozenset(
+    {"none", "low", "medium", "high", "xhigh", "max"}
+)
 
 all_supported_models = (
     supported_openai_models

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -145,6 +145,11 @@ MODELS_WITHOUT_TEMPERATURE = frozenset(
         "argo:gpt-5.6-luna",
         "argo:gpt-5.6-sol",
         "argo:gpt-5.6-terra",
+        "argo:gpt-5.5",
+        "argo:gpt-5",
+        "argo:gpt-5-mini",
+        "argo:gpt-5-nano",
+
     }
 )
 MODELS_WITH_REASONING_EFFORT = frozenset(

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -24,6 +24,57 @@ def test_chemgraph_initialization(tmp_path):
         )
         assert hasattr(agent, "workflow")
 
+
+@pytest.mark.parametrize(
+    ("model_name", "reasoning_effort", "expected_effort"),
+    [
+        ("argo:gpt-5.6-luna", None, "none"),
+        ("argo:gpt-5.6-sol", "high", "high"),
+        ("argo:gpt-5.6-terra", None, "none"),
+    ],
+)
+def test_gpt56_reasoning_effort_is_passed_to_loader(
+    tmp_path, model_name, reasoning_effort, expected_effort
+):
+    with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load:
+        mock_load.return_value = Mock()
+        agent = ChemGraph(
+            model_name=model_name,
+            reasoning_effort=reasoning_effort,
+            enable_memory=False,
+            log_dir=str(tmp_path / "logs"),
+        )
+
+    assert mock_load.call_args.kwargs["reasoning_effort"] == expected_effort
+    assert agent.reasoning_effort == expected_effort
+
+
+def test_reasoning_effort_is_not_passed_to_sonnet5(tmp_path):
+    with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load:
+        mock_load.return_value = Mock()
+        agent = ChemGraph(
+            model_name="argo:claude-sonnet-5",
+            enable_memory=False,
+            log_dir=str(tmp_path / "logs"),
+        )
+
+    assert "reasoning_effort" not in mock_load.call_args.kwargs
+    assert agent.reasoning_effort is None
+
+
+def test_reasoning_effort_rejects_unverified_model():
+    with pytest.raises(ValueError, match="does not have verified"):
+        ChemGraph(model_name="argo:gpt-5.4", reasoning_effort="none")
+
+
+@pytest.mark.parametrize("reasoning_effort", ["fast", ""])
+def test_reasoning_effort_rejects_invalid_value(reasoning_effort):
+    with pytest.raises(ValueError, match="Unsupported reasoning effort"):
+        ChemGraph(
+            model_name="argo:gpt-5.6-sol", reasoning_effort=reasoning_effort
+        )
+
+
 def test_agent_query(mock_llm, tmp_path):
     with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_init_load, patch(
         "chemgraph.models.loader.load_openai_model"


### PR DESCRIPTION
## Summary

- Construct manually verified Argo model routes with minimal ChatOpenAI sampling parameters, avoiding 400 responses for deprecated temperature, top_p, and related optional fields.
- Add Argo Claude Sonnet 5 and GPT-5.6 Sol/Terra/Luna routes, with validated Python reasoning_effort support for the GPT-5.6 variants and a default effort of none.
- Keep existing sampling defaults for models outside MODELS_WITHOUT_TEMPERATURE; include GPT-5, GPT-5 Mini/Nano, GPT-5.5, GPT-5.6 variants, and Sonnet 5 in the minimal-construction registry.
- Update Argo-supported models.

## Related issues

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- ruff check src tests
- pytest -q tests/test_openai_model_normalization.py tests/test_llm_agent.py (19 passed)
- pytest tests/ -k "not tblite" (310 passed, 30 skipped, 2 deselected; eight existing MACE fixture setup errors because mace_mp is unavailable)
- Local ChatOpenAI construction checks confirmed minimal models leave temperature, top-p, frequency penalty, and presence penalty unset.

No live LLM requests were made.

## Checklist

- [x] Branched off the latest main and targets main
- [x] PR is focused on a single logical change
- [ ] ruff check . passes (the local checkout contains unrelated untracked environments; ruff check src tests passes)
- [ ] pytest tests/ -k "not tblite" passes (eight MACE setup errors because MACE is unavailable locally)
- [x] Added/updated tests for the change
- [x] Docs / README reviewed; the Python API docstring is updated and no README change is needed