### PR TITLE
Add experimental Deep Agent subagent

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,9 @@ report = true
 thread = 1
 recursion_limit = 20
 human_supervised = false
+# Development-only: add a workspace Deep Agent to interactive main_agent.
+enable_deepagent = false
+# deepagent_workspace = "."
 verbose = false
 
 [logging]

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -28,6 +28,9 @@ thread = 1
 recursion_limit = 20
 # Allow the agent to pause and ask for human input
 human_supervised = false
+# Development-only workspace subagent for interactive main_agent sessions.
+enable_deepagent = false
+# deepagent_workspace = "."
 # Enable verbose output
 verbose = false
 
@@ -288,6 +291,8 @@ chemgraph [OPTIONS] -q "YOUR_QUERY"
 | `--output`          | `-o`  | Output format (`state`, `last_message`)              | `state`        |
 | `--structured`      | `-s`  | Use structured output format                         | `False`        |
 | `--report`          | `-r`  | Generate detailed report                             | `False`        |
+| `--deepagent`       |       | Enable the experimental `main_agent` workspace worker | `False`       |
+| `--deepagent-workspace` |   | Root used by the experimental workspace worker       | Current directory |
 | `--resume`          |       | Resume from a previous session ID (prefix supported) |                |
 | `--list-sessions`   |       | List recent sessions from the memory database        |                |
 | `--show-session`    |       | Show conversation for a session (prefix supported)   |                |
@@ -387,6 +392,48 @@ switching the model or workflow discards the process-local thread; durable
 `--resume` support for `main_agent` is not yet available. If a model or graph
 operation fails transiently, enter `/retry` to resume its checkpoint without
 adding the previous user message a second time.
+
+#### Experimental workspace Deep Agent
+
+For development and testing, `main_agent` can register an additional
+`deepagent` sibling alongside the existing `chemgraph` chemistry worker:
+
+```bash
+chemgraph --interactive -w main_agent --deepagent \
+  --deepagent-workspace /absolute/path/to/workspace
+```
+
+The supervisor routes molecular simulations and calculator work to
+`chemgraph`, while repository exploration, coding, file analysis, and test runs
+can be delegated to `deepagent`. The equivalent TOML settings are
+`general.enable_deepagent = true` and `general.deepagent_workspace = "..."`.
+An explicit `--no-deepagent` overrides an enabled TOML setting.
+
+!!! danger "Development-only host shell"
+    The experimental CLI uses Deep Agents' `LocalShellBackend`. Its filesystem
+    tools are rooted at the selected workspace, but shell commands are executed
+    directly on the host and can access paths outside that root. ChemGraph
+    displays a warning and requires startup confirmation, then requires an
+    approve/reject decision before every shell command and every file
+    write/edit/delete. Only a small environment allowlist is forwarded; API
+    keys and token variables are not copied. Do not use this mode for deployed
+    or untrusted workloads.
+
+Python callers can instead pass any compatible Deep Agents backend without
+using the host-shell CLI path:
+
+```python
+agent = ChemGraph(
+    model_name="gpt-4o-mini",
+    workflow_type="main_agent",
+    enable_deepagent=True,
+    deepagent_backend=my_sandbox_backend,
+)
+```
+
+A production release must use an isolated sandbox backend with explicit user
+approval, defined lifecycle and cleanup, artifact transfer, and network/secret
+policies. The experimental local backend is not a production sandbox.
 
 **Interactive Features:**
 - **Persistent conversation**: Maintain context across queries

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import os
 import time
-from typing import Callable, Collection, List, Optional
+from typing import Any, Callable, Collection, List, Optional
 import uuid
 
 from chemgraph.agent.events import EventCallback, _AstreamEventCallback
@@ -156,6 +156,12 @@ class ChemGraph:
     terminal_tool_names : Collection[str], optional
         Tool names that should terminate supported workflows after
         successful execution, by default empty.
+    enable_deepagent : bool, optional
+        Add the experimental workspace Deep Agent to ``main_agent``, by
+        default False.
+    deepagent_backend : BackendProtocol, optional
+        Backend used by the workspace Deep Agent. When omitted, its files are
+        stored in checkpointed agent state.
     on_event : callable, optional
         Callback invoked with dashboard workflow events, by default None.
 
@@ -196,9 +202,17 @@ class ChemGraph:
         human_input_handler: Optional[Callable[[str], str]] = None,
         human_supervised: bool = False,
         terminal_tool_names: Collection[str] = (),
+        enable_deepagent: bool = False,
+        deepagent_backend: Any | None = None,
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
     ):
