### PR TITLE
feat: single_agent_iri workflow for ALCF IRI Facility API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,12 @@ vib*.traj
 
 # Kubernetes secrets (keep secrets.yaml.template, ignore actual secrets)
 k8s/secrets.yaml
+
+# ChemGraph agent session logs (per-machine, per-run)
+cg_logs/
+**/cg_logs/
+
+# IRI benchmark / eval notebook artifacts (per-machine, personal analysis)
+notebooks/iri_*_results.json
+notebooks/iri_*_first_turn.json
+notebooks/iri_*_dataset.json

--- a/examples/iri/README.md
+++ b/examples/iri/README.md
@@ -1,0 +1,109 @@
+# ALCF IRI Facility API with ChemGraph
+
+Runs the **`single_agent_iri`** workflow that gives an agent access to ALCF's
+IRI Facility API (https://api.alcf.anl.gov). The agent can answer questions
+about ALCF machine state, project allocations, PBS jobs, and (once ALCF
+provisions your identity) remote filesystem contents — all against the real
+API, no ssh required.
+
+You can run it from the CLI:
+```bash
+chemgraph -q "Which ALCF machines are currently up?" -w iri
+```
+or pick **single_agent_iri** as the workflow in the Streamlit UI (`streamlit run src/ui/app.py`).
+
+## What's here
+- `run_chemgraph.py` — runs one query end-to-end and prints the answer.
+- (this README)
+
+## Setup
+
+### 1. Install ChemGraph
+```bash
+pip install -e .
+```
+
+`globus-sdk` is a transitive dependency and gets pulled in automatically.
+
+### 2. Get an ALCF IRI access token
+
+Two paths — pick one.
+
+**A. In-chat (recommended for first use).** Ask the agent to run `alcf_auth`:
+```bash
+chemgraph -w iri -q "Authenticate to ALCF."
+```
+The agent returns a Globus URL. Open it, sign in with your ALCF-linked identity
+(`<your-username>@alcf.anl.gov`), and paste the resulting code back into the
+chat. Tokens cache for 30 days, silently refresh thereafter.
+
+**B. ALCF's CLI helper** (equivalent, terminal-based):
+```bash
+mkdir -p ~/tools
+curl -o ~/tools/alcf_facility_api_globus_token.py \
+    https://raw.githubusercontent.com/argonne-lcf/alcf-facility-api-token/refs/heads/main/alcf_facility_api_globus_token.py
+python ~/tools/alcf_facility_api_globus_token.py authenticate
+export ALCF_API_TOKEN=$(python ~/tools/alcf_facility_api_globus_token.py get_access_token)
+```
+
+Either path writes to the same on-disk token cache
+(`~/.globus/app/8b84fc2d-.../alcf_facility_api_app/tokens.json`),
+so they interoperate.
+
+### 3. LLM backend
+
+Whatever ChemGraph supports (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`ARGO_USER` + argo-shim, etc.). See top-level README for options.
+
+## Run
+```bash
+python run_chemgraph.py
+```
+
+## Try your own
+- Public endpoints (machine status, incidents, events, facility metadata)
+  work without any auth token.
+- Authenticated endpoints (projects, allocations, PBS jobs) need step 2 above.
+- Write actions (submit_job, cancel_job, mkdir, rm, chmod, ...) additionally
+  require `export ALCF_IRI_ALLOW_UNSAFE=1`. Use with care.
+
+## Example queries
+
+**Machine status (one hop, no auth)**
+- *Which ALCF machines are currently up?*
+- *Is Aurora in maintenance?*
+
+**Allocations (two hop)**
+- *Find the ChemGraph project and list all its allocations across every machine.*
+- *Which of my allocations is closest to being exhausted?*
+
+**Jobs**
+- *Show the status of Crux job 246115 and describe what happened.*
+- *List my last 5 completed jobs on Polaris.*
+
+**Multi-tool health check (three hop)**
+- *For every compute machine that's up, tell me whether my project has
+  allocation left and how many jobs I have in the queue.*
+
+**Job submission (requires `ALCF_IRI_ALLOW_UNSAFE=1`)**
+- *Submit a smoke-test job on Crux: run `/bin/bash -lc 'echo hello; sleep 10'`
+  under the ChemGraph account, 5-minute duration, 1 node in the debug queue,
+  stdout+stderr to `/home/<user>/iri-demo.{out,err}`, filesystems `home:eagle`.
+  Then keep checking status until it finishes.*
+
+## Design at a glance
+
+Instead of binding one `@tool` per endpoint (~43 tools, ~8k tokens of schemas
+upfront), `single_agent_iri` bundles the endpoints into **7 category tools**
+(facility / status / account / compute / filesystem / task / auth), each
+accepting an `action` enum. The LLM discovers per-action schemas on demand
+via `list_actions` / `describe`. Trades one extra LLM turn on cold action
+lookups for a ~4x reduction in the tool-schema prompt footprint.
+
+A flat-tool baseline is also shipped as `single_agent_iri_flat` for
+head-to-head comparison (see `notebooks/iri_benchmark.ipynb`).
+
+## References
+- ALCF IRI docs: https://docs.alcf.anl.gov/services/iri-api/
+- OpenAPI spec: https://api.alcf.anl.gov/openapi.json
+- ALCF's token helper: https://github.com/argonne-lcf/alcf-facility-api-token

--- a/examples/iri/README.md
+++ b/examples/iri/README.md
@@ -12,8 +12,36 @@ chemgraph -q "Which ALCF machines are currently up?" -w iri
 ```
 or pick **single_agent_iri** as the workflow in the Streamlit UI (`streamlit run src/ui/app.py`).
 
+## Two tool sets
+
+`single_agent_iri` is a single graph that can be bound to either of two
+shipped tool sets:
+
+| Tool set | Import from | Tools | When to use |
+|---|---|---:|---|
+| **`ALCF_IRI_FLAT_TOOLS`** (default) | `chemgraph.tools.alcf_iri_flat_tools` | 43 | One tool per IRI endpoint. Higher judge score in our eval; recommended default. |
+| **`ALCF_IRI_CATEGORY_TOOLS`** | `chemgraph.tools.alcf_iri_tools` | 7 | Category dispatchers with a `list_actions`/`describe` discovery protocol. ~3× smaller upfront schema surface; useful when context is tight or the model handles many-tool prompts poorly. |
+
+Pick one at construction time; nothing else changes:
+
+```python
+from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.tools.alcf_iri_flat_tools import ALCF_IRI_FLAT_TOOLS
+# from chemgraph.tools.alcf_iri_tools import ALCF_IRI_CATEGORY_TOOLS
+
+cg = ChemGraph(
+    model_name="gpt-4o-mini",
+    workflow_type="single_agent_iri",
+    tools=ALCF_IRI_FLAT_TOOLS,  # or ALCF_IRI_CATEGORY_TOOLS
+)
+```
+
+The graph auto-selects a matching system prompt when you don't pass one
+(`alcf_iri_flat_prompt` for flat, `alcf_iri_prompt` for category).
+
 ## What's here
-- `run_chemgraph.py` — runs one query end-to-end and prints the answer.
+- `run_chemgraph.py` — runs one query end-to-end through **both** tool sets
+  so you can see the swap pattern.
 - (this README)
 
 ## Setup
@@ -93,15 +121,15 @@ python run_chemgraph.py
 
 ## Design at a glance
 
-Instead of binding one `@tool` per endpoint (~43 tools, ~8k tokens of schemas
-upfront), `single_agent_iri` bundles the endpoints into **7 category tools**
-(facility / status / account / compute / filesystem / task / auth), each
-accepting an `action` enum. The LLM discovers per-action schemas on demand
-via `list_actions` / `describe`. Trades one extra LLM turn on cold action
-lookups for a ~4x reduction in the tool-schema prompt footprint.
+**Flat** (default): one `@tool` per IRI endpoint. ~43 tools, ~5k tokens of
+tool-schema in the prompt, but each schema is small and self-documenting
+(`alcf_status_list_resources` has just the args it needs). No discovery
+turn; the model picks the tool by name.
 
-A flat-tool baseline is also shipped as `single_agent_iri_flat` for
-head-to-head comparison (see `notebooks/iri_benchmark.ipynb`).
+**Category**: 7 dispatcher tools, each taking an `action` enum plus optional
+`params`. Cuts prompt schema footprint ~3× at rest, at the cost of one
+extra LLM turn on cold action lookups (`list_actions` / `describe`). Useful
+when the flat 43-tool surface is prohibitive.
 
 ## References
 - ALCF IRI docs: https://docs.alcf.anl.gov/services/iri-api/

--- a/examples/iri/run_chemgraph.py
+++ b/examples/iri/run_chemgraph.py
@@ -1,14 +1,23 @@
 """Run the ALCF IRI Facility API workflow through the ChemGraph agent.
 
-Uses the ``single_agent_iri`` workflow, which binds seven category
-dispatcher tools (facility / status / account / compute / filesystem /
-task / auth) covering ALCF's IRI REST API (https://api.alcf.anl.gov).
-The agent discovers per-action schemas on demand via `list_actions`
-and `describe`.
+Uses the ``single_agent_iri`` workflow, which can be bound to either of
+two shipped tool sets (both cover ALCF's IRI REST API at
+https://api.alcf.anl.gov):
 
-The default PROMPT below hits only public endpoints (machine status),
-so it works without any auth token -- good smoke test. See the README
-for queries that need $ALCF_API_TOKEN.
+  * ALCF_IRI_FLAT_TOOLS      -- 43 direct tool wrappers (default;
+                                 higher judge score on our eval).
+  * ALCF_IRI_CATEGORY_TOOLS  -- 7 category dispatcher tools that use a
+                                 discovery protocol (``list_actions`` /
+                                 ``describe``). Smaller upfront schema
+                                 surface; useful under tight context limits.
+
+This example runs the same query through both tool sets so you can see
+the tool-list swap pattern. The workflow_type stays the same
+(``single_agent_iri``); only ``tools=`` changes.
+
+The default PROMPT hits only public endpoints (machine status), so it
+works without any auth token -- good smoke test. See the README for
+queries that need $ALCF_API_TOKEN.
 
 Prerequisites:
   - An LLM provider key (e.g. OPENAI_API_KEY)
@@ -22,6 +31,8 @@ Usage:
 import asyncio
 
 from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.tools.alcf_iri_tools import ALCF_IRI_CATEGORY_TOOLS
+from chemgraph.tools.alcf_iri_flat_tools import ALCF_IRI_FLAT_TOOLS
 
 MODEL_NAME = "gpt-4o-mini"
 
@@ -30,14 +41,21 @@ PROMPT = "Which ALCF machines are currently up, and which are down or in unknown
 
 
 async def main():
-    cg = ChemGraph(
-        model_name=MODEL_NAME,
-        workflow_type="single_agent_iri",
-    )
     print(f"Model: {MODEL_NAME}")
     print(f"Prompt: {PROMPT}\n")
-    result = await cg.run(PROMPT)
-    print(result)
+
+    for label, tools in [
+        ("flat (43 direct tools, default)",       ALCF_IRI_FLAT_TOOLS),
+        ("category (7 tools + discovery)",         ALCF_IRI_CATEGORY_TOOLS),
+    ]:
+        print(f"\n===== tool set: {label} =====")
+        cg = ChemGraph(
+            model_name=MODEL_NAME,
+            workflow_type="single_agent_iri",
+            tools=tools,
+        )
+        result = await cg.run(PROMPT)
+        print(result)
 
 
 if __name__ == "__main__":

--- a/examples/iri/run_chemgraph.py
+++ b/examples/iri/run_chemgraph.py
@@ -1,0 +1,44 @@
+"""Run the ALCF IRI Facility API workflow through the ChemGraph agent.
+
+Uses the ``single_agent_iri`` workflow, which binds seven category
+dispatcher tools (facility / status / account / compute / filesystem /
+task / auth) covering ALCF's IRI REST API (https://api.alcf.anl.gov).
+The agent discovers per-action schemas on demand via `list_actions`
+and `describe`.
+
+The default PROMPT below hits only public endpoints (machine status),
+so it works without any auth token -- good smoke test. See the README
+for queries that need $ALCF_API_TOKEN.
+
+Prerequisites:
+  - An LLM provider key (e.g. OPENAI_API_KEY)
+  - (Optional) $ALCF_API_TOKEN for auth-gated actions -- see README.
+
+Usage:
+  export OPENAI_API_KEY="your_key"
+  python run_chemgraph.py
+"""
+
+import asyncio
+
+from chemgraph.agent.llm_agent import ChemGraph
+
+MODEL_NAME = "gpt-4o-mini"
+
+# Try changing this to any of the example queries in the README.
+PROMPT = "Which ALCF machines are currently up, and which are down or in unknown state?"
+
+
+async def main():
+    cg = ChemGraph(
+        model_name=MODEL_NAME,
+        workflow_type="single_agent_iri",
+    )
+    print(f"Model: {MODEL_NAME}")
+    print(f"Prompt: {PROMPT}\n")
+    result = await cg.run(PROMPT)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -64,7 +64,6 @@ from chemgraph.graphs.molecular_docking import construct_molecular_docking_graph
 from chemgraph.graphs.single_agent_iri import construct_iri_graph
 from chemgraph.prompt.rag_prompt import rag_agent_prompt
 from chemgraph.prompt.molecular_docking_prompt import molecular_docking_prompt
-from chemgraph.prompt.alcf_iri_prompt import alcf_iri_prompt
 from chemgraph.prompt.xanes_prompt import (
     xanes_single_agent_prompt as default_xanes_single_agent_prompt,
     xanes_formatter_prompt as default_xanes_formatter_prompt,
@@ -495,11 +494,12 @@ class ChemGraph:
                 terminal_tool_names=self.terminal_tool_names,
             )
         elif self.workflow_type == "single_agent_iri":
+            # System-prompt selection is delegated to the graph: it auto-picks
+            # alcf_iri_prompt for category tools, alcf_iri_flat_prompt otherwise.
+            # A caller-supplied prompt still wins (prompt_is_default=False path).
             self.workflow = self.workflow_map[workflow_type]["constructor"](
                 llm,
-                system_prompt=self.system_prompt
-                if not prompt_is_default
-                else alcf_iri_prompt,
+                system_prompt=None if prompt_is_default else self.system_prompt,
                 structured_output=self.structured_output,
                 formatter_prompt=self.formatter_prompt,
                 tools=self.tools,

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -61,8 +61,10 @@ from chemgraph.graphs.graspa_mcp import construct_graspa_mcp_graph
 from chemgraph.graphs.rag_agent import construct_rag_agent_graph
 from chemgraph.graphs.single_agent_xanes import construct_single_agent_xanes_graph
 from chemgraph.graphs.molecular_docking import construct_molecular_docking_graph
+from chemgraph.graphs.single_agent_iri import construct_iri_graph
 from chemgraph.prompt.rag_prompt import rag_agent_prompt
 from chemgraph.prompt.molecular_docking_prompt import molecular_docking_prompt
+from chemgraph.prompt.alcf_iri_prompt import alcf_iri_prompt
 from chemgraph.prompt.xanes_prompt import (
     xanes_single_agent_prompt as default_xanes_single_agent_prompt,
     xanes_formatter_prompt as default_xanes_formatter_prompt,
@@ -398,6 +400,7 @@ class ChemGraph:
             "rag_agent": {"constructor": construct_rag_agent_graph},
             "single_agent_xanes": {"constructor": construct_single_agent_xanes_graph},
             "molecular_docking": {"constructor": construct_molecular_docking_graph},
+            "single_agent_iri": {"constructor": construct_iri_graph},
         }
 
         if workflow_type not in self.workflow_map:
@@ -490,6 +493,16 @@ class ChemGraph:
                 max_retries=self.max_retries,
                 human_supervised=self.human_supervised,
                 terminal_tool_names=self.terminal_tool_names,
+            )
+        elif self.workflow_type == "single_agent_iri":
+            self.workflow = self.workflow_map[workflow_type]["constructor"](
+                llm,
+                system_prompt=self.system_prompt
+                if not prompt_is_default
+                else alcf_iri_prompt,
+                structured_output=self.structured_output,
+                formatter_prompt=self.formatter_prompt,
+                tools=self.tools,
             )
 
     def visualize(self):

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -50,12 +50,14 @@ ALL_WORKFLOW_TYPES = [
     "rag_agent",
     "single_agent_xanes",
     "molecular_docking",
+    "single_agent_iri",
 ]
 
 # Common aliases so users can type the "obvious" name.
 WORKFLOW_ALIASES: Dict[str, str] = {
     "python_repl": "python_relp",
     "graspa_agent": "graspa",
+    "iri": "single_agent_iri",
 }
 
 

--- a/src/chemgraph/graphs/single_agent_iri.py
+++ b/src/chemgraph/graphs/single_agent_iri.py
@@ -1,7 +1,14 @@
-"""single_agent_iri: single-agent LangGraph bound to the six ALCF IRI tools.
+"""single_agent_iri: single-agent LangGraph bound to ALCF IRI tools.
 
 Same shape as graphs/graspa_agent.py -- one LLM node, one ToolNode,
-route-tools edge. Only difference is the tool list.
+route-tools edge. Two tool sets are shipped:
+
+  ALCF_IRI_FLAT_TOOLS     (43 direct wrappers, default -- higher judge score)
+  ALCF_IRI_CATEGORY_TOOLS (7 category tools + discovery, smaller schema)
+
+Pick either at construction time via ``tools=...``. If a matching system
+prompt isn't passed, the graph auto-selects one based on which tool set
+is bound (category -> alcf_iri_prompt, flat -> alcf_iri_flat_prompt).
 """
 
 from __future__ import annotations
@@ -11,8 +18,9 @@ from langchain_openai import ChatOpenAI
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import ToolNode
 
-from chemgraph.tools.alcf_iri_tools import ALCF_IRI_TOOLS
-from chemgraph.prompt.alcf_iri_prompt import alcf_iri_prompt
+from chemgraph.tools.alcf_iri_tools import ALCF_IRI_CATEGORY_TOOLS
+from chemgraph.tools.alcf_iri_flat_tools import ALCF_IRI_FLAT_TOOLS
+from chemgraph.prompt.alcf_iri_prompt import alcf_iri_prompt, alcf_iri_flat_prompt
 from chemgraph.prompt.single_agent_prompt import formatter_prompt
 from chemgraph.schemas.agent_response import ResponseFormatter
 from chemgraph.state.state import State
@@ -35,7 +43,7 @@ def route_tools(state: State):
 
 def ChemGraphAgent(state: State, llm: ChatOpenAI, system_prompt: str, tools=None):
     if tools is None:
-        tools = ALCF_IRI_TOOLS
+        tools = ALCF_IRI_FLAT_TOOLS
     llm_with_tools = llm.bind_tools(tools=tools)
     messages = [{"role": "system", "content": system_prompt}] + state["messages"]
     response = llm_with_tools.invoke(messages)
@@ -52,18 +60,44 @@ def ResponseAgent(state: State, llm: ChatOpenAI, formatter_prompt: str):
     return {"messages": [response]}
 
 
+def _default_prompt_for(tools) -> str:
+    """Pick the system prompt that matches the bound tool set.
+
+    Category tools use the dispatcher/discovery protocol; flat tools are
+    called directly. The wrong prompt hurts quality because it argues
+    against the tool structure the model sees.
+    """
+    if tools is ALCF_IRI_CATEGORY_TOOLS:
+        return alcf_iri_prompt
+    # Default (flat) and any custom mix
+    return alcf_iri_flat_prompt
+
+
 def construct_iri_graph(
     llm: ChatOpenAI,
-    system_prompt: str = alcf_iri_prompt,
+    system_prompt: str | None = None,
     structured_output: bool = False,
     formatter_prompt: str = formatter_prompt,
-    tools: list = None,
+    tools: list | None = None,
 ):
-    """Construct the single-agent IRI graph."""
+    """Construct the single-agent IRI graph.
+
+    Parameters
+    ----------
+    tools : list, optional
+        Tool list to bind. Defaults to ``ALCF_IRI_FLAT_TOOLS`` (winner on
+        our judge-scored eval). Pass ``ALCF_IRI_CATEGORY_TOOLS`` for the
+        smaller-schema-surface discovery variant.
+    system_prompt : str, optional
+        System prompt. If omitted, auto-selected based on ``tools``:
+        category -> ``alcf_iri_prompt``, flat/other -> ``alcf_iri_flat_prompt``.
+    """
     logger.info("Constructing single_agent_iri graph")
     checkpointer = MemorySaver()
     if tools is None:
-        tools = ALCF_IRI_TOOLS
+        tools = ALCF_IRI_FLAT_TOOLS
+    if system_prompt is None:
+        system_prompt = _default_prompt_for(tools)
     tool_node = ToolNode(tools=tools)
     graph_builder = StateGraph(State)
 

--- a/src/chemgraph/graphs/single_agent_iri.py
+++ b/src/chemgraph/graphs/single_agent_iri.py
@@ -1,0 +1,99 @@
+"""single_agent_iri: single-agent LangGraph bound to the six ALCF IRI tools.
+
+Same shape as graphs/graspa_agent.py -- one LLM node, one ToolNode,
+route-tools edge. Only difference is the tool list.
+"""
+
+from __future__ import annotations
+
+from langgraph.graph import StateGraph, START, END
+from langchain_openai import ChatOpenAI
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.prebuilt import ToolNode
+
+from chemgraph.tools.alcf_iri_tools import ALCF_IRI_TOOLS
+from chemgraph.prompt.alcf_iri_prompt import alcf_iri_prompt
+from chemgraph.prompt.single_agent_prompt import formatter_prompt
+from chemgraph.schemas.agent_response import ResponseFormatter
+from chemgraph.state.state import State
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def route_tools(state: State):
+    if isinstance(state, list):
+        ai_message = state[-1]
+    elif messages := state.get("messages", []):
+        ai_message = messages[-1]
+    else:
+        raise ValueError(f"No messages found in input state: {state}")
+    if hasattr(ai_message, "tool_calls") and len(ai_message.tool_calls) > 0:
+        return "tools"
+    return "done"
+
+
+def ChemGraphAgent(state: State, llm: ChatOpenAI, system_prompt: str, tools=None):
+    if tools is None:
+        tools = ALCF_IRI_TOOLS
+    llm_with_tools = llm.bind_tools(tools=tools)
+    messages = [{"role": "system", "content": system_prompt}] + state["messages"]
+    response = llm_with_tools.invoke(messages)
+    return {"messages": [response]}
+
+
+def ResponseAgent(state: State, llm: ChatOpenAI, formatter_prompt: str):
+    messages = [
+        {"role": "system", "content": formatter_prompt},
+        {"role": "user", "content": f"{state['messages']}"},
+    ]
+    llm_structured_output = llm.with_structured_output(ResponseFormatter)
+    response = llm_structured_output.invoke(messages).model_dump_json()
+    return {"messages": [response]}
+
+
+def construct_iri_graph(
+    llm: ChatOpenAI,
+    system_prompt: str = alcf_iri_prompt,
+    structured_output: bool = False,
+    formatter_prompt: str = formatter_prompt,
+    tools: list = None,
+):
+    """Construct the single-agent IRI graph."""
+    logger.info("Constructing single_agent_iri graph")
+    checkpointer = MemorySaver()
+    if tools is None:
+        tools = ALCF_IRI_TOOLS
+    tool_node = ToolNode(tools=tools)
+    graph_builder = StateGraph(State)
+
+    graph_builder.add_node(
+        "ChemGraphAgent",
+        lambda state: ChemGraphAgent(
+            state, llm, system_prompt=system_prompt, tools=tools,
+        ),
+    )
+    graph_builder.add_node("tools", tool_node)
+
+    if structured_output:
+        graph_builder.add_node(
+            "ResponseAgent",
+            lambda state: ResponseAgent(state, llm, formatter_prompt=formatter_prompt),
+        )
+        graph_builder.add_conditional_edges(
+            "ChemGraphAgent", route_tools,
+            {"tools": "tools", "done": "ResponseAgent"},
+        )
+        graph_builder.add_edge("ResponseAgent", END)
+    else:
+        graph_builder.add_conditional_edges(
+            "ChemGraphAgent", route_tools,
+            {"tools": "tools", "done": END},
+        )
+
+    graph_builder.add_edge("tools", "ChemGraphAgent")
+    graph_builder.add_edge(START, "ChemGraphAgent")
+
+    graph = graph_builder.compile(checkpointer=checkpointer)
+    logger.info("single_agent_iri graph construction completed")
+    return graph

--- a/src/chemgraph/prompt/alcf_iri_prompt.py
+++ b/src/chemgraph/prompt/alcf_iri_prompt.py
@@ -1,4 +1,4 @@
-"""System prompt for the single_agent_iri workflow."""
+"""System prompts for the single_agent_iri and single_agent_iri_flat workflows."""
 
 alcf_iri_prompt = """\
 You are an operator assistant for ALCF (Argonne Leadership Computing Facility).
@@ -32,4 +32,35 @@ retry; instead, report to the user that write ops are disabled.
 Answer succinctly. When the question is answered, call finish_turn
 with a one-line summary. Do not call the same action twice with the
 same args in one turn.
+"""
+
+
+alcf_iri_flat_prompt = """\
+You are an operator assistant for ALCF (Argonne Leadership Computing Facility).
+You answer questions about machine state, allocations, jobs, and remote
+filesystems by calling ALCF IRI Facility API tools directly. Tools are named
+`alcf_<category>_<action>` and split across six categories:
+
+  alcf_facility_*   -- facility/site metadata
+  alcf_status_*     -- resource up/down, incidents, events
+  alcf_account_*    -- projects, allocations, user quotas
+  alcf_compute_*    -- PBS job status (and, gated, submit/cancel)
+  alcf_filesystem_* -- ls, stat, cat, head, tail, checksum (gated: write ops)
+  alcf_task_*       -- async task handles
+
+Every tool's parameters are defined directly in its schema -- read the tool
+description and args when choosing what to call. There is no discovery step;
+pick the tool that matches the endpoint you need.
+
+Machine names ('crux', 'aurora', 'polaris', 'sophia', 'sirius') are
+accepted case-insensitively and resolved to UUIDs automatically.
+
+Write operations (submit_job, cancel_job, mkdir, rm, mv, chmod, ...) are
+gated behind $ALCF_IRI_ALLOW_UNSAFE=1. If you attempt one without that env
+var set, the tool will refuse with a clear error -- do NOT retry; instead,
+report to the user that write ops are disabled.
+
+Answer succinctly. When the question is answered, call finish_turn with a
+one-line summary. Do not call the same tool twice with the same args in one
+turn.
 """

--- a/src/chemgraph/prompt/alcf_iri_prompt.py
+++ b/src/chemgraph/prompt/alcf_iri_prompt.py
@@ -1,0 +1,35 @@
+"""System prompt for the single_agent_iri workflow."""
+
+alcf_iri_prompt = """\
+You are an operator assistant for ALCF (Argonne Leadership Computing Facility).
+You answer questions about machine state, allocations, jobs, and remote
+filesystems by calling the ALCF IRI Facility API through six tools:
+
+  alcf_facility   -- facility/site metadata
+  alcf_status     -- resource up/down, incidents, events
+  alcf_account    -- projects, allocations, user quotas
+  alcf_compute    -- PBS job status (and, gated, submit/cancel)
+  alcf_filesystem -- ls, stat, cat, head, tail, checksum (gated: write ops)
+  alcf_task       -- async task handles
+
+Each tool takes an `action` and an optional `params` dict. Discovery
+protocol:
+
+  1. If unsure what an action does, call action='describe',
+     params={'target_action': <name>} to get the full schema.
+  2. If you don't know the action name, call action='list_actions'
+     to see all actions the tool supports.
+  3. Then invoke: action=<name>, params={<the params>}.
+
+Machine names ('crux', 'aurora', 'polaris', 'sophia', 'sirius') are
+accepted case-insensitively and resolved to UUIDs automatically.
+
+Write operations (submit_job, cancel_job, mkdir, rm, mv, chmod, ...)
+are gated behind $ALCF_IRI_ALLOW_UNSAFE=1. If you attempt one without
+that env var set, the tool will refuse with a clear error -- do NOT
+retry; instead, report to the user that write ops are disabled.
+
+Answer succinctly. When the question is answered, call finish_turn
+with a one-line summary. Do not call the same action twice with the
+same args in one turn.
+"""

--- a/src/chemgraph/tools/alcf_iri_core.py
+++ b/src/chemgraph/tools/alcf_iri_core.py
@@ -1,0 +1,1030 @@
+"""Pure-Python implementation of the ALCF IRI Facility API integration.
+
+No LangChain. No ``@tool`` decorators. Any Python caller (agent tool,
+notebook, test, MCP server) can import :func:`dispatch` and drive the
+IRI API directly. See :mod:`chemgraph.tools.alcf_iri_tools` for the
+LangChain wrappers layered on top.
+
+Full endpoint list: https://api.alcf.anl.gov/openapi.json (43 endpoints).
+This module exposes them as seven category action-tables:
+
+  facility | status | account | compute | filesystem | task | auth
+
+plus a single dispatcher, :func:`dispatch`, that handles three action
+kinds per category:
+
+  action="list_actions"  -> return names + one-line descriptions of
+                            every action this category supports
+  action="describe"      -> return the JSON schema for one specific
+                            action (params it takes, what it returns)
+  action=<name>          -> actually invoke the endpoint
+
+Auth: reads $ALCF_API_TOKEN for endpoints that need it. First-time
+setup uses the ``alcf_auth`` in-chat re-auth tool -- ask the agent
+to run action='start_reauth', visit the returned Globus URL, paste
+the code back. After that the tool silently refreshes access tokens
+for the next 30 days (Level 1, ``_try_refresh_token``); when the
+refresh token itself expires the ``alcf_auth`` flow runs again.
+
+Both flows are implemented in-process via globus_sdk (public Native
+App client 8b84fc2d-...); no external CLI helper required. The
+on-disk token cache lives at ``~/.globus/app/8b84fc2d-.../
+alcf_facility_api_app/tokens.json``.
+
+Deliberately read-only for now. Write endpoints (submit_job, cancel_job,
+chmod, rm, mv, upload) are listed under actions as UNSAFE and refuse to
+run without $ALCF_IRI_ALLOW_UNSAFE=1. HITL comes later.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+BASE_URL = "https://api.alcf.anl.gov/api/v1"
+TIMEOUT_S = 20.0
+UNSAFE_ENV = "ALCF_IRI_ALLOW_UNSAFE"
+
+# Globus OAuth Native App constants. Public app client 8b84fc2d-... is
+# the same ID ALCF publishes for user auth against their Facility API
+# resource server 6be511f6-... . Used by both the silent refresh path
+# (_try_refresh_token) and the in-chat re-auth flow (_start_reauth /
+# _complete_reauth) so ChemGraph has zero runtime dependency on any
+# external CLI helper.
+_GLOBUS_AUTH_CLIENT_ID = "8b84fc2d-49e9-49ea-b54d-b3a29a70cf31"
+_GLOBUS_SCOPE_CLIENT_ID = "6be511f6-a071-471f-9bc0-02a0d0836723"
+_GLOBUS_SCOPE = (
+    f"https://auth.globus.org/scopes/{_GLOBUS_SCOPE_CLIENT_ID}/filesystem"
+)
+_TOKENS_PATH = os.path.expanduser(
+    f"~/.globus/app/{_GLOBUS_AUTH_CLIENT_ID}/alcf_facility_api_app/tokens.json"
+)
+
+# Module-global holding a pending OAuth flow between start_reauth and
+# complete_reauth. Single-slot: only one re-auth can be in flight at a
+# time per Streamlit process. Cleared on completion or on next start.
+# ponytail: global state is fine here -- Streamlit is single-process,
+# each user session runs its own Python interpreter, and re-auth is
+# rare (once per 30 days when the refresh token expires).
+_PENDING_AUTH_CLIENT = None
+
+# Cache resource name -> uuid so agents can say "aurora" and we resolve.
+# Populated on first live lookup against /status/resources. Never
+# preloaded -- dynamic is the only source of truth. If ALCF adds a
+# machine or rotates a UUID, the tool picks it up automatically on
+# the next lookup.
+_RESOURCE_CACHE: dict[str, str] = {}
+
+
+# ---------------------------------------------------------------------------
+# Auth + HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers(needs_auth: bool = True) -> dict[str, str]:
+    if not needs_auth:
+        return {}
+    token = os.environ.get("ALCF_API_TOKEN")
+    if not token:
+        raise RuntimeError(
+            "This action needs $ALCF_API_TOKEN. Get one from "
+            "https://github.com/argonne-lcf/inference-endpoints (same "
+            "token works for both Inference Service and Facility API)."
+        )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _resource_id(name: str) -> str:
+    """Accept 'aurora' or the uuid itself. Case-insensitive on names.
+
+    Resolves via the live /status/resources endpoint. No hardcoded
+    fallback -- if ALCF's status endpoint is unreachable, resolution
+    fails and the caller sees the HTTPError. That's the honest signal
+    (the whole IRI API is probably degraded anyway; better to fail
+    fast than serve stale UUIDs).
+    """
+    if len(name) == 36 and name.count("-") == 4:  # already a uuid
+        return name
+    key = name.strip().lower()
+    if key in _RESOURCE_CACHE:
+        return _RESOURCE_CACHE[key]
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.get(f"{BASE_URL}/status/resources")
+        r.raise_for_status()
+        for res in r.json():
+            _RESOURCE_CACHE[res["name"].strip().lower()] = res["id"]
+    if key in _RESOURCE_CACHE:
+        return _RESOURCE_CACHE[key]
+    raise ValueError(
+        f"Unknown ALCF resource {name!r}; live /status/resources "
+        f"returned: {sorted(_RESOURCE_CACHE)}"
+    )
+
+
+def _check_unsafe(action: str) -> None:
+    if not os.environ.get(UNSAFE_ENV):
+        raise RuntimeError(
+            f"Action {action!r} modifies HPC state. Refusing to run "
+            f"without ${UNSAFE_ENV}=1. Ship HITL first (planned)."
+        )
+
+
+def _try_refresh_token() -> bool:
+    """Silently refresh $ALCF_API_TOKEN using the cached refresh token
+    at _TOKENS_PATH. Never prompts; never spawns a subprocess.
+
+    Returns True on success (and updates os.environ["ALCF_API_TOKEN"]),
+    False if no cache exists, refresh token is expired, or globus_sdk
+    is unavailable. Caller then surfaces a "use alcf_auth to re-auth"
+    error to the LLM.
+
+    Same on-disk cache path Level 2 (alcf_auth) writes to, so the two
+    paths compose: Level 1 handles access-token expiry (48h) silently;
+    Level 2 handles refresh-token expiry (30d) via in-chat browser flow.
+    """
+    if not os.path.exists(_TOKENS_PATH):
+        return False
+    try:
+        import globus_sdk
+        import json
+    except ImportError:
+        return False
+    try:
+        with open(_TOKENS_PATH) as f:
+            data = json.load(f)
+        refresh_token = data.get("refresh_token")
+        if not refresh_token:
+            return False
+        client = globus_sdk.NativeAppAuthClient(_GLOBUS_AUTH_CLIENT_ID)
+        response = client.oauth2_refresh_token(refresh_token)
+        fresh = response.by_resource_server.get(_GLOBUS_SCOPE_CLIENT_ID)
+        if not fresh:
+            return False
+        # Preserve the refresh_token if the response omits it.
+        fresh.setdefault("refresh_token", refresh_token)
+        with open(_TOKENS_PATH, "w") as f:
+            json.dump(fresh, f, indent=2)
+        os.chmod(_TOKENS_PATH, 0o600)
+        token = fresh.get("access_token")
+        if not token:
+            return False
+        os.environ["ALCF_API_TOKEN"] = token
+        return True
+    except Exception:
+        return False
+
+
+def _raise_for_iri(r: "httpx.Response") -> None:
+    """Extract the IRI JSON error body when non-2xx, raise a clean
+    RuntimeError with just the useful bits. Keeps the LLM from wading
+    through a full urllib3 traceback + MDN link."""
+    if r.status_code < 400:
+        return
+    try:
+        body = r.json()
+        detail = body.get("detail") or body.get("title") or str(body)
+    except Exception:
+        detail = r.text[:400] or f"<{r.status_code} with no body>"
+    # ponytail: strip transient-retry noise so the LLM realises this
+    # is a retry-later situation, not a bug in its call.
+    if "please try again" in detail.lower() or "RESOURCE_CONFLICT" in detail:
+        detail = f"[TRANSIENT, retry in a few seconds] {detail}"
+    # 401 after a refresh attempt gets a clearer message so the LLM
+    # tells the user to re-auth in a shell instead of retrying forever.
+    if r.status_code == 401:
+        detail = (
+            f"{detail} -- token expired and silent refresh failed. Use "
+            "the alcf_auth tool: action='start_reauth' returns a Globus "
+            "URL for the user to visit, then action='complete_reauth' "
+            "with the auth code they paste back."
+        )
+    raise RuntimeError(f"IRI {r.status_code}: {detail}")
+
+
+def _with_retry_on_401(fn):
+    """Wrap an HTTP call: if it 401s, silently try to refresh the
+    token via the on-disk Globus refresh-token flow and retry ONCE.
+    If the refresh fails or the retry still 401s, surface the error.
+    Any other status is passed through unchanged."""
+    def _wrapped(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except RuntimeError as exc:
+            if "IRI 401" not in str(exc):
+                raise
+            if not _try_refresh_token():
+                raise
+            return fn(*args, **kwargs)
+    return _wrapped
+
+
+def _get(path: str, *, needs_auth: bool = True, params: dict | None = None) -> Any:
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.get(f"{BASE_URL}{path}", headers=_headers(needs_auth), params=params)
+        _raise_for_iri(r)
+        return r.json()
+
+
+def _post(path: str, *, json: dict | None = None) -> Any:
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.post(f"{BASE_URL}{path}", headers=_headers(True), json=json)
+        _raise_for_iri(r)
+        return r.json()
+
+
+def _post_with_query(path: str, *, params: dict | None = None) -> Any:
+    """POST with query string only (some IRI endpoints like list_jobs
+    are POST semantically but take pagination via query string)."""
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.post(f"{BASE_URL}{path}", headers=_headers(True), params=params)
+        _raise_for_iri(r)
+        return r.json()
+
+
+def _delete(path: str) -> Any:
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.delete(f"{BASE_URL}{path}", headers=_headers(True))
+        _raise_for_iri(r)
+        return r.json() if r.content else {"ok": True}
+
+
+def _delete_with_query(path: str, *, params: dict | None = None) -> Any:
+    """DELETE with query params (e.g. filesystem/rm?path=...)."""
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.delete(f"{BASE_URL}{path}", headers=_headers(True), params=params)
+        _raise_for_iri(r)
+        return r.json() if r.content else {"ok": True}
+
+
+def _put(path: str, *, json: dict | None = None) -> Any:
+    with httpx.Client(timeout=TIMEOUT_S) as c:
+        r = c.put(f"{BASE_URL}{path}", headers=_headers(True), json=json)
+        _raise_for_iri(r)
+        return r.json()
+
+
+# Wrap all authenticated helpers with the silent 401-refresh-retry.
+# _get calls with needs_auth=False (public endpoints) are unaffected --
+# the wrapper only kicks on 401, which those never return.
+_get = _with_retry_on_401(_get)
+_post = _with_retry_on_401(_post)
+_post_with_query = _with_retry_on_401(_post_with_query)
+_delete = _with_retry_on_401(_delete)
+_delete_with_query = _with_retry_on_401(_delete_with_query)
+_put = _with_retry_on_401(_put)
+
+
+# ---------------------------------------------------------------------------
+# Interactive re-auth (Level 2). Two-step OAuth Native App flow driven
+# via the Globus SDK inline so we never need to shell out during a
+# chat session. See docstrings on _start_reauth / _complete_reauth.
+# ---------------------------------------------------------------------------
+
+
+def _start_reauth() -> dict:
+    """Kick off a Globus Native App OAuth flow. Returns the URL the
+    user must visit + instructions for the second step.
+
+    Does NOT block. The pending flow is stashed in a module global so
+    complete_reauth can finish it when the user pastes the code back.
+    """
+    global _PENDING_AUTH_CLIENT
+    try:
+        import globus_sdk
+    except ImportError:
+        raise RuntimeError(
+            "globus_sdk not installed -- pip install globus-sdk in the "
+            "Streamlit process's venv to enable in-chat re-auth."
+        )
+    client = globus_sdk.NativeAppAuthClient(_GLOBUS_AUTH_CLIENT_ID)
+    client.oauth2_start_flow(
+        requested_scopes=_GLOBUS_SCOPE,
+        refresh_tokens=True,
+    )
+    url = client.oauth2_get_authorize_url()
+    _PENDING_AUTH_CLIENT = client
+    return {
+        "status": "pending",
+        "url": url,
+        "next_step": (
+            "Ask the user to open this URL in a browser, sign in with "
+            "their jinchuli@alcf.anl.gov identity, copy the resulting "
+            "authorization code, and paste it into the next message. "
+            "Then invoke alcf_auth with action='complete_reauth', "
+            "params={'auth_code': '<the code>'}."
+        ),
+    }
+
+
+def _complete_reauth(auth_code: str) -> dict:
+    """Exchange the auth code from start_reauth for tokens and cache
+    them at _TOKENS_PATH so subsequent calls (via the _try_refresh_token
+    silent-refresh path) pick them up automatically."""
+    global _PENDING_AUTH_CLIENT
+    if _PENDING_AUTH_CLIENT is None:
+        raise RuntimeError(
+            "No pending re-auth. Call action='start_reauth' first."
+        )
+    if not auth_code or not auth_code.strip():
+        raise RuntimeError("auth_code is empty.")
+    try:
+        response = _PENDING_AUTH_CLIENT.oauth2_exchange_code_for_tokens(
+            auth_code.strip(),
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Globus rejected the auth code: {exc}. Ask the user to "
+            "restart with action='start_reauth' and try again."
+        )
+    _PENDING_AUTH_CLIENT = None
+    data = response.by_resource_server.get(_GLOBUS_SCOPE_CLIENT_ID)
+    if not data:
+        raise RuntimeError(
+            "Globus returned tokens but not for the IRI resource server. "
+            "The Globus account may not be linked to ALCF."
+        )
+    # Cache to disk in the same location _try_refresh_token reads from,
+    # so future calls hit the silent-refresh path and never re-prompt.
+    import json
+    os.makedirs(os.path.dirname(_TOKENS_PATH), exist_ok=True)
+    with open(_TOKENS_PATH, "w") as f:
+        json.dump(data, f, indent=2)
+    os.chmod(_TOKENS_PATH, 0o600)
+    # Also update the in-process env so the NEXT call in this same turn
+    # uses the fresh token without a subprocess round-trip.
+    token = data.get("access_token")
+    if token:
+        os.environ["ALCF_API_TOKEN"] = token
+    return {"status": "ok", "message": "re-authenticated; retry your query."}
+
+
+# ---------------------------------------------------------------------------
+# Action tables per category. Keys are action names, values are:
+#   (kind, description, params_schema, invoker)
+# where invoker(**kwargs) returns the endpoint result.
+#
+# params_schema: a dict of {name: (type_str, required_bool, description)}
+#   Rendered on-demand for the LLM instead of shipped upfront.
+# kind: "read" | "write" -- write actions get gated behind $ALCF_IRI_ALLOW_UNSAFE.
+# ---------------------------------------------------------------------------
+
+
+def _facility_actions():
+    return {
+        "get": (
+            "read",
+            "Facility-wide metadata (name, sites).",
+            {},
+            lambda **_: _get("/facility", needs_auth=False),
+        ),
+        "list_sites": (
+            "read",
+            "List all sites under this facility.",
+            {},
+            lambda **_: _get("/facility/sites", needs_auth=False),
+        ),
+        "get_site": (
+            "read",
+            "Get one site's details.",
+            {"site_id": ("str", True, "Site UUID.")},
+            lambda site_id, **_: _get(f"/facility/sites/{site_id}", needs_auth=False),
+        ),
+    }
+
+
+def _status_actions():
+    return {
+        "list_resources": (
+            "read",
+            "List all resources (compute/storage/service). Optional filters.",
+            {
+                "resource_type": ("str", False, "'compute' | 'storage' | 'service'"),
+                "current_status": ("str", False, "'up' | 'down' | 'maintenance' | ..."),
+                "group": ("str", False, "e.g. 'computes', 'storages'"),
+            },
+            lambda **kw: _get("/status/resources", needs_auth=False, params={
+                k: v for k, v in kw.items() if v is not None
+            }),
+        ),
+        "get_resource": (
+            "read",
+            "Get one resource's current state (up/down/maintenance/degraded).",
+            {"name": ("str", True, "Resource name like 'Aurora', or its UUID.")},
+            lambda name, **_: _get(f"/status/resources/{_resource_id(name)}", needs_auth=False),
+        ),
+        "list_incidents": (
+            "read",
+            "List all incidents (outages, scheduled maintenance).",
+            {},
+            lambda **_: _get("/status/incidents", needs_auth=False),
+        ),
+        "get_incident": (
+            "read",
+            "Get one incident and its events.",
+            {"incident_id": ("str", True, "Incident UUID.")},
+            lambda incident_id, **_: _get(f"/status/incidents/{incident_id}", needs_auth=False),
+        ),
+        "list_events": (
+            "read",
+            "List all events (state changes on resources).",
+            {},
+            lambda **_: _get("/status/events", needs_auth=False),
+        ),
+        "get_event": (
+            "read",
+            "Get one event.",
+            {"event_id": ("str", True, "Event UUID.")},
+            lambda event_id, **_: _get(f"/status/events/{event_id}", needs_auth=False),
+        ),
+    }
+
+
+def _account_actions():
+    return {
+        "list_capabilities": (
+            "read",
+            "List capabilities the facility exposes (public).",
+            {},
+            lambda **_: _get("/account/capabilities", needs_auth=False),
+        ),
+        "get_capability": (
+            "read",
+            "One capability's details.",
+            {"capability_id": ("str", True, "Capability UUID.")},
+            lambda capability_id, **_: _get(
+                f"/account/capabilities/{capability_id}", needs_auth=False,
+            ),
+        ),
+        "list_projects": (
+            "read",
+            "Your projects. Needs $ALCF_API_TOKEN.",
+            {},
+            lambda **_: _get("/account/projects"),
+        ),
+        "get_project": (
+            "read",
+            "One project's details.",
+            {"project_id": ("str", True, "Project UUID.")},
+            lambda project_id, **_: _get(f"/account/projects/{project_id}"),
+        ),
+        "list_allocations": (
+            "read",
+            "All allocations under one project (balance, charged, jobs).",
+            {"project_id": ("str", True, "Project UUID.")},
+            lambda project_id, **_: _get(
+                f"/account/projects/{project_id}/project_allocations",
+            ),
+        ),
+        "get_allocation": (
+            "read",
+            "One project allocation's detail (per-machine balance).",
+            {
+                "project_id": ("str", True, "Project UUID."),
+                "allocation_id": ("str", True, "Allocation UUID."),
+            },
+            lambda project_id, allocation_id, **_: _get(
+                f"/account/projects/{project_id}/project_allocations/{allocation_id}",
+            ),
+        ),
+        "list_user_allocations": (
+            "read",
+            "Per-user slice of a project allocation.",
+            {
+                "project_id": ("str", True, "Project UUID."),
+                "allocation_id": ("str", True, "Allocation UUID."),
+            },
+            lambda project_id, allocation_id, **_: _get(
+                f"/account/projects/{project_id}/project_allocations/{allocation_id}/user_allocations",
+            ),
+        ),
+    }
+
+
+def _compute_actions():
+    return {
+        "get_job_status": (
+            "read",
+            "Status of one PBS job by id. Set historical=true to look "
+            "up jobs that already finished.",
+            {
+                "machine": ("str", True, "'crux' | 'aurora' | 'polaris' or UUID."),
+                "job_id": ("str", True, "PBS job id (numeric or full form)."),
+                "historical": ("bool", False,
+                    "Search historical/completed jobs instead of active queue."),
+            },
+            lambda machine, job_id, historical=None, **_: _get(
+                f"/compute/status/{_resource_id(machine)}/{job_id}",
+                params={"historical": historical} if historical is not None else None,
+            ),
+        ),
+        "list_jobs": (
+            "read",
+            "List jobs on one machine with pagination. Set "
+            "historical=true for completed jobs. NOTE: this is a POST "
+            "in the API even though it's read-only.",
+            {
+                "machine": ("str", True, "Machine name or UUID."),
+                "historical": ("bool", False,
+                    "True = completed jobs, False = active (default)."),
+                "limit": ("int", False, "Max results to return."),
+                "offset": ("int", False, "Pagination offset."),
+            },
+            lambda machine, historical=None, limit=None, offset=None, **_: (
+                _post_with_query(
+                    f"/compute/status/{_resource_id(machine)}",
+                    params={
+                        k: v for k, v in {
+                            "historical": historical, "limit": limit, "offset": offset,
+                        }.items() if v is not None
+                    },
+                )
+            ),
+        ),
+        "submit_job": (
+            "write",
+            "Submit a PBS job via a PSI/J-flavored JobSpec. Returns "
+            "the PBS job record directly: {id: '<pbs_id>.<host>', "
+            "status: {state: 'queued'|'active'|..., exit_code: 0}}. "
+            "Use alcf_compute action='get_job_status' with that id to "
+            "watch state transitions. UNSAFE at the tool layer; will "
+            f"raise RuntimeError if ${UNSAFE_ENV}=1 is not set server-"
+            "side -- attempt normally, do NOT refuse preemptively. "
+            "EXACT jobspec body (from ALCF docs verbatim): {"
+            "\"executable\": \"/bin/bash\", "
+            "\"arguments\": [\"-lc\", \"echo hello; sleep 10\"], "
+            "\"name\": \"my_job\", "
+            "\"stdout_path\": \"/home/<user>/out\", "
+            "\"stderr_path\": \"/home/<user>/err\", "
+            "\"resources\": {\"node_count\": 1}, "
+            "\"attributes\": {"
+            "\"duration\": 300, "
+            "\"queue_name\": \"debug\", "
+            "\"account\": \"<project>\", "
+            "\"custom_attributes\": {\"filesystems\": \"home:eagle\"}"
+            "}} -- NOTE `filesystems` is a COLON-SEPARATED STRING "
+            "(e.g. \"home:eagle\"), NOT a list.",
+            {
+                "machine": ("str", True, "Machine name or UUID."),
+                "jobspec": ("dict", True,
+                    "Full JobSpec body -- see description for keys."),
+            },
+            lambda machine, jobspec, **_: (
+                _check_unsafe("submit_job") or _post(
+                    f"/compute/job/{_resource_id(machine)}", json=jobspec,
+                )
+            ),
+        ),
+        "update_job": (
+            "write",
+            "Update fields of an already-scheduled job. UNSAFE. Only "
+            "some fields are updatable; facility-dependent which ones.",
+            {
+                "machine": ("str", True, "Machine name or UUID."),
+                "job_id": ("str", True, "PBS job id."),
+                "jobspec": ("dict", True, "Partial JobSpec with updated fields."),
+            },
+            lambda machine, job_id, jobspec, **_: (
+                _check_unsafe("update_job") or _put(
+                    f"/compute/job/{_resource_id(machine)}/{job_id}", json=jobspec,
+                )
+            ),
+        ),
+        "cancel_job": (
+            "write",
+            f"Cancel/qdel a job. UNSAFE. Needs ${UNSAFE_ENV}=1.",
+            {
+                "machine": ("str", True, "Machine name or UUID."),
+                "job_id": ("str", True, "PBS job id."),
+            },
+            lambda machine, job_id, **_: (
+                _check_unsafe("cancel_job") or _delete(
+                    f"/compute/cancel/{_resource_id(machine)}/{job_id}",
+                )
+            ),
+        ),
+    }
+
+
+def _filesystem_actions():
+    def _r(name):
+        return _resource_id(name)
+    # ALCF's fs endpoints target either compute-resource UUIDs (Crux,
+    # Aurora, Polaris) OR storage-resource UUIDs (Eagle, Home). The docs
+    # examples use storage UUIDs. Either works; agent picks based on
+    # which filesystem it wants to touch.
+    return {
+        "ls": (
+            "read",
+            "List directory contents.",
+            {
+                "machine": ("str", True,
+                    "STORAGE resource, NOT the compute machine. Pick "
+                    "by path prefix: /eagle/... -> 'eagle', /home/... "
+                    "-> 'home'. Do NOT pass 'aurora', 'crux', or "
+                    "'polaris' here -- IRI's filesystem endpoints "
+                    "target storage UUIDs, not compute UUIDs. "
+                    "/flare/... is not exposed."),
+                "path": ("str", True, "Absolute path to list."),
+                "show_hidden": ("bool", False, "Include dotfiles."),
+                "recursive": ("bool", False, "Recurse into subdirs."),
+                "dereference": ("bool", False, "Follow symlinks."),
+            },
+            lambda machine, path, show_hidden=False, recursive=False,
+                   dereference=False, **_: _get(
+                f"/filesystem/ls/{_r(machine)}",
+                params={"path": path, "showHidden": show_hidden,
+                        "recursive": recursive, "dereference": dereference},
+            ),
+        ),
+        "stat": (
+            "read",
+            "File metadata (size, mode, mtime). NOTE: ALCF returned "
+            "501 'not implemented yet' as of 2026-08-11 -- use `ls` "
+            "which returns similar per-entry metadata.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path.")},
+            lambda machine, path, **_: _get(
+                f"/filesystem/stat/{_r(machine)}", params={"path": path},
+            ),
+        ),
+        "cat": (
+            "read",
+            "Read full file contents (use `view` for large files with pagination).",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path.")},
+            lambda machine, path, **_: _get(
+                f"/filesystem/file/{_r(machine)}", params={"path": path},
+            ),
+        ),
+        "view": (
+            "read",
+            "Paginated file read. Returns up to `size` bytes starting "
+            "at `offset`. Preferred over `cat` for large files.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path."),
+             "size": ("int", False, "Max bytes to return (facility default if omitted)."),
+             "offset": ("int", False, "Byte offset to start from (default 0).")},
+            lambda machine, path, size=None, offset=None, **_: _get(
+                f"/filesystem/view/{_r(machine)}",
+                params={
+                    k: v for k, v in {
+                        "path": path, "size": size, "offset": offset,
+                    }.items() if v is not None
+                },
+            ),
+        ),
+        "head": (
+            "read",
+            "First N lines of a file.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path."),
+             "lines": ("int", False, "Number of lines (facility default if omitted).")},
+            lambda machine, path, lines=None, **_: _get(
+                f"/filesystem/head/{_r(machine)}",
+                params={
+                    k: v for k, v in {
+                        "path": path, "lines": lines,
+                    }.items() if v is not None
+                },
+            ),
+        ),
+        "tail": (
+            "read",
+            "Last N lines of a file (useful for job stderr/stdout).",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path."),
+             "lines": ("int", False, "Number of lines.")},
+            lambda machine, path, lines=None, **_: _get(
+                f"/filesystem/tail/{_r(machine)}",
+                params={
+                    k: v for k, v in {
+                        "path": path, "lines": lines,
+                    }.items() if v is not None
+                },
+            ),
+        ),
+        "checksum": (
+            "read",
+            "MD5/SHA of a file.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path.")},
+            lambda machine, path, **_: _get(
+                f"/filesystem/checksum/{_r(machine)}", params={"path": path},
+            ),
+        ),
+        "download": (
+            "read",
+            "Download a file to the caller (returns bytes; small files only).",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path.")},
+            lambda machine, path, **_: _get(
+                f"/filesystem/download/{_r(machine)}", params={"path": path},
+            ),
+        ),
+        "mkdir": (
+            "write",
+            "Create directory. UNSAFE.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path."),
+             "parent": ("bool", False,
+                 "If true, create parent dirs (like mkdir -p). Default false.")},
+            lambda machine, path, parent=False, **_: (
+                _check_unsafe("mkdir") or _post(
+                    f"/filesystem/mkdir/{_r(machine)}",
+                    json={"path": path, "parent": parent},
+                )
+            ),
+        ),
+        "rm": (
+            "write",
+            "Remove file/dir. UNSAFE.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path.")},
+            lambda machine, path, **_: (
+                _check_unsafe("rm") or _delete_with_query(
+                    f"/filesystem/rm/{_r(machine)}", params={"path": path},
+                )
+            ),
+        ),
+        "chmod": (
+            "write",
+            "Change permissions. UNSAFE. mode is octal string like '700'.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path."),
+             "mode": ("str", True, "Octal mode like '700' or '755'.")},
+            lambda machine, path, mode, **_: (
+                _check_unsafe("chmod") or _put(
+                    f"/filesystem/chmod/{_r(machine)}",
+                    json={"path": path, "mode": mode},
+                )
+            ),
+        ),
+        "chown": (
+            "write",
+            "Change owner/group. UNSAFE.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "path": ("str", True, "Absolute path."),
+             "owner": ("str", False, "New owner username or uid."),
+             "group": ("str", False, "New group name or gid.")},
+            lambda machine, path, owner=None, group=None, **_: (
+                _check_unsafe("chown") or _put(
+                    f"/filesystem/chown/{_r(machine)}",
+                    json={"path": path, **({"owner": owner} if owner else {}),
+                          **({"group": group} if group else {})},
+                )
+            ),
+        ),
+        # The following actions exist in the OpenAPI spec but ALCF has
+        # NOT published examples for them. Body shapes below are best
+        # guesses from the spec's schema references -- may return 400
+        # if ALCF expects different keys. Left in so the LLM can
+        # discover them; agent should prefer scp/ssh if these 400.
+        "mv": (
+            "write",
+            "Rename/move. UNSAFE. Body shape is unofficial (ALCF has "
+            "not documented an example).",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "src": ("str", True, "Source path."),
+             "dst": ("str", True, "Destination path.")},
+            lambda machine, src, dst, **_: (
+                _check_unsafe("mv") or _post(
+                    f"/filesystem/mv/{_r(machine)}",
+                    json={"source": src, "destination": dst},
+                )
+            ),
+        ),
+        "cp": (
+            "write",
+            "Copy. UNSAFE. Body shape unofficial.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "src": ("str", True, "Source path."),
+             "dst": ("str", True, "Destination path.")},
+            lambda machine, src, dst, **_: (
+                _check_unsafe("cp") or _post(
+                    f"/filesystem/cp/{_r(machine)}",
+                    json={"source": src, "destination": dst},
+                )
+            ),
+        ),
+        "symlink": (
+            "write",
+            "Create symlink. UNSAFE. Body shape unofficial.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "target": ("str", True, "Existing path being linked to."),
+             "link_path": ("str", True, "New symlink path.")},
+            lambda machine, target, link_path, **_: (
+                _check_unsafe("symlink") or _post(
+                    f"/filesystem/symlink/{_r(machine)}",
+                    json={"target": target, "link_path": link_path},
+                )
+            ),
+        ),
+        "compress": (
+            "write",
+            "tar/gzip files. UNSAFE. Body shape unofficial.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "paths": ("list[str]", True, "Absolute paths to include."),
+             "archive": ("str", True, "Output archive path.")},
+            lambda machine, paths, archive, **_: (
+                _check_unsafe("compress") or _post(
+                    f"/filesystem/compress/{_r(machine)}",
+                    json={"paths": paths, "archive": archive},
+                )
+            ),
+        ),
+        "extract": (
+            "write",
+            "Untar. UNSAFE. Body shape unofficial.",
+            {"machine": ("str", True,
+                "STORAGE resource, NOT the compute machine. Pick by "
+                "path prefix: /eagle/... -> 'eagle', /home/... -> "
+                "'home'. Do NOT pass 'aurora', 'crux', or 'polaris' "
+                "here -- IRI's filesystem endpoints target storage "
+                "UUIDs, not compute UUIDs. /flare/... is not exposed."),
+             "archive": ("str", True, "Archive path."),
+             "dest": ("str", True, "Destination directory.")},
+            lambda machine, archive, dest, **_: (
+                _check_unsafe("extract") or _post(
+                    f"/filesystem/extract/{_r(machine)}",
+                    json={"archive": archive, "destination": dest},
+                )
+            ),
+        ),
+    }
+
+
+def _auth_actions():
+    return {
+        "start_reauth": (
+            "read",  # not a write op -- doesn't change ALCF state
+            "Begin an interactive Globus re-auth flow. Returns a URL "
+            "the user must visit + instructions for step 2.",
+            {},
+            lambda **_: _start_reauth(),
+        ),
+        "complete_reauth": (
+            "read",
+            "Finish the re-auth flow with the auth code the user pasted.",
+            {"auth_code": ("str", True,
+                "The 30-char code Globus displayed after the user "
+                "signed in via the start_reauth URL.")},
+            lambda auth_code, **_: _complete_reauth(auth_code),
+        ),
+    }
+
+
+def _task_actions():
+    return {
+        "list": (
+            "read",
+            "List all async task handles owned by the caller.",
+            {},
+            lambda **_: _get("/task"),
+        ),
+        "get": (
+            "read",
+            "Get one task's state (many FS/compute ops return a task_id).",
+            {"task_id": ("str", True, "Task UUID.")},
+            lambda task_id, **_: _get(f"/task/{task_id}"),
+        ),
+        "cancel": (
+            "write",
+            "Cancel an in-flight task. UNSAFE.",
+            {"task_id": ("str", True, "Task UUID.")},
+            lambda task_id, **_: (
+                _check_unsafe("task.cancel") or _delete(f"/task/{task_id}")
+            ),
+        ),
+    }
+
+
+CATEGORIES: dict[str, dict[str, tuple]] = {
+    "facility": _facility_actions(),
+    "status": _status_actions(),
+    "account": _account_actions(),
+    "compute": _compute_actions(),
+    "filesystem": _filesystem_actions(),
+    "task": _task_actions(),
+    "auth": _auth_actions(),
+}
+
+
+def dispatch(category: str, action: str, params: dict[str, Any]) -> Any:
+    """Route a category+action pair to the right invoker.
+
+    Three action kinds:
+      - "list_actions" -> list of {name: {kind, description}} for the category
+      - "describe"     -> full schema for one action; requires
+                          params={"target_action": <name>}
+      - <name>         -> invoke that action with the supplied params
+
+    Raises ValueError for unknown actions, RuntimeError for API errors
+    (bubbled up from _raise_for_iri).
+    """
+    actions = CATEGORIES[category]
+    if action == "list_actions":
+        return {
+            name: {"kind": spec[0], "description": spec[1]}
+            for name, spec in actions.items()
+        }
+    if action == "describe":
+        target = params.get("target_action")
+        if target not in actions:
+            raise ValueError(
+                f"Unknown action {target!r} for category {category!r}. "
+                f"Available: {sorted(actions)}"
+            )
+        kind, desc, params_schema, _ = actions[target]
+        return {
+            "action": target,
+            "kind": kind,
+            "description": desc,
+            "params": {
+                p: {"type": t, "required": req, "description": d}
+                for p, (t, req, d) in params_schema.items()
+            },
+        }
+    if action not in actions:
+        raise ValueError(
+            f"Unknown action {action!r} for category {category!r}. "
+            f"Available: {sorted(actions)}. Call action='list_actions' "
+            "to see all, or action='describe' target_action=<name> for one."
+        )
+    return actions[action][3](**params)

--- a/src/chemgraph/tools/alcf_iri_core.py
+++ b/src/chemgraph/tools/alcf_iri_core.py
@@ -87,6 +87,8 @@ def _headers(needs_auth: bool = True) -> dict[str, str]:
     if not needs_auth:
         return {}
     token = os.environ.get("ALCF_API_TOKEN")
+    if not token and _try_refresh_token():
+        token = os.environ.get("ALCF_API_TOKEN")
     if not token:
         raise RuntimeError(
             "This action needs $ALCF_API_TOKEN. Get one from "
@@ -154,7 +156,18 @@ def _try_refresh_token() -> bool:
     try:
         with open(_TOKENS_PATH) as f:
             data = json.load(f)
+        # Two shapes exist in the wild for the same on-disk path:
+        #   flat -- written by _complete_reauth below
+        #   nested -- written by ALCF's helper script (globus_sdk.UserApp),
+        #             tokens under data["data"]["DEFAULT"][<scope-uuid>]
         refresh_token = data.get("refresh_token")
+        if not refresh_token:
+            nested = (
+                data.get("data", {})
+                .get("DEFAULT", {})
+                .get(_GLOBUS_SCOPE_CLIENT_ID, {})
+            )
+            refresh_token = nested.get("refresh_token")
         if not refresh_token:
             return False
         client = globus_sdk.NativeAppAuthClient(_GLOBUS_AUTH_CLIENT_ID)

--- a/src/chemgraph/tools/alcf_iri_flat_tools.py
+++ b/src/chemgraph/tools/alcf_iri_flat_tools.py
@@ -1,0 +1,90 @@
+"""Flat @tool variant of the ALCF IRI Facility API integration.
+
+Comparison baseline for :mod:`chemgraph.tools.alcf_iri_tools`. Instead
+of exposing 7 category-dispatcher tools (each with a discovery
+protocol), this module generates one @tool per action -- ~43 tools
+bound to the LLM upfront.
+
+Purpose: benchmark the category-plus-discovery design (current) vs.
+flat-all-schemas-upfront (this module). Answers "is the discovery
+overhead paying for itself in reduced schema token cost?"
+
+Same underlying implementation via :mod:`chemgraph.tools.alcf_iri_core`;
+only the LLM-facing binding shape differs.
+
+Tool naming: `alcf_<category>_<action>`. Names are globally unique
+because action names may collide across categories (e.g. `get` lives
+in both `facility` and `task`; `list_resources` vs `list_projects`
+etc.). The prefix keeps the schemas unambiguous to the LLM.
+
+Not shipped by the single_agent_iri workflow -- use single_agent_iri_flat.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from langchain_core.tools import StructuredTool
+from pydantic import Field, create_model
+
+from chemgraph.tools.alcf_iri_core import CATEGORIES
+
+
+_TYPE_MAP = {
+    "str": str,
+    "int": int,
+    "bool": bool,
+    "dict": dict,
+    "list[str]": list,
+}
+
+
+def _build_args_model(category: str, action: str, params_schema: dict):
+    """Turn an action's params_schema (as stored in CATEGORIES) into
+    a Pydantic model LangChain can use to derive the tool's JSON schema.
+    """
+    fields: dict[str, Any] = {}
+    for name, (type_str, required, description) in params_schema.items():
+        py_type = _TYPE_MAP.get(type_str, str)
+        default = ... if required else None
+        fields[name] = (py_type, Field(default, description=description))
+    if not fields:
+        # StructuredTool requires SOME schema even for zero-arg actions.
+        # Add a single ignored placeholder so the LLM has a valid (empty)
+        # payload to send. Pydantic rejects leading-underscore field names,
+        # so we use "noop" and drop it in the wrapper.
+        fields["noop"] = (str, Field(None, description="unused; no args"))
+    return create_model(f"AlcfIri_{category}_{action}_Args", **fields)
+
+
+def _make_tool(category: str, action: str, kind: str, description: str,
+               params_schema: dict, invoker: Callable) -> StructuredTool:
+    tool_name = f"alcf_{category}_{action}"
+    # Wrap invoker so it takes kwargs from the LLM's JSON payload and
+    # forwards them to the underlying lambda (which expects **kwargs).
+    # Drop the "_" placeholder we may have added.
+    def _call(**kwargs) -> Any:
+        kwargs.pop("noop", None)
+        return invoker(**kwargs)
+    args_model = _build_args_model(category, action, params_schema)
+    return StructuredTool.from_function(
+        func=_call,
+        name=tool_name,
+        description=f"[{kind}] {description}",
+        args_schema=args_model,
+    )
+
+
+def _build_all_tools() -> list[StructuredTool]:
+    tools: list[StructuredTool] = []
+    for category, actions in CATEGORIES.items():
+        for action, (kind, desc, params_schema, invoker) in actions.items():
+            tools.append(_make_tool(category, action, kind, desc,
+                                    params_schema, invoker))
+    return tools
+
+
+ALCF_IRI_FLAT_TOOLS = _build_all_tools()
+
+
+__all__ = ["ALCF_IRI_FLAT_TOOLS"]

--- a/src/chemgraph/tools/alcf_iri_tools.py
+++ b/src/chemgraph/tools/alcf_iri_tools.py
@@ -33,7 +33,8 @@ __all__ = [
     "alcf_filesystem",
     "alcf_task",
     "alcf_auth",
-    "ALCF_IRI_TOOLS",
+    "ALCF_IRI_CATEGORY_TOOLS",
+    "ALCF_IRI_TOOLS",  # backwards-compat alias for ALCF_IRI_CATEGORY_TOOLS
 ]
 
 
@@ -132,7 +133,10 @@ def alcf_auth(action: str, params: dict | None = None) -> Any:
     return dispatch("auth", action, params or {})
 
 
-ALCF_IRI_TOOLS = [
+ALCF_IRI_CATEGORY_TOOLS = [
     alcf_facility, alcf_status, alcf_account,
     alcf_compute, alcf_filesystem, alcf_task, alcf_auth,
 ]
+
+# Backwards-compat alias: old code / notebooks importing ALCF_IRI_TOOLS keeps working.
+ALCF_IRI_TOOLS = ALCF_IRI_CATEGORY_TOOLS

--- a/src/chemgraph/tools/alcf_iri_tools.py
+++ b/src/chemgraph/tools/alcf_iri_tools.py
@@ -1,0 +1,138 @@
+"""LangChain ``@tool`` wrappers for the ALCF IRI Facility API.
+
+Each tool delegates to the pure-Python implementation in
+:mod:`chemgraph.tools.alcf_iri_core`.
+
+Seven category tools (facility, status, account, compute, filesystem,
+task, auth) instead of one @tool per endpoint. Each accepts an
+``action`` enum plus optional ``params`` dict, and uses the discovery
+protocol (action='list_actions' | 'describe' | <name>) to keep the
+LLM's initial prompt schema small. See the module docstring in
+alcf_iri_core.py for the full design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import tool
+
+from chemgraph.tools.alcf_iri_core import (
+    # Re-export so existing `from alcf_iri_tools import ...` keeps working
+    CATEGORIES,
+    dispatch,
+)
+
+__all__ = [
+    "CATEGORIES",
+    "dispatch",
+    "alcf_facility",
+    "alcf_status",
+    "alcf_account",
+    "alcf_compute",
+    "alcf_filesystem",
+    "alcf_task",
+    "alcf_auth",
+    "ALCF_IRI_TOOLS",
+]
+
+
+_DISCOVERY_HINT = (
+    " Discovery: call action='list_actions' to see the available actions "
+    "on this tool, then action='describe' with params={'target_action':"
+    "<name>} to see the schema for one, then invoke with action=<name>, "
+    "params={...}. Do not guess action names."
+)
+
+
+@tool(description=(
+    "ALCF Facility API — facility and site metadata (what facility this "
+    "is, which physical sites belong to it). No auth required."
+    + _DISCOVERY_HINT
+))
+def alcf_facility(action: str, params: dict | None = None) -> Any:
+    return dispatch("facility", action, params or {})
+
+
+@tool(description=(
+    "ALCF Facility API — real-time state of ALCF resources (compute, "
+    "storage, services), plus incidents and events. Use for questions "
+    "about whether a machine is up, planned outages, or state history. "
+    "No auth required."
+    + _DISCOVERY_HINT
+))
+def alcf_status(action: str, params: dict | None = None) -> Any:
+    return dispatch("status", action, params or {})
+
+
+@tool(description=(
+    "ALCF Facility API — accounts, projects, allocations, per-user "
+    "quotas, and the catalog of capabilities the facility exposes. Use "
+    "for questions about who you are, what projects you belong to, and "
+    "how much allocation you have. Most actions need $ALCF_API_TOKEN."
+    + _DISCOVERY_HINT
+))
+def alcf_account(action: str, params: dict | None = None) -> Any:
+    return dispatch("account", action, params or {})
+
+
+@tool(description=(
+    "ALCF Facility API — PBS batch job control on ALCF machines. "
+    "Read actions (get_job_status, list_jobs) work unconditionally. "
+    "Write actions (submit_job, update_job, cancel_job) will succeed "
+    "if the server is configured to permit them and raise a clear "
+    "RuntimeError otherwise -- ALWAYS ATTEMPT them if the user asks; "
+    "do NOT refuse preemptively. Needs $ALCF_API_TOKEN."
+    + _DISCOVERY_HINT
+))
+def alcf_compute(action: str, params: dict | None = None) -> Any:
+    return dispatch("compute", action, params or {})
+
+
+@tool(description=(
+    "ALCF Facility API — remote filesystem ops on ALCF storage via "
+    "HTTPS. Read actions (ls, stat, cat, head, tail, checksum, "
+    "download) work unconditionally. Write actions (mkdir, rm, chmod, "
+    "...) will succeed if the server is configured to permit them and "
+    "raise a clear RuntimeError otherwise -- ALWAYS ATTEMPT them if "
+    "the user asks; do NOT refuse preemptively. Needs $ALCF_API_TOKEN. "
+    "IMPORTANT: filesystem targets STORAGE resources, NOT compute. "
+    "Pick the `machine` argument by path prefix: /eagle/... -> "
+    "'eagle', /home/... -> 'home'. Do NOT pass 'aurora', 'crux', or "
+    "'polaris' -- those are compute UUIDs and IRI's filesystem "
+    "endpoints will 400. /flare/... is not exposed by IRI at all; "
+    "tell the user to use scp for /flare paths."
+    + _DISCOVERY_HINT
+))
+def alcf_filesystem(action: str, params: dict | None = None) -> Any:
+    return dispatch("filesystem", action, params or {})
+
+
+@tool(description=(
+    "ALCF Facility API — handles for asynchronous operations returned "
+    "by other endpoints (long-running filesystem or compute ops give "
+    "you a task_id to poll). Needs $ALCF_API_TOKEN."
+    + _DISCOVERY_HINT
+))
+def alcf_task(action: str, params: dict | None = None) -> Any:
+    return dispatch("task", action, params or {})
+
+
+@tool(description=(
+    "ALCF Facility API — interactive Globus re-auth. Use this ONLY "
+    "when another alcf_* tool returned a 401 that mentioned expired "
+    "token AND silent refresh failed. Two-step: (1) call "
+    "action='start_reauth' to get a URL for the user to visit, show "
+    "them the URL and ask for the auth code they get after signing "
+    "in; (2) call action='complete_reauth' with params={'auth_code': "
+    "'<the code>'}. After success, retry the original query."
+    + _DISCOVERY_HINT
+))
+def alcf_auth(action: str, params: dict | None = None) -> Any:
+    return dispatch("auth", action, params or {})
+
+
+ALCF_IRI_TOOLS = [
+    alcf_facility, alcf_status, alcf_account,
+    alcf_compute, alcf_filesystem, alcf_task, alcf_auth,
+]

--- a/src/ui/_pages/configuration.py
+++ b/src/ui/_pages/configuration.py
@@ -24,6 +24,7 @@ WORKFLOW_OPTIONS: list[str] = [
     "python_relp",
     "graspa",
     "molecular_docking",
+    "single_agent_iri",
     "mock_agent",
 ]
 


### PR DESCRIPTION
## Summary

Adds a new `single_agent_iri` workflow that exposes ALCF's IRI Facility API (https://api.alcf.anl.gov, 43 endpoints) to the LLM as **seven category-dispatcher tools** with a discovery protocol.

Rather than binding one `@tool` per endpoint (~8k tokens of schemas upfront), each category tool accepts an `action` enum and uses `list_actions` / `describe` for on-demand schema discovery (~1k tokens upfront). Trades one extra LLM turn on cold calls for a ~8x reduction in the tool-schema footprint.

## Demo queries

### Discovery protocol

- `What tool categories do you have?`
- `List every action the alcf_filesystem tool supports, and describe the schema of the `ls` action in detail.`

### One hop

- `Which ALCF machines are currently up, and which are down or in unknown state?`

### Two hop

- `Find the ChemGraph project and list all its allocations across every machine, including how much has been used.`

### Three hop

- `Health check: for every compute machine that's currently up, tell me whether my project has allocation left and how many jobs I have in the queue right now.`
- `Would a Crux job survive right now? Check Crux is up, that ChemGraph has positive allocation on Crux, and if either check fails suggest which other ALCF machine I should try instead.`

### Compute — real PBS actions

- `Show the status of Crux job 246115 and describe what happened.`
- `Submit a smoke-test job on Crux: run /bin/bash -lc 'echo hello; sleep 10' under the ChemGraph account, 5-minute duration, 1 node in the debug queue, stdout+stderr to /home/jinchuli/iri-demo.{out,err}, filesystems home:eagle. `
- `Check the status of the job you just submitted`

### Auth

- `Re-authenticate my ALCF session.`

### Adversarial

- `List the files under `/flare/ChemGraph/jinchu` on Aurora.`
- `Submit a job on Aurora to test whether IRI submission works there yet.`

## Files added

| file | purpose |
|---|---|
| `src/chemgraph/tools/alcf_iri_core.py` | Pure-Python IRI client. Seven action tables (facility, status, account, compute, filesystem, task, auth), the `dispatch()` public API, in-process Globus OAuth for both silent access-token refresh and interactive re-auth. No LangChain deps -- usable from any Python client. |
| `src/chemgraph/tools/alcf_iri_tools.py` | Seven `@tool`-decorated wrappers around `dispatch()`. Mirrors the repo's `*_core.py` + `*_tools.py` split (see cheminformatics, graspa, xanes, pacmof2, ase). |
| `src/chemgraph/graphs/single_agent_iri.py` | LangGraph wiring. Same shape as `graphs/graspa_agent.py`. |
| `src/chemgraph/prompt/alcf_iri_prompt.py` | System prompt for the workflow. |

## Files modified (wiring)

- `src/chemgraph/agent/llm_agent.py` — import, `workflow_map` entry, `single_agent_iri` dispatch branch
- `src/chemgraph/cli/commands.py` — added to `ALL_WORKFLOW_TYPES` + `iri` alias in `WORKFLOW_ALIASES`
- `src/ui/_pages/configuration.py` — added to Streamlit `WORKFLOW_OPTIONS` dropdown

## Design highlights

**Category-plus-discovery pattern.** Six of the seven tools cover ALCF's REST API groups (facility / status / account / compute / filesystem / task). Each accepts `action=<name>` and `params={...}`; three meta-actions (`list_actions`, `describe`, `<any real action>`) let the LLM discover the surface on demand.

**Zero external CLI dependency for auth.** Both silent access-token refresh (Level 1) and interactive browser re-auth (Level 2) use `globus_sdk` in-process with the same public Native App client ID (`8b84fc2d-...`) and scope that ALCF publishes for its `alcf-facility-api-token` helper. The on-disk token cache path is shared, so users who already authenticated via ALCF's CLI helper are unaffected; users who haven't can bootstrap entirely through the in-chat `alcf_auth` tool.

**Two-step OAuth in a chat context.** The `alcf_auth` tool splits the OAuth flow across two tool calls: `start_reauth` returns a Globus URL (agent shows it to the user), `complete_reauth` takes the auth code the user pastes back. No `input()`, no subprocess prompt, works cleanly through Streamlit chat.

**Write actions gated at the tool layer.** `submit_job`, `cancel_job`, `mkdir`, `rm`, `chmod`, etc. raise a clear `RuntimeError` unless `$ALCF_IRI_ALLOW_UNSAFE=1` is set. Tool descriptions explicitly tell the LLM to attempt these normally rather than refuse preemptively — the error surface handles authorization.

**Dynamic resource resolution.** `_resource_id()` calls `GET /status/resources` on first use and caches results per-session. No hardcoded machine-name → UUID fallback table; if ALCF adds a machine or rotates a UUID, the tool picks it up on the next lookup.

## Verified

- Machine status (`get_resource`, `list_resources`, incidents, events) — all 9 currently-registered ALCF resources resolve correctly via live lookup.
- Account (`list_projects`, `list_allocations`) — returns real ChemGraph project + allocation breakdowns.
- Compute (`get_job_status`, `list_jobs`, `submit_job`) — real PBS jobs on Crux (state transitions queued→active→completed).
- Interactive Globus re-auth (`alcf_auth`) end-to-end from a fresh cache: start_reauth → user pastes code → complete_reauth → subsequent tool calls succeed with no restart.
- Silent refresh (`_try_refresh_token`) when access token expires mid-session — invisible recovery, no user interaction.

Not verified in this PR (blocked on ALCF-side identity mapping, tracked in an ALCF support ticket — the code path is correct):
- Filesystem read endpoints (`ls`, `cat`, `head`, ...) — return 422 "Identity failed to map to a local user name" until ALCF ops adds this Globus identity to their identity table. Confirmed working for another user on the same project, so the code is right.
- `stat` — returns 501 "not implemented yet" on ALCF's side.
- Aurora and Sophia `/compute/*` — return 404 "Endpoint resource does not exist for API component compute"; ALCF hasn't wired those clusters into the compute router yet.

## Test plan

- [ ] Fresh `pip install -e .` — verify `chemgraph -w iri -q "is Aurora up"` runs end-to-end.
- [ ] `single_agent_iri` shows in the Streamlit workflow dropdown.
- [ ] Fresh Globus auth via in-chat `alcf_auth`: agent returns a URL, accepts pasted code, subsequent queries succeed.
- [ ] Regression check: other workflows (`single_agent`, `graspa`, `molecular_docking`) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
