### PR TITLE
Add Deep Agents main-agent supervisor

### DIFF
--- a/.github/workflows/conda-tests.yml
+++ b/.github/workflows/conda-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
@@ -40,9 +40,9 @@ jobs:
       run: |
         # Activate the test environment
         conda activate chemgraph-mace
-        # Install nwchem only for Python versions that support it (3.10, 3.11)
+        # Install nwchem only for Python 3.11, which conda-forge supports here.
         # nwchem doesn't support Python 3.12+ yet
-        if [[ "${{ matrix.python-version }}" == "3.10" || "${{ matrix.python-version }}" == "3.11" ]]; then
+        if [[ "${{ matrix.python-version }}" == "3.11" ]]; then
           conda install -c conda-forge nwchem -y
         else
           echo "Skipping nwchem installation for Python 3.12+ (not supported yet)"
@@ -84,7 +84,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   strategy:
   #     matrix:
-  #       python-version: ["3.10", "3.11", "3.12"]
+  #       python-version: ["3.11", "3.12"]
 
   #   steps:
   #   - uses: actions/checkout@v4

--- a/.github/workflows/dependency_tests.yml
+++ b/.github/workflows/dependency_tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
         install_extras: [core, calculators, uma, ui, parsl, xanes, rag]
 
     steps:

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install build tools
         run: |

--- a/.github/workflows/test-pypi-package.yml
+++ b/.github/workflows/test-pypi-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install lint dependencies
       run: |
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -59,7 +59,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
 
     steps:
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12"]
     runs-on: ubuntu-latest
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ this repository. Human contributors should read
 ChemGraph is a computational-chemistry agent framework (PyPI package
 `chemgraph`, import package `chemgraph`). It connects natural-language queries to
 molecular simulations via a LangGraph/LangChain agent architecture, ASE, RDKit,
-and MCP servers. Requires Python >= 3.10.
+and MCP servers. Requires Python >= 3.11.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ChemGraph supports diverse simulation backends, including ab initio quantum chem
 <details open>
   <summary><strong>Installation Instructions</strong></summary>
 
-Ensure you have **Python 3.10 or higher** installed on your system. 
+Ensure you have **Python 3.11 or higher** installed on your system.
 
 **Install-Free Method (Docker from GHCR)**
 
@@ -141,7 +141,7 @@ If you need to install from source for the latest version:
    ```
 
    The `environment.yml` file automatically installs all required dependencies including:
-   - Python 3.10
+   - Python 3.11
    - Core packages (numpy, pandas, pytest, rich, toml)
    - Computational chemistry packages (nwchem, tblite)
    - All ChemGraph dependencies via pip

--- a/README.md
+++ b/README.md
@@ -608,9 +608,15 @@ chemgraph \
   --query "What is the SMILES string for aspirin?"
 ```
 
-This experimental provider supports only `single_agent`. It does not use
-`OPENAI_API_KEY` or the OpenAI Platform API, and it rejects Codex sessions that
-are authenticated with an API key. See
+For a long-lived Codex-backed supervisor, use interactive mode:
+
+```bash
+chemgraph --interactive --model "codex:<codex-model-id>" --workflow main_agent
+```
+
+This experimental provider supports `single_agent` and `main_agent`. It does
+not use `OPENAI_API_KEY` or the OpenAI Platform API, and it rejects Codex
+sessions that are authenticated with an API key. See
 [Experimental Codex subscription support](docs/codex_subscription.md) for
 details.
 
@@ -729,6 +735,7 @@ chemgraph -q "Your query" -m groq:llama-3.3-70b-versatile
 
 # Codex SDK with a ChatGPT subscription login (experimental)
 chemgraph -q "Your query" -m "codex:<codex-model-id>" -w single_agent
+chemgraph --interactive -m "codex:<codex-model-id>" -w main_agent
 
 # Local models (Ollama)
 chemgraph -q "Your query" -m llama3.2
@@ -787,18 +794,23 @@ chemgraph --interactive
 **Interactive Commands:**
 ```bash
 # In interactive mode, type:
-help                    # Show available commands
-clear                   # Clear screen
-config                  # Show current configuration and session ID
-quit                    # Exit interactive mode
-model gpt-4o           # Change model
-workflow multi_agent   # Change workflow
+/help                   # Show available commands
+/clear                  # Clear screen
+/config                 # Show current configuration and session ID
+/quit                   # Exit interactive mode
+/model gpt-4o           # Change model
+/workflow multi_agent   # Change workflow
 
 # Session management:
-history                 # List recent sessions
-show <session_id>       # Show a session's conversation
-resume <session_id>     # Resume from a previous session
+/history                # List recent sessions
+/show <session_id>      # Show a session's conversation
+/resume <session_id>    # Resume from a previous session
+/retry                  # Retry a failed main_agent operation
 ```
+
+Exact bare aliases for commands without arguments, such as `help`, `quit`, and
+`history`, remain supported. Commands with arguments require `/`, so a natural
+prompt such as `show me the available tools` is sent to the agent.
 
 #### Utility Commands
 

--- a/docs/codex_subscription.md
+++ b/docs/codex_subscription.md
@@ -55,6 +55,16 @@ chemgraph \
   --query "What is the SMILES string for aspirin?"
 ```
 
+For a long-lived supervisor that delegates chemistry work to a subagent, use
+interactive mode:
+
+```bash
+chemgraph \
+  --interactive \
+  --model "codex:<codex-model-id>" \
+  --workflow main_agent
+```
+
 The same model syntax works through the Python API:
 
 ```python