+        if enable_deepagent and workflow_type != "main_agent":
+            raise ValueError(
+                "enable_deepagent is supported only for the main_agent workflow."
+            )
+        if deepagent_backend is not None and not enable_deepagent:
+            raise ValueError("deepagent_backend requires enable_deepagent=True.")
         if model_name.startswith("codex:") and workflow_type not in {
             "single_agent",
             "main_agent",
@@ -344,6 +358,8 @@ class ChemGraph:
         self.human_input_handler = human_input_handler
         self.human_supervised = human_supervised
         self.terminal_tool_names = tuple(terminal_tool_names)
+        self.enable_deepagent = enable_deepagent
+        self.deepagent_backend = deepagent_backend
         self.on_event = on_event
 
         # Record whether the caller relied on the default system prompt before
@@ -439,6 +455,9 @@ class ChemGraph:
                 subagent_max_retries=self.max_retries,
                 subagent_human_supervised=self.human_supervised,
                 subagent_terminal_tool_names=self.terminal_tool_names,
+                enable_deepagent=self.enable_deepagent,
+                deepagent_backend=self.deepagent_backend,
+                deepagent_recursion_limit=self.recursion_limit,
             )
         elif self.workflow_type == "multi_agent":
             self.workflow = self.workflow_map[workflow_type]["constructor"](

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -150,6 +150,8 @@ class MainAgentSession:
         if "" in expected:
             raise RuntimeError("Pending interrupts do not expose stable IDs.")
         provided = {str(key) for key in response}
+        if len(self._pending) == 1 and provided != expected:
+            return dict(response)
         if provided != expected:
             raise ValueError(
                 "Interrupt response IDs must exactly match the pending interrupts."

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from rich.panel import Panel
 from rich.markup import escape
 from rich.progress import Progress, SpinnerColumn, TextColumn
-from rich.prompt import Prompt
+from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from chemgraph.memory.store import SessionStore
@@ -171,6 +172,52 @@ def check_api_keys(model_name: str) -> tuple[bool, str]:
 
 _INIT_TIMEOUT_SECONDS = 30
 
+_DEEPAGENT_ENV_ALLOWLIST = (
+    "PATH",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+    "CONDA_PREFIX",
+    "TMPDIR",
+    "CHEMGRAPH_LOG_DIR",
+)
+
+
+def _create_experimental_deepagent_backend(workspace: str | None):
+    """Create the explicitly approved development-only host-shell backend."""
+    from deepagents.backends import LocalShellBackend
+
+    root = Path(workspace or Path.cwd()).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"Deep Agent workspace is not a directory: {root}")
+
+    console.print(
+        Panel(
+            "The experimental Deep Agent can read and modify files under "
+            f"{root} and can run arbitrary shell commands on this host. The "
+            "shell is not confined to that directory. Every shell command and "
+            "file mutation will require approval.",
+            title="[bold red]Experimental host-shell access[/bold red]",
+            style="red",
+        )
+    )
+    if not Confirm.ask(
+        "Enable this development-only capability?",
+        default=False,
+    ):
+        raise RuntimeError("Experimental Deep Agent access was not approved.")
+
+    environment = {
+        name: os.environ[name]
+        for name in _DEEPAGENT_ENV_ALLOWLIST
+        if name in os.environ
+    }
+    return LocalShellBackend(
+        root_dir=root,
+        virtual_mode=True,
+        env=environment,
+        inherit_env=False,
+    )
+
 
 def initialize_agent(
     model_name: str,
@@ -185,6 +232,8 @@ def initialize_agent(
     human_supervised: bool = False,
     tools: Optional[list] = None,
     on_event: Optional[Any] = None,
+    enable_deepagent: bool = False,
+    deepagent_workspace: str | None = None,
 ) -> Any:
     """Initialize a ChemGraph agent with progress indication.
 
@@ -216,6 +265,10 @@ def initialize_agent(
     tools : list, optional
         Custom tools for MCP-backed workflows, or supervisor-level tools for
         ``main_agent``. The default chemistry subagent retains its built-ins.
+    enable_deepagent : bool, optional
+        Enable the development-only workspace worker for ``main_agent``.
+    deepagent_workspace : str, optional
+        Root directory exposed to the development-only local backend.
 
     Returns
     -------
@@ -225,6 +278,22 @@ def initialize_agent(
     """
     # Resolve workflow alias before initializing.
     workflow_type = resolve_workflow(workflow_type)
+    if enable_deepagent and workflow_type != "main_agent":
+        raise ValueError(
+            "The experimental Deep Agent is available only with main_agent."
+        )
+    if deepagent_workspace is not None and not enable_deepagent:
+        raise ValueError("--deepagent-workspace requires --deepagent.")
+
+    deepagent_backend = None
+    if enable_deepagent:
+        try:
+            deepagent_backend = _create_experimental_deepagent_backend(
+                deepagent_workspace
+            )
+        except (RuntimeError, ValueError) as exc:
+            console.print(f"[red]{escape(str(exc))}[/red]")
+            return None
 
     if verbose:
         console.print("[blue]Initializing agent with:[/blue]")
@@ -235,6 +304,7 @@ def initialize_agent(
         console.print(f"  Generate Report: {generate_report}")
         console.print(f"  Human Supervised: {human_supervised}")
         console.print(f"  Recursion Limit: {recursion_limit}")
+        console.print(f"  Deep Agent: {enable_deepagent}")
         if base_url:
             console.print(f"  Base URL: {base_url}")
         if argo_user:
@@ -290,6 +360,8 @@ def initialize_agent(
                 human_supervised=human_supervised,
                 tools=tools,
                 on_event=on_event,
+                enable_deepagent=enable_deepagent,
+                deepagent_backend=deepagent_backend,
             )
 
         try:
@@ -522,6 +594,64 @@ def _interrupt_question(payload: Any) -> str:
     return str(payload)
 
 
+def _is_tool_review(payload: Any) -> bool:
+    """Return whether an interrupt is a Deep Agents tool-review request."""
+    return (
+        isinstance(payload, dict)
+        and isinstance(payload.get("action_requests"), list)
+        and isinstance(payload.get("review_configs"), list)
+    )
+
+
+def _prompt_for_interrupt(payload: Any) -> Any:
+    """Render one interrupt and collect its resume value."""
+    if not _is_tool_review(payload):
+        console.print(
+            Panel(
+                _interrupt_question(payload),
+                title="[bold yellow]Agent needs your input[/bold yellow]",
+                style="yellow",
+            )
+        )
+        return Prompt.ask("[bold cyan]Your response[/bold cyan]")
+
+    review_configs = {
+        item.get("action_name"): item
+        for item in payload["review_configs"]
+        if isinstance(item, dict)
+    }
+    decisions = []
+    for action in payload["action_requests"]:
+        if not isinstance(action, dict):
+            raise ValueError("Invalid Deep Agent approval request.")
+        name = str(action.get("name", "unknown"))
+        args = action.get("args", {})
+        config = review_configs.get(name, {})
+        allowed = [
+            item
+            for item in config.get("allowed_decisions", [])
+            if item in {"approve", "reject"}
+        ]
+        if not allowed:
+            raise ValueError(
+                f"Deep Agent action {name!r} does not allow approve/reject."
+            )
+        console.print(
+            Panel(
+                f"Tool: {escape(name)}\nArguments: {escape(repr(args))}",
+                title="[bold red]Deep Agent approval required[/bold red]",
+                style="red",
+            )
+        )
+        decision = Prompt.ask(
+            "[bold cyan]Decision[/bold cyan]",
+            choices=allowed,
+            default="reject" if "reject" in allowed else allowed[0],
+        )
+        decisions.append({"type": decision})
+    return {"decisions": decisions}
+
+
 def _main_agent_failure_hint(session: Any) -> None:
     if getattr(session, "failed", False):
         console.print(
@@ -562,30 +692,11 @@ def _run_main_agent_operation(
         answers: Any
         if len(result.interrupts) == 1:
             pending = result.interrupts[0]
-            console.print(
-                Panel(
-                    _interrupt_question(pending.payload),
-                    title="[bold yellow]Agent needs your input[/bold yellow]",
-                    style="yellow",
-                )
-            )
-            answers = Prompt.ask("[bold cyan]Your response[/bold cyan]")
+            answers = _prompt_for_interrupt(pending.payload)
         else:
             answers = {}
             for pending in result.interrupts:
-                console.print(
-                    Panel(
-                        _interrupt_question(pending.payload),
-                        title=(
-                            "[bold yellow]Agent needs your input"
-                            f" ({pending.id})[/bold yellow]"
-                        ),
-                        style="yellow",
-                    )
-                )
-                answers[pending.id] = Prompt.ask(
-                    "[bold cyan]Your response[/bold cyan]"
-                )
+                answers[pending.id] = _prompt_for_interrupt(pending.payload)
 
         try:
             result = run_async_callable(lambda: session.resume(answers))
@@ -863,6 +974,8 @@ def interactive_mode(
     argo_user: Optional[str] = None,
     verbose: bool = False,
     tools: Optional[list] = None,
+    enable_deepagent: bool = False,
+    deepagent_workspace: str | None = None,
 ) -> None:
     """Start interactive REPL mode for ChemGraph CLI.
 
@@ -894,6 +1007,11 @@ def interactive_mode(
         Whether to print diagnostic output.
     tools : list, optional
         Custom tool list for MCP-backed workflows.
+    enable_deepagent : bool, optional
+        Whether to add the experimental workspace Deep Agent whenever the
+        selected workflow is ``main_agent``.
+    deepagent_workspace : str, optional
+        Local workspace used by the experimental host-shell backend.
     """
     console.print(create_banner())
     console.print("[bold green]Welcome to ChemGraph Interactive Mode![/bold green]")
@@ -928,6 +1046,12 @@ def interactive_mode(
         verbose=verbose,
         human_supervised=human_supervised,
         tools=tools,
+        enable_deepagent=enable_deepagent and workflow == "main_agent",
+        deepagent_workspace=(
+            deepagent_workspace
+            if enable_deepagent and workflow == "main_agent"
+            else None
+        ),
     )
     if not agent:
         return
@@ -1016,6 +1140,10 @@ Example queries:
                     continue
                 console.print(f"Model: {model}")
                 console.print(f"Workflow: {workflow}")
+                console.print(
+                    "Deep Agent: "
+                    f"{'enabled' if enable_deepagent and workflow == 'main_agent' else 'disabled'}"
+                )
                 if main_session is not None:
                     console.print(f"Thread ID: {main_session.thread_id}")
                     console.print(f"Failed: {main_session.failed}")
@@ -1088,6 +1216,12 @@ Example queries:
                     argo_user=argo_user,
                     human_supervised=human_supervised,
                     tools=tools,
+                    enable_deepagent=enable_deepagent and workflow == "main_agent",
+                    deepagent_workspace=(
+                        deepagent_workspace
+                        if enable_deepagent and workflow == "main_agent"
+                        else None
+                    ),
                 )
                 if new_agent:
                     model = new_model
@@ -1116,6 +1250,14 @@ Example queries:
                         argo_user=argo_user,
                         human_supervised=human_supervised,
                         tools=tools,
+                        enable_deepagent=(
+                            enable_deepagent and new_workflow == "main_agent"
+                        ),
+                        deepagent_workspace=(
+                            deepagent_workspace
+                            if enable_deepagent and new_workflow == "main_agent"
+                            else None
+                        ),
                     )
                     if new_agent:
                         workflow = new_workflow

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -106,6 +106,22 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         help="Enable the ask_human tool for human-in-the-loop interaction",
     )
     parser.add_argument(
+        "--deepagent",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Experimentally add a workspace Deep Agent to main_agent "
+            "(interactive mode only)"
+        ),
+    )
+    parser.add_argument(
+        "--deepagent-workspace",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Workspace root for the experimental local-shell Deep Agent",
+    )
+    parser.add_argument(
         "--recursion-limit",
         type=int,
         default=20,
@@ -349,6 +365,8 @@ def load_config(config_file: str) -> Dict[str, Any]:
                 "thread": 1,
                 "recursion_limit": 20,
                 "human_supervised": False,
+                "enable_deepagent": False,
+                "deepagent_workspace": None,
                 "verbose": False,
             },
             "api": {},
@@ -394,6 +412,9 @@ def _handle_run(args: argparse.Namespace) -> None:
     args : argparse.Namespace
         Parsed CLI arguments.
     """
+    cli_deepagent = getattr(args, "deepagent", None)
+    cli_deepagent_workspace = getattr(args, "deepagent_workspace", None)
+
     # Handle special commands first
     if getattr(args, "list_models", False):
         list_models()
@@ -427,6 +448,8 @@ def _handle_run(args: argparse.Namespace) -> None:
         # Honour config recursion_limit unless user gave explicit flag.
         if "recursion_limit" in config and "--recursion-limit" not in sys.argv:
             args.recursion_limit = config["recursion_limit"]
+        if getattr(args, "deepagent", None) is None and "enable_deepagent" in config:
+            args.deepagent = bool(config["enable_deepagent"])
 
     # ---- Configure logging verbosity --------------------------------
     import logging as _logging
@@ -452,6 +475,19 @@ def _handle_run(args: argparse.Namespace) -> None:
 
     # Resolve workflow alias (e.g. python_repl -> python_relp)
     args.workflow = resolve_workflow(args.workflow)
+    enable_deepagent = bool(getattr(args, "deepagent", False))
+    deepagent_workspace = getattr(args, "deepagent_workspace", None)
+    if deepagent_workspace is not None and not enable_deepagent:
+        if cli_deepagent is False and cli_deepagent_workspace is None:
+            deepagent_workspace = None
+        else:
+            console.print("[red]--deepagent-workspace requires --deepagent.[/red]")
+            sys.exit(2)
+    if enable_deepagent and not getattr(args, "interactive", False):
+        console.print(
+            "[red]The experimental Deep Agent requires interactive mode.[/red]"
+        )
+        sys.exit(2)
 
     if args.workflow == "main_agent":
         if getattr(args, "resume", None):
@@ -501,6 +537,8 @@ def _handle_run(args: argparse.Namespace) -> None:
             argo_user=argo_user,
             verbose=(args.verbose > 0),
             tools=mcp_tools,
+            enable_deepagent=enable_deepagent,
+            deepagent_workspace=deepagent_workspace,
         )
         return
 

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 from typing import Any
 
+from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
+from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware import SubAgentMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent
 from langchain.agents import create_agent
@@ -30,7 +32,36 @@ Rules:
 3. Review subagent results and give the user a complete response. If required
    input is missing, ask a clear question in your response.
 4. Use supervisor-level tools directly when their descriptions match the task.
+5. When available, use `chemgraph` for molecular construction, simulation,
+   calculator use, and other computational chemistry work. Use `deepagent` for
+   repository exploration, coding, testing, file analysis, and other long
+   workspace tasks when that specialist is available.
+6. Do not launch parallel workspace-mutating tasks. Parallel delegation is
+   appropriate only for independent read-only work.
+7. If deepagent is available, do not generate the code or file edits yourself;
+   delegate those tasks to deepagent.
 """
+
+
+DEFAULT_DEEPAGENT_PROMPT = """\
+You are ChemGraph's workspace specialist. Complete repository exploration,
+coding, testing, file analysis, and other multi-step workspace tasks. Use the
+built-in filesystem and execution tools when needed. Do not perform molecular
+simulations or invent chemistry results; return those tasks to the supervisor
+for delegation to the `chemgraph` specialist.
+
+The calling supervisor sees only your final assistant message. Return a concise,
+self-contained report including important results, changed paths, commands run,
+and any failures or unresolved risks.
+"""
+
+
+_DEEPAGENT_INTERRUPT_ON = {
+    "execute": {"allowed_decisions": ["approve", "reject"]},
+    "write_file": {"allowed_decisions": ["approve", "reject"]},
+    "edit_file": {"allowed_decisions": ["approve", "reject"]},
+    "delete": {"allowed_decisions": ["approve", "reject"]},
+}
 
 
 def latest_assistant_text(messages: list[Any]) -> str:
@@ -144,10 +175,18 @@ def construct_main_agent_graph(
     subagent_max_retries: int = 1,
     subagent_human_supervised: bool = False,
     subagent_terminal_tool_names: Collection[str] = (),
+    enable_deepagent: bool = False,
+    deepagent_backend: BackendProtocol | None = None,
+    deepagent_recursion_limit: int = 50,
     system_prompt: str = DEFAULT_MAIN_AGENT_PROMPT,
     checkpointer: Any | None = None,
 ):
     """Construct a checkpointed supervisor with Deep Agents delegation."""
+    if deepagent_recursion_limit <= 0:
+        raise ValueError("deepagent_recursion_limit must be positive.")
+    if deepagent_backend is not None and not enable_deepagent:
+        raise ValueError("deepagent_backend requires enable_deepagent=True.")
+
     if subagents is None:
         worker_kwargs: dict[str, Any] = {
             "tools": subagent_tools,
@@ -165,7 +204,7 @@ def construct_main_agent_graph(
         if subagent_report_prompt is not None:
             worker_kwargs["report_prompt"] = subagent_report_prompt
         worker = construct_single_agent_graph(llm, **worker_kwargs)
-        subagents = [
+        registered_subagents: list[CompiledSubAgent] = [
             {
                 "name": "chemgraph",
                 "description": (
@@ -175,8 +214,36 @@ def construct_main_agent_graph(
                 "runnable": worker,
             }
         ]
+    else:
+        registered_subagents = list(subagents)
 
-    validated_subagents = _validate_subagents(subagents)
+    if enable_deepagent:
+        workspace_agent = create_deep_agent(
+            model=llm,
+            tools=[],
+            system_prompt=DEFAULT_DEEPAGENT_PROMPT,
+            backend=(
+                deepagent_backend
+                if deepagent_backend is not None
+                else StateBackend()
+            ),
+            interrupt_on=_DEEPAGENT_INTERRUPT_ON,
+            checkpointer=None,
+            name="deepagent",
+        ).with_config({"recursion_limit": deepagent_recursion_limit})
+        registered_subagents.append(
+            {
+                "name": "deepagent",
+                "description": (
+                    "Explores repositories and workspaces, edits files, runs tests, "
+                    "and completes long multi-step coding or data-analysis tasks. "
+                    "Use chemgraph instead for molecular simulations."
+                ),
+                "runnable": workspace_agent,
+            }
+        )
+
+    validated_subagents = _validate_subagents(registered_subagents)
     supervisor_tools = list(main_tools or [])
     _validate_main_tools(supervisor_tools)
     middleware = SubAgentMiddleware(
@@ -194,6 +261,7 @@ def construct_main_agent_graph(
 
 
 __all__ = [
+    "DEFAULT_DEEPAGENT_PROMPT",
     "DEFAULT_MAIN_AGENT_PROMPT",
     "construct_main_agent_graph",
     "latest_assistant_text",

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -154,6 +154,7 @@ def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tm
     captured = {}
     workflow = _FakeWorkflow()
     main_tool = _DummyTool("read_file")
+    deepagent_backend = object()
 
     def fake_constructor(*args, **kwargs):
         captured["args"] = args
@@ -182,6 +183,8 @@ def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tm
         max_retries=4,
         human_supervised=True,
         terminal_tool_names=("save_result",),
+        enable_deepagent=True,
+        deepagent_backend=deepagent_backend,
     )
 
     assert cg.workflow is workflow
@@ -197,6 +200,9 @@ def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tm
     assert captured["kwargs"]["subagent_max_retries"] == cg.max_retries
     assert captured["kwargs"]["subagent_human_supervised"] is True
     assert captured["kwargs"]["subagent_terminal_tool_names"] == ("save_result",)
+    assert captured["kwargs"]["enable_deepagent"] is True
+    assert captured["kwargs"]["deepagent_backend"] is deepagent_backend
+    assert captured["kwargs"]["deepagent_recursion_limit"] == cg.recursion_limit
 
 
 @pytest.mark.asyncio

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any, TypedDict
 
 import pytest
+from deepagents.backends import LocalShellBackend
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
@@ -58,6 +59,12 @@ def _task_call(call_id: str, description: str = "do the work") -> dict:
         "id": call_id,
         "type": "tool_call",
     }
+
+
+def _deepagent_task_call(call_id: str, description: str = "inspect workspace") -> dict:
+    call = _task_call(call_id, description)
+    call["args"]["subagent_type"] = "deepagent"
+    return call
 
 
 def _answering_subgraph(answer: str, calls: list[str] | None = None):
@@ -354,6 +361,205 @@ def test_default_worker_forwards_options_and_inherits_parent_checkpoint(monkeypa
         "report_prompt": "report prompt",
     }
     assert isinstance(graph.checkpointer, InMemorySaver)
+
+
+def test_deepagent_is_opt_in_and_receives_backend_configuration(monkeypatch):
+    captured = {}
+
+    class FakeDeepAgent:
+        def invoke(self, state, config=None):
+            return {"messages": [AIMessage(content="done")]}
+
+        async def ainvoke(self, state, config=None):
+            return self.invoke(state, config=config)
+
+        def with_config(self, config):
+            captured["config"] = config
+            return self
+
+    def fake_create_deep_agent(**kwargs):
+        captured["kwargs"] = kwargs
+        return FakeDeepAgent()
+
+    backend = object()
+    monkeypatch.setattr(
+        "chemgraph.graphs.main_agent.create_deep_agent",
+        fake_create_deep_agent,
+    )
+
+    construct_main_agent_graph(
+        _ScriptedChatModel(responses=[]),
+        subagents=[_subagent(_answering_subgraph("chemistry"), name="chemgraph")],
+        enable_deepagent=True,
+        deepagent_backend=backend,
+        deepagent_recursion_limit=17,
+    )
+
+    assert captured["kwargs"]["backend"] is backend
+    assert captured["kwargs"]["tools"] == []
+    assert captured["kwargs"]["checkpointer"] is None
+    assert set(captured["kwargs"]["interrupt_on"]) == {
+        "execute",
+        "write_file",
+        "edit_file",
+        "delete",
+    }
+    assert captured["config"] == {"recursion_limit": 17}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"deepagent_backend": object()}, "requires enable_deepagent"),
+        (
+            {"enable_deepagent": True, "deepagent_recursion_limit": 0},
+            "must be positive",
+        ),
+    ],
+)
+def test_deepagent_configuration_validation(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        construct_main_agent_graph(
+            _ScriptedChatModel(responses=[]),
+            subagents=[_subagent(_answering_subgraph("done"))],
+            **kwargs,
+        )
+
+
+@pytest.mark.asyncio
+async def test_deepagent_execute_requires_structured_approval(tmp_path):
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[_deepagent_task_call("workspace-task")],
+            ),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "execute",
+                        "args": {"command": "pwd"},
+                        "id": "execute-call",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            AIMessage(content="Workspace inspection complete."),
+            AIMessage(content="The workspace specialist completed the task."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[
+            _subagent(_answering_subgraph("chemistry"), name="chemgraph")
+        ],
+        enable_deepagent=True,
+        deepagent_backend=LocalShellBackend(root_dir=tmp_path, env={}),
+    )
+    session = MainAgentSession(graph, thread_id="deepagent-approval")
+
+    pending = await session.run("Inspect the workspace")
+
+    assert pending.status == "waiting_for_user"
+    assert len(pending.interrupts) == 1
+    payload = pending.interrupts[0].payload
+    assert payload["action_requests"] == [
+        {
+            "name": "execute",
+            "args": {"command": "pwd"},
+            "description": (
+                "Tool execution requires approval\n\n"
+                "Tool: execute\nArgs: {'command': 'pwd'}"
+            ),
+        }
+    ]
+
+    completed = await session.resume({"decisions": [{"type": "approve"}]})
+
+    assert completed.status == "completed"
+    assert completed.assistant_response == (
+        "The workspace specialist completed the task."
+    )
+
+
+@pytest.mark.asyncio
+async def test_rejected_deepagent_write_leaves_workspace_unchanged(tmp_path):
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_deepagent_task_call("write-task")]),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "write_file",
+                        "args": {"file_path": "/blocked.txt", "content": "blocked"},
+                        "id": "write-call",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            AIMessage(content="The write was rejected."),
+            AIMessage(content="No files were changed."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[
+            _subagent(_answering_subgraph("chemistry"), name="chemgraph")
+        ],
+        enable_deepagent=True,
+        deepagent_backend=LocalShellBackend(root_dir=tmp_path, env={}),
+    )
+    session = MainAgentSession(graph, thread_id="deepagent-rejection")
+
+    pending = await session.run("Create a file")
+    assert pending.status == "waiting_for_user"
+    completed = await session.resume({"decisions": [{"type": "reject"}]})
+
+    assert completed.assistant_response == "No files were changed."
+    assert not (tmp_path / "blocked.txt").exists()
+
+
+@pytest.mark.asyncio
+async def test_deepagent_can_delegate_to_its_general_purpose_subagent():
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_deepagent_task_call("outer-task")]),
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {
+                            "subagent_type": "general-purpose",
+                            "description": "Summarize the workspace task.",
+                        },
+                        "id": "inner-task",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            AIMessage(content="Inner analysis complete."),
+            AIMessage(content="Workspace report complete."),
+            AIMessage(content="The workspace task is complete."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[
+            _subagent(_answering_subgraph("chemistry"), name="chemgraph")
+        ],
+        enable_deepagent=True,
+    )
+
+    result = await MainAgentSession(
+        graph,
+        thread_id="nested-deepagent",
+    ).run("Analyze the workspace")
+
+    assert result.status == "completed"
+    assert result.assistant_response == "The workspace task is complete."
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -4,6 +4,7 @@ import importlib
 from types import SimpleNamespace
 
 import pytest
