### PR TITLE
Make mace-torch an optional extra

### DIFF
--- a/.github/workflows/conda-tests.yml
+++ b/.github/workflows/conda-tests.yml
@@ -63,7 +63,8 @@ jobs:
     - name: Install ChemGraph with MACE support
       shell: bash -l {0}
       run: |
-        pip install --no-cache-dir -e .
+        # MACE is an optional extra, and this job exists to exercise it.
+        pip install --no-cache-dir -e ".[mace]"
         pip install --no-cache-dir pytest
     
     - name: Run tests with MACE
@@ -107,18 +108,10 @@ jobs:
   #     run: |
   #       conda install -c conda-forge nwchem -y
 
-  #   - name: Temporarily modify pyproject.toml for UMA e3nn compatibility
-  #     shell: bash -l {0}
-  #     run: |
-  #       echo "Backing up pyproject.toml to pyproject.toml.original..."
-  #       cp pyproject.toml pyproject.toml.original
-  #       echo "Commenting out mace-torch from pyproject.toml..."
-  #       # This sed command finds lines starting with optional whitespace,
-  #       # then "mace-torch>=0.3.13", and prepends a '#' to the matched line.
-  #       sed -i 's/^[[:space:]]*"mace-torch>=0.3.13",/#&/' pyproject.toml
-  #       echo "pyproject.toml after modification:"
-  #       cat pyproject.toml
-    
+  #   # mace-torch is an optional extra, so a plain install brings in neither
+  #   # it nor the old e3nn, and the pyproject edit this job used to perform
+  #   # is no longer needed.
+
   #   - name: Install ChemGraph with UMA support
   #     shell: bash -l {0}
   #     env:
@@ -145,14 +138,4 @@ jobs:
   #     run: |
   #       python -m pytest tests/ -v 
     
-  #   - name: Restore pyproject.toml
-  #     shell: bash -l {0}
-  #     if: always() # Ensures this step runs even if previous steps fail
-  #     run: |
-  #       echo "Restoring pyproject.toml from pyproject.toml.original..."
-  #       if [ -f pyproject.toml.original ]; then
-  #         mv pyproject.toml.original pyproject.toml
-  #         echo "pyproject.toml restored."
-  #       else
-  #         echo "Backup pyproject.toml.original not found. Cannot restore."
-  #       fi 
+ 

--- a/.github/workflows/dependency_tests.yml
+++ b/.github/workflows/dependency_tests.yml
@@ -28,30 +28,22 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ "${{ matrix.install_extras }}" == "uma" ]; then
-          # 1. Install the main package (installs mace-torch + old e3nn)
-          pip install .
-          
-          # 2. FORCE UNINSTALL the conflicting packages
-          echo "💥 Forcefully removing mace-torch and e3nn for UMA compatibility..."
-          pip uninstall -y mace-torch e3nn
-          
-          # 3. MANUALLY install the UMA dependencies.
+          # mace-torch is an optional extra now, so a core install brings in
+          # neither it nor the old e3nn and there is nothing to remove first.
           # torchtnt 0.2.4 (via fairchem-core) imports pkg_resources, which was
-          # removed in setuptools 82.
-          # (We cannot use pip install .[uma] because it would trigger the resolution error)
+          # removed in setuptools 82, so setuptools stays pinned below that.
+          pip install "setuptools<82" .
           pip install "setuptools<82" "fairchem-core==2.13.0" "e3nn>=0.5"
-          
+
         elif [ "${{ matrix.install_extras }}" == "core" ]; then
           pip install .
         else
           pip install ".[${{ matrix.install_extras }}]"
         fi
 
-    # The UMA job intentionally removes the core MACE dependency to work
-    # around their incompatible e3nn requirements. Dependency consistency for
-    # that environment will be enabled when the extras are separated.
+    # Now that mace is its own extra, the UMA environment no longer has a
+    # conflicting mace-torch to work around, so it is checked like the rest.
     - name: Verify Dependency Consistency
-      if: matrix.install_extras != 'uma'
       run: python -m pip check
 
     - name: Verify Imports
@@ -72,8 +64,15 @@ jobs:
         extras = '${{ matrix.install_extras }}'
         failures = []
 
