### PR TITLE
Add experimental Codex subscription support

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,14 +586,40 @@ chemgraph -q "Optimize methane" -m groq:openai/gpt-oss-120b
 
 No curated model list is maintained -- any model available on Groq can be used by prefixing it with `groq:`. See the [Groq docs](https://console.groq.com/docs/models) for current models.
 
+#### Experimental Codex subscription support
+
+ChemGraph can use the official Codex Python SDK with an existing ChatGPT-backed
+Codex login. Install the optional extra and authenticate with ChatGPT:
+
+```bash
+pip install "chemgraph[codex]"
+codex login
+```
+
+Then prefix a model available to your Codex account with `codex:`:
+
+```bash
+chemgraph \
+  --model "codex:<codex-model-id>" \
+  --workflow single_agent \
+  --query "What is the SMILES string for aspirin?"
+```
+
+This experimental provider supports only `single_agent`. It does not use
+`OPENAI_API_KEY` or the OpenAI Platform API, and it rejects Codex sessions that
+are authenticated with an API key. See
+[Experimental Codex subscription support](docs/codex_subscription.md) for
+details.
+
 #### LLM Provider Prefixes
 
 For third-party providers that share model names with other services, ChemGraph uses a prefix convention to route models unambiguously:
 
-| Prefix  | Provider                    | Auth Env Var     | Example                               |
-| ------- | --------------------------- | ---------------- | ------------------------------------- |
-| `argo:` | Argo API (Argonne internal) | `OPENAI_API_KEY` | `argo:gpt-4o`, `argo:claude-sonnet-4` |
-| `groq:` | Groq Cloud                  | `GROQ_API_KEY`   | `groq:llama-3.3-70b-versatile`        |
+| Prefix  | Provider                    | Authentication       | Example                               |
+| ------- | --------------------------- | -------------------- | ------------------------------------- |
+| `codex:` | Codex SDK (experimental)   | ChatGPT Codex login  | `codex:<codex-model-id>`              |
+| `argo:` | Argo API (Argonne internal) | `OPENAI_API_KEY`     | `argo:gpt-4o`, `argo:claude-sonnet-4` |
+| `groq:` | Groq Cloud                  | `GROQ_API_KEY`       | `groq:llama-3.3-70b-versatile`        |
 
 Direct model names (no prefix) are used for:
 
@@ -697,6 +723,9 @@ chemgraph -q "Your query" -m meta-llama/Meta-Llama-3.1-70B-Instruct
 
 # Groq models (groq: prefix, any Groq model)
 chemgraph -q "Your query" -m groq:llama-3.3-70b-versatile
+
+# Codex SDK with a ChatGPT subscription login (experimental)
+chemgraph -q "Your query" -m "codex:<codex-model-id>" -w single_agent
 
 # Local models (Ollama)
 chemgraph -q "Your query" -m llama3.2

--- a/README.md
+++ b/README.md
@@ -589,7 +589,10 @@ No curated model list is maintained -- any model available on Groq can be used b
 #### Experimental Codex subscription support
 
 ChemGraph can use the official Codex Python SDK with an existing ChatGPT-backed
-Codex login. Install the optional extra and authenticate with ChatGPT:
+Codex login. The Codex CLI is a separate prerequisite; the Python SDK does not
+install the `codex` shell command. Follow the
+[official Codex CLI installation guide](https://learn.chatgpt.com/docs/codex/cli),
+then install the ChemGraph extra and authenticate with ChatGPT:
 
 ```bash
 pip install "chemgraph[codex]"

--- a/docs/codex_subscription.md
+++ b/docs/codex_subscription.md
@@ -6,7 +6,20 @@ path does not use the OpenAI Platform API or `OPENAI_API_KEY`.
 
 ## Install and authenticate
 
-Install the optional dependency:
+### 1. Install the Codex CLI
+
+The `openai-codex` Python package provides the SDK and its internal runtime,
+but it does not install a `codex` command on your shell `PATH`. Follow the
+[official Codex CLI installation guide](https://learn.chatgpt.com/docs/codex/cli),
+then verify that the command is available:
+
+```bash
+codex --version
+```
+
+### 2. Install the ChemGraph Codex extra
+
+For a package installation:
 
 ```bash
 pip install "chemgraph[codex]"
@@ -18,7 +31,9 @@ For an editable source checkout, install the extra into the active environment:
 pip install -e ".[codex]"
 ```
 
-Then authenticate Codex with ChatGPT:
+### 3. Authenticate with ChatGPT
+
+Use the separately installed CLI to authenticate Codex with ChatGPT:
 
 ```bash
 codex login
@@ -61,6 +76,7 @@ agent = ChemGraph(
 - ChemGraph does not start a login flow. Run `codex login` before initializing
   a `codex:` model.
 
-See the official [Codex SDK documentation](https://learn.chatgpt.com/docs/codex-sdk)
-and [authentication guide](https://learn.chatgpt.com/docs/auth) for supported
-Codex login and account behavior.
+See the official [Codex SDK documentation](https://learn.chatgpt.com/docs/codex-sdk),
+[Codex CLI installation guide](https://learn.chatgpt.com/docs/codex/cli), and
+[authentication guide](https://learn.chatgpt.com/docs/auth) for supported
+installation and account behavior.

--- a/docs/codex_subscription.md
+++ b/docs/codex_subscription.md
@@ -1,0 +1,66 @@
+# Experimental Codex subscription support
+
+ChemGraph can experimentally use the official Codex Python SDK with the
+ChatGPT-backed login already used by Codex CLI or the Codex IDE extension. This
+path does not use the OpenAI Platform API or `OPENAI_API_KEY`.
+
+## Install and authenticate
+
+Install the optional dependency:
+
+```bash
+pip install "chemgraph[codex]"
+```
+
+For an editable source checkout, install the extra into the active environment:
+
+```bash
+pip install -e ".[codex]"
+```
+
+Then authenticate Codex with ChatGPT:
+
+```bash
+codex login
+codex login status
+```
+
+The active login must be a ChatGPT login. ChemGraph deliberately rejects a
+Codex session authenticated with an API key instead of silently falling back to
+usage-based OpenAI Platform billing.
+
+## Run ChemGraph
+
+Prefix a model available to your Codex account with `codex:`:
+
+```bash
+chemgraph \
+  --model "codex:<codex-model-id>" \
+  --workflow single_agent \
+  --query "What is the SMILES string for aspirin?"
+```
+
+The same model syntax works through the Python API:
+
+```python
+from chemgraph import ChemGraph
+
+agent = ChemGraph(
+    model_name="codex:<codex-model-id>",
+    workflow_type="single_agent",
+)
+```
+
+## Current limitations
+
+- Only the `single_agent` workflow is supported.
+- The integration is experimental and pins `openai-codex==0.144.4` together
+  with that SDK's bundled Codex runtime.
+- ChemGraph starts ephemeral, read-only Codex threads. ChemGraph's LangGraph
+  workflow executes chemistry tools; Codex is used only for model decisions.
+- ChemGraph does not start a login flow. Run `codex login` before initializing
+  a `codex:` model.
+
+See the official [Codex SDK documentation](https://learn.chatgpt.com/docs/codex-sdk)
+and [authentication guide](https://learn.chatgpt.com/docs/auth) for supported
+Codex login and account behavior.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,9 @@ pip install "chemgraph[calculators]"
 ```
 
 To use the experimental Codex subscription provider with an existing ChatGPT
-login:
+login, first follow the
+[official Codex CLI installation guide](https://learn.chatgpt.com/docs/codex/cli).
+The Python SDK does not install the `codex` shell command. Then run:
 
 ```bash
 pip install "chemgraph[codex]"
@@ -41,7 +43,8 @@ source chemgraph-env/bin/activate  # Windows: .\chemgraph-env\Scripts\activate
 pip install -e .
 ```
 
-For experimental Codex subscription support, include the optional extra:
+For experimental Codex subscription support, install the Codex CLI as shown
+above, then include the optional extra in the editable install:
 
 ```bash
 pip install -e ".[codex]"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,17 @@ To include optional calculator extras (including `tblite`):
 pip install "chemgraph[calculators]"
 ```
 
+To use the experimental Codex subscription provider with an existing ChatGPT
+login:
+
+```bash
+pip install "chemgraph[codex]"
+codex login
+```
+
+See [Experimental Codex subscription support](codex_subscription.md) for usage
+and authentication constraints.
+
 !!! warning
     On platforms without a prebuilt `tblite` wheel, installing `calculators` may require a local Fortran toolchain.
 
@@ -28,6 +39,13 @@ cd ChemGraph
 python -m venv chemgraph-env
 source chemgraph-env/bin/activate  # Windows: .\chemgraph-env\Scripts\activate
 pip install -e .
+```
+
+For experimental Codex subscription support, include the optional extra:
+
+```bash
+pip install -e ".[codex]"
+codex login
 ```
 
 ### conda

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ plugins:
 nav:
   - Overview: index.md
   - Installation: installation.md
+  - Experimental Codex Support: codex_subscription.md
   - Example Usage: example_usage.md
   - Streamlit Web Interface: streamlit_web_interface.md
   - MCP Servers: mcp_servers.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,9 @@ dependencies = [
     ]
 
 [project.optional-dependencies]
+codex = [
+    "openai-codex==0.144.4",
+]
 calculators = [
     "tblite==0.4.0; python_version < '3.13' or platform_system != 'Darwin'",
 ]

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -14,6 +14,7 @@ from chemgraph.models.local_model import load_ollama_model
 from chemgraph.models.anthropic import load_anthropic_model
 from chemgraph.models.gemini import load_gemini_model
 from chemgraph.models.groq import load_groq_model
+from chemgraph.models.codex import load_codex_model
 from chemgraph.models.supported_models import (
     MODELS_WITH_REASONING_EFFORT,
     SUPPORTED_REASONING_EFFORTS,
@@ -102,7 +103,9 @@ class ChemGraph:
     Parameters
     ----------
     model_name : str, optional
-        Name of the language model to use, by default "gpt-4o-mini"
+        Name of the language model to use, by default "gpt-4o-mini".
+        Experimental ChatGPT subscription-backed Codex models use the
+        ``codex:<model-id>`` prefix and support only ``single_agent``.
     workflow_type : str, optional
         Type of workflow to use. Options:
         - "single_agent"
@@ -192,6 +195,11 @@ class ChemGraph:
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
     ):
+        if model_name.startswith("codex:") and workflow_type != "single_agent":
+            raise ValueError(
+                "Experimental codex: models currently support only the "
+                "single_agent workflow."
+            )
         reasoning_effort = _resolve_reasoning_effort(model_name, reasoning_effort)
 
         # Always generate a unique identifier for this instance
@@ -232,7 +240,9 @@ class ChemGraph:
             frequency_penalty = 0.0  # No repetition penalty
             presence_penalty = 0.0  # No presence penalty
 
-            if (
+            if model_name.startswith("codex:"):
+                llm = load_codex_model(model_name)
+            elif (
                 model_name in supported_openai_models
                 or model_name in supported_argo_models
             ):

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeou
 from typing import Any, Dict, Optional
 
 from rich.panel import Panel
+from rich.markup import escape
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Prompt
 from rich.table import Table
@@ -93,6 +94,11 @@ def check_api_keys(model_name: str) -> tuple[bool, str]:
         required credentials are available or not required.
     """
     model_lower = model_name.lower()
+
+    # Codex subscription models reuse the user's ChatGPT-backed Codex login.
+    # They must never fall through to OpenAI Platform API-key validation.
+    if model_name.startswith("codex:"):
+        return True, ""
 
     # OpenAI models (including GPT family, o-series, and Argo OpenAI)
     if (
@@ -304,10 +310,15 @@ def initialize_agent(
             return None
         except Exception as e:
             progress.update(task, description="[red]Agent initialization failed!")
-            console.print(f"[red]Error initializing agent: {e}[/red]")
+            console.print(f"[red]Error initializing agent: {escape(str(e))}[/red]")
 
             err_str = str(e).lower()
-            if "authentication" in err_str or "api" in err_str:
+            if model_name.startswith("codex:"):
+                console.print(
+                    "[dim]Codex models require the optional chemgraph\\[codex] "
+                    "extra and an active ChatGPT login from `codex login`.[/dim]"
+                )
+            elif "authentication" in err_str or "api" in err_str:
                 console.print(
                     "[dim]This looks like an API key issue. Check your credentials.[/dim]"
                 )

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -315,8 +315,9 @@ def initialize_agent(
             err_str = str(e).lower()
             if model_name.startswith("codex:"):
                 console.print(
-                    "[dim]Codex models require the optional chemgraph\\[codex] "
-                    "extra and an active ChatGPT login from `codex login`.[/dim]"
+                    "[dim]Install the Codex CLI separately, install the optional "
+                    "chemgraph\\[codex] extra, then run `codex login` and choose "
+                    "ChatGPT authentication.[/dim]"
                 )
             elif "authentication" in err_str or "api" in err_str:
                 console.print(

--- a/src/chemgraph/cli/formatting.py
+++ b/src/chemgraph/cli/formatting.py
@@ -79,9 +79,15 @@ def list_models() -> None:
 
         table.add_row(model, provider, model_type)
 
+    table.add_row(
+        "codex:<model-id>",
+        "Codex / ChatGPT",
+        "Experimental",
+    )
+
     console.print(table)
     console.print(
-        f"\n[bold green]Total models available: {len(all_supported_models)}[/bold green]"
+        f"\n[bold green]Curated models available: {len(all_supported_models)}[/bold green]"
     )
 
 

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -73,7 +73,10 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         "--model",
         type=str,
         default="gpt-4o-mini",
-        help="LLM model to use (default: gpt-4o-mini)",
+        help=(
+            "LLM model to use; experimental Codex subscription models use "
+            "codex:<model-id> (default: gpt-4o-mini)"
+        ),
     )
     parser.add_argument(
         "-w",
@@ -486,7 +489,11 @@ def _handle_run(args: argparse.Namespace) -> None:
         )
         return
 
-    if args.model not in all_supported_models:
+    if args.model.startswith("codex:"):
+        console.print(
+            "[yellow]Using experimental Codex subscription support.[/yellow]"
+        )
+    elif args.model not in all_supported_models:
         console.print(
             f"[yellow]Using custom model ID: {args.model} (not in curated list)[/yellow]"
         )

--- a/src/chemgraph/models/codex.py
+++ b/src/chemgraph/models/codex.py
@@ -1,0 +1,429 @@
+"""Experimental Codex SDK model adapter.
+
+This module adapts the official ``openai-codex`` Python SDK to LangChain's
+chat-model interface.  Codex is used only as the model backend; ChemGraph's
+existing LangGraph workflow remains responsible for executing chemistry tools.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import uuid
+from copy import deepcopy
+from typing import Any, Callable, Mapping, Sequence
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+
+CODEX_MODEL_PREFIX = "codex:"
+
+_BASE_INSTRUCTIONS = """\
+You are acting only as a language-model backend for ChemGraph.
+Do not inspect files, run commands, browse the web, or use any Codex-provided
+tools. Follow the conversation's system instructions and return only the JSON
+object required by the supplied output schema. ChemGraph, not Codex, executes
+all requested chemistry tools.
+"""
+
+
+class CodexAuthenticationError(RuntimeError):
+    """Raised when Codex is not using a ChatGPT subscription login."""
+
+
+class CodexResponseError(RuntimeError):
+    """Raised when Codex returns an invalid ChemGraph model decision."""
+
+
+def _load_codex_sdk():
+    """Import and return the official Codex SDK public classes lazily."""
+    try:
+        from openai_codex import ApprovalMode, Codex, CodexConfig, Sandbox
+    except ImportError as exc:
+        raise ImportError(
+            "Codex support requires the optional official SDK. Install it with "
+            "`pip install 'chemgraph[codex]'`."
+        ) from exc
+    return Codex, CodexConfig, Sandbox, ApprovalMode
+
+
+def _strip_codex_prefix(model_name: str) -> str:
+    """Return the Codex model ID from a ``codex:<id>`` model name."""
+    if not model_name.startswith(CODEX_MODEL_PREFIX):
+        raise ValueError(
+            f"Codex model names must use the {CODEX_MODEL_PREFIX}<model-id> prefix."
+        )
+    model_id = model_name.removeprefix(CODEX_MODEL_PREFIX).strip()
+    if not model_id:
+        raise ValueError("Codex model ID cannot be empty; use codex:<model-id>.")
+    return model_id
+
+
+def _model_dump(value: Any) -> Any:
+    """Convert a Pydantic SDK object into plain Python data when possible."""
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json", by_alias=True)
+    return value
+
+
+def _require_chatgpt_account(account_response: Any) -> None:
+    """Require the SDK's active account to be a ChatGPT-managed login."""
+    data = _model_dump(account_response)
+    if not isinstance(data, Mapping):
+        raise CodexAuthenticationError(
+            "Could not determine Codex authentication. Run `codex login` and "
+            "sign in with ChatGPT."
+        )
+
+    account = _model_dump(data.get("account"))
+    if account is None:
+        raise CodexAuthenticationError(
+            "No Codex login is available. Run `codex login` and sign in with "
+            "ChatGPT before using a codex: model."
+        )
+    if not isinstance(account, Mapping):
+        raise CodexAuthenticationError(
+            "Could not determine the active Codex login type. Run `codex login "
+            "status` and verify that ChatGPT authentication is active."
+        )
+
+    account_type = account.get("type")
+    if account_type == "chatgpt":
+        return
+    if account_type == "apiKey":
+        raise CodexAuthenticationError(
+            "The active Codex login uses an API key, which ChemGraph's "
+            "experimental codex: provider refuses. Run `codex logout`, then "
+            "`codex login` and choose ChatGPT subscription authentication."
+        )
+    raise CodexAuthenticationError(
+        f"The active Codex login type is {account_type!r}, not ChatGPT. Run "
+        "`codex login` and sign in with ChatGPT."
+    )
+
+
+def _message_content(message: BaseMessage) -> str:
+    content = message.content
+    if isinstance(content, str):
+        return content
+    return json.dumps(content, default=str, ensure_ascii=False)
+
+
+def _serialize_messages(messages: list[BaseMessage]) -> list[dict[str, str]]:
+    role_by_type = {
+        "system": "system",
+        "human": "user",
+        "ai": "assistant",
+        "tool": "tool",
+    }
+    return [
+        {
+            "role": role_by_type.get(message.type, message.type),
+            "content": _message_content(message),
+        }
+        for message in messages
+    ]
+
+
+def _normalize_tool_choice(tool_choice: Any, tool_names: set[str]) -> str | None:
+    if tool_choice is None or tool_choice == "auto":
+        return None
+    if tool_choice is True or (
+        isinstance(tool_choice, str) and tool_choice in {"any", "required"}
+    ):
+        return "required"
+    if tool_choice is False or tool_choice == "none":
+        return "none"
+    if isinstance(tool_choice, str):
+        if tool_choice not in tool_names:
+            raise ValueError(f"Unknown required tool {tool_choice!r}.")
+        return tool_choice
+    if isinstance(tool_choice, Mapping):
+        function = tool_choice.get("function")
+        name = function.get("name") if isinstance(function, Mapping) else None
+        if not isinstance(name, str) or name not in tool_names:
+            raise ValueError(f"Invalid Codex tool choice: {tool_choice!r}.")
+        return name
+    raise ValueError(f"Unsupported Codex tool choice: {tool_choice!r}.")
+
+
+def _decision_schema(
+    tool_names: list[str],
+    tool_choice: str | None,
+    parallel_tool_calls: bool,
+) -> dict[str, Any]:
+    if tool_names:
+        item_schema: dict[str, Any] = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "enum": tool_names},
+                "arguments": {"type": "string"},
+            },
+            "required": ["name", "arguments"],
+            "additionalProperties": False,
+        }
+    else:
+        item_schema = {
+            "type": "object",
+            "properties": {},
+            "required": [],
+            "additionalProperties": False,
+        }
+
+    calls_schema: dict[str, Any] = {
+        "type": "array",
+        "items": item_schema,
+    }
+    if not tool_names or tool_choice == "none":
+        calls_schema["maxItems"] = 0
+    elif tool_choice == "required" or tool_choice in tool_names:
+        calls_schema["minItems"] = 1
+    if not parallel_tool_calls:
+        calls_schema["maxItems"] = 1
+
+    return {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string"},
+            "tool_calls": calls_schema,
+        },
+        "required": ["content", "tool_calls"],
+        "additionalProperties": False,
+    }
+
+
+def _decision_prompt(
+    messages: list[BaseMessage],
+    tools: tuple[dict[str, Any], ...],
+    tool_choice: str | None,
+) -> str:
+    tool_instruction = (
+        "No tools are available. Return the answer in content and an empty "
+        "tool_calls array."
+    )
+    if tools:
+        tool_instruction = (
+            "Either answer in content with an empty tool_calls array, or request "
+            "the necessary tools. Each tool call's arguments field must be a "
+            "JSON-encoded object string matching that tool's parameters schema."
+        )
+    if tool_choice == "required":
+        tool_instruction = "Request at least one of the available tools."
+    elif tool_choice == "none":
+        tool_instruction = "Do not request a tool; answer in content."
+    elif tool_choice:
+        tool_instruction = f"Request the {tool_choice!r} tool."
+
+    payload = {
+        "conversation": _serialize_messages(messages),
+        "available_tools": list(tools),
+    }
+    return (
+        f"{tool_instruction}\n"
+        "Return only the schema-constrained decision for this conversation:\n"
+        f"{json.dumps(payload, ensure_ascii=False, default=str)}"
+    )
+
+
+def _usage_metadata(result: Any) -> dict[str, int] | None:
+    usage = getattr(result, "usage", None)
+    last = getattr(usage, "last", None)
+    if last is None:
+        return None
+    values = _model_dump(last)
+    if not isinstance(values, Mapping):
+        return None
+
+    def token_value(camel_name: str, snake_name: str) -> Any:
+        if camel_name in values:
+            return values[camel_name]
+        return values.get(snake_name)
+
+    try:
+        return {
+            "input_tokens": int(token_value("inputTokens", "input_tokens")),
+            "output_tokens": int(token_value("outputTokens", "output_tokens")),
+            "total_tokens": int(token_value("totalTokens", "total_tokens")),
+        }
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+class CodexChatModel(BaseChatModel):
+    """LangChain chat model backed by the official Codex Python SDK."""
+
+    model_id: str
+    bound_tools: tuple[dict[str, Any], ...] = ()
+    tool_choice: str | None = None
+    parallel_tool_calls: bool = True
+
+    @property
+    def _llm_type(self) -> str:
+        return "openai-codex-sdk"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {"model": self.model_id, "provider": "codex-subscription"}
+
+    def bind_tools(
+        self,
+        tools: Sequence[
+            dict[str, Any] | type | Callable[..., Any] | BaseTool
+        ],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> "CodexChatModel":
+        converted = tuple(convert_to_openai_tool(tool) for tool in tools)
+        functions = [tool.get("function") for tool in converted]
+        if not all(isinstance(function, Mapping) for function in functions):
+            raise ValueError("CodexChatModel supports only function tools.")
+        tool_names = {function["name"] for function in functions}
+        normalized_choice = _normalize_tool_choice(tool_choice, tool_names)
+        parallel = bool(kwargs.pop("parallel_tool_calls", True))
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise ValueError(f"Unsupported Codex tool options: {unsupported}.")
+        return self.model_copy(
+            update={
+                "bound_tools": deepcopy(converted),
+                "tool_choice": normalized_choice,
+                "parallel_tool_calls": parallel,
+            }
+        )
+
+    def validate_authentication(self) -> None:
+        """Validate that the reusable Codex login is ChatGPT-managed."""
+        Codex, CodexConfig, _Sandbox, _ApprovalMode = _load_codex_sdk()
+        with tempfile.TemporaryDirectory(prefix="chemgraph-codex-") as temp_dir:
+            config = CodexConfig(
+                cwd=temp_dir,
+                env={"OPENAI_API_KEY": "", "CODEX_API_KEY": ""},
+                client_name="chemgraph",
+                client_title="ChemGraph",
+            )
+            with Codex(config=config) as codex:
+                _require_chatgpt_account(codex.account())
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del run_manager
+        if stop:
+            raise ValueError("CodexChatModel does not support stop sequences.")
+        if kwargs:
+            unsupported = ", ".join(sorted(kwargs))
+            raise ValueError(f"Unsupported Codex invocation options: {unsupported}.")
+
+        Codex, CodexConfig, Sandbox, ApprovalMode = _load_codex_sdk()
+        tool_names = [tool["function"]["name"] for tool in self.bound_tools]
+        schema = _decision_schema(
+            tool_names,
+            self.tool_choice,
+            self.parallel_tool_calls,
+        )
+        prompt = _decision_prompt(messages, self.bound_tools, self.tool_choice)
+
+        with tempfile.TemporaryDirectory(prefix="chemgraph-codex-") as temp_dir:
+            config = CodexConfig(
+                cwd=temp_dir,
+                env={"OPENAI_API_KEY": "", "CODEX_API_KEY": ""},
+                client_name="chemgraph",
+                client_title="ChemGraph",
+            )
+            with Codex(config=config) as codex:
+                _require_chatgpt_account(codex.account())
+                thread = codex.thread_start(
+                    approval_mode=ApprovalMode.deny_all,
+                    base_instructions=_BASE_INSTRUCTIONS,
+                    cwd=temp_dir,
+                    ephemeral=True,
+                    model=self.model_id,
+                    sandbox=Sandbox.read_only,
+                )
+                result = thread.run(
+                    prompt,
+                    approval_mode=ApprovalMode.deny_all,
+                    output_schema=schema,
+                    sandbox=Sandbox.read_only,
+                )
+
+        raw_response = getattr(result, "final_response", None)
+        if not isinstance(raw_response, str) or not raw_response.strip():
+            raise CodexResponseError("Codex returned no final response.")
+        try:
+            decision = json.loads(raw_response)
+        except json.JSONDecodeError as exc:
+            raise CodexResponseError("Codex returned an invalid JSON decision.") from exc
+        if not isinstance(decision, Mapping):
+            raise CodexResponseError("Codex decision must be a JSON object.")
+
+        content = decision.get("content")
+        calls = decision.get("tool_calls")
+        if not isinstance(content, str) or not isinstance(calls, list):
+            raise CodexResponseError(
+                "Codex decision must contain string content and a tool_calls list."
+            )
+        if not self.parallel_tool_calls and len(calls) > 1:
+            raise CodexResponseError("Codex returned parallel tool calls when disabled.")
+        if self.tool_choice in {"required", *tool_names} and not calls:
+            raise CodexResponseError("Codex did not return the required tool call.")
+        if self.tool_choice == "none" and calls:
+            raise CodexResponseError("Codex returned a tool call when tools were disabled.")
+
+        tool_calls = []
+        for call in calls:
+            if not isinstance(call, Mapping):
+                raise CodexResponseError("Codex returned an invalid tool call.")
+            name = call.get("name")
+            arguments = call.get("arguments")
+            if name not in tool_names or not isinstance(arguments, str):
+                raise CodexResponseError(f"Codex returned an unknown tool call: {name!r}.")
+            if self.tool_choice not in {None, "required", name}:
+                raise CodexResponseError(
+                    f"Codex called {name!r} instead of required tool {self.tool_choice!r}."
+                )
+            try:
+                parsed_arguments = json.loads(arguments)
+            except json.JSONDecodeError as exc:
+                raise CodexResponseError(
+                    f"Codex returned invalid arguments for tool {name!r}."
+                ) from exc
+            if not isinstance(parsed_arguments, dict):
+                raise CodexResponseError(
+                    f"Codex tool arguments for {name!r} must be a JSON object."
+                )
+            tool_calls.append(
+                {
+                    "name": name,
+                    "args": parsed_arguments,
+                    "id": f"call_{uuid.uuid4().hex}",
+                }
+            )
+
+        message = AIMessage(
+            content=content,
+            tool_calls=tool_calls,
+            usage_metadata=_usage_metadata(result),
+            response_metadata={"model": self.model_id, "provider": "codex"},
+        )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+def load_codex_model(
+    model_name: str,
+    *,
+    validate_authentication: bool = True,
+) -> CodexChatModel:
+    """Load an experimental Codex subscription-backed chat model."""
+    model = CodexChatModel(model_id=_strip_codex_prefix(model_name))
+    if validate_authentication:
+        model.validate_authentication()
+    return model

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from chemgraph.models.alcf_endpoints import load_alcf_model
 from chemgraph.models.anthropic import load_anthropic_model
+from chemgraph.models.codex import load_codex_model
 from chemgraph.models.gemini import load_gemini_model
 from chemgraph.models.groq import load_groq_model
 from chemgraph.models.local_model import load_ollama_model
@@ -73,7 +74,9 @@ def load_chat_model(
     if model_name is None:
         raise ValueError("load_chat_model requires model_name or settings")
 
-    if model_name in supported_openai_models or model_name in supported_argo_models:
+    if model_name.startswith("codex:"):
+        return load_codex_model(model_name)
+    elif model_name in supported_openai_models or model_name in supported_argo_models:
         kwargs = {
             "model_name": model_name,
             "temperature": temperature,
@@ -106,5 +109,5 @@ def load_chat_model(
         raise ValueError(
             f"Model '{model_name}' not found in any supported model list. "
             "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
-            "argo:<model>, ALCF, or Ollama."
+            "codex:<model>, argo:<model>, ALCF, or Ollama."
         )

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -1,0 +1,325 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+
+from chemgraph.agent import llm_agent
+from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.cli import commands
+from chemgraph.cli.commands import check_api_keys
+from chemgraph.cli.formatting import console
+from chemgraph.graphs.single_agent import construct_single_agent_graph
+from chemgraph.models import codex as codex_model
+from chemgraph.models.codex import (
+    CodexAuthenticationError,
+    CodexChatModel,
+    CodexResponseError,
+    _strip_codex_prefix,
+)
+from chemgraph.models import loader
+
+
+class _FakeCodexConfig:
+    created = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.created.append(self)
+
+
+class _FakeSandbox:
+    read_only = "read-only"
+
+
+class _FakeApprovalMode:
+    deny_all = "deny-all"
+
+
+class _FakeAccountResponse:
+    def __init__(self, account):
+        self._account = account
+
+    def model_dump(self, **_kwargs):
+        return {"account": self._account, "requiresOpenaiAuth": True}
+
+
+class _FakeUsageBreakdown:
+    def model_dump(self, **_kwargs):
+        return {
+            "inputTokens": 11,
+            "outputTokens": 7,
+            "totalTokens": 18,
+        }
+
+
+class _FakeThread:
+    def __init__(self, state):
+        self.state = state
+
+    def run(self, prompt, **kwargs):
+        self.state.run_calls.append((prompt, kwargs))
+        response = self.state.responses.pop(0)
+        return SimpleNamespace(
+            final_response=response,
+            usage=SimpleNamespace(last=_FakeUsageBreakdown()),
+        )
+
+
+@pytest.fixture
+def fake_codex_sdk(monkeypatch):
+    state = SimpleNamespace(
+        account={"type": "chatgpt", "email": "chemist@example.com"},
+        responses=[],
+        clients=[],
+        thread_start_calls=[],
+        run_calls=[],
+    )
+    _FakeCodexConfig.created.clear()
+
+    class FakeCodex:
+        def __init__(self, config=None):
+            self.config = config
+            state.clients.append(self)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def account(self):
+            return _FakeAccountResponse(state.account)
+
+        def thread_start(self, **kwargs):
+            state.thread_start_calls.append(kwargs)
+            return _FakeThread(state)
+
+    monkeypatch.setattr(
+        codex_model,
+        "_load_codex_sdk",
+        lambda: (
+            FakeCodex,
+            _FakeCodexConfig,
+            _FakeSandbox,
+            _FakeApprovalMode,
+        ),
+    )
+    return state
+
+
+def test_codex_prefix_validation():
+    assert _strip_codex_prefix("codex:gpt-5.6-terra") == "gpt-5.6-terra"
+    with pytest.raises(ValueError, match="cannot be empty"):
+        _strip_codex_prefix("codex:")
+    with pytest.raises(ValueError, match="must use"):
+        _strip_codex_prefix("gpt-5.6-terra")
+
+
+@pytest.mark.parametrize(
+    ("account", "message"),
+    [
+        (None, "No Codex login"),
+        ({"type": "apiKey"}, "uses an API key"),
+        ({"type": "amazonBedrock"}, "not ChatGPT"),
+    ],
+)
+def test_codex_rejects_non_chatgpt_authentication(
+    fake_codex_sdk,
+    account,
+    message,
+):
+    fake_codex_sdk.account = account
+    model = CodexChatModel(model_id="gpt-5.6-terra")
+
+    with pytest.raises(CodexAuthenticationError, match=message):
+        model.validate_authentication()
+
+
+def test_codex_sdk_text_invocation_is_ephemeral_and_read_only(fake_codex_sdk):
+    fake_codex_sdk.responses.append(
+        json.dumps({"content": "Aspirin is acetylsalicylic acid.", "tool_calls": []})
+    )
+    model = CodexChatModel(model_id="gpt-5.6-terra")
+
+    response = model.invoke([HumanMessage(content="What is aspirin?")])
+
+    assert response.content == "Aspirin is acetylsalicylic acid."
+    assert response.usage_metadata == {
+        "input_tokens": 11,
+        "output_tokens": 7,
+        "total_tokens": 18,
+    }
+    config = _FakeCodexConfig.created[-1].kwargs
+    assert config["env"] == {"OPENAI_API_KEY": "", "CODEX_API_KEY": ""}
+    thread_call = fake_codex_sdk.thread_start_calls[-1]
+    assert thread_call["model"] == "gpt-5.6-terra"
+    assert thread_call["ephemeral"] is True
+    assert thread_call["sandbox"] == _FakeSandbox.read_only
+    assert thread_call["approval_mode"] == _FakeApprovalMode.deny_all
+    assert thread_call["cwd"] == config["cwd"]
+    run_prompt, run_kwargs = fake_codex_sdk.run_calls[-1]
+    assert "What is aspirin?" in run_prompt
+    assert run_kwargs["sandbox"] == _FakeSandbox.read_only
+    assert run_kwargs["output_schema"]["additionalProperties"] is False
+
+
+@tool
+def lookup_smiles(name: str) -> str:
+    """Return a deterministic test SMILES string for a molecule name."""
+    assert name == "aspirin"
+    return "CC(=O)OC1=CC=CC=C1C(=O)O"
+
+
+def test_codex_tool_bridge_creates_langchain_tool_call(fake_codex_sdk):
+    fake_codex_sdk.responses.append(
+        json.dumps(
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "name": "lookup_smiles",
+                        "arguments": json.dumps({"name": "aspirin"}),
+                    }
+                ],
+            }
+        )
+    )
+    model = CodexChatModel(model_id="gpt-5.6-terra").bind_tools(
+        [lookup_smiles],
+        tool_choice="lookup_smiles",
+        parallel_tool_calls=False,
+    )
+
+    response = model.invoke([HumanMessage(content="Look up aspirin")])
+
+    assert response.tool_calls[0]["name"] == "lookup_smiles"
+    assert response.tool_calls[0]["args"] == {"name": "aspirin"}
+    assert response.tool_calls[0]["id"].startswith("call_")
+    schema = fake_codex_sdk.run_calls[-1][1]["output_schema"]
+    assert schema["properties"]["tool_calls"]["minItems"] == 1
+    assert schema["properties"]["tool_calls"]["maxItems"] == 1
+
+
+def test_codex_tool_bridge_rejects_unknown_tool(fake_codex_sdk):
+    fake_codex_sdk.responses.append(
+        json.dumps(
+            {
+                "content": "",
+                "tool_calls": [
+                    {"name": "not_bound", "arguments": json.dumps({})}
+                ],
+            }
+        )
+    )
+    model = CodexChatModel(model_id="gpt-5.6-terra").bind_tools([lookup_smiles])
+
+    with pytest.raises(CodexResponseError, match="unknown tool"):
+        model.invoke([HumanMessage(content="Look up aspirin")])
+
+
+def test_codex_adapter_runs_existing_single_agent_tool_loop(fake_codex_sdk):
+    fake_codex_sdk.responses.extend(
+        [
+            json.dumps(
+                {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "name": "lookup_smiles",
+                            "arguments": json.dumps({"name": "aspirin"}),
+                        }
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "content": "The aspirin SMILES is CC(=O)OC1=CC=CC=C1C(=O)O.",
+                    "tool_calls": [],
+                }
+            ),
+        ]
+    )
+    graph = construct_single_agent_graph(
+        CodexChatModel(model_id="gpt-5.6-terra"),
+        system_prompt="Use the lookup tool before answering.",
+        tools=[lookup_smiles],
+    )
+
+    state = graph.invoke(
+        {"messages": "What is the SMILES for aspirin?"},
+        config={"configurable": {"thread_id": "codex-test"}},
+    )
+
+    assert state["messages"][-2].name == "lookup_smiles"
+    assert state["messages"][-1].content.startswith("The aspirin SMILES")
+    assert len(fake_codex_sdk.run_calls) == 2
+
+
+def test_shared_loader_routes_codex_prefix(monkeypatch):
+    monkeypatch.setattr(
+        loader,
+        "load_codex_model",
+        lambda model_name: ("codex-model", model_name),
+    )
+
+    assert loader.load_chat_model("codex:test-model") == (
+        "codex-model",
+        "codex:test-model",
+    )
+
+
+def test_chemgraph_routes_codex_to_single_agent(monkeypatch, tmp_path):
+    captured = {}
+    monkeypatch.setattr(
+        llm_agent,
+        "load_codex_model",
+        lambda model_name: ("codex-model", model_name),
+    )
+    monkeypatch.setattr(
+        llm_agent,
+        "construct_single_agent_graph",
+        lambda llm, *_args, **_kwargs: captured.setdefault("llm", llm),
+    )
+
+    ChemGraph(
+        model_name="codex:test-model",
+        workflow_type="single_agent",
+        enable_memory=False,
+        log_dir=str(tmp_path),
+    )
+
+    assert captured["llm"] == ("codex-model", "codex:test-model")
+
+
+def test_chemgraph_rejects_codex_for_other_workflows():
+    with pytest.raises(ValueError, match="only the single_agent workflow"):
+        ChemGraph(model_name="codex:test-model", workflow_type="multi_agent")
+
+
+def test_codex_models_never_require_openai_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert check_api_keys("codex:o3") == (True, "")
+
+
+def test_codex_install_hint_preserves_extra_name(monkeypatch):
+    def fail_to_initialize(*args, **kwargs):
+        raise ImportError(
+            "Install it with `pip install 'chemgraph[codex]'`."
+        )
+
+    monkeypatch.setattr("chemgraph.agent.llm_agent.ChemGraph", fail_to_initialize)
+
+    with console.capture() as capture:
+        agent = commands.initialize_agent(
+            model_name="codex:test-model",
+            workflow_type="single_agent",
+            structured_output=False,
+            return_option="last_message",
+            generate_report=False,
+            recursion_limit=10,
+        )
+
+    assert agent is None
+    assert "chemgraph[codex]" in capture.get()

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -322,4 +322,7 @@ def test_codex_install_hint_preserves_extra_name(monkeypatch):
         )
 
     assert agent is None
-    assert "chemgraph[codex]" in capture.get()
+    output = capture.get()
+    assert "Codex CLI separately" in output
+    assert "chemgraph[codex]" in output
+    assert "codex login" in output


### PR DESCRIPTION
## Summary

- Add an experimental codex:<model-id> provider backed exclusively by the official openai-codex Python SDK and the user's existing ChatGPT/Codex login.
- Adapt Codex structured responses and tool calls to ChemGraph's existing single-agent LangGraph workflow, using ephemeral read-only threads with approvals denied.
- Reject missing, API-key, and non-ChatGPT Codex authentication; do not use OPENAI_API_KEY, the OpenAI Platform API, or LangChain's private Codex class.
- Add CLI routing and guidance, hermetic adapter/tool-loop tests, and installation and usage documentation.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- ruff check src tests
- pytest -q tests/test_codex_model.py tests/test_graphs.py tests/test_graph_constructors.py tests/test_llm_agent.py tests/test_cli_formatting.py tests/test_turn_executed_tools.py (58 passed)
- Official SDK authentication initialization against an existing ChatGPT login succeeded; no live model request was completed.
- The sandboxed core-suite run reached 305 passed, 29 skipped, and 2 deselected; 12 existing SQLite/multiprocessing tests could not access required macOS facilities in the sandbox.

## Checklist

- [x] Branched off the latest main and targets main
- [x] PR is focused on a single logical change
- [x] ruff check . passes 
- [x] pytest passes
- [x] Updated docs / README for the user-facing change