@@ -68,7 +78,9 @@ agent = ChemGraph(
 
 ## Current limitations
 
-- Only the `single_agent` workflow is supported.
+- Only the `single_agent` and `main_agent` workflows are supported.
+- `main_agent` sessions are process-local and must be run in interactive mode;
+  durable `--resume` support is not yet available.
 - The integration is experimental and pins `openai-codex==0.144.4` together
   with that SDK's bundled Codex runtime.
 - ChemGraph starts ephemeral, read-only Codex threads. ChemGraph's LangGraph

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -326,6 +326,9 @@ chemgraph -q "Your query" -m llama3.2
 # Single agent (default) - best for most tasks
 chemgraph -q "Optimize water molecule" -w single_agent
 
+# Long-lived supervisor - delegates chemistry tasks to the existing agent
+chemgraph --interactive -w main_agent
+
 # Multi-agent - complex tasks with planning
 chemgraph -q "Complex analysis" -w multi_agent
 
@@ -371,9 +374,23 @@ Start an interactive session for continuous conversations:
 chemgraph --interactive
 ```
 
+To test the long-lived supervisor, select `main_agent` explicitly:
+
+```bash
+chemgraph --interactive -w main_agent
+```
+
+Each prompt runs as a normal turn on the same checkpointed, process-lifetime
+thread, and chemistry work is delegated through Deep Agents' `task` middleware
+tool. A nested chemistry worker can still pause to request input. Quitting or
+switching the model or workflow discards the process-local thread; durable
+`--resume` support for `main_agent` is not yet available. If a model or graph
+operation fails transiently, enter `retry` to resume its checkpoint without
+adding the previous user message a second time.
+
 **Interactive Features:**
 - **Persistent conversation**: Maintain context across queries
-- **Session memory**: Conversations are automatically saved to a local SQLite database (`~/.chemgraph/sessions.db`) and can be resumed later
+- **Session memory**: Standard workflows are saved to a local SQLite database (`~/.chemgraph/sessions.db`) and can be resumed later; `main_agent` is process-local in this first version
 - **Model switching**: Change models mid-conversation
 - **Workflow switching**: Switch between different agent types
 - **Built-in commands**: Help, clear, config, session management, etc.

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -385,7 +385,7 @@ thread, and chemistry work is delegated through Deep Agents' `task` middleware
 tool. A nested chemistry worker can still pause to request input. Quitting or
 switching the model or workflow discards the process-local thread; durable
 `--resume` support for `main_agent` is not yet available. If a model or graph
-operation fails transiently, enter `retry` to resume its checkpoint without
+operation fails transiently, enter `/retry` to resume its checkpoint without
 adding the previous user message a second time.
 
 **Interactive Features:**
@@ -398,18 +398,24 @@ adding the previous user message a second time.
 **Interactive Commands:**
 ```bash
 # In interactive mode, type:
-help                    # Show available commands
-clear                   # Clear screen
-config                  # Show current configuration and session ID
-quit                    # Exit interactive mode
-model gpt-4o           # Change model
-workflow multi_agent   # Change workflow
+/help                   # Show available commands
+/clear                  # Clear screen
+/config                 # Show current configuration and session ID
+/quit                   # Exit interactive mode
+/model gpt-4o           # Change model
+/workflow multi_agent   # Change workflow
 
 # Session management:
-history                 # List recent sessions
-show <session_id>       # Show a session's conversation
-resume <session_id>     # Resume from a previous session
+/history                # List recent sessions
+/show <session_id>      # Show a session's conversation
+/resume <session_id>    # Resume from a previous session
+/retry                  # Retry a failed main_agent operation
 ```
+
+Exact bare aliases for commands without arguments, such as `help`, `quit`, and
+`history`, remain supported. Commands with arguments require `/`, so natural
+prompts beginning with words such as `show`, `model`, or `workflow` are sent to
+the active agent.
 
 #### Utility Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 !!! info "Session Memory"
 
-    ChemGraph automatically persists every conversation to a local SQLite database. You can browse past sessions, review tool calls and results, and resume previous conversations with full context using the CLI (`--list-sessions`, `--show-session`, `--resume`) or interactive mode (`history`, `show`, `resume`).
+    ChemGraph automatically persists every conversation to a local SQLite database. You can browse past sessions, review tool calls and results, and resume previous conversations with full context using the CLI (`--list-sessions`, `--show-session`, `--resume`) or interactive mode (`/history`, `/show`, `/resume`).
 
 !!! info "Evaluation & Benchmarking"
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,5 @@
 !!! note
-    ChemGraph requires **Python 3.10+**.
+    ChemGraph requires **Python 3.11+**.
 
 ## Install from PyPI (recommended)
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip
   - numpy=2.2.6
   - pandas=2.2.3
@@ -20,13 +20,14 @@ dependencies:
     - langgraph-prebuilt==1.1.0
     - langgraph-sdk==0.4.2
     - langchain==1.3.14
-    - langchain-core==1.5.1
+    - langchain-core==1.5.3
     - langchain-openai==1.4.1
     - langchain-ollama==1.1.0
-    - langchain-anthropic==1.5.2
+    - langchain-anthropic==1.5.4
     - langchain-google-genai==4.3.1
     - langchain-groq==1.1.3
     - langchain-mcp-adapters==0.3.0
+    - deepagents==0.7.5
     - pydantic==2.13.4
     - pubchempy==1.0.5
     - numexpr==2.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,18 @@ authors = [
     { name = "Murat Keçeli", email = "keceli@anl.gov" },
     { name = "Aditya Tanikanti", email = "atanikanti@anl.gov" }
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
+    "deepagents==0.7.5",
     "langgraph==1.2.9",
     "langgraph-checkpoint==4.1.1",
     "langgraph-prebuilt==1.1.0",
     "langgraph-sdk==0.4.2",
     "langchain==1.3.14",
-    "langchain-core==1.5.1",
+    "langchain-core==1.5.3",
     "langchain-openai==1.4.1",
     "langchain-ollama==1.1.0",
-    "langchain-anthropic==1.5.2",
+    "langchain-anthropic==1.5.4",
     "langchain-google-genai==4.3.1",
     "langchain-groq==1.1.3",
     "langchain-mcp-adapters==0.3.0",
@@ -126,7 +127,7 @@ where = ["src/"]
 
 [tool.ruff]
 line-length = 88  # Match Black's default (adjust as needed)
-target-version = "py310"  # Adjust based on your Python version
+target-version = "py311"  # Adjust based on your Python version
 exclude = ["notebooks/"]  # Add files/folders to ignore
 
 [tool.ruff.lint]

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -108,7 +108,8 @@ class ChemGraph:
     model_name : str, optional
         Name of the language model to use, by default "gpt-4o-mini".
         Experimental ChatGPT subscription-backed Codex models use the
-        ``codex:<model-id>`` prefix and support only ``single_agent``.
+        ``codex:<model-id>`` prefix and support ``single_agent`` and
+        ``main_agent``.
     workflow_type : str, optional
         Type of workflow to use. Options:
         - "single_agent"
@@ -199,10 +200,13 @@ class ChemGraph:
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
     ):
-        if model_name.startswith("codex:") and workflow_type != "single_agent":
+        if model_name.startswith("codex:") and workflow_type not in {
+            "single_agent",
+            "main_agent",
+        }:
             raise ValueError(
                 "Experimental codex: models currently support only the "
-                "single_agent workflow."
+                "single_agent and main_agent workflows."
             )
         reasoning_effort = _resolve_reasoning_effort(model_name, reasoning_effort)
 

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -49,6 +49,7 @@ from langgraph.types import Command
 from langgraph.errors import GraphInterrupt
 
 from chemgraph.graphs.single_agent import construct_single_agent_graph
+from chemgraph.graphs.main_agent import construct_main_agent_graph
 from chemgraph.agent.turn import serialize_state
 
 
@@ -111,6 +112,7 @@ class ChemGraph:
     workflow_type : str, optional
         Type of workflow to use. Options:
         - "single_agent"
+        - "main_agent" (drive with ``MainAgentSession``, not ``run``)
         - "multi_agent"
         - "python_relp"
         - "graspa_agent"
@@ -376,7 +378,12 @@ class ChemGraph:
                 return prompt
             return f"{prompt}{self.calculator_selection_context}"
 
-        if self.workflow_type in {"single_agent", "mock_agent", "single_agent_mcp"}:
+        if self.workflow_type in {
+            "single_agent",
+            "main_agent",
+            "mock_agent",
+            "single_agent_mcp",
+        }:
             self.system_prompt = append_calculator_context(self.system_prompt)
         elif self.workflow_type == "multi_agent":
             self.planner_prompt = append_calculator_context(self.planner_prompt)
@@ -389,6 +396,7 @@ class ChemGraph:
 
         self.workflow_map = {
             "single_agent": {"constructor": construct_single_agent_graph},
+            "main_agent": {"constructor": construct_main_agent_graph},
             "multi_agent": {"constructor": construct_multi_agent_graph},
             "python_relp": {"constructor": construct_relp_graph},
             "graspa": {"constructor": construct_graspa_graph},
@@ -417,6 +425,19 @@ class ChemGraph:
                 max_retries=self.max_retries,
                 human_supervised=self.human_supervised,
                 terminal_tool_names=self.terminal_tool_names,
+            )
+        elif self.workflow_type == "main_agent":
+            self.workflow = self.workflow_map[workflow_type]["constructor"](
+                llm,
+                main_tools=self.tools,
+                subagent_system_prompt=self.system_prompt,
+                subagent_formatter_prompt=self.formatter_prompt,
+                subagent_report_prompt=self.report_prompt,
+                subagent_structured_output=self.structured_output,
+                subagent_generate_report=self.generate_report,
+                subagent_max_retries=self.max_retries,
+                subagent_human_supervised=self.human_supervised,
+                subagent_terminal_tool_names=self.terminal_tool_names,
             )
         elif self.workflow_type == "multi_agent":
             self.workflow = self.workflow_map[workflow_type]["constructor"](
@@ -774,6 +795,12 @@ class ChemGraph:
             Session ID to load context from. The previous conversation
             summary is prepended to the query.
         """
+        if self.workflow_type == "main_agent":
+            raise RuntimeError(
+                "The main_agent workflow maintains a checkpointed conversation. "
+                "Drive it with MainAgentSession instead of ChemGraph.run()."
+            )
+
         from chemgraph.agent.turn import (
             _executed_tool_names,
             _state_messages,

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -1,0 +1,206 @@
+"""Session driver for the checkpointed ChemGraph supervisor graph."""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from langchain_core.messages import HumanMessage
+from langgraph.errors import GraphInterrupt
+from langgraph.types import Command
+
+from chemgraph.agent.turn import serialize_state
+from chemgraph.graphs.main_agent import latest_assistant_text
+
+
+SessionStatus = Literal["completed", "waiting_for_user"]
+
+
+@dataclass(frozen=True)
+class PendingInterrupt:
+    """One pending request for user input."""
+
+    id: str
+    payload: Any
+
+
+@dataclass(frozen=True)
+class MainAgentTurnResult:
+    """Result returned when a supervisor turn completes or pauses."""
+
+    thread_id: str
+    status: SessionStatus
+    assistant_response: str
+    interrupts: tuple[PendingInterrupt, ...]
+    state: dict[str, Any]
+
+
+def _pending_interrupts(values: Any) -> list[PendingInterrupt]:
+    if values is None:
+        return []
+    if not isinstance(values, (list, tuple)):
+        values = [values]
+
+    return [
+        PendingInterrupt(
+            id=str(getattr(item, "id", "") or ""),
+            payload=getattr(item, "value", item),
+        )
+        for item in values
+    ]
+
+
+def _deduplicate_interrupts(
+    interrupts: list[PendingInterrupt],
+) -> tuple[PendingInterrupt, ...]:
+    unique: list[PendingInterrupt] = []
+    seen: set[str] = set()
+    for item in interrupts:
+        key = item.id or repr(item.payload)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return tuple(unique)
+
+
+class MainAgentSession:
+    """Drive one resumable, process-lifetime main-agent thread."""
+
+    def __init__(
+        self,
+        workflow: Any,
+        *,
+        thread_id: str | None = None,
+        recursion_limit: int = 50,
+    ):
+        if recursion_limit <= 0:
+            raise ValueError("recursion_limit must be positive.")
+        self.workflow = workflow
+        self._thread_id = thread_id or str(uuid.uuid4())
+        self.config = {
+            "configurable": {"thread_id": self._thread_id},
+            "recursion_limit": recursion_limit,
+        }
+        self._failed = False
+        self._pending: tuple[PendingInterrupt, ...] = ()
+
+    @property
+    def thread_id(self) -> str:
+        """Return the stable LangGraph thread identifier."""
+        return self._thread_id
+
+    @property
+    def pending_interrupts(self) -> tuple[PendingInterrupt, ...]:
+        """Return the current pending user-input requests."""
+        return self._pending
+
+    @property
+    def failed(self) -> bool:
+        """Return whether the most recent graph operation raised an error."""
+        return self._failed
+
+    async def run(self, message: str) -> MainAgentTurnResult:
+        """Run a normal user turn on this checkpointed thread."""
+        if self._failed:
+            raise RuntimeError(
+                "The main-agent session failed; retry it before running a new turn."
+            )
+        if self._pending:
+            raise RuntimeError(
+                "The main-agent session is waiting for interrupt responses."
+            )
+        if not isinstance(message, str) or not message.strip():
+            raise ValueError("The user message must be a non-empty string.")
+        return await self._run({"messages": [HumanMessage(content=message)]})
+
+    async def resume(
+        self,
+        response: str | Mapping[str, Any],
+    ) -> MainAgentTurnResult:
+        """Answer one or more pending nested-graph interrupts."""
+        if self._failed:
+            raise RuntimeError(
+                "The main-agent session failed; retry it before resuming."
+            )
+        if not self._pending:
+            raise RuntimeError("The main-agent session is not waiting for input.")
+        return await self._run(Command(resume=self._resume_value(response)))
+
+    async def retry(self) -> MainAgentTurnResult:
+        """Resume the failed checkpoint without duplicating user input."""
+        if not self._failed:
+            raise RuntimeError("The main-agent session has no failed operation to retry.")
+        return await self._run(None)
+
+    def _resume_value(self, response: str | Mapping[str, Any]) -> Any:
+        if isinstance(response, str):
+            if len(self._pending) != 1:
+                raise ValueError(
+                    "Multiple interrupts require a mapping from interrupt ID "
+                    "to response."
+                )
+            if not response.strip():
+                raise ValueError("The interrupt response must not be empty.")
+            return response
+
+        expected = {item.id for item in self._pending}
+        if "" in expected:
+            raise RuntimeError("Pending interrupts do not expose stable IDs.")
+        provided = {str(key) for key in response}
+        if provided != expected:
+            raise ValueError(
+                "Interrupt response IDs must exactly match the pending interrupts."
+            )
+        return {str(key): value for key, value in response.items()}
+
+    async def _run(self, stream_input: Any) -> MainAgentTurnResult:
+        try:
+            result = await self._run_once(stream_input)
+        except Exception:
+            self._failed = True
+            raise
+        self._failed = False
+        return result
+
+    async def _run_once(self, stream_input: Any) -> MainAgentTurnResult:
+        last_state: dict[str, Any] | None = None
+        found: list[PendingInterrupt] = []
+        try:
+            async for state in self.workflow.astream(
+                stream_input,
+                stream_mode="values",
+                config=self.config,
+            ):
+                last_state = state
+                found.extend(_pending_interrupts(state.get("__interrupt__")))
+        except GraphInterrupt as exc:
+            raw_interrupts = exc.args[0] if exc.args else []
+            found.extend(_pending_interrupts(raw_interrupts))
+
+        snapshot = self.workflow.get_state(self.config)
+        state_values = snapshot.values if snapshot else (last_state or {})
+        if snapshot:
+            for task in snapshot.tasks:
+                found.extend(_pending_interrupts(getattr(task, "interrupts", ())))
+
+        pending = _deduplicate_interrupts(found)
+        self._pending = pending
+        return MainAgentTurnResult(
+            thread_id=self.thread_id,
+            status="waiting_for_user" if pending else "completed",
+            assistant_response=latest_assistant_text(
+                list(state_values.get("messages", []) or [])
+            ),
+            interrupts=pending,
+            state=serialize_state(state_values),
+        )
+
+
+__all__ = [
+    "MainAgentSession",
+    "MainAgentTurnResult",
+    "PendingInterrupt",
+]

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -526,7 +526,7 @@ def _interrupt_question(payload: Any) -> str:
 def _main_agent_failure_hint(session: Any) -> None:
     if getattr(session, "failed", False):
         console.print(
-            "[yellow]The checkpoint can be resumed with the `retry` command.[/yellow]"
+            "[yellow]The checkpoint can be resumed with the `/retry` command.[/yellow]"
         )
 
 
@@ -803,6 +803,55 @@ def save_output(content: str, output_file: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+_INTERACTIVE_COMMANDS = {
+    "clear",
+    "config",
+    "help",
+    "history",
+    "model",
+    "quit",
+    "resume",
+    "retry",
+    "show",
+    "workflow",
+}
+_INTERACTIVE_BARE_ALIASES = {
+    "clear": "clear",
+    "config": "config",
+    "exit": "quit",
+    "help": "help",
+    "history": "history",
+    "q": "quit",
+    "quit": "quit",
+    "retry": "retry",
+}
+_INTERACTIVE_SLASH_ALIASES = {
+    "exit": "quit",
+    "q": "quit",
+}
+
+
+def _parse_interactive_input(query: str) -> tuple[str, str] | None:
+    """Return a canonical interactive command and its argument, if any."""
+    stripped = query.strip()
+    bare_command = _INTERACTIVE_BARE_ALIASES.get(stripped.lower())
+    if bare_command is not None:
+        return bare_command, ""
+    if not stripped.startswith("/"):
+        return None
+
+    command_text = stripped[1:].strip()
+    if not command_text:
+        return "unknown", ""
+    parts = command_text.split(maxsplit=1)
+    name = parts[0]
+    argument = parts[1] if len(parts) == 2 else ""
+    name = _INTERACTIVE_SLASH_ALIASES.get(name.lower(), name.lower())
+    if name not in _INTERACTIVE_COMMANDS:
+        return "unknown", name
+    return name, argument.strip()
+
+
 def interactive_mode(
     model: str = "gpt-4o-mini",
     workflow: str = "single_agent",
@@ -853,7 +902,8 @@ def interactive_mode(
         "Type your queries and get AI-powered computational chemistry insights."
     )
     console.print(
-        "[dim]Type 'quit', 'exit', or 'q' to exit. Type 'help' for commands.[/dim]\n"
+        "[dim]Type '/quit' to exit or '/help' for commands. Exact bare "
+        "aliases such as 'quit' and 'help' also work.[/dim]\n"
     )
 
     # Allow the user to override model/workflow at startup.
@@ -894,30 +944,54 @@ def interactive_mode(
     while True:
         try:
             query = Prompt.ask("\n[bold cyan]ChemGraph[/bold cyan]")
+            parsed_command = _parse_interactive_input(query)
 
-            if query.lower() in ("quit", "exit", "q"):
+            if parsed_command is None:
+                command = None
+                argument = ""
+            else:
+                command, argument = parsed_command
+
+            if command == "unknown":
+                label = f"/{argument}" if argument else "/"
+                console.print(
+                    f"[red]Unknown interactive command: {label}[/red]"
+                )
+                console.print("[dim]Type /help to see available commands.[/dim]")
+                continue
+            if command == "quit":
+                if argument:
+                    console.print("[red]Usage: /quit[/red]")
+                    continue
                 console.print("[yellow]Goodbye![/yellow]")
                 break
-            elif query.lower() == "help":
+            elif command == "help":
+                if argument:
+                    console.print("[red]Usage: /help[/red]")
+                    continue
                 console.print(
                     Panel(
                         """
 Available commands:
-  quit/exit/q        Exit interactive mode
-  help               Show this help message
-  clear              Clear screen
-  config             Show current configuration
-  model <name>       Change model
-  workflow <type>    Change workflow type
+  /quit              Exit interactive mode
+  /help              Show this help message
+  /clear             Clear screen
+  /config            Show current configuration
+  /model <name>      Change model
+  /workflow <type>   Change workflow type
 
 Session commands:
-  history            List recent sessions
-  show <id>          Show a session's conversation
-  resume <id>        Resume from a previous session
-  retry              Retry a failed main_agent operation
+  /history           List recent sessions
+  /show <id>         Show a session's conversation
+  /resume <id>       Resume from a previous session
+  /retry             Retry a failed main_agent operation
+
+Exact bare aliases for commands without arguments remain supported. Commands
+with arguments require the leading slash so prompts beginning with words such
+as "show", "model", or "workflow" are sent to the agent.
 
 main_agent keeps one checkpointed thread until you quit or switch
-model/workflow. Its thread is process-local; `resume` does not currently
+model/workflow. Its thread is process-local; `/resume` does not currently
 restore it later. Nested chemistry workers may pause to request input.
 
 Example queries:
@@ -931,10 +1005,16 @@ Example queries:
                     )
                 )
                 continue
-            elif query.lower() == "clear":
+            elif command == "clear":
+                if argument:
+                    console.print("[red]Usage: /clear[/red]")
+                    continue
                 console.clear()
                 continue
-            elif query.lower() == "config":
+            elif command == "config":
+                if argument:
+                    console.print("[red]Usage: /config[/red]")
+                    continue
                 console.print(f"Model: {model}")
                 console.print(f"Workflow: {workflow}")
                 if main_session is not None:
@@ -943,26 +1023,27 @@ Example queries:
                 elif hasattr(agent, "session_id"):
                     console.print(f"Session ID: {agent.session_id}")
                 continue
-            elif query.lower() == "history":
+            elif command == "history":
+                if argument:
+                    console.print("[red]Usage: /history[/red]")
+                    continue
                 list_sessions()
                 continue
-            elif query.lower().startswith("show "):
-                sid = query[5:].strip()
-                if sid:
-                    show_session(sid)
-                else:
-                    console.print("[red]Usage: show <session_id>[/red]")
+            elif command == "show":
+                if not argument:
+                    console.print("[red]Usage: /show <session_id>[/red]")
+                    continue
+                show_session(argument)
                 continue
-            elif query.lower().startswith("resume "):
+            elif command == "resume":
+                if not argument:
+                    console.print("[red]Usage: /resume <session_id>[/red]")
+                    continue
                 if main_session is not None:
                     console.print(
                         "[yellow]Persistent resume is not supported for the "
                         "process-lifetime main_agent workflow.[/yellow]"
                     )
-                    continue
-                sid = query[7:].strip()
-                if not sid:
-                    console.print("[red]Usage: resume <session_id>[/red]")
                     continue
                 resume_query = Prompt.ask(
                     "[bold cyan]Enter query to continue with[/bold cyan]"
@@ -972,19 +1053,31 @@ Example queries:
                         agent,
                         resume_query,
                         verbose=verbose,
-                        resume_from=sid,
+                        resume_from=argument,
                     )
                     if result:
                         format_response(result, verbose=verbose)
                 continue
-            elif query.lower() == "retry" and main_session is not None:
+            elif command == "retry":
+                if argument:
+                    console.print("[red]Usage: /retry[/red]")
+                    continue
+                if main_session is None:
+                    console.print(
+                        "[yellow]/retry is available only for the main_agent "
+                        "workflow.[/yellow]"
+                    )
+                    continue
                 result = retry_main_agent_session(main_session, verbose=verbose)
                 if result:
                     format_response(result, verbose=verbose)
                     console.print(f"[dim]Thread: {main_session.thread_id}[/dim]")
                 continue
-            elif query.startswith("model "):
-                new_model = query[6:].strip()
+            elif command == "model":
+                if not argument:
+                    console.print("[red]Usage: /model <name>[/red]")
+                    continue
+                new_model = argument
                 new_agent = initialize_agent(
                     new_model,
                     workflow,
@@ -1007,8 +1100,11 @@ Example queries:
                     )
                     console.print(f"[green]Model changed to: {model}[/green]")
                 continue
-            elif query.startswith("workflow "):
-                new_workflow = resolve_workflow(query[9:].strip())
+            elif command == "workflow":
+                if not argument:
+                    console.print("[red]Usage: /workflow <type>[/red]")
+                    continue
+                new_workflow = resolve_workflow(argument)
                 if new_workflow in ALL_WORKFLOW_TYPES:
                     new_agent = initialize_agent(
                         model,
@@ -1058,7 +1154,7 @@ Example queries:
 
         except KeyboardInterrupt:
             console.print(
-                "\n[yellow]Interrupted. Type 'quit' to exit.[/yellow]"
+                "\n[yellow]Interrupted. Type '/quit' to exit.[/yellow]"
             )
         except Exception as e:
             console.print(f"[red]Error: {e}[/red]")

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -41,6 +41,7 @@ from chemgraph.cli.formatting import (
 # All workflow types registered in ChemGraph.workflow_map
 ALL_WORKFLOW_TYPES = [
     "single_agent",
+    "main_agent",
     "multi_agent",
     "python_relp",
     "graspa",
@@ -214,7 +215,8 @@ def initialize_agent(
     human_supervised : bool, optional
         Whether to enable human-interrupt tooling.
     tools : list, optional
-        Custom tool list for MCP-backed workflows.
+        Custom tools for MCP-backed workflows, or supervisor-level tools for
+        ``main_agent``. The default chemistry subagent retains its built-ins.
 
     Returns
     -------
@@ -498,6 +500,127 @@ def run_query(
     return None
 
 
+def create_main_agent_session(agent: Any):
+    """Create the CLI session driver for a constructed main-agent workflow."""
+    from chemgraph.agent.main_session import MainAgentSession
+
+    return MainAgentSession(
+        agent.workflow,
+        thread_id=agent.session_id,
+        recursion_limit=agent.recursion_limit,
+    )
+
+
+def _interrupt_question(payload: Any) -> str:
+    """Extract readable question text from an interrupt payload."""
+    if isinstance(payload, dict):
+        return str(
+            payload.get(
+                "question",
+                payload.get("message", payload.get("instruction", payload)),
+            )
+        )
+    return str(payload)
+
+
+def _main_agent_failure_hint(session: Any) -> None:
+    if getattr(session, "failed", False):
+        console.print(
+            "[yellow]The checkpoint can be resumed with the `retry` command.[/yellow]"
+        )
+
+
+def _run_main_agent_operation(
+    session: Any,
+    operation: Any,
+    *,
+    progress_description: str,
+) -> Any:
+    """Run one session operation and resolve nested-graph interrupts."""
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+            transient=True,
+        ) as progress:
+            progress.add_task(progress_description, total=None)
+            result = run_async_callable(operation)
+    except Exception as exc:
+        console.print(f"[red]Error processing main-agent session: {exc}[/red]")
+        _main_agent_failure_hint(session)
+        return None
+
+    interrupt_count = 0
+    while result.status == "waiting_for_user" and result.interrupts:
+        interrupt_count += len(result.interrupts)
+        if interrupt_count > 10:
+            console.print(
+                "[red]Exceeded maximum number of nested clarifications.[/red]"
+            )
+            return None
+
+        answers: Any
+        if len(result.interrupts) == 1:
+            pending = result.interrupts[0]
+            console.print(
+                Panel(
+                    _interrupt_question(pending.payload),
+                    title="[bold yellow]Agent needs your input[/bold yellow]",
+                    style="yellow",
+                )
+            )
+            answers = Prompt.ask("[bold cyan]Your response[/bold cyan]")
+        else:
+            answers = {}
+            for pending in result.interrupts:
+                console.print(
+                    Panel(
+                        _interrupt_question(pending.payload),
+                        title=(
+                            "[bold yellow]Agent needs your input"
+                            f" ({pending.id})[/bold yellow]"
+                        ),
+                        style="yellow",
+                    )
+                )
+                answers[pending.id] = Prompt.ask(
+                    "[bold cyan]Your response[/bold cyan]"
+                )
+
+        try:
+            result = run_async_callable(lambda: session.resume(answers))
+        except Exception as exc:
+            console.print(f"[red]Error resuming main-agent session: {exc}[/red]")
+            _main_agent_failure_hint(session)
+            return None
+
+    return result
+
+
+def run_main_agent_query(session: Any, query: str, verbose: bool = False) -> Any:
+    """Run one main-agent turn and resolve nested clarifications."""
+    if verbose:
+        console.print(f"[blue]Main-agent thread:[/blue] {session.thread_id}")
+
+    return _run_main_agent_operation(
+        session,
+        lambda: session.run(query),
+        progress_description="Processing main-agent turn...",
+    )
+
+
+def retry_main_agent_session(session: Any, verbose: bool = False) -> Any:
+    """Retry the failed operation for one main-agent session."""
+    if verbose:
+        console.print(f"[blue]Main-agent thread:[/blue] {session.thread_id}")
+    return _run_main_agent_operation(
+        session,
+        session.retry,
+        progress_description="Retrying main-agent operation...",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Session management
 # ---------------------------------------------------------------------------
@@ -760,6 +883,10 @@ def interactive_mode(
     if not agent:
         return
 
+    main_session = (
+        create_main_agent_session(agent) if workflow == "main_agent" else None
+    )
+
     console.print(
         "[green]Ready! You can now ask computational chemistry questions.[/green]\n"
     )
@@ -787,6 +914,11 @@ Session commands:
   history            List recent sessions
   show <id>          Show a session's conversation
   resume <id>        Resume from a previous session
+  retry              Retry a failed main_agent operation
+
+main_agent keeps one checkpointed thread until you quit or switch
+model/workflow. Its thread is process-local; `resume` does not currently
+restore it later. Nested chemistry workers may pause to request input.
 
 Example queries:
   What is the SMILES string for water?
@@ -805,7 +937,10 @@ Example queries:
             elif query.lower() == "config":
                 console.print(f"Model: {model}")
                 console.print(f"Workflow: {workflow}")
-                if hasattr(agent, "session_id"):
+                if main_session is not None:
+                    console.print(f"Thread ID: {main_session.thread_id}")
+                    console.print(f"Failed: {main_session.failed}")
+                elif hasattr(agent, "session_id"):
                     console.print(f"Session ID: {agent.session_id}")
                 continue
             elif query.lower() == "history":
@@ -819,6 +954,12 @@ Example queries:
                     console.print("[red]Usage: show <session_id>[/red]")
                 continue
             elif query.lower().startswith("resume "):
+                if main_session is not None:
+                    console.print(
+                        "[yellow]Persistent resume is not supported for the "
+                        "process-lifetime main_agent workflow.[/yellow]"
+                    )
+                    continue
                 sid = query[7:].strip()
                 if not sid:
                     console.print("[red]Usage: resume <session_id>[/red]")
@@ -836,11 +977,16 @@ Example queries:
                     if result:
                         format_response(result, verbose=verbose)
                 continue
+            elif query.lower() == "retry" and main_session is not None:
+                result = retry_main_agent_session(main_session, verbose=verbose)
+                if result:
+                    format_response(result, verbose=verbose)
+                    console.print(f"[dim]Thread: {main_session.thread_id}[/dim]")
+                continue
             elif query.startswith("model "):
                 new_model = query[6:].strip()
-                model = new_model
-                agent = initialize_agent(
-                    model,
+                new_agent = initialize_agent(
+                    new_model,
                     workflow,
                     structured,
                     return_option,
@@ -851,16 +997,22 @@ Example queries:
                     human_supervised=human_supervised,
                     tools=tools,
                 )
-                if agent:
+                if new_agent:
+                    model = new_model
+                    agent = new_agent
+                    main_session = (
+                        create_main_agent_session(agent)
+                        if workflow == "main_agent"
+                        else None
+                    )
                     console.print(f"[green]Model changed to: {model}[/green]")
                 continue
             elif query.startswith("workflow "):
                 new_workflow = resolve_workflow(query[9:].strip())
                 if new_workflow in ALL_WORKFLOW_TYPES:
-                    workflow = new_workflow
-                    agent = initialize_agent(
+                    new_agent = initialize_agent(
                         model,
-                        workflow,
+                        new_workflow,
                         structured,
                         return_option,
                         generate_report,
@@ -870,7 +1022,14 @@ Example queries:
                         human_supervised=human_supervised,
                         tools=tools,
                     )
-                    if agent:
+                    if new_agent:
+                        workflow = new_workflow
+                        agent = new_agent
+                        main_session = (
+                            create_main_agent_session(agent)
+                            if workflow == "main_agent"
+                            else None
+                        )
                         console.print(
                             f"[green]Workflow changed to: {workflow}[/green]"
                         )
@@ -881,11 +1040,20 @@ Example queries:
                     )
                 continue
 
-            # Execute query (each query gets a unique thread ID)
-            result = run_query(agent, query, verbose=verbose)
+            if main_session is not None:
+                result = run_main_agent_query(
+                    main_session,
+                    query,
+                    verbose=verbose,
+                )
+            else:
+                # Existing workflows use a fresh thread for each query.
+                result = run_query(agent, query, verbose=verbose)
             if result:
                 format_response(result, verbose=verbose)
-                if hasattr(agent, "session_id") and agent.session_id:
+                if main_session is not None:
+                    console.print(f"[dim]Thread: {main_session.thread_id}[/dim]")
+                elif hasattr(agent, "session_id") and agent.session_id:
                     console.print(f"[dim]Session: {agent.session_id}[/dim]")
 
         except KeyboardInterrupt:

--- a/src/chemgraph/cli/formatting.py
+++ b/src/chemgraph/cli/formatting.py
@@ -232,6 +232,21 @@ def format_response(result: Any, verbose: bool = False) -> None:
         console.print("[red]No response received from agent.[/red]")
         return
 
+    if hasattr(result, "assistant_response"):
+        response = str(getattr(result, "assistant_response", "")).strip()
+        if response:
+            console.print(
+                Panel(
+                    Markdown(response),
+                    title="ChemGraph Response",
+                    style="green",
+                    padding=(1, 2),
+                )
+            )
+        elif verbose:
+            console.print("[dim]Main agent returned no assistant text.[/dim]")
+        return
+
     # Extract messages from result
     messages: list[Any] = []
     if isinstance(result, list):

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -198,6 +198,7 @@ Examples:
   # Legacy style (still works)
   %(prog)s -q "What is the SMILES string for water?"
   %(prog)s --interactive
+  %(prog)s --interactive -w main_agent
   %(prog)s --list-models
 
   # Subcommand style
@@ -451,6 +452,20 @@ def _handle_run(args: argparse.Namespace) -> None:
 
     # Resolve workflow alias (e.g. python_repl -> python_relp)
     args.workflow = resolve_workflow(args.workflow)
+
+    if args.workflow == "main_agent":
+        if getattr(args, "resume", None):
+            console.print(
+                "[red]--resume is not supported for the process-lifetime "
+                "main_agent workflow.[/red]"
+            )
+            sys.exit(2)
+        if not getattr(args, "interactive", False):
+            console.print(
+                "[red]main_agent requires interactive mode. Use "
+                "`chemgraph --interactive -w main_agent`.[/red]"
+            )
+            sys.exit(2)
 
     # ---- MCP tool loading ----------------------------------------------
     mcp_tools = None

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -1,0 +1,200 @@
+"""Long-lived ChemGraph supervisor built from LangChain agent middleware."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Sequence
+from typing import Any
+
+from deepagents.backends import StateBackend
+from deepagents.middleware import SubAgentMiddleware
+from deepagents.middleware.subagents import CompiledSubAgent
+from langchain.agents import create_agent
+from langchain_core.messages import AIMessage, ToolMessage, convert_to_messages
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.tools import BaseTool
+from langgraph.checkpoint.memory import InMemorySaver
+
+from chemgraph.graphs.single_agent import construct_single_agent_graph
+
+
+DEFAULT_MAIN_AGENT_PROMPT = """\
+You are the long-lived ChemGraph supervisor. You manage the conversation,
+decompose user requests, delegate specialist work, and synthesize the returned
+results into a clear response.
+
+Rules:
+1. Delegate computational chemistry tasks and any work requiring specialist
+   tools through `task`; do not invent scientific results.
+2. Give each subagent a self-contained task containing the relevant inputs and
+   constraints. You may call multiple subagents when tasks are independent.
+3. Review subagent results and give the user a complete response. If required
+   input is missing, ask a clear question in your response.
+4. Use supervisor-level tools directly when their descriptions match the task.
+"""
+
+
+def latest_assistant_text(messages: list[Any]) -> str:
+    """Return the latest assistant message text from a message history."""
+    for message in reversed(convert_to_messages(messages)):
+        if isinstance(message, AIMessage):
+            return str(message.text)
+    return ""
+
+
+def _preserve_terminal_tool_output(result: Any) -> Any:
+    """Expose trailing worker tool output to Deep Agents as a final AI message."""
+    if not isinstance(result, dict) or result.get("structured_response") is not None:
+        return result
+
+    messages = convert_to_messages(result.get("messages", []))
+    if not messages or not isinstance(messages[-1], ToolMessage):
+        return result
+
+    trailing_text: list[str] = []
+    for message in reversed(messages):
+        if not isinstance(message, ToolMessage):
+            break
+        if text := str(message.text).strip():
+            trailing_text.append(text)
+    if not trailing_text:
+        return result
+
+    return {
+        **result,
+        "messages": [
+            *messages,
+            AIMessage(content="\n".join(reversed(trailing_text))),
+        ],
+    }
+
+
+def _adapt_subagent(spec: CompiledSubAgent) -> CompiledSubAgent:
+    runnable = spec["runnable"]
+
+    def invoke(state: Any, config: RunnableConfig) -> Any:
+        return _preserve_terminal_tool_output(runnable.invoke(state, config=config))
+
+    async def ainvoke(state: Any, config: RunnableConfig) -> Any:
+        result = await runnable.ainvoke(state, config=config)
+        return _preserve_terminal_tool_output(result)
+
+    return {
+        "name": spec["name"],
+        "description": spec["description"],
+        "runnable": RunnableLambda(invoke, afunc=ainvoke),
+    }
+
+
+def _validate_subagents(
+    subagents: Sequence[CompiledSubAgent],
+) -> list[CompiledSubAgent]:
+    if not subagents:
+        raise ValueError("At least one subagent must be registered.")
+
+    validated: list[CompiledSubAgent] = []
+    names: set[str] = set()
+    for spec in subagents:
+        name = spec.get("name")
+        description = spec.get("description")
+        runnable = spec.get("runnable")
+        if not isinstance(name, str):
+            raise TypeError("Subagent names must be strings.")
+        if not name:
+            raise ValueError("Subagent names must not be empty.")
+        if name != name.strip():
+            raise ValueError("Subagent names must not have surrounding whitespace.")
+        if name in names:
+            raise ValueError(f"Duplicate subagent name: {name!r}.")
+        if not isinstance(description, str):
+            raise TypeError(f"Subagent {name!r} must have a string description.")
+        if not description.strip():
+            raise ValueError(f"Subagent {name!r} must have a description.")
+        if not callable(getattr(runnable, "invoke", None)) or not callable(
+            getattr(runnable, "ainvoke", None)
+        ):
+            raise TypeError(
+                f"Subagent {name!r} must provide invoke and ainvoke methods."
+            )
+        names.add(name)
+        validated.append(_adapt_subagent(spec))
+    return validated
+
+
+def _validate_main_tools(main_tools: Sequence[BaseTool]) -> None:
+    names = [getattr(item, "name", "") for item in main_tools]
+    if any(not name for name in names):
+        raise ValueError("Every supervisor tool must have a non-empty name.")
+    if "task" in names:
+        raise ValueError("Supervisor tool name 'task' is reserved for subagents.")
+    if len(names) != len(set(names)):
+        raise ValueError("Supervisor tool names must be unique.")
+
+
+def construct_main_agent_graph(
+    llm: Any,
+    *,
+    subagents: Sequence[CompiledSubAgent] | None = None,
+    main_tools: list[BaseTool] | None = None,
+    subagent_tools: list[BaseTool] | None = None,
+    subagent_system_prompt: str | None = None,
+    subagent_formatter_prompt: str | None = None,
+    subagent_report_prompt: str | None = None,
+    subagent_structured_output: bool = False,
+    subagent_generate_report: bool = False,
+    subagent_max_retries: int = 1,
+    subagent_human_supervised: bool = False,
+    subagent_terminal_tool_names: Collection[str] = (),
+    system_prompt: str = DEFAULT_MAIN_AGENT_PROMPT,
+    checkpointer: Any | None = None,
+):
+    """Construct a checkpointed supervisor with Deep Agents delegation."""
+    if subagents is None:
+        worker_kwargs: dict[str, Any] = {
+            "tools": subagent_tools,
+            "structured_output": subagent_structured_output,
+            "generate_report": subagent_generate_report,
+            "max_retries": subagent_max_retries,
+            "human_supervised": subagent_human_supervised,
+            "terminal_tool_names": subagent_terminal_tool_names,
+            "checkpointer": None,
+        }
+        if subagent_system_prompt is not None:
+            worker_kwargs["system_prompt"] = subagent_system_prompt
+        if subagent_formatter_prompt is not None:
+            worker_kwargs["formatter_prompt"] = subagent_formatter_prompt
+        if subagent_report_prompt is not None:
+            worker_kwargs["report_prompt"] = subagent_report_prompt
+        worker = construct_single_agent_graph(llm, **worker_kwargs)
+        subagents = [
+            {
+                "name": "chemgraph",
+                "description": (
+                    "Executes computational chemistry and molecular simulation "
+                    "tasks with the existing ChemGraph single-agent workflow."
+                ),
+                "runnable": worker,
+            }
+        ]
+
+    validated_subagents = _validate_subagents(subagents)
+    supervisor_tools = list(main_tools or [])
+    _validate_main_tools(supervisor_tools)
+    middleware = SubAgentMiddleware(
+        backend=StateBackend(),
+        subagents=validated_subagents,
+    )
+    return create_agent(
+        model=llm,
+        tools=supervisor_tools,
+        system_prompt=system_prompt,
+        middleware=[middleware],
+        checkpointer=checkpointer or InMemorySaver(),
+        name="main_agent",
+    )
+
+
+__all__ = [
+    "DEFAULT_MAIN_AGENT_PROMPT",
+    "construct_main_agent_graph",
+    "latest_assistant_text",
+]

--- a/src/chemgraph/graphs/multi_agent.py
+++ b/src/chemgraph/graphs/multi_agent.py
@@ -297,9 +297,8 @@ def human_review_node(
     if config is None:
         human_response = interrupt({"question": question})
     else:
-        # LangGraph cannot propagate its runnable context into async graph
-        # nodes on Python 3.10. Restore it explicitly so interrupt() works
-        # when this synchronous node is driven through astream().
+        # Restore the runnable context explicitly so interrupt() works when
+        # this synchronous node is driven through astream().
         with set_config_context(config) as context:
             human_response = context.run(interrupt, {"question": question})
 

--- a/src/chemgraph/graphs/single_agent.py
+++ b/src/chemgraph/graphs/single_agent.py
@@ -26,6 +26,8 @@ from chemgraph.state.state import State
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def _tool_call_signature(tool_calls) -> tuple:
     """Create a comparable signature for a list of tool calls.
@@ -454,6 +456,7 @@ def construct_single_agent_graph(
     max_retries: int = 1,
     human_supervised: bool = False,
     terminal_tool_names: Collection[str] = (),
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct a geometry optimization graph.
 
@@ -482,6 +485,11 @@ def construct_single_agent_graph(
     terminal_tool_names : Collection[str], optional
         Tool names that should terminate the graph after successful tool
         execution instead of routing back to the LLM, by default empty.
+    checkpointer : optional
+        LangGraph checkpointer used to compile the graph. When omitted, a new
+        ``MemorySaver`` preserves the existing standalone behavior. Pass
+        ``None`` when embedding this graph as a subgraph so it inherits the
+        parent graph's checkpointer.
 
     Returns
     -------
@@ -490,7 +498,8 @@ def construct_single_agent_graph(
     """
     try:
         logger.info("Constructing single agent graph")
-        checkpointer = MemorySaver()
+        if checkpointer is _DEFAULT_CHECKPOINTER:
+            checkpointer = MemorySaver()
         if tools is None:
             tools = [
                 smiles_to_coordinate_file,

--- a/tests/test_cli_formatting.py
+++ b/tests/test_cli_formatting.py
@@ -2,6 +2,7 @@ import json
 
 from langchain_core.messages import AIMessage
 
+from chemgraph.agent.main_session import MainAgentTurnResult
 from chemgraph.cli.formatting import _content_text, console, format_response
 
 
@@ -58,3 +59,20 @@ def test_format_response_detects_atomic_json_in_structured_content():
     assert "ChemGraph Response" in output
     assert "Water optimized" in output
     assert "Molecular Structure Data" in output
+
+
+def test_format_response_renders_main_agent_turn_result():
+    result = MainAgentTurnResult(
+        thread_id="thread-1",
+        status="waiting_for_user",
+        assistant_response="Delegated calculation complete.",
+        interrupts=(),
+        state={},
+    )
+
+    with console.capture() as capture:
+        format_response(result)
+
+    output = capture.get()
+    assert "ChemGraph Response" in output
+    assert "Delegated calculation complete" in output

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -7,9 +7,11 @@ from langchain_core.tools import tool
 
 from chemgraph.agent import llm_agent
 from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.agent.main_session import MainAgentSession
 from chemgraph.cli import commands
 from chemgraph.cli.commands import check_api_keys
 from chemgraph.cli.formatting import console
+from chemgraph.graphs.main_agent import construct_main_agent_graph
 from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.models import codex as codex_model
 from chemgraph.models.codex import (
@@ -270,7 +272,19 @@ def test_shared_loader_routes_codex_prefix(monkeypatch):
     )
 
 
-def test_chemgraph_routes_codex_to_single_agent(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("workflow_type", "constructor_name"),
+    [
+        ("single_agent", "construct_single_agent_graph"),
+        ("main_agent", "construct_main_agent_graph"),
+    ],
+)
+def test_chemgraph_routes_codex_to_supported_workflow(
+    monkeypatch,
+    tmp_path,
+    workflow_type,
+    constructor_name,
+):
     captured = {}
     monkeypatch.setattr(
         llm_agent,
@@ -279,13 +293,13 @@ def test_chemgraph_routes_codex_to_single_agent(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(
         llm_agent,
-        "construct_single_agent_graph",
+        constructor_name,
         lambda llm, *_args, **_kwargs: captured.setdefault("llm", llm),
     )
 
     ChemGraph(
         model_name="codex:test-model",
-        workflow_type="single_agent",
+        workflow_type=workflow_type,
         enable_memory=False,
         log_dir=str(tmp_path),
     )
@@ -293,9 +307,85 @@ def test_chemgraph_routes_codex_to_single_agent(monkeypatch, tmp_path):
     assert captured["llm"] == ("codex-model", "codex:test-model")
 
 
-def test_chemgraph_rejects_codex_for_other_workflows():
-    with pytest.raises(ValueError, match="only the single_agent workflow"):
+def test_chemgraph_rejects_codex_for_unsupported_workflows():
+    with pytest.raises(ValueError, match="single_agent and main_agent workflows"):
         ChemGraph(model_name="codex:test-model", workflow_type="multi_agent")
+
+
+@pytest.mark.asyncio
+async def test_codex_adapter_runs_main_agent_delegation(fake_codex_sdk):
+    fake_codex_sdk.responses.extend(
+        [
+            json.dumps(
+                {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "name": "task",
+                            "arguments": json.dumps(
+                                {
+                                    "subagent_type": "chemgraph",
+                                    "description": "Look up the aspirin SMILES.",
+                                }
+                            ),
+                        }
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "name": "lookup_smiles",
+                            "arguments": json.dumps({"name": "aspirin"}),
+                        }
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "content": "The aspirin SMILES is "
+                    "CC(=O)OC1=CC=CC=C1C(=O)O.",
+                    "tool_calls": [],
+                }
+            ),
+            json.dumps(
+                {
+                    "content": "The chemistry worker found the aspirin SMILES.",
+                    "tool_calls": [],
+                }
+            ),
+        ]
+    )
+    model = CodexChatModel(model_id="gpt-5.6-terra")
+    worker = construct_single_agent_graph(
+        model,
+        system_prompt="Use the lookup tool before answering.",
+        tools=[lookup_smiles],
+        checkpointer=None,
+    )
+    graph = construct_main_agent_graph(
+        model,
+        subagents=[
+            {
+                "name": "chemgraph",
+                "description": "Executes chemistry lookup tasks.",
+                "runnable": worker,
+            }
+        ],
+    )
+
+    result = await MainAgentSession(
+        graph,
+        thread_id="codex-main-agent-test",
+    ).run("Find the aspirin SMILES")
+
+    assert result.status == "completed"
+    assert result.assistant_response == (
+        "The chemistry worker found the aspirin SMILES."
+    )
+    assert len(fake_codex_sdk.run_calls) == 4
 
 
 def test_codex_models_never_require_openai_api_key(monkeypatch):

--- a/tests/test_graph_constructors.py
+++ b/tests/test_graph_constructors.py
@@ -4,6 +4,7 @@ from chemgraph.agent.llm_agent import ChemGraph
 
 WORKFLOWS = [
     "single_agent",
+    "main_agent",
     "multi_agent",
     "python_relp",
     "graspa",
@@ -26,6 +27,7 @@ def test_constructor_is_called(monkeypatch, workflow_type):
     # Patch the constructor name used by chemgraph.agent.llm_agent
     constructor_attr = {
         "single_agent": "construct_single_agent_graph",
+        "main_agent": "construct_main_agent_graph",
         "multi_agent": "construct_multi_agent_graph",
         "python_relp": "construct_relp_graph",
         "graspa": "construct_graspa_graph",

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -34,6 +34,7 @@ class _FakeWorkflow:
     ("workflow_type", "constructor_attr", "kwargs"),
     [
         ("single_agent", "construct_single_agent_graph", {}),
+        ("main_agent", "construct_main_agent_graph", {}),
         ("multi_agent", "construct_multi_agent_graph", {}),
         ("python_relp", "construct_relp_graph", {}),
         ("graspa", "construct_graspa_graph", {}),
@@ -152,6 +153,76 @@ def test_single_agent_initialization_injects_calculator_availability(monkeypatch
     assert "Calculator availability detected during ChemGraph initialization" in system_prompt
     assert cg.default_calculator in system_prompt
     assert cg.default_calculator in cg.available_calculators
+
+
+def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tmp_path):
+    captured = {}
+    workflow = _FakeWorkflow()
+    main_tool = _DummyTool("read_file")
+
+    def fake_constructor(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return workflow
+
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.construct_main_agent_graph",
+        fake_constructor,
+    )
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_openai_model",
+        lambda **_kwargs: "FAKE_LLM",
+    )
+
+    cg = ChemGraph(
+        model_name="gpt-4o-mini",
+        workflow_type="main_agent",
+        enable_memory=False,
+        log_dir=str(tmp_path / "logs"),
+        tools=[main_tool],
+        formatter_prompt="custom formatter",
+        report_prompt="custom report",
+        structured_output=True,
+        generate_report=True,
+        max_retries=4,
+        human_supervised=True,
+        terminal_tool_names=("save_result",),
+    )
+
+    assert cg.workflow is workflow
+    assert captured["args"] == ("FAKE_LLM",)
+    assert captured["kwargs"]["main_tools"] == [main_tool]
+    assert "Calculator availability detected" in captured["kwargs"][
+        "subagent_system_prompt"
+    ]
+    assert captured["kwargs"]["subagent_formatter_prompt"] == cg.formatter_prompt
+    assert captured["kwargs"]["subagent_report_prompt"] == cg.report_prompt
+    assert captured["kwargs"]["subagent_structured_output"] is True
+    assert captured["kwargs"]["subagent_generate_report"] is True
+    assert captured["kwargs"]["subagent_max_retries"] == cg.max_retries
+    assert captured["kwargs"]["subagent_human_supervised"] is True
+    assert captured["kwargs"]["subagent_terminal_tool_names"] == ("save_result",)
+
+
+@pytest.mark.asyncio
+async def test_main_agent_rejects_one_shot_run(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.construct_main_agent_graph",
+        lambda *_args, **_kwargs: _FakeWorkflow(),
+    )
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_openai_model",
+        lambda **_kwargs: "FAKE_LLM",
+    )
+    cg = ChemGraph(
+        model_name="gpt-4o-mini",
+        workflow_type="main_agent",
+        enable_memory=False,
+        log_dir=str(tmp_path / "logs"),
+    )
+
+    with pytest.raises(RuntimeError, match="MainAgentSession"):
+        await cg.run("hello")
 
 
 def test_rag_and_xanes_default_prompts_are_preserved(monkeypatch, tmp_path):

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -1,0 +1,507 @@
+"""Tests for the middleware-based main-agent supervisor."""
+
+from typing import Annotated, Any, TypedDict
+
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, StateGraph, add_messages
+from langgraph.types import interrupt
+from pydantic import Field
+
+from chemgraph.agent.main_session import MainAgentSession
+from chemgraph.graphs.main_agent import (
+    construct_main_agent_graph,
+    latest_assistant_text,
+)
+from chemgraph.graphs.single_agent import construct_single_agent_graph
+
+
+class _MessageState(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+class _ScriptedChatModel(BaseChatModel):
+    responses: list[Any]
+    response_index: int = 0
+    bound_tools: list[Any] = Field(default_factory=list)
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted-main-agent-test"
+
+    def bind_tools(self, tools, **_kwargs):
+        self.bound_tools = list(tools)
+        return self
+
+    def _generate(
+        self,
+        _messages,
+        stop=None,
+        run_manager=None,
+        **_kwargs,
+    ) -> ChatResult:
+        response = self.responses[self.response_index]
+        self.response_index += 1
+        if isinstance(response, BaseException):
+            raise response
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+
+def _task_call(call_id: str, description: str = "do the work") -> dict:
+    return {
+        "name": "task",
+        "args": {"subagent_type": "worker", "description": description},
+        "id": call_id,
+        "type": "tool_call",
+    }
+
+
+def _answering_subgraph(answer: str, calls: list[str] | None = None):
+    def answer_node(state):
+        if calls is not None:
+            calls.append(state["messages"][-1].content)
+        return {"messages": [AIMessage(content=answer)]}
+
+    builder = StateGraph(_MessageState)
+    builder.add_node("answer", answer_node)
+    builder.add_edge(START, "answer")
+    builder.add_edge("answer", END)
+    return builder.compile(checkpointer=None)
+
+
+def _interrupting_subgraph():
+    def clarification_node(_state):
+        answer = interrupt({"question": "Which calculator should I use?"})
+        return {"messages": [AIMessage(content=f"worker used {answer}")]}
+
+    builder = StateGraph(_MessageState)
+    builder.add_node("clarification", clarification_node)
+    builder.add_edge(START, "clarification")
+    builder.add_edge("clarification", END)
+    return builder.compile(checkpointer=None)
+
+
+def _parallel_interrupting_subgraph():
+    def first_node(_state):
+        answer = interrupt({"question": "first"})
+        return {"messages": [AIMessage(content=f"first={answer}")]}
+
+    def second_node(_state):
+        answer = interrupt({"question": "second"})
+        return {"messages": [AIMessage(content=f"second={answer}")]}
+
+    builder = StateGraph(_MessageState)
+    builder.add_node("first", first_node)
+    builder.add_node("second", second_node)
+    builder.add_edge(START, "first")
+    builder.add_edge(START, "second")
+    builder.add_edge("first", END)
+    builder.add_edge("second", END)
+    return builder.compile(checkpointer=None)
+
+
+def _terminal_tool_subgraph():
+    def terminal_node(state):
+        return {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "write_report",
+                            "args": {},
+                            "id": "report-1",
+                            "type": "tool_call",
+                        },
+                        {
+                            "name": "save_data",
+                            "args": {},
+                            "id": "data-1",
+                            "type": "tool_call",
+                        },
+                    ],
+                ),
+                ToolMessage(
+                    content="Report written to report.html",
+                    tool_call_id="report-1",
+                    name="write_report",
+                ),
+                ToolMessage(
+                    content="Data written to results.csv",
+                    tool_call_id="data-1",
+                    name="save_data",
+                ),
+            ]
+        }
+
+    builder = StateGraph(_MessageState)
+    builder.add_node("terminal", terminal_node)
+    builder.add_edge(START, "terminal")
+    builder.add_edge("terminal", END)
+    return builder.compile(checkpointer=None)
+
+
+def _subagent(runnable, *, name: str = "worker", description: str = "Test worker"):
+    return {"name": name, "description": description, "runnable": runnable}
+
+
+@pytest.mark.asyncio
+async def test_main_agent_delegates_and_keeps_normal_turns_on_one_thread():
+    worker_calls = []
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_task_call("call-1")]),
+            AIMessage(content="The worker found 42."),
+            AIMessage(content="Here is the follow-up answer."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_answering_subgraph("42", worker_calls))],
+    )
+    session = MainAgentSession(graph, thread_id="main-agent-turns")
+
+    first = await session.run("Calculate something")
+    second = await session.run("Explain that result")
+
+    assert first.status == "completed"
+    assert first.assistant_response == "The worker found 42."
+    assert first.interrupts == ()
+    assert second.status == "completed"
+    assert second.assistant_response == "Here is the follow-up answer."
+    assert worker_calls == ["do the work"]
+    messages = graph.get_state(session.config).values["messages"]
+    assert [message.content for message in messages if isinstance(message, HumanMessage)] == [
+        "Calculate something",
+        "Explain that result",
+    ]
+    assert {tool.name for tool in llm.bound_tools} == {"task"}
+
+
+@pytest.mark.asyncio
+async def test_nested_subagent_interrupt_resumes_then_completes_turn():
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_task_call("call-1")]),
+            AIMessage(content="The calculation used EMT."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_interrupting_subgraph())],
+    )
+    session = MainAgentSession(graph, thread_id="nested-interrupt")
+
+    clarification = await session.run("Run a calculation")
+
+    assert clarification.status == "waiting_for_user"
+    assert len(clarification.interrupts) == 1
+    assert clarification.interrupts[0].payload == {
+        "question": "Which calculator should I use?"
+    }
+    with pytest.raises(RuntimeError, match="waiting for interrupt"):
+        await session.run("Do not skip the pending answer")
+
+    completed = await session.resume("EMT")
+
+    assert completed.status == "completed"
+    assert completed.assistant_response == "The calculation used EMT."
+    assert completed.interrupts == ()
+
+
+@pytest.mark.asyncio
+async def test_parallel_subagent_interrupts_require_id_mapped_responses():
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_task_call("parallel-call")]),
+            AIMessage(content="Both clarifications were applied."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_parallel_interrupting_subgraph())],
+    )
+    session = MainAgentSession(graph, thread_id="parallel-interrupts")
+    clarification = await session.run("Run both tasks")
+
+    assert len(clarification.interrupts) == 2
+    assert {item.payload["question"] for item in clarification.interrupts} == {
+        "first",
+        "second",
+    }
+    assert all(item.id for item in clarification.interrupts)
+    with pytest.raises(ValueError, match="require a mapping"):
+        await session.resume("one answer")
+
+    responses = {
+        item.id: f"answer-{item.payload['question']}"
+        for item in clarification.interrupts
+    }
+    completed = await session.resume(responses)
+
+    assert completed.status == "completed"
+    assert completed.assistant_response == "Both clarifications were applied."
+
+
+@pytest.mark.asyncio
+async def test_terminal_tool_outputs_are_returned_to_supervisor():
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_task_call("report-call")]),
+            AIMessage(content="Artifacts are ready."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_terminal_tool_subgraph())],
+    )
+    session = MainAgentSession(graph, thread_id="terminal-output")
+
+    result = await session.run("Create report artifacts")
+
+    assert result.assistant_response == "Artifacts are ready."
+    task_results = [
+        message.content
+        for message in graph.get_state(session.config).values["messages"]
+        if isinstance(message, ToolMessage) and message.name == "task"
+    ]
+    assert task_results == [
+        "Report written to report.html\nData written to results.csv"
+    ]
+
+
+def test_latest_assistant_text_uses_standard_message_normalization():
+    messages = [
+        {"role": "assistant", "content": "older"},
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "new"},
+                {"type": "reasoning", "reasoning": "hidden"},
+                {"type": "text", "text": " answer"},
+            ],
+        },
+    ]
+
+    assert latest_assistant_text(messages) == "new answer"
+
+
+@pytest.mark.asyncio
+async def test_unknown_subagent_is_reported_to_main_model():
+    call = _task_call("unknown-id")
+    call["args"]["subagent_type"] = "missing"
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[call]),
+            AIMessage(content="That specialist is unavailable."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_answering_subgraph("done"))],
+    )
+    session = MainAgentSession(graph, thread_id="unknown-worker")
+
+    result = await session.run("Use a missing worker")
+
+    assert result.assistant_response == "That specialist is unavailable."
+    tool_messages = [
+        message.text
+        for message in graph.get_state(session.config).values["messages"]
+        if isinstance(message, ToolMessage)
+    ]
+    assert any("does not exist" in text for text in tool_messages)
+
+
+def test_default_worker_forwards_options_and_inherits_parent_checkpoint(monkeypatch):
+    captured = {}
+
+    def fake_single_agent(*_args, **kwargs):
+        captured.update(kwargs)
+        return _answering_subgraph("done")
+
+    monkeypatch.setattr(
+        "chemgraph.graphs.main_agent.construct_single_agent_graph",
+        fake_single_agent,
+    )
+    graph = construct_main_agent_graph(
+        _ScriptedChatModel(responses=[]),
+        subagent_system_prompt="worker prompt",
+        subagent_formatter_prompt="formatter prompt",
+        subagent_report_prompt="report prompt",
+        subagent_structured_output=True,
+        subagent_generate_report=True,
+        subagent_max_retries=3,
+        subagent_human_supervised=True,
+        subagent_terminal_tool_names=("save_result",),
+    )
+
+    assert captured == {
+        "tools": None,
+        "structured_output": True,
+        "generate_report": True,
+        "max_retries": 3,
+        "human_supervised": True,
+        "terminal_tool_names": ("save_result",),
+        "checkpointer": None,
+        "system_prompt": "worker prompt",
+        "formatter_prompt": "formatter prompt",
+        "report_prompt": "report prompt",
+    }
+    assert isinstance(graph.checkpointer, InMemorySaver)
+
+
+@pytest.mark.parametrize(
+    ("specs", "error", "match"),
+    [
+        ([], ValueError, "At least one"),
+        (
+            [_subagent(_answering_subgraph("done"), name=" worker ")],
+            ValueError,
+            "surrounding whitespace",
+        ),
+        (
+            [
+                _subagent(_answering_subgraph("one")),
+                _subagent(_answering_subgraph("two")),
+            ],
+            ValueError,
+            "Duplicate",
+        ),
+        (
+            [_subagent(_answering_subgraph("done"), description=" ")],
+            ValueError,
+            "description",
+        ),
+    ],
+)
+def test_subagent_validation(specs, error, match):
+    with pytest.raises(error, match=match):
+        construct_main_agent_graph(
+            _ScriptedChatModel(responses=[]),
+            subagents=specs,
+        )
+
+
+def test_main_tools_are_extensible_and_task_is_reserved():
+    @tool
+    def read_file(path: str) -> str:
+        """Return test file contents."""
+        return path
+
+    llm = _ScriptedChatModel(responses=[AIMessage(content="done")])
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_answering_subgraph("done"))],
+        main_tools=[read_file],
+    )
+    assert graph is not None
+
+    @tool("task")
+    def duplicate_task(description: str) -> str:
+        """Conflict with the middleware task tool."""
+        return description
+
+    with pytest.raises(ValueError, match="reserved"):
+        construct_main_agent_graph(
+            llm,
+            subagents=[_subagent(_answering_subgraph("done"))],
+            main_tools=[duplicate_task],
+        )
+
+
+def test_single_agent_preserves_default_and_allows_inherited_checkpointer():
+    llm = _ScriptedChatModel(responses=[AIMessage(content="done")])
+
+    standalone = construct_single_agent_graph(llm)
+    embedded = construct_single_agent_graph(llm, checkpointer=None)
+
+    assert isinstance(standalone.checkpointer, InMemorySaver)
+    assert embedded.checkpointer is None
+
+
+@pytest.mark.asyncio
+async def test_session_validation():
+    graph = construct_main_agent_graph(
+        _ScriptedChatModel(responses=[AIMessage(content="ready")]),
+        subagents=[_subagent(_answering_subgraph("done"))],
+    )
+    session = MainAgentSession(graph, thread_id="lifecycle")
+
+    assert session.failed is False
+    assert session.pending_interrupts == ()
+    with pytest.raises(RuntimeError, match="not waiting"):
+        await session.resume("too early")
+    with pytest.raises(RuntimeError, match="no failed operation"):
+        await session.retry()
+    with pytest.raises(ValueError, match="non-empty"):
+        await session.run(" ")
+
+    result = await session.run("hello")
+
+    assert result.status == "completed"
+    assert session.failed is False
+
+
+@pytest.mark.asyncio
+async def test_failed_initial_turn_can_retry_without_duplicate_user_message():
+    graph = construct_main_agent_graph(
+        _ScriptedChatModel(
+            responses=[RuntimeError("transient failure"), AIMessage(content="ready")]
+        ),
+        subagents=[_subagent(_answering_subgraph("done"))],
+    )
+    session = MainAgentSession(graph, thread_id="retry-initial")
+
+    with pytest.raises(RuntimeError, match="transient failure"):
+        await session.run("hello")
+    assert session.failed is True
+    with pytest.raises(RuntimeError, match="retry it"):
+        await session.run("duplicate")
+
+    result = await session.retry()
+
+    assert result.assistant_response == "ready"
+    assert session.failed is False
+    human_messages = [
+        message
+        for message in graph.get_state(session.config).values["messages"]
+        if isinstance(message, HumanMessage)
+    ]
+    assert [message.content for message in human_messages] == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_failed_follow_up_can_retry_without_duplicate_user_message():
+    graph = construct_main_agent_graph(
+        _ScriptedChatModel(
+            responses=[
+                AIMessage(content="first response"),
+                RuntimeError("follow-up failure"),
+                AIMessage(content="second response"),
+            ]
+        ),
+        subagents=[_subagent(_answering_subgraph("done"))],
+    )
+    session = MainAgentSession(graph, thread_id="retry-follow-up")
+
+    await session.run("first question")
+    with pytest.raises(RuntimeError, match="follow-up failure"):
+        await session.run("second question")
+    result = await session.retry()
+
+    assert result.assistant_response == "second response"
+    human_messages = [
+        message
+        for message in graph.get_state(session.config).values["messages"]
+        if isinstance(message, HumanMessage)
+    ]
+    assert [message.content for message in human_messages] == [
+        "first question",
+        "second question",
+    ]

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -1,0 +1,209 @@
+"""CLI tests for the long-lived main-agent workflow."""
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+from chemgraph.agent.main_session import MainAgentTurnResult, PendingInterrupt
+from chemgraph.cli import commands
+from chemgraph.cli.formatting import console
+
+cli_main = importlib.import_module("chemgraph.cli.main")
+
+
+def _turn_result(*interrupts: PendingInterrupt) -> MainAgentTurnResult:
+    return MainAgentTurnResult(
+        thread_id="main-thread",
+        status="waiting_for_user" if interrupts else "completed",
+        assistant_response="turn complete",
+        interrupts=interrupts,
+        state={},
+    )
+
+
+class _FakeMainSession:
+    def __init__(self, results, *, failed=False):
+        self.thread_id = "main-thread"
+        self.failed = failed
+        self.results = iter(results)
+        self.calls = []
+
+    def _next_result(self):
+        result = next(self.results)
+        if isinstance(result, BaseException):
+            self.failed = True
+            raise result
+        return result
+
+    async def run(self, message):
+        self.calls.append(("run", message))
+        return self._next_result()
+
+    async def resume(self, response):
+        self.calls.append(("resume", response))
+        return self._next_result()
+
+    async def retry(self):
+        self.calls.append(("retry", None))
+        result = self._next_result()
+        self.failed = False
+        return result
+
+def test_main_agent_is_a_cli_workflow():
+    assert "main_agent" in commands.ALL_WORKFLOW_TYPES
+    assert "main_agent" in cli_main._WORKFLOW_CHOICES
+
+
+def test_main_agent_query_runs_each_turn_on_same_session():
+    session = _FakeMainSession([_turn_result(), _turn_result()])
+
+    first = commands.run_main_agent_query(session, "first")
+    second = commands.run_main_agent_query(session, "second")
+
+    assert first.assistant_response == "turn complete"
+    assert second.assistant_response == "turn complete"
+    assert session.calls == [("run", "first"), ("run", "second")]
+
+
+def test_main_agent_query_answers_subagent_interrupt(monkeypatch):
+    clarification = PendingInterrupt(
+        id="worker-question",
+        payload={"question": "Which calculator?"},
+    )
+    session = _FakeMainSession([_turn_result(clarification), _turn_result()])
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: "EMT",
+    )
+
+    with console.capture() as capture:
+        result = commands.run_main_agent_query(session, "calculate")
+
+    assert result.assistant_response == "turn complete"
+    assert session.calls == [("run", "calculate"), ("resume", "EMT")]
+    assert "Which calculator?" in capture.get()
+
+
+def test_main_agent_query_failure_suggests_retry():
+    session = _FakeMainSession([RuntimeError("temporary")])
+
+    with console.capture() as capture:
+        result = commands.run_main_agent_query(session, "calculate")
+
+    assert result is None
+    assert session.failed is True
+    assert "`retry` command" in capture.get()
+
+
+def test_retry_main_agent_session_resumes_failed_operation():
+    session = _FakeMainSession(
+        [_turn_result()],
+        failed=True,
+    )
+
+    result = commands.retry_main_agent_session(session)
+
+    assert result.assistant_response == "turn complete"
+    assert session.failed is False
+    assert session.calls == [("retry", None)]
+
+
+def test_interactive_main_agent_discards_session_on_quit(monkeypatch):
+    session = _FakeMainSession([])
+    agent = SimpleNamespace()
+    answers = iter(["gpt-4o-mini", "main_agent", "calculate", "quit"])
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: session,
+    )
+
+    def fake_run(active_session, query, verbose=False):
+        assert active_session is session
+        assert query == "calculate"
+        assert verbose is False
+        return _turn_result()
+
+    monkeypatch.setattr(commands, "run_main_agent_query", fake_run)
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    assert session.calls == []
+
+
+def test_interactive_main_agent_retry_command(monkeypatch):
+    session = _FakeMainSession([], failed=True)
+    agent = SimpleNamespace()
+    answers = iter(["gpt-4o-mini", "main_agent", "retry", "quit"])
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: session,
+    )
+
+    calls = []
+
+    def fake_retry(active_session, verbose=False):
+        calls.append((active_session, verbose))
+        active_session.failed = False
+        return _turn_result()
+
+    monkeypatch.setattr(commands, "retry_main_agent_session", fake_retry)
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    assert calls == [(session, False)]
+    assert session.calls == []
+
+
+def _run_args(**overrides):
+    values = {
+        "list_models": False,
+        "check_keys": False,
+        "list_sessions": False,
+        "show_session": None,
+        "delete_session": None,
+        "config": None,
+        "verbose": 0,
+        "base_url": None,
+        "model": "gpt-4o-mini",
+        "workflow": "main_agent",
+        "resume": None,
+        "interactive": False,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_main_agent_requires_interactive_cli_mode():
+    with console.capture() as capture, pytest.raises(SystemExit) as exc_info:
+        cli_main._handle_run(_run_args())
+
+    assert exc_info.value.code == 2
+    assert "requires interactive mode" in capture.get()
+
+
+def test_main_agent_rejects_persistent_resume():
+    with console.capture() as capture, pytest.raises(SystemExit) as exc_info:
+        cli_main._handle_run(_run_args(interactive=True, resume="old-thread"))
+
+    assert exc_info.value.code == 2
+    assert "--resume is not supported" in capture.get()

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -50,6 +50,7 @@ class _FakeMainSession:
         self.failed = False
         return result
 
+
 def test_main_agent_is_a_cli_workflow():
     assert "main_agent" in commands.ALL_WORKFLOW_TYPES
     assert "main_agent" in cli_main._WORKFLOW_CHOICES
@@ -94,7 +95,7 @@ def test_main_agent_query_failure_suggests_retry():
 
     assert result is None
     assert session.failed is True
-    assert "`retry` command" in capture.get()
+    assert "`/retry` command" in capture.get()
 
 
 def test_retry_main_agent_session_resumes_failed_operation():
@@ -144,7 +145,7 @@ def test_interactive_main_agent_discards_session_on_quit(monkeypatch):
 def test_interactive_main_agent_retry_command(monkeypatch):
     session = _FakeMainSession([], failed=True)
     agent = SimpleNamespace()
-    answers = iter(["gpt-4o-mini", "main_agent", "retry", "quit"])
+    answers = iter(["gpt-4o-mini", "main_agent", "/retry", "quit"])
 
     monkeypatch.setattr(
         commands.Prompt,
@@ -172,6 +173,187 @@ def test_interactive_main_agent_retry_command(monkeypatch):
 
     assert calls == [(session, False)]
     assert session.calls == []
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("/show AbC123", ("show", "AbC123")),
+        ("/resume old-thread", ("resume", "old-thread")),
+        ("/model Provider/Model-X", ("model", "Provider/Model-X")),
+        ("/workflow single_agent", ("workflow", "single_agent")),
+        ("/SHOW MixedCase", ("show", "MixedCase")),
+        ("help", ("help", "")),
+        ("retry", ("retry", "")),
+        ("show me the tools", None),
+        ("model a molecule", None),
+    ],
+)
+def test_parse_interactive_input(value, expected):
+    assert commands._parse_interactive_input(value) == expected
+
+
+def test_interactive_show_prompt_reaches_main_agent(monkeypatch):
+    prompt = "show me the list of all the tools your subagent has"
+    session = _FakeMainSession([])
+    agent = SimpleNamespace()
+    answers = iter(["gpt-4o-mini", "main_agent", prompt, "quit"])
+    calls = []
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: session,
+    )
+    monkeypatch.setattr(
+        commands,
+        "show_session",
+        lambda _sid: pytest.fail("natural-language prompt called show_session"),
+    )
+
+    def fake_run(active_session, query, verbose=False):
+        calls.append((active_session, query, verbose))
+        return _turn_result()
+
+    monkeypatch.setattr(commands, "run_main_agent_query", fake_run)
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    assert calls == [(session, prompt, False)]
+
+
+def test_interactive_slash_show_dispatches_to_session_command(monkeypatch):
+    session = _FakeMainSession([])
+    agent = SimpleNamespace()
+    answers = iter(["gpt-4o-mini", "main_agent", "/show AbC123", "quit"])
+    shown = []
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: session,
+    )
+    monkeypatch.setattr(commands, "show_session", shown.append)
+    monkeypatch.setattr(
+        commands,
+        "run_main_agent_query",
+        lambda *_args, **_kwargs: pytest.fail("/show reached the agent"),
+    )
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    assert shown == ["AbC123"]
+
+
+def test_interactive_slash_resume_dispatches_to_saved_session(monkeypatch):
+    agent = SimpleNamespace(session_id="active-session")
+    answers = iter(
+        ["gpt-4o-mini", "single_agent", "/resume old-thread", "continue", "quit"]
+    )
+    calls = []
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+
+    def fake_run(active_agent, query, verbose=False, resume_from=None):
+        calls.append((active_agent, query, verbose, resume_from))
+        return None
+
+    monkeypatch.setattr(commands, "run_query", fake_run)
+
+    with console.capture():
+        commands.interactive_mode(generate_report=False)
+
+    assert calls == [(agent, "continue", False, "old-thread")]
+
+
+def test_interactive_slash_model_and_workflow_switches(monkeypatch):
+    answers = iter(
+        [
+            "first-model",
+            "main_agent",
+            "/model Provider/Next-Model",
+            "/workflow single_agent",
+            "quit",
+        ]
+    )
+    initial_agent = SimpleNamespace()
+    next_agent = SimpleNamespace()
+    single_agent = SimpleNamespace(session_id="single")
+    agents = iter([initial_agent, next_agent, single_agent])
+    initialization_calls = []
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+
+    def fake_initialize(model, workflow, *_args, **_kwargs):
+        initialization_calls.append((model, workflow))
+        return next(agents)
+
+    monkeypatch.setattr(commands, "initialize_agent", fake_initialize)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: SimpleNamespace(thread_id="main", failed=False),
+    )
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    assert initialization_calls == [
+        ("first-model", "main_agent"),
+        ("Provider/Next-Model", "main_agent"),
+        ("Provider/Next-Model", "single_agent"),
+    ]
+
+
+def test_interactive_reports_invalid_slash_commands(monkeypatch):
+    agent = SimpleNamespace()
+    session = _FakeMainSession([])
+    answers = iter(
+        ["gpt-4o-mini", "main_agent", "/show", "/not-a-command", "quit"]
+    )
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: session,
+    )
+
+    with console.capture() as capture:
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    output = capture.get()
+    assert "Usage: /show <session_id>" in output
+    assert "Unknown interactive command: /not-a-command" in output
+    assert "Type /help" in output
 
 
 def _run_args(**overrides):


### PR DESCRIPTION
## Summary

- Add a long-lived main_agent supervisor built with LangChain create_agent and Deep Agents SubAgentMiddleware, delegating chemistry work through the built-in task tool.
- Preserve the existing compiled ChemGraph worker, including terminal artifact output and nested single or parallel human interrupts.
- Add a checkpointed MainAgentSession with normal threaded turns, interrupt resume, and explicit retry behavior, plus interactive CLI integration.
- Raise the supported Python floor to 3.11 and pin Deep Agents 0.7.5 with compatible LangChain dependencies; update CI matrices, environment metadata, and user documentation.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- Exact Deep Agents and LangChain pin resolver dry run
- ruff check . in a clean detached worktree
- Focused main-agent, CLI, graph, formatting, and interrupt suite: 87 passed

## Checklist

- [x] Branched off the latest main and targets main
- [x] PR is focused on a single logical change
- [x] ruff check . passes
- [ ] pytest tests/ -k "not tblite" passes (340 passed; remaining failures are due to missing MACE and the non-editable temporary test checkout)
- [x] Added/updated tests for the change
- [x] Updated docs / README for the user-facing change

## Compatibility note

Deep Agents 0.7.5 requires Python 3.11 or newer, so this PR intentionally drops Python 3.10 support.