-        # Core imports that should always work
-        core_packages = ['chemgraph']
+        # Core imports that should always work. The submodules matter as much
+        # as the top-level package: importing chemgraph alone succeeds even
+        # when a calculator schema pulls in a package the core install lacks.
+        core_packages = [
+            'chemgraph',
+            'chemgraph.schemas.ase_input',
+            'chemgraph.tools.ase_tools',
+            'chemgraph.agent.llm_agent',
+        ]
         for pkg in core_packages:
             if not check_import(pkg):
                 failures.append(pkg)

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -24,8 +24,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
-            
+        # MACE is an optional extra; install it so the mace_mp tests run here
+        # as they did when mace-torch was a hard dependency.
+        pip install -e ".[mace]"
+
     - name: Run tests
       run: |
         python -m pytest tests/ -v -k "not tblite"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,9 +48,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        # MACE is an optional extra; install it here so the mace_mp tests run
+        # in CI. Without it they skip.
+        pip install -e ".[mace]"
         python -m pip check
-            
+
     - name: Run tests
       run: |
         python -m pytest tests/ -v -k "not tblite"

--- a/.opencode/skills/chemgraph/SKILL.md
+++ b/.opencode/skills/chemgraph/SKILL.md
@@ -268,7 +268,7 @@ docker compose --profile jupyter up
 - `rdkit` -- cheminformatics, 3D structure generation
 - `pubchempy` -- PubChem molecule lookup
 - `mcp` + `fastmcp` -- Model Context Protocol servers
-- `mace-torch` -- MACE ML potentials
+- `mace-torch` -- MACE ML potentials (optional, `[mace]` extra)
 - `pydantic` -- data validation
 - `parsl` -- HPC parallel execution (optional)
 - `streamlit` + `stmol` -- web UI (optional)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ pip install -e .                                  # core
 pip install -e ".[academy,parsl,globus_compute]"  # to run the HPC/Academy tests
 ```
 
-Optional extras: `calculators`, `uma`, `ui`, `parsl`, `ensemble_launcher`,
-`globus_compute`, `academy`, `xanes`, `rag`.
+Optional extras: `calculators`, `mace`, `uma`, `ui`, `parsl`,
+`ensemble_launcher`, `globus_compute`, `academy`, `xanes`, `rag`, `docking`.
 
 ## Build / test / lint commands
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,9 @@ RUN conda install -y -c conda-forge \
     nwchem \
     && conda clean -afy
 
-# Install ChemGraph and UI runtime
-RUN pip install --no-cache-dir . && \
+# Install ChemGraph and UI runtime. MACE is an optional extra, requested here
+# so the image keeps offering the mace_mp calculator the docs demonstrate.
+RUN pip install --no-cache-dir ".[mace]" && \
     pip install --no-cache-dir jupyterlab
 
 # Install Python tblite from source with conservative flags to avoid ABI/symbol issues on ARM.

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -26,7 +26,9 @@ RUN conda install -y -c conda-forge \
     nwchem \
     && conda clean -afy
 
-RUN pip install --no-cache-dir . && \
+# MACE is an optional extra, requested here so the image keeps offering the
+# mace_mp calculator the docs demonstrate.
+RUN pip install --no-cache-dir ".[mace]" && \
     pip install --no-cache-dir jupyterlab
 
 # Install Python tblite from source with conservative flags to avoid ABI/symbol issues on ARM.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ pip install chemgraph[calculators]
 > wheel is available), installing the `calculators` extra may require a local
 > Fortran toolchain.
 
+To install with MACE (`mace_mp`, `mace_off`, `mace_anicc`):
+```bash
+pip install "chemgraph[mace]"
+```
+
+> `mace-torch` is an optional extra. A default installation leaves the MACE
+> calculators unregistered, and requesting `mace_mp` then raises a pydantic
+> `ValidationError`, a `ValueError` subclass, listing the calculators the
+> environment does offer.
+
 **Install from Source (Alternative Methods)**
 
 If you need to install from source for the latest version:
@@ -171,22 +181,19 @@ If you need to install from source for the latest version:
 
 **Optional: Install with UMA support**
 
-> ⚠️ **Note on e3nn Conflict for UMA Installation:** The `uma` extras (requiring `e3nn>=0.5`) conflict with the base `mace-torch` dependency (which pins `e3nn==0.4.4`). 
-> 
-> **For PyPI installations**, you can try:
+> ⚠️ **Note on e3nn Conflict for UMA Installation:** The `uma` extras (requiring `e3nn>=0.5`) conflict with `mace-torch` (which pins `e3nn==0.4.4`).
+>
+> MACE is an optional extra, so a plain install pulls in neither `mace-torch`
+> nor its `e3nn==0.4.4` pin, which is what blocked UMA. Try:
 > ```bash
