### PR TITLE
Make run_docking a default single-agent tool (CLI/Streamlit discovera…

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Create a `config.toml` file in your project directory to configure ChemGraph beh
 [general]
 # Default model to use for queries
 model = "gpt-4o-mini"
-# Workflow type: single_agent, multi_agent, python_relp, graspa, mock_agent
+# Workflow type: single_agent, multi_agent, python_relp, graspa, molecular_docking, mock_agent
 # Alias accepted by CLI/UI: python_repl -> python_relp
 workflow = "single_agent"
 # Output format: state, last_message
@@ -716,6 +716,9 @@ chemgraph -q "Write analysis code" -w python_repl
 
 # gRASPA - molecular simulation
 chemgraph -q "Run adsorption simulation" -w graspa
+
+# Molecular docking - dock a candidate into a receptor (AutoDock Vina)
+chemgraph -q "Dock aspirin into 'receptor.pdbqt'" -w molecular_docking
 ```
 
 **Output Formats:**

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -12,7 +12,7 @@ Create a `config.toml` file in your project directory to configure ChemGraph beh
 [general]
 # Default model to use for queries
 model = "gpt-4o-mini"
-# Workflow type: single_agent, multi_agent, python_relp, graspa, mock_agent
+# Workflow type: single_agent, multi_agent, python_relp, graspa, molecular_docking, mock_agent
 # Alias accepted by CLI/UI: python_repl -> python_relp
 workflow = "single_agent"
 # Output format: state, last_message
@@ -334,7 +334,18 @@ chemgraph -q "Write analysis code" -w python_repl
 
 # gRASPA - molecular simulation
 chemgraph -q "Run adsorption simulation" -w graspa
+
+# Molecular docking - dock a candidate into a receptor (AutoDock Vina)
+chemgraph -q "Dock aspirin into 'receptor.pdbqt'" -w molecular_docking
 ```
+
+!!! note "Molecular docking workflow requirements"
+    The `molecular_docking` workflow needs the optional docking dependency (`pip
+    install -e ".[docking]"` for Meeko) plus AutoDock Vina from conda-forge
+    (`conda install -c conda-forge vina`). The candidate may be a SMILES, a
+    molecule name, or a PubChem CID; the receptor is a prepared rigid receptor
+    `.pdbqt`, or a SMILES/name/CID for a small-molecule target. The search box is
+    detected automatically.
 
 **Output Formats:**
 

--- a/examples/docking/README.md
+++ b/examples/docking/README.md
@@ -1,12 +1,17 @@
 # Molecular docking with ChemGraph
 
-Runs the `run_docking` tool (AutoDock Vina) through the ChemGraph **single-agent**
-graph with a docking-specific prompt — no dedicated graph or workflow needed. The
-agent takes a candidate (SMILES / name / PubChem CID) and a receptor, and returns the
-predicted binding affinity and poses.
+Runs the AutoDock Vina docking tool through the ChemGraph **`molecular_docking`**
+workflow. The agent takes a candidate (SMILES / name / PubChem CID) and a receptor,
+and returns the predicted binding affinity and poses.
+
+You can also run it straight from the CLI:
+```bash
+chemgraph -q "Dock aspirin into 'vancomycin_receptor.pdbqt'" -w molecular_docking
+```
+or pick **molecular_docking** as the workflow in the Streamlit UI (`streamlit run src/ui/app.py`).
 
 ## What's here
-- `run_chemgraph.py` — binds `run_docking` + `docking_prompt` to the single-agent graph and docks a candidate into the receptor.
+- `run_chemgraph.py` — runs the `molecular_docking` workflow to dock a candidate into the receptor.
 - `vancomycin_receptor.pdbqt` — a prepared rigid receptor: **vancomycin (chain A of RCSB PDB [1FVM](https://www.rcsb.org/structure/1FVM))**, in PDBQT format (coordinates + Gasteiger charges + AutoDock atom types). PDB data is public domain.
 
 ## Setup

--- a/examples/docking/run_chemgraph.py
+++ b/examples/docking/run_chemgraph.py
@@ -1,9 +1,9 @@
 """Run molecular docking through the ChemGraph agent.
 
-Docks a small-molecule candidate into a receptor with AutoDock Vina, driven by the
-ChemGraph single-agent graph bound to the ``run_docking`` tool and a docking-specific
-prompt. The candidate can be a SMILES, a molecule name, or a PubChem CID; the receptor
-here is the prepared vancomycin PDBQT that ships alongside this example.
+Docks a small-molecule candidate into a receptor with AutoDock Vina using the
+``molecular_docking`` workflow, which binds the docking tools and prompt for you. The
+candidate can be a SMILES, a molecule name, or a PubChem CID; the receptor here is the
+prepared vancomycin PDBQT that ships alongside this example.
 
 Prerequisites:
   - An LLM provider key (e.g. OPENAI_API_KEY)
@@ -20,8 +20,6 @@ import asyncio
 import os
 
 from chemgraph.agent.llm_agent import ChemGraph
-from chemgraph.prompt.docking_prompt import docking_prompt
-from chemgraph.tools.docking_tools import run_docking
 
 MODEL_NAME = "gpt-4o-mini"
 
@@ -38,9 +36,7 @@ PROMPT = (
 async def main():
     cg = ChemGraph(
         model_name=MODEL_NAME,
-        workflow_type="single_agent",
-        system_prompt=docking_prompt,
-        tools=[run_docking],
+        workflow_type="molecular_docking",
     )
     print(f"Model: {MODEL_NAME}")
     print(f"Prompt: {PROMPT}\n")

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -57,7 +57,9 @@ from chemgraph.graphs.single_agent_mcp import construct_single_agent_mcp_graph
 from chemgraph.graphs.graspa_mcp import construct_graspa_mcp_graph
 from chemgraph.graphs.rag_agent import construct_rag_agent_graph
 from chemgraph.graphs.single_agent_xanes import construct_single_agent_xanes_graph
+from chemgraph.graphs.molecular_docking import construct_molecular_docking_graph
 from chemgraph.prompt.rag_prompt import rag_agent_prompt
+from chemgraph.prompt.molecular_docking_prompt import molecular_docking_prompt
 from chemgraph.prompt.xanes_prompt import (
     xanes_single_agent_prompt as default_xanes_single_agent_prompt,
     xanes_formatter_prompt as default_xanes_formatter_prompt,
@@ -350,6 +352,7 @@ class ChemGraph:
             "graspa_mcp": {"constructor": construct_graspa_mcp_graph},
             "rag_agent": {"constructor": construct_rag_agent_graph},
             "single_agent_xanes": {"constructor": construct_single_agent_xanes_graph},
+            "molecular_docking": {"constructor": construct_molecular_docking_graph},
         }
 
         if workflow_type not in self.workflow_map:
@@ -429,6 +432,19 @@ class ChemGraph:
                 if self.formatter_prompt != default_formatter_prompt
                 else default_xanes_formatter_prompt,
                 tools=self.tools,
+            )
+        elif self.workflow_type == "molecular_docking":
+            self.workflow = self.workflow_map[workflow_type]["constructor"](
+                llm,
+                system_prompt=self.system_prompt
+                if not prompt_is_default
+                else molecular_docking_prompt,
+                structured_output=self.structured_output,
+                formatter_prompt=self.formatter_prompt,
+                tools=self.tools,
+                max_retries=self.max_retries,
+                human_supervised=self.human_supervised,
+                terminal_tool_names=self.terminal_tool_names,
             )
 
     def visualize(self, method: str = "ascii"):

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -48,6 +48,7 @@ ALL_WORKFLOW_TYPES = [
     "graspa_mcp",
     "rag_agent",
     "single_agent_xanes",
+    "molecular_docking",
 ]
 
 # Common aliases so users can type the "obvious" name.

--- a/src/chemgraph/graphs/molecular_docking.py
+++ b/src/chemgraph/graphs/molecular_docking.py
@@ -1,0 +1,73 @@
+"""Molecular docking graph.
+
+Reuses the single-agent graph setup, changing only the default tool list and the
+default system prompt so the agent is focused on molecular docking. Keeping docking
+tools in their own graph (rather than in the single-agent defaults) means the general
+single-agent workflow and its evaluations are unaffected.
+
+The graph is intentionally easy to grow: add docking-related tools (receptor
+preparation, pocket/box detection, redocking validation, pose visualization, ...) to
+the default tool list below as they become available.
+"""
+
+from collections.abc import Collection
+
+from langchain_openai import ChatOpenAI
+
+from chemgraph.graphs.single_agent import construct_single_agent_graph
+from chemgraph.prompt.molecular_docking_prompt import molecular_docking_prompt
+from chemgraph.prompt.single_agent_prompt import formatter_prompt, report_prompt
+from chemgraph.tools.cheminformatics_tools import molecule_name_to_smiles
+from chemgraph.tools.docking_tools import run_docking
+
+# Default tools for the molecular docking workflow. Only tools helpful when studying
+# ligand-receptor binding are included; general gas-phase/DFT tools are omitted.
+DEFAULT_DOCKING_TOOLS = [run_docking, molecule_name_to_smiles]
+
+
+def construct_molecular_docking_graph(
+    llm: ChatOpenAI,
+    system_prompt: str = molecular_docking_prompt,
+    structured_output: bool = False,
+    formatter_prompt: str = formatter_prompt,
+    generate_report: bool = False,
+    report_prompt: str = report_prompt,
+    tools: list | None = None,
+    max_retries: int = 1,
+    human_supervised: bool = False,
+    terminal_tool_names: Collection[str] = (),
+):
+    """Construct the molecular docking graph.
+
+    Identical to :func:`construct_single_agent_graph` except the default tool list is
+    the docking tool set and the default system prompt is the docking prompt.
+
+    Parameters
+    ----------
+    llm : ChatOpenAI
+        The language model to use for the graph.
+    system_prompt : str, optional
+        System prompt, by default :data:`molecular_docking_prompt`.
+    tools : list, optional
+        Tools for the agent. Defaults to :data:`DEFAULT_DOCKING_TOOLS` when ``None``.
+    (remaining parameters match :func:`construct_single_agent_graph`.)
+
+    Returns
+    -------
+    StateGraph
+        The constructed molecular docking graph.
+    """
+    if tools is None:
+        tools = list(DEFAULT_DOCKING_TOOLS)
+    return construct_single_agent_graph(
+        llm,
+        system_prompt=system_prompt,
+        structured_output=structured_output,
+        formatter_prompt=formatter_prompt,
+        generate_report=generate_report,
+        report_prompt=report_prompt,
+        tools=tools,
+        max_retries=max_retries,
+        human_supervised=human_supervised,
+        terminal_tool_names=terminal_tool_names,
+    )

--- a/src/chemgraph/graphs/single_agent.py
+++ b/src/chemgraph/graphs/single_agent.py
@@ -15,7 +15,6 @@ from chemgraph.tools.cheminformatics_tools import (
 )
 from chemgraph.tools.report_tools import generate_html
 from chemgraph.tools.generic_tools import calculator, ask_human
-from chemgraph.tools.docking_tools import run_docking
 from chemgraph.prompt.single_agent_prompt import (
     single_agent_prompt,
     formatter_prompt,
@@ -307,7 +306,6 @@ def ChemGraphAgent(
             molecule_name_to_smiles,
             extract_output_json,
             calculator,
-            run_docking,
         ]
         if human_supervised:
             tools.append(ask_human)
@@ -500,7 +498,6 @@ def construct_single_agent_graph(
                 run_ase,
                 extract_output_json,
                 calculator,
-                run_docking,
             ]
             if human_supervised:
                 tools.append(ask_human)

--- a/src/chemgraph/graphs/single_agent.py
+++ b/src/chemgraph/graphs/single_agent.py
@@ -15,6 +15,7 @@ from chemgraph.tools.cheminformatics_tools import (
 )
 from chemgraph.tools.report_tools import generate_html
 from chemgraph.tools.generic_tools import calculator, ask_human
+from chemgraph.tools.docking_tools import run_docking
 from chemgraph.prompt.single_agent_prompt import (
     single_agent_prompt,
     formatter_prompt,
@@ -306,6 +307,7 @@ def ChemGraphAgent(
             molecule_name_to_smiles,
             extract_output_json,
             calculator,
+            run_docking,
         ]
         if human_supervised:
             tools.append(ask_human)
@@ -498,6 +500,7 @@ def construct_single_agent_graph(
                 run_ase,
                 extract_output_json,
                 calculator,
+                run_docking,
             ]
             if human_supervised:
                 tools.append(ask_human)

--- a/src/chemgraph/prompt/molecular_docking_prompt.py
+++ b/src/chemgraph/prompt/molecular_docking_prompt.py
@@ -1,13 +1,17 @@
 """System prompt for the molecular docking agent."""
 
-docking_prompt = """You are a molecular docking assistant. You help users estimate how
-strongly a small-molecule candidate binds a receptor (target) and obtain its best pose,
-using the `run_docking` tool (AutoDock Vina).
+molecular_docking_prompt = """You are a molecular docking assistant. You help users estimate
+how strongly a small-molecule candidate binds a receptor (target) and obtain its best pose.
+
+Available tools:
+- `run_docking`: dock a candidate into a receptor with AutoDock Vina.
+- `molecule_name_to_smiles`: resolve a molecule name or PubChem CID to a SMILES string.
 
 Instructions:
 1. Identify the candidate and the receptor from the user's request. Each may be given as
    a SMILES string, a molecule name, or a PubChem CID; the receptor may also be a path to
-   a prepared '.pdbqt' file. Names/CIDs are resolved to SMILES automatically by the tool.
+   a prepared '.pdbqt' file. Names/CIDs are resolved to SMILES automatically by the tool
+   (use `molecule_name_to_smiles` if the user asks for a SMILES directly).
 2. If the candidate or receptor is missing or ambiguous, ask the user instead of guessing.
 3. If they matter and were not specified, ask the user for the number of poses (`n_poses`)
    and the site-detection method (`site_detection`: auto/reference/fpocket/blind);

--- a/src/ui/_pages/configuration.py
+++ b/src/ui/_pages/configuration.py
@@ -23,6 +23,7 @@ WORKFLOW_OPTIONS: list[str] = [
     "multi_agent",
     "python_relp",
     "graspa",
+    "molecular_docking",
     "mock_agent",
 ]
 

--- a/tests/test_docking_tools.py
+++ b/tests/test_docking_tools.py
@@ -31,12 +31,16 @@ def test_mock_docking_shape():
     assert isinstance(res["best_affinity_kcal_mol"], float)
 
 
-def test_single_agent_binds_run_docking():
-    """The single-agent graph builds with run_docking bound (no LLM calls)."""
-    from chemgraph.graphs.single_agent import construct_single_agent_graph
+def test_molecular_docking_graph_builds():
+    """The molecular_docking graph builds with docking tools by default (no LLM calls)."""
+    from chemgraph.graphs.molecular_docking import (
+        DEFAULT_DOCKING_TOOLS,
+        construct_molecular_docking_graph,
+    )
     from chemgraph.tools.docking_tools import run_docking
 
-    graph = construct_single_agent_graph(MagicMock(), tools=[run_docking])
+    assert run_docking in DEFAULT_DOCKING_TOOLS
+    graph = construct_molecular_docking_graph(MagicMock())
     assert graph is not None
 
 

--- a/tests/test_graph_constructors.py
+++ b/tests/test_graph_constructors.py
@@ -11,6 +11,7 @@ WORKFLOWS = [
     "single_agent_mcp",
     "graspa_mcp",
     "single_agent_xanes",
+    "molecular_docking",
 ]
 
 
@@ -32,6 +33,7 @@ def test_constructor_is_called(monkeypatch, workflow_type):
         "single_agent_mcp": "construct_single_agent_mcp_graph",
         "graspa_mcp": "construct_graspa_mcp_graph",
         "single_agent_xanes": "construct_single_agent_xanes_graph",
+        "molecular_docking": "construct_molecular_docking_graph",
     }[workflow_type]
 
     monkeypatch.setattr(

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -50,6 +50,7 @@ class _FakeWorkflow:
         ),
         ("rag_agent", "construct_rag_agent_graph", {}),
         ("single_agent_xanes", "construct_single_agent_xanes_graph", {}),
+        ("molecular_docking", "construct_molecular_docking_graph", {}),
     ],
 )
 def test_graph_constructor_is_called(


### PR DESCRIPTION
…ble)

<!--
Thanks for contributing! Keep PRs small and focused — one logical change.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

<!-- Commands you ran, new tests added, manual verification -->

## Checklist

- [ ] Branched off the latest `main` and targets `main`
- [ ] PR is focused on a single logical change (split if it grew large)
- [ ] `ruff check .` passes
- [ ] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [ ] Added/updated tests for the change
- [ ] Updated docs / README for any user-facing change