+import toml
 
 from chemgraph.agent.main_session import MainAgentTurnResult, PendingInterrupt
 from chemgraph.cli import commands
@@ -575,9 +576,14 @@ def test_deepagent_toml_and_cli_precedence(
 ):
     config_path = tmp_path / "config.toml"
     config_path.write_text(
-        "[general]\n"
-        "enable_deepagent = true\n"
-        f'deepagent_workspace = "{tmp_path}"\n'
+        toml.dumps(
+            {
+                "general": {
+                    "enable_deepagent": True,
+                    "deepagent_workspace": str(tmp_path),
+                }
+            }
+        )
     )
     captured = {}
     monkeypatch.setattr(

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -87,6 +87,116 @@ def test_main_agent_query_answers_subagent_interrupt(monkeypatch):
     assert "Which calculator?" in capture.get()
 
 
+def test_main_agent_query_handles_deepagent_approval(monkeypatch):
+    approval = PendingInterrupt(
+        id="approval-id",
+        payload={
+            "action_requests": [
+                {"name": "execute", "args": {"command": "pytest -q"}}
+            ],
+            "review_configs": [
+                {
+                    "action_name": "execute",
+                    "allowed_decisions": ["approve", "reject"],
+                }
+            ],
+        },
+    )
+    session = _FakeMainSession([_turn_result(approval), _turn_result()])
+    monkeypatch.setattr(commands.Prompt, "ask", lambda *_args, **_kwargs: "approve")
+
+    with console.capture() as capture:
+        result = commands.run_main_agent_query(session, "run tests")
+
+    assert result.assistant_response == "turn complete"
+    assert session.calls == [
+        ("run", "run tests"),
+        ("resume", {"decisions": [{"type": "approve"}]}),
+    ]
+    assert "pytest -q" in capture.get()
+
+
+def test_experimental_backend_requires_confirmation_and_filters_environment(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+
+    class FakeBackend:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("deepagents.backends.LocalShellBackend", FakeBackend)
+    monkeypatch.setattr(commands.Confirm, "ask", lambda *_args, **_kwargs: True)
+    monkeypatch.setenv("PATH", "/test/bin")
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-leak")
+
+    backend = commands._create_experimental_deepagent_backend(str(tmp_path))
+
+    assert isinstance(backend, FakeBackend)
+    assert captured["root_dir"] == tmp_path.resolve()
+    assert captured["virtual_mode"] is True
+    assert captured["inherit_env"] is False
+    assert captured["env"]["PATH"] == "/test/bin"
+    assert "OPENAI_API_KEY" not in captured["env"]
+
+
+def test_experimental_backend_stops_when_confirmation_is_declined(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(commands.Confirm, "ask", lambda *_args, **_kwargs: False)
+
+    with pytest.raises(RuntimeError, match="was not approved"):
+        commands._create_experimental_deepagent_backend(str(tmp_path))
+
+
+def test_experimental_backend_rejects_missing_workspace(tmp_path):
+    with pytest.raises(ValueError, match="not a directory"):
+        commands._create_experimental_deepagent_backend(
+            str(tmp_path / "missing")
+        )
+
+
+def test_deepagent_approval_preserves_batched_action_order(monkeypatch):
+    answers = iter(["approve", "reject"])
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    payload = {
+        "action_requests": [
+            {"name": "write_file", "args": {"file_path": "/one"}},
+            {"name": "delete", "args": {"file_path": "/two"}},
+        ],
+        "review_configs": [
+            {
+                "action_name": "write_file",
+                "allowed_decisions": ["approve", "reject"],
+            },
+            {
+                "action_name": "delete",
+                "allowed_decisions": ["approve", "reject"],
+            },
+        ],
+    }
+
+    with console.capture():
+        response = commands._prompt_for_interrupt(payload)
+
+    assert response == {
+        "decisions": [{"type": "approve"}, {"type": "reject"}]
+    }
+
+
+def test_deepagent_cli_boolean_flags():
+    parser = cli_main.create_argument_parser()
+
+    assert parser.parse_args(["--deepagent"]).deepagent is True
+    assert parser.parse_args(["--no-deepagent"]).deepagent is False
+
+
 def test_main_agent_query_failure_suggests_retry():
     session = _FakeMainSession([RuntimeError("temporary")])
 
@@ -328,6 +438,58 @@ def test_interactive_slash_model_and_workflow_switches(monkeypatch):
     ]
 
 
+def test_interactive_deepagent_setting_survives_workflow_switches(monkeypatch):
+    answers = iter(
+        [
+            "first-model",
+            "main_agent",
+            "/workflow single_agent",
+            "/workflow main_agent",
+            "quit",
+        ]
+    )
+    agents = iter(
+        [
+            SimpleNamespace(),
+            SimpleNamespace(session_id="single"),
+            SimpleNamespace(),
+        ]
+    )
+    initialization_calls = []
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+
+    def fake_initialize(*_args, **kwargs):
+        initialization_calls.append(
+            (kwargs["enable_deepagent"], kwargs["deepagent_workspace"])
+        )
+        return next(agents)
+
+    monkeypatch.setattr(commands, "initialize_agent", fake_initialize)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda _agent: SimpleNamespace(thread_id="main", failed=False),
+    )
+
+    with console.capture():
+        commands.interactive_mode(
+            workflow="main_agent",
+            generate_report=False,
+            enable_deepagent=True,
+            deepagent_workspace="/workspace",
+        )
+
+    assert initialization_calls == [
+        (True, "/workspace"),
+        (False, None),
+        (True, "/workspace"),
+    ]
+
+
 def test_interactive_reports_invalid_slash_commands(monkeypatch):
     agent = SimpleNamespace()
     session = _FakeMainSession([])
@@ -370,6 +532,16 @@ def _run_args(**overrides):
         "workflow": "main_agent",
         "resume": None,
         "interactive": False,
+        "structured": False,
+        "output": "state",
+        "report": False,
+        "human_supervised": False,
+        "recursion_limit": 20,
+        "deepagent": None,
+        "deepagent_workspace": None,
+        "mcp_url": None,
+        "mcp_command": None,
+        "mcp_server_name": None,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -389,3 +561,40 @@ def test_main_agent_rejects_persistent_resume():
 
     assert exc_info.value.code == 2
     assert "--resume is not supported" in capture.get()
+
+
+@pytest.mark.parametrize(
+    ("cli_value", "expected"),
+    [(None, True), (False, False)],
+)
+def test_deepagent_toml_and_cli_precedence(
+    monkeypatch,
+    tmp_path,
+    cli_value,
+    expected,
+):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        "[general]\n"
+        "enable_deepagent = true\n"
+        f'deepagent_workspace = "{tmp_path}"\n'
+    )
+    captured = {}
+    monkeypatch.setattr(
+        cli_main,
+        "interactive_mode",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    cli_main._handle_run(
+        _run_args(
+            config=str(config_path),
+            interactive=True,
+            deepagent=cli_value,
+        )
+    )
+
+    assert captured["enable_deepagent"] is expected
+    assert captured["deepagent_workspace"] == (
+        str(tmp_path) if expected else None
+    )


### PR DESCRIPTION
## Summary

- Add an opt-in Deep Agent sibling to the `main_agent` supervisor for repository exploration, coding, file analysis, and test execution.
- Add an experimental interactive CLI path backed by `LocalShellBackend`, with explicit startup confirmation, filtered environment inheritance, and approve/reject review for shell commands and file mutations.
- Support injected Deep Agents backends for future isolated sandboxes, and document that production release requires a user-approved sandbox rather than the development host-shell backend.
- Add coverage for graph construction, nested delegation, structured interrupts, rejected mutations, CLI configuration precedence, and workflow switching.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check src tests`
- `git diff --check`
- `PYTHONNOUSERSITE=1 PYTHONPATH=src pytest -q tests/test_main_agent.py tests/test_main_agent_cli.py tests/test_graphs.py tests/test_graph_constructors.py tests/test_codex_model.py` (94 passed)

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change
- [x] Tracked source and tests pass Ruff checks
- [ ] `pytest tests/ -k "not tblite"` passes without environment-related exclusions
- [x] Added/updated tests for the change
- [x] Updated documentation for the user-facing CLI and sandbox requirements