-> pip install chemgraph[uma]
+> pip install "chemgraph[uma]"     # or: pip install -e ".[uma]" from source
 > ```
-> However, this may fail due to the e3nn version conflict. If it does, you'll need to install from source using the workaround below.
+> If resolution still fails, install UMA in a dedicated environment. The `uma`
+> extra pins `fairchem-core==2.3.0`, which has no Python 3.13 build.
+> Install MACE on its own with `pip install "chemgraph[mace]"`. Requesting both
+> in one environment (`".[mace,uma]"`) hits the `e3nn` conflict.
 >
-> **For source installations**, if you need to install UMA support in an environment where `mace-torch` might cause this conflict, you can try the following workaround:
-> 1. **Temporarily modify `pyproject.toml`**: Open the `pyproject.toml` file in the root of the ChemGraph project.
-> 2. Find the line containing `"mace-torch",` in the `dependencies` list.
-> 3. Comment out this line by adding a `#` at the beginning (e.g., `#    "mace-torch",`).
-> 4. **Install UMA extras**: Run `pip install -e ".[uma]"`.
-> 5. **(Optional) Restore `pyproject.toml`**: After installation, you can uncomment the `mace-torch` line if you still need it for other purposes in the same environment. Be aware that `mace-torch` might not function correctly due to the `e3nn` version mismatch (`e3nn>=0.5` will be present for UMA).
->
-> **The most robust solution for using both MACE and UMA with their correct dependencies is to create separate Conda environments, as highlighted in the "Note on Compatibility" above.**
+> **Separate Conda environments give both MACE and UMA their correct dependencies, as highlighted in the "Note on Compatibility" above.**
 
 > **Important for UMA Model Access:** The `facebook/UMA` model is a gated model on Hugging Face. To use it, you must:
 > 1. Visit the [facebook/UMA model page](https://huggingface.co/facebook/UMA) on Hugging Face.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,9 +49,18 @@ source chemgraph-env/bin/activate  # Windows: .\chemgraph-env\Scripts\activate
 uv pip install -e .
 ```
 
+## Optional MACE install
+
+MACE is an optional extra, so a plain install leaves `mace-torch` out and the
+`mace_mp`, `mace_off`, and `mace_anicc` calculators stay unregistered:
+
+```bash
+pip install "chemgraph[mace]"     # or: pip install -e ".[mace]" from source
+```
+
 ## Optional UMA install
 
-`uma` and `mace-torch` can conflict through different `e3nn` requirements.
+`uma` and `mace` can conflict through different `e3nn` requirements.
 Use separate environments if you need both MACE and UMA.
 
 PyPI attempt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "ase",
     "rdkit",
     "pymatgen",
-    "mace-torch",
     "globus_sdk",
     "streamlit==1.48.1",
     "stmol==0.0.9",
@@ -54,6 +53,9 @@ dependencies = [
 [project.optional-dependencies]
 calculators = [
     "tblite==0.4.0; python_version < '3.13' or platform_system != 'Darwin'",
+]
+mace = [
+    "mace-torch",
 ]
 uma = [
     "fairchem-core==2.3.0",

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -231,8 +231,8 @@ class ASEInputSchema(BaseModel):
     calculator : Union[FAIRChemCalc, MaceCalc, NWChemCalc, OrcaCalc, TBLiteCalc, EMTCalc, AIMNET2Calc]
         ASE-compatible calculator used for the simulation. Supported types are determined
         by installed packages and may include:
-        - FAIRChem, MACE, NWChem, Orca, TBLite and EMT. The order determines the priority of the calculators.
-        - Use MACE or FAIRChem if the calculator is not specified.
+        - FAIRChem, MACE, AIMNET2, TBLite, EMT, NWChem and Orca. The order determines the priority of the calculators.
+        - Omitting the calculator selects the first one available in this environment.
     fmax : float
         Force convergence criterion in eV/Å. Optimization stops when all force components fall below this threshold.
     steps : int

--- a/src/chemgraph/schemas/calculators/fairchem_calc.py
+++ b/src/chemgraph/schemas/calculators/fairchem_calc.py
@@ -1,7 +1,6 @@
 from pydantic import BaseModel, Field, model_validator
 
 from typing import Any, Optional, Dict
-import torch
 import logging
 
 try:
@@ -10,6 +9,27 @@ except ImportError:
     logging.warning("fairchem is not installed. .")
     FAIRChemCalculator = None
     pretrained_mlip = None
+
+
+DEFAULT_DEVICE = "cpu"
+
+
+def _resolve_device(device: str) -> str:
+    """Upgrade the default device to ``"cuda"`` when a GPU is visible.
+
+    torch ships with the optional ``uma`` and ``mace`` extras, so it can be
+    absent on a core install. ``ase_input`` imports this module to decide
+    whether FAIRChemCalc is available, which makes a module-level torch import
+    fatal for every calculator, so the probe happens here. A device the caller
+    asked for is returned untouched.
+    """
+    if device != DEFAULT_DEVICE:
+        return device
+    try:
+        import torch
+    except ImportError:
+        return DEFAULT_DEVICE
+    return "cuda" if torch.cuda.is_available() else DEFAULT_DEVICE
 
 
 class FAIRChemCalc(BaseModel):
@@ -57,8 +77,11 @@ class FAIRChemCalc(BaseModel):
         default="uma-s-1p1", description="Model names. Options are 'uma-s-1p1' and 'uma-m-1'"
     )
     device: str = Field(
-        default="cuda" if torch.cuda.is_available() else "cpu",
-        description="Computation device to use, either 'cpu' or 'cuda'.",
+        default=DEFAULT_DEVICE,
+        description=(
+            "Computation device to use, either 'cpu' or 'cuda'. Left at the "
+            "default, a visible GPU is used when one is present."
+        ),
     )
     inference_settings: str = Field(
         default="default", description="Settings for inference. Can be 'default' or 'turbo'"
@@ -106,7 +129,7 @@ class FAIRChemCalc(BaseModel):
         predict_unit = pretrained_mlip.get_predict_unit(
             model_name=self.model_name,
             inference_settings=self.inference_settings,
-            device=self.device,
+            device=_resolve_device(self.device),
         )
         return FAIRChemCalculator(
             predict_unit=predict_unit,

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional, Union
 from pydantic import BaseModel, Field
-import torch
 
 _logger = logging.getLogger(__name__)
 
@@ -177,6 +176,11 @@ class MaceCalc(BaseModel):
         ValueError
             If an invalid calculator_type is specified
         """
+        # torch arrives with mace-torch, which is an optional extra, so import
+        # it here alongside mace. A module-level import would break every
+        # calculator on a core install, since ase_input imports this module to
+        # decide whether MaceCalc is available.
+        import torch
         from mace.modules.models import ScaleShiftMACE
 
         # Allow loading slice and ScaleShiftMACE objects for compatibility with older model files

--- a/tests/test_faircalc.py
+++ b/tests/test_faircalc.py
@@ -22,6 +22,14 @@ if is_fairchem_installed():
     pass
 
 
+# The fixtures below request mace_mp, so these tests need mace-torch as well as
+# fairchem. With fairchem present and mace absent the skipif would let them run
+# and the fixtures would fail schema validation, since MaceCalc is unregistered.
+requires_mace = pytest.mark.skipif(
+    importlib.util.find_spec("mace") is None, reason="MACE not installed"
+)
+
+
 @pytest.fixture
 def base_ase_input():
     """Base fixture for ASE input with common parameters"""
@@ -60,6 +68,7 @@ def thermo_ase_schema(base_ase_input):
     return ASEInputSchema(**input_dict)
 
 
+@requires_mace
 @pytest.mark.skipif(not is_fairchem_installed(), reason="FairChem is not installed")
 def test_run_ase_opt(opt_ase_schema):
     """Test ASE geometry optimization."""
@@ -82,6 +91,7 @@ def test_run_ase_opt(opt_ase_schema):
     assert data["simulation_input"]["driver"] == "opt"
 
 
+@requires_mace
 @pytest.mark.skipif(not is_fairchem_installed(), reason="FairChem is not installed")
 def test_run_ase_vib(vib_ase_schema):
     """Test ASE vibrational analysis."""
@@ -103,6 +113,7 @@ def test_run_ase_vib(vib_ase_schema):
     assert len(data["vibrational_frequencies"]["energies"]) > 0
 
 
+@requires_mace
 @pytest.mark.skipif(not is_fairchem_installed(), reason="FairChem is not installed")
 def test_run_ase_thermo(thermo_ase_schema):
     """Test ASE thermochemistry calculation."""

--- a/tests/test_mace.py
+++ b/tests/test_mace.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import importlib.util
 import json
 import pytest
 from chemgraph.tools.ase_tools import (
@@ -7,6 +8,14 @@ from chemgraph.tools.ase_tools import (
 from chemgraph.schemas.ase_input import ASEInputSchema
 
 TEST_DIR = Path(__file__).parent
+
+# Every test here runs a mace_mp calculation. MaceCalc is unregistered when
+# mace-torch is absent, so the schema fixtures below fail validation at setup.
+# Guard the whole module the way test_calculators.py guards its own
+# engine-specific tests.
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("mace") is None, reason="MACE not installed"
+)
 
 
 @pytest.fixture

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import importlib.util
 import json
 import pytest
 from chemgraph.tools.ase_tools import (
@@ -14,6 +15,14 @@ from chemgraph.schemas.atomsdata import AtomsData
 from chemgraph.schemas.ase_input import ASEInputSchema
 
 TEST_DIR = Path(__file__).parent
+
+# The run_ase tests below drive mace_mp. MaceCalc is unregistered when
+# mace-torch is absent, so their schema fixtures fail validation at setup.
+# Guard them so they skip. The cheminformatics tests need no calculator and
+# stay live.
+requires_mace = pytest.mark.skipif(
+    importlib.util.find_spec("mace") is None, reason="MACE not installed"
+)
 
 
 def test_molecule_name_to_smiles(monkeypatch):
@@ -139,6 +148,7 @@ def thermo_ase_schema(base_ase_input):
     return ASEInputSchema(**input_dict)
 
 
+@requires_mace
 def test_run_ase_energy(energy_ase_schema):
     """Test ASE energy calculation."""
     result = run_ase.invoke({"params": energy_ase_schema})
@@ -149,6 +159,7 @@ def test_run_ase_energy(energy_ase_schema):
     assert result['unit'] == "eV"
 
 
+@requires_mace
 def test_run_ase_opt(opt_ase_schema):
     """Test ASE geometry optimization."""
     result = run_ase.invoke({"params": opt_ase_schema})
@@ -170,6 +181,7 @@ def test_run_ase_opt(opt_ase_schema):
     assert data["simulation_input"]["driver"] == "opt"
 
 
+@requires_mace
 def test_run_ase_vib(vib_ase_schema):
     """Test ASE vibrational analysis."""
     result = run_ase.invoke({"params": vib_ase_schema})
@@ -190,6 +202,7 @@ def test_run_ase_vib(vib_ase_schema):
     assert len(data["vibrational_frequencies"]["energies"]) > 0
 
 
+@requires_mace
 def test_run_ase_thermo(thermo_ase_schema):
     """Test ASE thermochemistry calculation."""
     result = run_ase.invoke({"params": thermo_ase_schema})


### PR DESCRIPTION
## Summary

`mace-torch` is currently a required dependency, although the schema path
already treats MACE as optional. `ase_input.py` registers `MaceCalc` only when
`_engine_available("mace")` is true, leaving `pyproject.toml` and several tests
as the remaining gaps.

On a cluster without MACE installed, MACE-specific tests errored during fixture
setup where a skip was the intended outcome. The fixtures construct an
`ASEInputSchema` with `mace_mp`, which is unregistered in that environment and
fails Pydantic validation. The `mace-torch` dependency also complicates UMA
installation, because it requires `e3nn==0.4.4` while the `uma` extra requires
`e3nn>=0.5`.

This PR moves `mace-torch` to a `mace` extra, defers torch imports that were
previously satisfied transitively, and adds the missing test guards.

### User-visible behavior change

After this change, `pip install chemgraph` no longer installs `mace-torch` or
registers `MaceCalc`.

* If `calculator` is omitted, selection proceeds to the first available class
  in the `ase_input` priority list (FAIRChem, MACE, AIMNET2, TBLite, EMT,
  NWChem, Orca). On the tested minimal installation, this resolves to EMT.
* Explicitly requesting `mace_mp` raises a Pydantic `ValidationError` listing
  the available calculators. No fallback calculator is substituted.
* `pip install "chemgraph[mace]"` restores the previous behavior.
* `get_calculator_selection_context()` already injects real availability into
  the prompt, so the agent selects from what is installed.

**Existing environments or CI jobs that install plain `chemgraph` and
explicitly use `mace_mp` will need `chemgraph[mace]` after this change.** This
is the main compatibility tradeoff for maintainers to consider.

A narrower alternative is to keep `mace-torch` required and add only the test
guards. That fixes the fixture errors and leaves the UMA conflict and
installation size unchanged.

### Benefits

* **UMA installation no longer requires manually removing `mace-torch` and
  `e3nn`.** The README walked users through hand-editing `pyproject.toml`,
  installing `[uma]`, then restoring the file, and `dependency_tests.yml` did
  the CI equivalent with `pip uninstall -y mace-torch e3nn`. Neither is needed
  now.
* **The tested core installation resolves 35 fewer packages**, including
  `torch`, `triton`, `nvidia-cublas`, `nvidia-cudnn-cu13`, and other CUDA
  runtime packages. Users running EMT or the subprocess DFT engines no longer
  download any of it.
* **Tests for unavailable engines now skip as intended.**

### Deferred torch imports

`torch` is not a declared ChemGraph dependency and was previously installed
transitively through `mace-torch`. Because `mace_calc.py` and
`fairchem_calc.py` imported torch at module scope, making MACE optional caused
`chemgraph.schemas.ase_input` to fail on a core installation, also blocking EMT
and TBLite. These imports are now deferred to the functions that require them,
following the `AGENTS.md` rule on optional dependencies.

`fairchem_calc.py` read `torch.cuda.is_available()` in a Pydantic field
default, which runs at class definition. The field now defaults to the literal
`"cpu"`, and GPU detection occurs when the calculator is built. This preserves
the `"default"` entry in the generated JSON schema used by `tool_call_eval` and
`bind_tools`. That module already treated `fairchem.core` as optional and
applied no equivalent guard to torch, so this gap predates the PR.

### Deliberate non-changes

* Direct `run_ase_core` calls still bypass the availability gate. Requesting
  `mace_mp` without MACE therefore raises `ModuleNotFoundError`, while the
  schema path raises a validation error listing available calculators. This
  pre-existing inconsistency affects every gated calculator.
* Several defaults, documentation examples, and few-shot prompts still select
  `mace_mp`: `config.toml`, `src/ui/config.py`, the copies of that block in
  `README.md` and `docs/configuration_with_toml.md`, and
  `src/chemgraph/prompt/`. These references are intentionally unchanged here.
* `environment.yml` names `mace-torch==0.3.13` explicitly, so the conda path is
  unaffected. A pip `[mace]` installation remains unpinned and may resolve to a
  different version.
* The UMA CI job manually installs `fairchem-core==2.13.0` while the `uma`
  extra pins `2.3.0`. That mismatch, and the Python 3.13 resolution failure the
  pin causes, are unchanged in this PR.
* No MACE-specific matrix leg is added to `dependency_tests.yml`, because the
  three full-suite jobs already install `.[mace]`.

Handling these as follow-ups would keep this PR focused, though any of them can
be folded in on request.

### Overlap with #162

The only conflict with #162 is the `calculator` field docstring in
`ase_input.py`. #162 adds VASP and Quantum ESPRESSO to the list there, and this
PR corrects the ordering and the "use MACE or FAIRChem" line that a core
install no longer satisfies. Everything else merges cleanly, including
`ase_core.py`. Since #162 is further along, merging it first and rebasing this
branch afterward seems best.

## Related issues

None

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [x] Chore / refactor / CI

## How was this tested?

* `pytest tests/ -k "not tblite"` in a core installation with `tblite`,
  `parsl`, and `globus_compute` installed: **305 passed, 29 skipped, 2
  deselected**.
* The same suite with MACE hidden through a patched
  `importlib.util.find_spec`: **296 passed, 38 skipped, 2 deselected**. The
  same run on the parent commit produces **8 fixture-setup errors**, 4 in
  `test_mace.py` and 4 in `test_tools.py`, confirming the original failure
  mode.
* With `torch`, `mace`, and `fairchem` all hidden, `chemgraph`,
  `schemas.ase_input`, `tools.ase_tools`, `agent.llm_agent`, and
  `graphs.single_agent` all import successfully. A package-wide import sweep
  covering `src/ui/` found no other top-level imports of optional engines.
* Dry-run resolution produced **245 packages** for the core install, with
  `torch`, `mace-torch`, and `e3nn` all absent, and **280** for `.[mace]`, with
  `torch 2.13.0`, `mace-torch 0.3.16`, and `e3nn 0.4.4` present. A fresh
  editable `.[mace]` install succeeded and `python -m pip check` passed.
* The UMA dependency job passes without the forced uninstall, including
  `pip check`.
* In a fairchem-present, MACE-absent environment, all three `test_faircalc.py`
  tests errored during fixture setup before the guard and skipped cleanly
  afterward.
* `ruff check .` passes.

No DFT calculations were run; validation covered tests, imports, and dependency
resolution only.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change
