### PR TITLE
Add durable main-agent threads

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,8 @@ human_supervised = false
 # Development-only: add a workspace Deep Agent to interactive main_agent.
 enable_deepagent = false
 # deepagent_workspace = "."
+# Durable main-agent checkpoint database.
+# checkpoint_db = "~/.chemgraph/checkpoints.db"
 verbose = false
 
 [logging]

--- a/docs/codex_subscription.md
+++ b/docs/codex_subscription.md
@@ -79,8 +79,9 @@ agent = ChemGraph(
 ## Current limitations
 
 - Only the `single_agent` and `main_agent` workflows are supported.
-- `main_agent` sessions are process-local and must be run in interactive mode;
-  durable `--resume` support is not yet available.
+- `main_agent` must be run in interactive mode. Its supervisor checkpoint is
+  durable and can be restored with `--resume` or `/resume`; individual Codex
+  model calls still start fresh read-only Codex threads.
 - The integration is experimental and pins `openai-codex==0.144.4` together
   with that SDK's bundled Codex runtime.
 - ChemGraph starts ephemeral, read-only Codex threads. ChemGraph's LangGraph

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -31,6 +31,8 @@ human_supervised = false
 # Development-only workspace subagent for interactive main_agent sessions.
 enable_deepagent = false
 # deepagent_workspace = "."
+# Durable main-agent checkpoint database
+# checkpoint_db = "~/.chemgraph/checkpoints.db"
 # Enable verbose output
 verbose = false
 
@@ -293,6 +295,7 @@ chemgraph [OPTIONS] -q "YOUR_QUERY"
 | `--report`          | `-r`  | Generate detailed report                             | `False`        |
 | `--deepagent`       |       | Enable the experimental `main_agent` workspace worker | `False`       |
 | `--deepagent-workspace` |   | Root used by the experimental workspace worker       | Current directory |
+| `--checkpoint-db`    |       | SQLite checkpoints for durable `main_agent` threads | `~/.chemgraph/checkpoints.db` |
 | `--resume`          |       | Resume from a previous session ID (prefix supported) |                |
 | `--list-sessions`   |       | List recent sessions from the memory database        |                |
 | `--show-session`    |       | Show conversation for a session (prefix supported)   |                |
@@ -385,13 +388,19 @@ To test the long-lived supervisor, select `main_agent` explicitly:
 chemgraph --interactive -w main_agent
 ```
 
-Each prompt runs as a normal turn on the same checkpointed, process-lifetime
-thread, and chemistry work is delegated through Deep Agents' `task` middleware
-tool. A nested chemistry worker can still pause to request input. Quitting or
-switching the model or workflow discards the process-local thread; durable
-`--resume` support for `main_agent` is not yet available. If a model or graph
-operation fails transiently, enter `/retry` to resume its checkpoint without
-adding the previous user message a second time.
+Each prompt runs on one durable thread, and chemistry work is delegated through
+Deep Agents' `task` middleware tool. The CLI stores exact graph state in
+`~/.chemgraph/checkpoints.db` and readable transcripts in
+`~/.chemgraph/sessions.db`. Quitting or switching model/workflow leaves the old
+thread available for exact recovery:
+
+```bash
+chemgraph --interactive -w main_agent --resume <session-id>
+```
+
+Use `/resume <session-id>` to switch threads inside the REPL. Pending
+clarifications and approvals are presented immediately. Use `/retry` after a
+recoverable failure; the original user message is not added again.
 
 #### Experimental workspace Deep Agent
 
@@ -437,7 +446,7 @@ policies. The experimental local backend is not a production sandbox.
 
 **Interactive Features:**
 - **Persistent conversation**: Maintain context across queries
-- **Session memory**: Standard workflows are saved to a local SQLite database (`~/.chemgraph/sessions.db`) and can be resumed later; `main_agent` is process-local in this first version
+- **Session memory**: Standard workflows use summary-injection resume; `main_agent` additionally uses durable LangGraph checkpoints for exact recovery
 - **Model switching**: Change models mid-conversation
 - **Workflow switching**: Switch between different agent types
 - **Built-in commands**: Help, clear, config, session management, etc.
@@ -500,6 +509,9 @@ chemgraph --show-session a3b2
 ```bash
 # Injects previous conversation context into the new query
 chemgraph -q "Now optimize the geometry at 500K" --resume a3b2
+
+# Restore exact main-agent state, including pending interrupts
+chemgraph --interactive -w main_agent --resume a3b2
 ```
 
 **Delete a Session:**
@@ -508,6 +520,50 @@ chemgraph --delete-session a3b2c1d4
 ```
 
 Session IDs support prefix matching -- you only need to type enough characters to uniquely identify the session.
+
+Main-agent checkpoints and full tool transcripts can contain sensitive prompts,
+arguments, and outputs. They are unencrypted; ChemGraph restricts local file
+permissions where the platform supports POSIX modes. SQLite is intended for
+local use. Python deployments should inject an async production saver such as
+`AsyncPostgresSaver` and retain ownership of its lifecycle.
+
+When injecting `AsyncSqliteSaver`, create, invoke, inspect, and close it on the
+same event loop and pass it through `ChemGraph(..., checkpointer=saver)`. Exact
+restore also requires recreating custom tools, prompts, credentials, MCP
+bindings, and sandbox backends with the same graph topology.
+
+```python
+import aiosqlite
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.agent.main_session import MainAgentSession
+
+
+async def run_durable_thread():
+    async with aiosqlite.connect("checkpoints.db") as connection:
+        saver = AsyncSqliteSaver(
+            connection,
+            serde=JsonPlusSerializer(
+                pickle_fallback=False,
+                allowed_msgpack_modules=None,
+            ),
+        )
+        await saver.setup()
+        agent = ChemGraph(workflow_type="main_agent", checkpointer=saver)
+        session = MainAgentSession(
+            agent.workflow,
+            thread_id="your-stable-thread-id",
+            session_store=agent.session_store,
+            session_metadata=agent.main_agent_metadata,
+        )
+        await session.run("Optimize a water molecule")
+```
+
+The CLI recreates its local-shell Deep Agent only after showing the host-access
+warning and receiving fresh approval. Python callers must recreate their own
+injected sandbox backend before restoring a thread.
 
 #### Configuration File Support
 

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -402,6 +402,14 @@ Use `/resume <session-id>` to switch threads inside the REPL. Pending
 clarifications and approvals are presented immediately. Use `/retry` after a
 recoverable failure; the original user message is not added again.
 
+The checkpoint database is authoritative. The sessions database is a
+best-effort readable projection: a projection write failure is logged but does
+not change a completed graph result. Checkpoint serialization remains strict
+and does not use pickle, so unsupported objects in graph state still fail the
+authoritative graph operation. When a retry follows a different branch, the
+readable transcript is replaced with the branch represented by the latest
+checkpoint.
+
 #### Experimental workspace Deep Agent
 
 For development and testing, `main_agent` can register an additional
@@ -526,6 +534,10 @@ arguments, and outputs. They are unencrypted; ChemGraph restricts local file
 permissions where the platform supports POSIX modes. SQLite is intended for
 local use. Python deployments should inject an async production saver such as
 `AsyncPostgresSaver` and retain ownership of its lifecycle.
+
+Without an injected saver, Python `main_agent` sessions use process-local
+memory checkpoints. Their readable records can be reviewed and deleted, but
+they cannot be restored after the process that owns the checkpointer exits.
 
 When injecting `AsyncSqliteSaver`, create, invoke, inspect, and close it on the
 same event loop and pass it through `ChemGraph(..., checkpointer=saver)`. Exact

--- a/docs/streamlit_web_interface.md
+++ b/docs/streamlit_web_interface.md
@@ -54,7 +54,7 @@ API keys entered in the UI are applied as process environment variables for the 
 
 ## Sessions
 
-The main sidebar lists recent saved sessions. Loading a session rebuilds the visible conversation history from `~/.chemgraph/sessions.db`; deleting a session removes it from that database. A new chat clears the visible conversation and starts a new saved session on the next successful exchange.
+The main sidebar lists recent saved sessions. Loading a session rebuilds the visible conversation history from `~/.chemgraph/sessions.db`; it does not restore a durable CLI `main_agent` graph. Deleting a durable local main-agent session removes its LangGraph checkpoints before removing its readable transcript. A new chat clears the visible conversation and starts a new saved session on the next successful exchange.
 
 The UI uses the active saved configuration for model, workflow, thread, report generation, and human-supervision settings. To change these settings, use the Configuration page, save the configuration, then click **Reload Config** or **Refresh Agents** on the main page.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "deepagents==0.7.5",
     "langgraph==1.2.9",
     "langgraph-checkpoint==4.1.1",
+    "langgraph-checkpoint-sqlite==3.1.1",
     "langgraph-prebuilt==1.1.0",
     "langgraph-sdk==0.4.2",
     "langchain==1.3.14",

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -1,13 +1,22 @@
 import asyncio
 import datetime
+import hashlib
+import json
 import os
+from pathlib import Path
 import time
 from typing import Any, Callable, Collection, List, Optional
 import uuid
 
 from chemgraph.agent.events import EventCallback, _AstreamEventCallback
 from chemgraph.memory.store import SessionStore
-from chemgraph.memory.schemas import SessionMessage
+from chemgraph import __version__
+from chemgraph.memory.schemas import (
+    MainAgentGraphConfig,
+    MainAgentSessionMetadata,
+    SessionMessage,
+)
+from chemgraph.memory.subagent_recorder import SubagentRunRecorder
 from chemgraph.models.openai import load_openai_model
 from chemgraph.models.alcf_endpoints import load_alcf_model
 from chemgraph.models.local_model import load_ollama_model
@@ -47,6 +56,7 @@ from chemgraph.prompt.multi_agent_prompt import (
 )
 from langgraph.types import Command
 from langgraph.errors import GraphInterrupt
+from langgraph.checkpoint.base import BaseCheckpointSaver
 
 from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.graphs.main_agent import construct_main_agent_graph
@@ -206,6 +216,7 @@ class ChemGraph:
         deepagent_backend: Any | None = None,
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
+        checkpointer: BaseCheckpointSaver | None = None,
     ):
         if enable_deepagent and workflow_type != "main_agent":
             raise ValueError(
@@ -213,6 +224,8 @@ class ChemGraph:
             )
         if deepagent_backend is not None and not enable_deepagent:
             raise ValueError("deepagent_backend requires enable_deepagent=True.")
+        if checkpointer is not None and workflow_type != "main_agent":
+            raise ValueError("checkpointer is supported only for the main_agent workflow.")
         if model_name.startswith("codex:") and workflow_type not in {
             "single_agent",
             "main_agent",
@@ -224,7 +237,9 @@ class ChemGraph:
         reasoning_effort = _resolve_reasoning_effort(model_name, reasoning_effort)
 
         # Always generate a unique identifier for this instance
-        self.uuid = str(uuid.uuid4())[:8]
+        self.uuid = (
+            str(uuid.uuid4()) if workflow_type == "main_agent" else str(uuid.uuid4())[:8]
+        )
 
         # Initialize log directory.  Explicit ``log_dir`` argument takes
         # precedence over the ``CHEMGRAPH_LOG_DIR`` environment variable,
@@ -360,6 +375,7 @@ class ChemGraph:
         self.terminal_tool_names = tuple(terminal_tool_names)
         self.enable_deepagent = enable_deepagent
         self.deepagent_backend = deepagent_backend
+        self.checkpointer = checkpointer
         self.on_event = on_event
 
         # Record whether the caller relied on the default system prompt before
@@ -412,6 +428,61 @@ class ChemGraph:
         else:
             self.support_structured_output = support_structured_output
 
+        tool_signatures = tuple(
+            sorted(
+                f"{getattr(tool, 'name', type(tool).__name__)}:"
+                f"{getattr(getattr(tool, 'args_schema', None), '__name__', '')}"
+                for tool in self.tools or []
+            )
+        )
+        workspace = getattr(self.deepagent_backend, "cwd", None)
+        topology_payload = {
+            "model_name": self.model_name,
+            "reasoning_effort": self.reasoning_effort,
+            "recursion_limit": self.recursion_limit,
+            "structured_output": self.structured_output,
+            "generate_report": self.generate_report,
+            "max_retries": self.max_retries,
+            "human_supervised": self.human_supervised,
+            "terminal_tool_names": self.terminal_tool_names,
+            "enable_deepagent": self.enable_deepagent,
+            "workspace": str(workspace) if workspace is not None else None,
+            "tool_signatures": tool_signatures,
+            "system_prompt": self.system_prompt,
+            "formatter_prompt": self.formatter_prompt,
+            "report_prompt": self.report_prompt,
+        }
+        topology_fingerprint = hashlib.sha256(
+            json.dumps(topology_payload, sort_keys=True, default=str).encode("utf-8")
+        ).hexdigest()
+        self.main_agent_metadata = MainAgentSessionMetadata(
+            graph_config=MainAgentGraphConfig(
+                model_name=self.model_name,
+                recursion_limit=self.recursion_limit,
+                reasoning_effort=self.reasoning_effort,
+                structured_output=self.structured_output,
+                generate_report=self.generate_report,
+                max_retries=self.max_retries,
+                human_supervised=self.human_supervised,
+                terminal_tool_names=self.terminal_tool_names,
+                enable_deepagent=self.enable_deepagent,
+                deepagent_workspace=(
+                    str(Path(workspace).resolve()) if workspace is not None else None
+                ),
+                subagent_names=(
+                    ("chemgraph", "deepagent")
+                    if self.enable_deepagent
+                    else ("chemgraph",)
+                ),
+                tool_signatures=tool_signatures,
+                package_version=__version__,
+                topology_fingerprint=topology_fingerprint,
+            ),
+            checkpoint_backend=(
+                type(checkpointer).__name__ if checkpointer is not None else "memory"
+            ),
+        )
+
         self.workflow_map = {
             "single_agent": {"constructor": construct_single_agent_graph},
             "main_agent": {"constructor": construct_main_agent_graph},
@@ -458,6 +529,12 @@ class ChemGraph:
                 enable_deepagent=self.enable_deepagent,
                 deepagent_backend=self.deepagent_backend,
                 deepagent_recursion_limit=self.recursion_limit,
+                checkpointer=self.checkpointer,
+                subagent_recorder=(
+                    SubagentRunRecorder(self.session_store)
+                    if self.session_store is not None
+                    else None
+                ),
             )
         elif self.workflow_type == "multi_agent":
             self.workflow = self.workflow_map[workflow_type]["constructor"](
@@ -545,7 +622,17 @@ class ChemGraph:
         list
             List of messages in the current state
         """
+        if type(getattr(self.workflow, "checkpointer", None)).__name__.startswith(
+            "Async"
+        ):
+            raise RuntimeError(
+                "This workflow uses an async checkpointer; use `await aget_state()` instead."
+            )
         return self.workflow.get_state(config).values
+
+    async def aget_state(self, config={"configurable": {"thread_id": "1"}}):
+        """Asynchronously return the current workflow state values."""
+        return (await self.workflow.aget_state(config)).values
 
     def write_state(
         self,

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -608,7 +608,7 @@ class ChemGraph:
         """Return an ASCII representation of the LangGraph workflow."""
         return self.workflow.get_graph().draw_ascii()
 
-    def get_state(self, config={"configurable": {"thread_id": "1"}}):
+    def get_state(self, config: dict | None = None):
         """Get the current state of the workflow.
 
         Parameters
@@ -622,16 +622,14 @@ class ChemGraph:
         list
             List of messages in the current state
         """
-        if type(getattr(self.workflow, "checkpointer", None)).__name__.startswith(
-            "Async"
-        ):
-            raise RuntimeError(
-                "This workflow uses an async checkpointer; use `await aget_state()` instead."
-            )
+        if config is None:
+            config = {"configurable": {"thread_id": "1"}}
         return self.workflow.get_state(config).values
 
-    async def aget_state(self, config={"configurable": {"thread_id": "1"}}):
+    async def aget_state(self, config: dict | None = None):
         """Asynchronously return the current workflow state values."""
+        if config is None:
+            config = {"configurable": {"thread_id": "1"}}
         return (await self.workflow.aget_state(config)).values
 
     def write_state(

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -13,9 +13,24 @@ from langgraph.types import Command
 
 from chemgraph.agent.turn import serialize_state
 from chemgraph.graphs.main_agent import latest_assistant_text
+from chemgraph.memory.schemas import MainAgentGraphConfig, MainAgentSessionMetadata
+from chemgraph.memory.serialization import serialize_messages
+from chemgraph.memory.store import SessionStore
 
 
-SessionStatus = Literal["completed", "waiting_for_user"]
+SessionStatus = Literal["completed", "waiting_for_user", "failed"]
+
+
+class MainAgentRestoreError(RuntimeError):
+    """Base error raised when a durable main-agent thread cannot be restored."""
+
+
+class MissingCheckpointError(MainAgentRestoreError):
+    """Raised when a stored session has no corresponding graph checkpoint."""
+
+
+class IncompatibleCheckpointError(MainAgentRestoreError):
+    """Raised when stored graph metadata is incompatible with the active graph."""
 
 
 @dataclass(frozen=True)
@@ -75,6 +90,8 @@ class MainAgentSession:
         *,
         thread_id: str | None = None,
         recursion_limit: int = 50,
+        session_store: SessionStore | None = None,
+        session_metadata: MainAgentSessionMetadata | None = None,
     ):
         if recursion_limit <= 0:
             raise ValueError("recursion_limit must be positive.")
@@ -86,6 +103,12 @@ class MainAgentSession:
         }
         self._failed = False
         self._pending: tuple[PendingInterrupt, ...] = ()
+        self.session_store = session_store
+        self.session_metadata = session_metadata
+        self._registered = False
+        if self.session_store is not None:
+            existing = self.session_store.get_session_metadata(self._thread_id)
+            self._registered = existing is not None
 
     @property
     def thread_id(self) -> str:
@@ -114,6 +137,7 @@ class MainAgentSession:
             )
         if not isinstance(message, str) or not message.strip():
             raise ValueError("The user message must be a non-empty string.")
+        self._ensure_registered(message)
         return await self._run({"messages": [HumanMessage(content=message)]})
 
     async def resume(
@@ -134,6 +158,44 @@ class MainAgentSession:
         if not self._failed:
             raise RuntimeError("The main-agent session has no failed operation to retry.")
         return await self._run(None)
+
+    async def restore(self) -> MainAgentTurnResult:
+        """Restore pending, failed, or idle state without adding a message."""
+        if self.session_store is not None:
+            stored = self.session_store.get_session_metadata(self.thread_id)
+            if stored is None:
+                raise MainAgentRestoreError(
+                    f"Session {self.thread_id!r} does not exist in the session store."
+                )
+            _, metadata = stored
+            if metadata is not None and self.session_metadata is not None:
+                stored_config = metadata.graph_config
+                active_config = self.session_metadata.graph_config
+                if stored_config.graph_schema_version != active_config.graph_schema_version:
+                    raise IncompatibleCheckpointError(
+                        "The stored graph schema is incompatible with this ChemGraph version."
+                    )
+                if (
+                    stored_config.topology_fingerprint
+                    and active_config.topology_fingerprint
+                    and stored_config.topology_fingerprint
+                    != active_config.topology_fingerprint
+                ):
+                    raise IncompatibleCheckpointError(
+                        "The active graph topology does not match the stored session."
+                    )
+
+        snapshot = await self.workflow.aget_state(self.config)
+        if not snapshot or not snapshot.created_at:
+            raise MissingCheckpointError(
+                f"No checkpoint exists for main-agent thread {self.thread_id!r}."
+            )
+        result = self._result_from_snapshot(snapshot)
+        self._pending = result.interrupts
+        self._failed = result.status == "failed"
+        self._registered = True
+        self._synchronize(snapshot.values, result.status)
+        return result
 
     def _resume_value(self, response: str | Mapping[str, Any]) -> Any:
         if isinstance(response, str):
@@ -159,12 +221,25 @@ class MainAgentSession:
         return {str(key): value for key, value in response.items()}
 
     async def _run(self, stream_input: Any) -> MainAgentTurnResult:
+        if self.session_store is not None:
+            self.session_store.update_session_status(self.thread_id, "running")
         try:
             result = await self._run_once(stream_input)
         except Exception:
             self._failed = True
+            try:
+                snapshot = await self.workflow.aget_state(self.config)
+                if snapshot and snapshot.values:
+                    self._synchronize(snapshot.values, "failed")
+                elif self.session_store is not None:
+                    self.session_store.update_session_status(self.thread_id, "failed")
+            except Exception:
+                if self.session_store is not None:
+                    self.session_store.update_session_status(self.thread_id, "failed")
             raise
         self._failed = False
+        snapshot = await self.workflow.aget_state(self.config)
+        self._synchronize(snapshot.values if snapshot else {}, result.status)
         return result
 
     async def _run_once(self, stream_input: Any) -> MainAgentTurnResult:
@@ -182,7 +257,7 @@ class MainAgentSession:
             raw_interrupts = exc.args[0] if exc.args else []
             found.extend(_pending_interrupts(raw_interrupts))
 
-        snapshot = self.workflow.get_state(self.config)
+        snapshot = await self.workflow.aget_state(self.config)
         state_values = snapshot.values if snapshot else (last_state or {})
         if snapshot:
             for task in snapshot.tasks:
@@ -200,9 +275,66 @@ class MainAgentSession:
             state=serialize_state(state_values),
         )
 
+    def _ensure_registered(self, message: str) -> None:
+        if self.session_store is None or self._registered:
+            return
+        metadata = self.session_metadata or MainAgentSessionMetadata(
+            graph_config=MainAgentGraphConfig(model_name="unknown")
+        )
+        self.session_store.create_session(
+            session_id=self.thread_id,
+            model_name=metadata.graph_config.model_name,
+            workflow_type="main_agent",
+            title=SessionStore.generate_title(message),
+            status="new",
+            session_metadata=metadata,
+        )
+        self._registered = True
+
+    def _synchronize(
+        self,
+        state: Any,
+        status: SessionStatus,
+    ) -> None:
+        if self.session_store is None or not self._registered:
+            return
+        values = state if isinstance(state, dict) else {}
+        raw_messages = values.get("messages", [])
+        self.session_store.synchronize_messages(
+            self.thread_id,
+            serialize_messages(list(raw_messages or [])),
+        )
+        self.session_store.update_session_status(self.thread_id, status)
+
+    def _result_from_snapshot(self, snapshot: Any) -> MainAgentTurnResult:
+        found = list(_pending_interrupts(getattr(snapshot, "interrupts", ())))
+        failed = bool(getattr(snapshot, "next", ()))
+        for task in snapshot.tasks:
+            found.extend(_pending_interrupts(getattr(task, "interrupts", ())))
+            failed = failed or bool(getattr(task, "error", None))
+        pending = _deduplicate_interrupts(found)
+        status: SessionStatus
+        if pending:
+            status = "waiting_for_user"
+        elif failed:
+            status = "failed"
+        else:
+            status = "completed"
+        values = snapshot.values or {}
+        return MainAgentTurnResult(
+            thread_id=self.thread_id,
+            status=status,
+            assistant_response=latest_assistant_text(list(values.get("messages", []) or [])),
+            interrupts=pending,
+            state=serialize_state(values),
+        )
+
 
 __all__ = [
     "MainAgentSession",
     "MainAgentTurnResult",
+    "MainAgentRestoreError",
+    "MissingCheckpointError",
+    "IncompatibleCheckpointError",
     "PendingInterrupt",
 ]

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -17,6 +18,8 @@ from chemgraph.memory.schemas import MainAgentGraphConfig, MainAgentSessionMetad
 from chemgraph.memory.serialization import serialize_messages
 from chemgraph.memory.store import SessionStore
 
+
+logger = logging.getLogger(__name__)
 
 SessionStatus = Literal["completed", "waiting_for_user", "failed"]
 
@@ -107,8 +110,16 @@ class MainAgentSession:
         self.session_metadata = session_metadata
         self._registered = False
         if self.session_store is not None:
-            existing = self.session_store.get_session_metadata(self._thread_id)
-            self._registered = existing is not None
+            try:
+                existing = self.session_store.get_session_metadata(self._thread_id)
+            except Exception:
+                logger.warning(
+                    "Could not inspect readable storage for main-agent thread %s.",
+                    self._thread_id,
+                    exc_info=True,
+                )
+            else:
+                self._registered = existing is not None
 
     @property
     def thread_id(self) -> str:
@@ -171,9 +182,13 @@ class MainAgentSession:
             if metadata is not None and self.session_metadata is not None:
                 stored_config = metadata.graph_config
                 active_config = self.session_metadata.graph_config
-                if stored_config.graph_schema_version != active_config.graph_schema_version:
+                if (
+                    stored_config.graph_schema_version
+                    != active_config.graph_schema_version
+                ):
                     raise IncompatibleCheckpointError(
-                        "The stored graph schema is incompatible with this ChemGraph version."
+                        "The stored graph schema is incompatible with this "
+                        "ChemGraph version."
                     )
                 if (
                     stored_config.topology_fingerprint
@@ -221,28 +236,31 @@ class MainAgentSession:
         return {str(key): value for key, value in response.items()}
 
     async def _run(self, stream_input: Any) -> MainAgentTurnResult:
-        if self.session_store is not None:
-            self.session_store.update_session_status(self.thread_id, "running")
+        self._update_status("running")
         try:
-            result = await self._run_once(stream_input)
+            result, state_values = await self._run_once(stream_input)
         except Exception:
             self._failed = True
             try:
                 snapshot = await self.workflow.aget_state(self.config)
-                if snapshot and snapshot.values:
-                    self._synchronize(snapshot.values, "failed")
-                elif self.session_store is not None:
-                    self.session_store.update_session_status(self.thread_id, "failed")
             except Exception:
-                if self.session_store is not None:
-                    self.session_store.update_session_status(self.thread_id, "failed")
+                snapshot = None
+                logger.debug(
+                    "Could not inspect checkpoint after main-agent failure.",
+                    exc_info=True,
+                )
+            if snapshot and snapshot.values:
+                self._synchronize(snapshot.values, "failed")
+            else:
+                self._update_status("failed")
             raise
         self._failed = False
-        snapshot = await self.workflow.aget_state(self.config)
-        self._synchronize(snapshot.values if snapshot else {}, result.status)
+        self._synchronize(state_values, result.status)
         return result
 
-    async def _run_once(self, stream_input: Any) -> MainAgentTurnResult:
+    async def _run_once(
+        self, stream_input: Any
+    ) -> tuple[MainAgentTurnResult, dict[str, Any]]:
         last_state: dict[str, Any] | None = None
         found: list[PendingInterrupt] = []
         try:
@@ -265,7 +283,7 @@ class MainAgentSession:
 
         pending = _deduplicate_interrupts(found)
         self._pending = pending
-        return MainAgentTurnResult(
+        result = MainAgentTurnResult(
             thread_id=self.thread_id,
             status="waiting_for_user" if pending else "completed",
             assistant_response=latest_assistant_text(
@@ -274,6 +292,7 @@ class MainAgentSession:
             interrupts=pending,
             state=serialize_state(state_values),
         )
+        return result, state_values
 
     def _ensure_registered(self, message: str) -> None:
         if self.session_store is None or self._registered:
@@ -281,15 +300,29 @@ class MainAgentSession:
         metadata = self.session_metadata or MainAgentSessionMetadata(
             graph_config=MainAgentGraphConfig(model_name="unknown")
         )
-        self.session_store.create_session(
-            session_id=self.thread_id,
-            model_name=metadata.graph_config.model_name,
-            workflow_type="main_agent",
-            title=SessionStore.generate_title(message),
-            status="new",
-            session_metadata=metadata,
-        )
-        self._registered = True
+        try:
+            self.session_store.create_session(
+                session_id=self.thread_id,
+                model_name=metadata.graph_config.model_name,
+                workflow_type="main_agent",
+                title=SessionStore.generate_title(message),
+                status="new",
+                session_metadata=metadata,
+            )
+        except Exception:
+            logger.warning(
+                "Could not register readable storage for main-agent thread %s.",
+                self.thread_id,
+                exc_info=True,
+            )
+            try:
+                self._registered = (
+                    self.session_store.get_session_metadata(self.thread_id) is not None
+                )
+            except Exception:
+                pass
+        else:
+            self._registered = True
 
     def _synchronize(
         self,
@@ -300,11 +333,31 @@ class MainAgentSession:
             return
         values = state if isinstance(state, dict) else {}
         raw_messages = values.get("messages", [])
-        self.session_store.synchronize_messages(
-            self.thread_id,
-            serialize_messages(list(raw_messages or [])),
-        )
-        self.session_store.update_session_status(self.thread_id, status)
+        try:
+            self.session_store.synchronize_messages(
+                self.thread_id,
+                serialize_messages(list(raw_messages or [])),
+            )
+        except Exception:
+            logger.warning(
+                "Could not synchronize the readable transcript for main-agent "
+                "thread %s.",
+                self.thread_id,
+                exc_info=True,
+            )
+        self._update_status(status)
+
+    def _update_status(self, status: str) -> None:
+        if self.session_store is None or not self._registered:
+            return
+        try:
+            self.session_store.update_session_status(self.thread_id, status)
+        except Exception:
+            logger.warning(
+                "Could not update readable status for main-agent thread %s.",
+                self.thread_id,
+                exc_info=True,
+            )
 
     def _result_from_snapshot(self, snapshot: Any) -> MainAgentTurnResult:
         found = list(_pending_interrupts(getattr(snapshot, "interrupts", ())))

--- a/src/chemgraph/cli/checkpoint_runtime.py
+++ b/src/chemgraph/cli/checkpoint_runtime.py
@@ -1,0 +1,108 @@
+"""Single-loop ownership for asynchronous local LangGraph checkpointers."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+
+DEFAULT_CHECKPOINT_DB = str(Path.home() / ".chemgraph" / "checkpoints.db")
+
+
+class CheckpointRuntime:
+    """Own one background event loop and its async SQLite connections."""
+
+    def __init__(self):
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+        self._savers: dict[str, Any] = {}
+        self._connections: dict[str, Any] = {}
+        self._closed = False
+
+    def _run_loop(self) -> None:
+        asyncio.set_event_loop(self._loop)
+        self._loop.run_forever()
+
+    def run(self, operation: Callable[[], Any]) -> Any:
+        """Execute one awaitable-producing callable on the owner loop."""
+        if self._closed:
+            raise RuntimeError("Checkpoint runtime is closed.")
+
+        async def invoke():
+            return await operation()
+
+        return asyncio.run_coroutine_threadsafe(invoke(), self._loop).result()
+
+    def open_sqlite(self, db_path: str | None = None):
+        """Open or reuse a strict ``AsyncSqliteSaver`` on the owner loop."""
+        path = os.path.abspath(os.path.expanduser(db_path or DEFAULT_CHECKPOINT_DB))
+        if path in self._savers:
+            return self._savers[path]
+
+        async def open_saver():
+            import aiosqlite
+            from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+            parent = os.path.dirname(path) or os.curdir
+            parent_existed = os.path.exists(parent)
+            os.makedirs(parent, mode=0o700, exist_ok=True)
+            default_parent = os.path.dirname(os.path.abspath(DEFAULT_CHECKPOINT_DB))
+            if os.name == "posix" and (
+                not parent_existed or parent == default_parent
+            ):
+                os.chmod(parent, 0o700)
+            connection = await aiosqlite.connect(path)
+            saver = AsyncSqliteSaver(
+                connection,
+                serde=JsonPlusSerializer(
+                    pickle_fallback=False,
+                    allowed_msgpack_modules=None,
+                ),
+            )
+            await saver.setup()
+            if os.name == "posix":
+                os.chmod(path, 0o600)
+                for suffix in ("-wal", "-shm"):
+                    companion = path + suffix
+                    if os.path.exists(companion):
+                        os.chmod(companion, 0o600)
+            self._connections[path] = connection
+            self._savers[path] = saver
+            return saver
+
+        return asyncio.run_coroutine_threadsafe(open_saver(), self._loop).result()
+
+    def delete_thread(self, saver: Any, thread_id: str) -> None:
+        """Delete every checkpoint namespace belonging to a root thread."""
+        self.run(lambda: saver.adelete_thread(thread_id))
+
+    def close(self) -> None:
+        """Close saver connections and stop the owner loop."""
+        if self._closed:
+            return
+
+        async def close_connections():
+            for connection in self._connections.values():
+                await connection.close()
+
+        asyncio.run_coroutine_threadsafe(close_connections(), self._loop).result()
+        self._closed = True
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        self._thread.join(timeout=5)
+        self._loop.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info):
+        self.close()
+
+
+__all__ = ["CheckpointRuntime", "DEFAULT_CHECKPOINT_DB"]

--- a/src/chemgraph/cli/checkpoint_runtime.py
+++ b/src/chemgraph/cli/checkpoint_runtime.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import threading
+import time
 from collections.abc import Callable
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +16,9 @@ from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 
 
 DEFAULT_CHECKPOINT_DB = str(Path.home() / ".chemgraph" / "checkpoints.db")
+_CLOSE_TIMEOUT_SECONDS = 5.0
+
+logger = logging.getLogger(__name__)
 
 
 class CheckpointRuntime:
@@ -21,35 +27,61 @@ class CheckpointRuntime:
     def __init__(self):
         self._loop = asyncio.new_event_loop()
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
-        self._thread.start()
         self._savers: dict[str, Any] = {}
         self._connections: dict[str, Any] = {}
         self._closed = False
+        self._lifecycle_lock = threading.Lock()
+        self._thread.start()
 
     def _run_loop(self) -> None:
         asyncio.set_event_loop(self._loop)
-        self._loop.run_forever()
+        try:
+            self._loop.run_forever()
+        finally:
+            pending = asyncio.all_tasks(self._loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                self._loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            self._loop.close()
+
+    @staticmethod
+    def _normalize_path(db_path: str | None = None) -> str:
+        return os.path.abspath(os.path.expanduser(db_path or DEFAULT_CHECKPOINT_DB))
 
     def run(self, operation: Callable[[], Any]) -> Any:
         """Execute one awaitable-producing callable on the owner loop."""
-        if self._closed:
-            raise RuntimeError("Checkpoint runtime is closed.")
-
         async def invoke():
             return await operation()
 
-        return asyncio.run_coroutine_threadsafe(invoke(), self._loop).result()
+        coroutine = invoke()
+        with self._lifecycle_lock:
+            if self._closed:
+                coroutine.close()
+                raise RuntimeError("Checkpoint runtime is closed.")
+            try:
+                future = asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+            except Exception:
+                coroutine.close()
+                raise
+        try:
+            return future.result()
+        except BaseException:
+            future.cancel()
+            raise
 
     def open_sqlite(self, db_path: str | None = None):
         """Open or reuse a strict ``AsyncSqliteSaver`` on the owner loop."""
-        path = os.path.abspath(os.path.expanduser(db_path or DEFAULT_CHECKPOINT_DB))
-        if path in self._savers:
-            return self._savers[path]
+        path = self._normalize_path(db_path)
 
         async def open_saver():
             import aiosqlite
             from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
+            if path in self._savers:
+                return self._savers[path]
             parent = os.path.dirname(path) or os.curdir
             parent_existed = os.path.exists(parent)
             os.makedirs(parent, mode=0o700, exist_ok=True)
@@ -59,14 +91,18 @@ class CheckpointRuntime:
             ):
                 os.chmod(parent, 0o700)
             connection = await aiosqlite.connect(path)
-            saver = AsyncSqliteSaver(
-                connection,
-                serde=JsonPlusSerializer(
-                    pickle_fallback=False,
-                    allowed_msgpack_modules=None,
-                ),
-            )
-            await saver.setup()
+            try:
+                saver = AsyncSqliteSaver(
+                    connection,
+                    serde=JsonPlusSerializer(
+                        pickle_fallback=False,
+                        allowed_msgpack_modules=None,
+                    ),
+                )
+                await saver.setup()
+            except Exception:
+                await connection.close()
+                raise
             if os.name == "posix":
                 os.chmod(path, 0o600)
                 for suffix in ("-wal", "-shm"):
@@ -77,7 +113,20 @@ class CheckpointRuntime:
             self._savers[path] = saver
             return saver
 
-        return asyncio.run_coroutine_threadsafe(open_saver(), self._loop).result()
+        return self.run(open_saver)
+
+    def close_sqlite(self, db_path: str | None = None) -> None:
+        """Close and forget one cached SQLite saver connection."""
+        path = self._normalize_path(db_path)
+
+        async def close_saver():
+            connection = self._connections.get(path)
+            if connection is not None:
+                await connection.close()
+            self._connections.pop(path, None)
+            self._savers.pop(path, None)
+
+        self.run(close_saver)
 
     def delete_thread(self, saver: Any, thread_id: str) -> None:
         """Delete every checkpoint namespace belonging to a root thread."""
@@ -85,18 +134,54 @@ class CheckpointRuntime:
 
     def close(self) -> None:
         """Close saver connections and stop the owner loop."""
-        if self._closed:
+        with self._lifecycle_lock:
+            if self._closed:
+                return
+            self._closed = True
+
+        async def shutdown():
+            for path, connection in list(self._connections.items()):
+                try:
+                    await connection.close()
+                except Exception:
+                    logger.warning(
+                        "Could not close checkpoint database %s", path, exc_info=True
+                    )
+            self._connections.clear()
+            self._savers.clear()
+            self._loop.call_soon(self._loop.stop)
+
+        if threading.current_thread() is self._thread:
+            self._loop.create_task(shutdown())
             return
 
-        async def close_connections():
-            for connection in self._connections.values():
-                await connection.close()
+        deadline = time.monotonic() + _CLOSE_TIMEOUT_SECONDS
+        coroutine = shutdown()
+        try:
+            future = asyncio.run_coroutine_threadsafe(coroutine, self._loop)
+        except RuntimeError:
+            coroutine.close()
+            logger.warning("Checkpoint event loop stopped before shutdown completed.")
+            return
+        try:
+            future.result(timeout=_CLOSE_TIMEOUT_SECONDS)
+        except FutureTimeoutError:
+            logger.warning(
+                "Checkpoint shutdown is still pending after %.1f seconds; "
+                "the daemon owner thread will finish it in the background.",
+                _CLOSE_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.warning("Checkpoint shutdown failed.", exc_info=True)
+            try:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+            except RuntimeError:
+                pass
 
-        asyncio.run_coroutine_threadsafe(close_connections(), self._loop).result()
-        self._closed = True
-        self._loop.call_soon_threadsafe(self._loop.stop)
-        self._thread.join(timeout=5)
-        self._loop.close()
+        remaining = max(0.0, deadline - time.monotonic())
+        self._thread.join(timeout=remaining)
+        if self._thread.is_alive():
+            logger.warning("Checkpoint owner thread is still running after shutdown.")
 
     def __enter__(self):
         return self

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -25,6 +25,7 @@ from chemgraph.cli.checkpoint_runtime import (
     CheckpointRuntime,
 )
 from chemgraph.models.supported_models import (
+    MODELS_WITH_REASONING_EFFORT,
     supported_alcf_models,
     supported_anthropic_models,
     supported_gemini_models,
@@ -958,12 +959,11 @@ def delete_session_cmd(session_id: str, db_path: Optional[str] = None) -> None:
         deleted = delete_durable_session(store, session_id)
     except Exception as exc:
         console.print(
-            "[red]Checkpoint deletion failed; the session record was kept: "
-            f"{escape(str(exc))}[/red]"
+            f"[red]Could not fully delete the session: {escape(str(exc))}[/red]"
         )
         return
     if deleted:
-        console.print("[green]Session and checkpoints deleted.[/green]")
+        console.print("[green]Session deleted.[/green]")
     else:
         console.print("[red]Failed to delete session.[/red]")
 
@@ -1112,14 +1112,35 @@ def interactive_mode(
     checkpoint_saver = None
     restored_thread_id: str | None = None
     stored_graph_config = None
+    reasoning_effort: str | None = None
+    max_retries = 1
+    terminal_tool_names: tuple[str, ...] = ()
     if resume_session:
         resolved = SessionStore().get_session_metadata(resume_session)
-        if resolved is None or resolved[1] is None:
+        if resolved is None:
             console.print(
                 f"[red]Durable main-agent session '{resume_session}' was not found.[/red]"
             )
             return
+        if resolved[1] is None:
+            console.print(
+                f"[red]Session '{resume_session}' exists but is not a durable "
+                "main-agent thread.[/red]"
+            )
+            return
         restored_thread_id, stored_metadata = resolved
+        if stored_metadata.checkpoint_backend == "memory":
+            console.print(
+                f"[red]Session '{resume_session}' used a process-local checkpoint "
+                "and cannot be restored after its owner process exits.[/red]"
+            )
+            return
+        if stored_metadata.checkpoint_backend not in {None, "AsyncSqliteSaver"}:
+            console.print(
+                f"[red]Session '{resume_session}' uses a caller-owned external "
+                "checkpointer and cannot be restored by the CLI.[/red]"
+            )
+            return
         stored_graph_config = stored_metadata.graph_config
         model = stored_graph_config.model_name
         workflow = "main_agent"
@@ -1129,6 +1150,9 @@ def interactive_mode(
         human_supervised = stored_graph_config.human_supervised
         enable_deepagent = stored_graph_config.enable_deepagent
         deepagent_workspace = stored_graph_config.deepagent_workspace
+        reasoning_effort = stored_graph_config.reasoning_effort
+        max_retries = stored_graph_config.max_retries
+        terminal_tool_names = stored_graph_config.terminal_tool_names
         checkpoint_db = stored_metadata.checkpoint_db or checkpoint_db
     else:
         # Allow the user to override model/workflow at startup.
@@ -1172,13 +1196,9 @@ def interactive_mode(
             else None
         ),
         checkpointer=checkpoint_saver,
-        reasoning_effort=(
-            stored_graph_config.reasoning_effort if stored_graph_config else None
-        ),
-        max_retries=(stored_graph_config.max_retries if stored_graph_config else 1),
-        terminal_tool_names=(
-            stored_graph_config.terminal_tool_names if stored_graph_config else ()
-        ),
+        reasoning_effort=reasoning_effort,
+        max_retries=max_retries,
+        terminal_tool_names=terminal_tool_names,
     )
     if not agent:
         if checkpoint_runtime is not None:
@@ -1320,14 +1340,38 @@ Example queries:
                     console.print("[red]Usage: /resume <session_id>[/red]")
                     continue
                 target = SessionStore().get_session_metadata(argument)
+                if target is None and main_session is not None:
+                    console.print(f"[red]Session '{argument}' was not found.[/red]")
+                    continue
                 if target is not None and target[1] is not None:
                     target_id, target_metadata = target
+                    if target_metadata.checkpoint_backend == "memory":
+                        console.print(
+                            "[red]The selected session used a process-local "
+                            "checkpoint and is no longer restorable.[/red]"
+                        )
+                        continue
+                    if target_metadata.checkpoint_backend not in {
+                        None,
+                        "AsyncSqliteSaver",
+                    }:
+                        console.print(
+                            "[red]The selected session uses a caller-owned external "
+                            "checkpointer and cannot be restored by the CLI.[/red]"
+                        )
+                        continue
                     target_config = target_metadata.graph_config
+                    candidate_db = (
+                        target_metadata.checkpoint_db or DEFAULT_CHECKPOINT_DB
+                    )
+                    previous_db = (
+                        checkpoint_db or DEFAULT_CHECKPOINT_DB
+                        if checkpoint_runtime is not None
+                        else None
+                    )
                     candidate_runtime = checkpoint_runtime or CheckpointRuntime()
                     try:
-                        candidate_saver = candidate_runtime.open_sqlite(
-                            target_metadata.checkpoint_db or DEFAULT_CHECKPOINT_DB
-                        )
+                        candidate_saver = candidate_runtime.open_sqlite(candidate_db)
                         candidate_agent = initialize_agent(
                             target_config.model_name,
                             "main_agent",
@@ -1352,9 +1396,7 @@ Example queries:
                         candidate_session = create_main_agent_session(
                             candidate_agent,
                             thread_id=target_id,
-                            checkpoint_db=(
-                                target_metadata.checkpoint_db or DEFAULT_CHECKPOINT_DB
-                            ),
+                            checkpoint_db=candidate_db,
                         )
                         restored = restore_main_agent_session(
                             candidate_session,
@@ -1365,6 +1407,15 @@ Example queries:
                     except Exception as exc:
                         if checkpoint_runtime is None:
                             candidate_runtime.close()
+                        elif (
+                            previous_db is not None
+                            and os.path.abspath(os.path.expanduser(candidate_db))
+                            != os.path.abspath(os.path.expanduser(previous_db))
+                        ):
+                            try:
+                                candidate_runtime.close_sqlite(candidate_db)
+                            except Exception:
+                                pass
                         console.print(f"[red]Could not restore session: {exc}[/red]")
                         continue
                     checkpoint_runtime = candidate_runtime
@@ -1373,9 +1424,28 @@ Example queries:
                     main_session = candidate_session
                     model = target_config.model_name
                     workflow = "main_agent"
-                    checkpoint_db = target_metadata.checkpoint_db
+                    checkpoint_db = candidate_db
+                    structured = target_config.structured_output
+                    generate_report = target_config.generate_report
+                    human_supervised = target_config.human_supervised
+                    recursion_limit = target_config.recursion_limit
+                    reasoning_effort = target_config.reasoning_effort
+                    max_retries = target_config.max_retries
+                    terminal_tool_names = target_config.terminal_tool_names
                     enable_deepagent = target_config.enable_deepagent
                     deepagent_workspace = target_config.deepagent_workspace
+                    if (
+                        previous_db is not None
+                        and os.path.abspath(os.path.expanduser(previous_db))
+                        != os.path.abspath(os.path.expanduser(candidate_db))
+                    ):
+                        try:
+                            checkpoint_runtime.close_sqlite(previous_db)
+                        except Exception as exc:
+                            console.print(
+                                "[yellow]Could not release the previous checkpoint "
+                                f"database: {escape(str(exc))}[/yellow]"
+                            )
                     if restored.status == "failed":
                         console.print(
                             "[yellow]The restored operation can be continued with "
@@ -1429,6 +1499,11 @@ Example queries:
                     console.print("[red]Usage: /model <name>[/red]")
                     continue
                 new_model = argument
+                new_reasoning_effort = (
+                    reasoning_effort
+                    if new_model in MODELS_WITH_REASONING_EFFORT
+                    else None
+                )
                 new_agent = initialize_agent(
                     new_model,
                     workflow,
@@ -1447,9 +1522,18 @@ Example queries:
                         else None
                     ),
                     checkpointer=(checkpoint_saver if workflow == "main_agent" else None),
+                    reasoning_effort=new_reasoning_effort,
+                    max_retries=max_retries,
+                    terminal_tool_names=terminal_tool_names,
                 )
                 if new_agent:
+                    if reasoning_effort is not None and new_reasoning_effort is None:
+                        console.print(
+                            "[yellow]Reasoning effort was reset because the new "
+                            "model does not support it.[/yellow]"
+                        )
                     model = new_model
+                    reasoning_effort = new_reasoning_effort
                     agent = new_agent
                     main_session = (
                         create_main_agent_session(
@@ -1494,6 +1578,9 @@ Example queries:
                         checkpointer=(
                             checkpoint_saver if new_workflow == "main_agent" else None
                         ),
+                        reasoning_effort=reasoning_effort,
+                        max_retries=max_retries,
+                        terminal_tool_names=terminal_tool_names,
                     )
                     if new_agent:
                         workflow = new_workflow
@@ -1540,6 +1627,11 @@ Example queries:
                 elif hasattr(agent, "session_id") and agent.session_id:
                     console.print(f"[dim]Session: {agent.session_id}[/dim]")
 
+        except EOFError:
+            console.print("\n[yellow]Goodbye![/yellow]")
+            if checkpoint_runtime is not None:
+                checkpoint_runtime.close()
+            break
         except KeyboardInterrupt:
             console.print(
                 "\n[yellow]Interrupted. Type '/quit' to exit.[/yellow]"

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -19,6 +19,11 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from chemgraph.memory.store import SessionStore
+from chemgraph.memory.durable import delete_durable_session
+from chemgraph.cli.checkpoint_runtime import (
+    DEFAULT_CHECKPOINT_DB,
+    CheckpointRuntime,
+)
 from chemgraph.models.supported_models import (
     supported_alcf_models,
     supported_anthropic_models,
@@ -234,6 +239,10 @@ def initialize_agent(
     on_event: Optional[Any] = None,
     enable_deepagent: bool = False,
     deepagent_workspace: str | None = None,
+    checkpointer: Any | None = None,
+    reasoning_effort: str | None = None,
+    max_retries: int = 1,
+    terminal_tool_names: tuple[str, ...] = (),
 ) -> Any:
     """Initialize a ChemGraph agent with progress indication.
 
@@ -362,6 +371,10 @@ def initialize_agent(
                 on_event=on_event,
                 enable_deepagent=enable_deepagent,
                 deepagent_backend=deepagent_backend,
+                checkpointer=checkpointer,
+                reasoning_effort=reasoning_effort,
+                max_retries=max_retries,
+                terminal_tool_names=terminal_tool_names,
             )
 
         try:
@@ -571,14 +584,25 @@ def run_query(
     return None
 
 
-def create_main_agent_session(agent: Any):
+def create_main_agent_session(
+    agent: Any,
+    *,
+    thread_id: str | None = None,
+    checkpoint_db: str | None = None,
+):
     """Create the CLI session driver for a constructed main-agent workflow."""
     from chemgraph.agent.main_session import MainAgentSession
 
+    metadata = agent.main_agent_metadata.model_copy(deep=True)
+    if checkpoint_db is not None:
+        metadata.checkpoint_backend = "AsyncSqliteSaver"
+        metadata.checkpoint_db = os.path.abspath(os.path.expanduser(checkpoint_db))
     return MainAgentSession(
         agent.workflow,
-        thread_id=agent.session_id,
+        thread_id=thread_id or agent.session_id,
         recursion_limit=agent.recursion_limit,
+        session_store=agent.session_store,
+        session_metadata=metadata,
     )
 
 
@@ -664,6 +688,7 @@ def _run_main_agent_operation(
     operation: Any,
     *,
     progress_description: str,
+    checkpoint_runtime: CheckpointRuntime | None = None,
 ) -> Any:
     """Run one session operation and resolve nested-graph interrupts."""
     try:
@@ -674,7 +699,11 @@ def _run_main_agent_operation(
             transient=True,
         ) as progress:
             progress.add_task(progress_description, total=None)
-            result = run_async_callable(operation)
+            result = (
+                checkpoint_runtime.run(operation)
+                if checkpoint_runtime is not None
+                else run_async_callable(operation)
+            )
     except Exception as exc:
         console.print(f"[red]Error processing main-agent session: {exc}[/red]")
         _main_agent_failure_hint(session)
@@ -699,7 +728,11 @@ def _run_main_agent_operation(
                 answers[pending.id] = _prompt_for_interrupt(pending.payload)
 
         try:
-            result = run_async_callable(lambda: session.resume(answers))
+            result = (
+                checkpoint_runtime.run(lambda: session.resume(answers))
+                if checkpoint_runtime is not None
+                else run_async_callable(lambda: session.resume(answers))
+            )
         except Exception as exc:
             console.print(f"[red]Error resuming main-agent session: {exc}[/red]")
             _main_agent_failure_hint(session)
@@ -708,7 +741,12 @@ def _run_main_agent_operation(
     return result
 
 
-def run_main_agent_query(session: Any, query: str, verbose: bool = False) -> Any:
+def run_main_agent_query(
+    session: Any,
+    query: str,
+    verbose: bool = False,
+    checkpoint_runtime: CheckpointRuntime | None = None,
+) -> Any:
     """Run one main-agent turn and resolve nested clarifications."""
     if verbose:
         console.print(f"[blue]Main-agent thread:[/blue] {session.thread_id}")
@@ -717,10 +755,15 @@ def run_main_agent_query(session: Any, query: str, verbose: bool = False) -> Any
         session,
         lambda: session.run(query),
         progress_description="Processing main-agent turn...",
+        checkpoint_runtime=checkpoint_runtime,
     )
 
 
-def retry_main_agent_session(session: Any, verbose: bool = False) -> Any:
+def retry_main_agent_session(
+    session: Any,
+    verbose: bool = False,
+    checkpoint_runtime: CheckpointRuntime | None = None,
+) -> Any:
     """Retry the failed operation for one main-agent session."""
     if verbose:
         console.print(f"[blue]Main-agent thread:[/blue] {session.thread_id}")
@@ -728,6 +771,21 @@ def retry_main_agent_session(session: Any, verbose: bool = False) -> Any:
         session,
         session.retry,
         progress_description="Retrying main-agent operation...",
+        checkpoint_runtime=checkpoint_runtime,
+    )
+
+
+def restore_main_agent_session(
+    session: Any,
+    *,
+    checkpoint_runtime: CheckpointRuntime | None = None,
+) -> Any:
+    """Restore one durable thread and immediately resolve pending interrupts."""
+    return _run_main_agent_operation(
+        session,
+        session.restore,
+        progress_description="Restoring main-agent thread...",
+        checkpoint_runtime=checkpoint_runtime,
     )
 
 
@@ -762,6 +820,8 @@ def list_sessions(limit: int = 20, db_path: Optional[str] = None) -> None:
     table.add_column("Workflow", style="yellow", width=14)
     table.add_column("Queries", style="white", justify="right", width=8)
     table.add_column("Messages", style="white", justify="right", width=9)
+    table.add_column("Children", style="white", justify="right", width=8)
+    table.add_column("Status", style="magenta", width=16)
     table.add_column("Date", style="dim", width=16)
 
     for s in sessions:
@@ -772,6 +832,8 @@ def list_sessions(limit: int = 20, db_path: Optional[str] = None) -> None:
             s.workflow_type,
             str(s.query_count),
             str(s.message_count),
+            str(s.child_run_count),
+            s.status,
             s.updated_at.strftime("%Y-%m-%d %H:%M"),
         )
 
@@ -818,6 +880,8 @@ def show_session(
     meta_table.add_row("Model", session.model_name)
     meta_table.add_row("Workflow", session.workflow_type)
     meta_table.add_row("Queries", str(session.query_count))
+    meta_table.add_row("Status", session.status)
+    meta_table.add_row("Child Runs", str(session.child_run_count))
     meta_table.add_row("Created", session.created_at.strftime("%Y-%m-%d %H:%M:%S"))
     meta_table.add_row("Updated", session.updated_at.strftime("%Y-%m-%d %H:%M:%S"))
     if session.log_dir:
@@ -855,6 +919,17 @@ def show_session(
         console.print(f"  {label} [dim]{timestamp}[/dim]")
         console.print(f"    {content}\n")
 
+    for child in session.child_runs:
+        child_title = (
+            f"{child.agent_name} · {child.status} · {child.run_id[:8]}"
+        )
+        console.print(Panel(child.delegated_task, title=child_title, style="magenta"))
+        if child.error_text:
+            console.print(f"  [red]{escape(child.error_text)}[/red]")
+        for msg in child.messages:
+            tool_label = f" ({msg.tool_name})" if msg.tool_name else ""
+            console.print(f"  [bold]{msg.role}{tool_label}[/bold]: {msg.content}")
+
 
 def delete_session_cmd(session_id: str, db_path: Optional[str] = None) -> None:
     """Delete a session from the database.
@@ -879,8 +954,16 @@ def delete_session_cmd(session_id: str, db_path: Optional[str] = None) -> None:
         f"({session.title or 'Untitled'})[/yellow]"
     )
 
-    if store.delete_session(session_id):
-        console.print("[green]Session deleted.[/green]")
+    try:
+        deleted = delete_durable_session(store, session_id)
+    except Exception as exc:
+        console.print(
+            "[red]Checkpoint deletion failed; the session record was kept: "
+            f"{escape(str(exc))}[/red]"
+        )
+        return
+    if deleted:
+        console.print("[green]Session and checkpoints deleted.[/green]")
     else:
         console.print("[red]Failed to delete session.[/red]")
 
@@ -976,6 +1059,8 @@ def interactive_mode(
     tools: Optional[list] = None,
     enable_deepagent: bool = False,
     deepagent_workspace: str | None = None,
+    checkpoint_db: str | None = None,
+    resume_session: str | None = None,
 ) -> None:
     """Start interactive REPL mode for ChemGraph CLI.
 
@@ -1023,15 +1108,49 @@ def interactive_mode(
         "aliases such as 'quit' and 'help' also work.[/dim]\n"
     )
 
-    # Allow the user to override model/workflow at startup.
-    model = Prompt.ask(
-        "Select model (or type a custom model ID)", default=model
-    )
-    workflow = Prompt.ask(
-        "Select workflow",
-        choices=ALL_WORKFLOW_TYPES,
-        default=resolve_workflow(workflow),
-    )
+    checkpoint_runtime: CheckpointRuntime | None = None
+    checkpoint_saver = None
+    restored_thread_id: str | None = None
+    stored_graph_config = None
+    if resume_session:
+        resolved = SessionStore().get_session_metadata(resume_session)
+        if resolved is None or resolved[1] is None:
+            console.print(
+                f"[red]Durable main-agent session '{resume_session}' was not found.[/red]"
+            )
+            return
+        restored_thread_id, stored_metadata = resolved
+        stored_graph_config = stored_metadata.graph_config
+        model = stored_graph_config.model_name
+        workflow = "main_agent"
+        recursion_limit = stored_graph_config.recursion_limit
+        structured = stored_graph_config.structured_output
+        generate_report = stored_graph_config.generate_report
+        human_supervised = stored_graph_config.human_supervised
+        enable_deepagent = stored_graph_config.enable_deepagent
+        deepagent_workspace = stored_graph_config.deepagent_workspace
+        checkpoint_db = stored_metadata.checkpoint_db or checkpoint_db
+    else:
+        # Allow the user to override model/workflow at startup.
+        model = Prompt.ask(
+            "Select model (or type a custom model ID)", default=model
+        )
+        workflow = Prompt.ask(
+            "Select workflow",
+            choices=ALL_WORKFLOW_TYPES,
+            default=resolve_workflow(workflow),
+        )
+
+    if workflow == "main_agent":
+        checkpoint_runtime = CheckpointRuntime()
+        try:
+            checkpoint_saver = checkpoint_runtime.open_sqlite(
+                checkpoint_db or DEFAULT_CHECKPOINT_DB
+            )
+        except Exception as exc:
+            checkpoint_runtime.close()
+            console.print(f"[red]Could not open checkpoint database: {exc}[/red]")
+            return
 
     # Initialize agent with the full config context.
     agent = initialize_agent(
@@ -1052,13 +1171,45 @@ def interactive_mode(
             if enable_deepagent and workflow == "main_agent"
             else None
         ),
+        checkpointer=checkpoint_saver,
+        reasoning_effort=(
+            stored_graph_config.reasoning_effort if stored_graph_config else None
+        ),
+        max_retries=(stored_graph_config.max_retries if stored_graph_config else 1),
+        terminal_tool_names=(
+            stored_graph_config.terminal_tool_names if stored_graph_config else ()
+        ),
     )
     if not agent:
+        if checkpoint_runtime is not None:
+            checkpoint_runtime.close()
         return
 
     main_session = (
-        create_main_agent_session(agent) if workflow == "main_agent" else None
+        create_main_agent_session(
+            agent,
+            thread_id=restored_thread_id,
+            checkpoint_db=checkpoint_db or DEFAULT_CHECKPOINT_DB,
+        )
+        if workflow == "main_agent"
+        else None
     )
+
+    if restored_thread_id and main_session is not None:
+        result = restore_main_agent_session(
+            main_session,
+            checkpoint_runtime=checkpoint_runtime,
+        )
+        if result is None:
+            if checkpoint_runtime is not None:
+                checkpoint_runtime.close()
+            return
+        if result.status == "failed":
+            console.print(
+                "[yellow]The restored operation can be continued with /retry.[/yellow]"
+            )
+        elif result.assistant_response:
+            format_response(result, verbose=verbose)
 
     console.print(
         "[green]Ready! You can now ask computational chemistry questions.[/green]\n"
@@ -1087,6 +1238,8 @@ def interactive_mode(
                     console.print("[red]Usage: /quit[/red]")
                     continue
                 console.print("[yellow]Goodbye![/yellow]")
+                if checkpoint_runtime is not None:
+                    checkpoint_runtime.close()
                 break
             elif command == "help":
                 if argument:
@@ -1113,9 +1266,9 @@ Exact bare aliases for commands without arguments remain supported. Commands
 with arguments require the leading slash so prompts beginning with words such
 as "show", "model", or "workflow" are sent to the agent.
 
-main_agent keeps one checkpointed thread until you quit or switch
-model/workflow. Its thread is process-local; `/resume` does not currently
-restore it later. Nested chemistry workers may pause to request input.
+main_agent keeps one durable checkpointed thread. `/resume <id>` restores
+completed, interrupted, or retryable threads. Nested chemistry workers may
+pause to request input.
 
 Example queries:
   What is the SMILES string for water?
@@ -1166,10 +1319,74 @@ Example queries:
                 if not argument:
                     console.print("[red]Usage: /resume <session_id>[/red]")
                     continue
+                target = SessionStore().get_session_metadata(argument)
+                if target is not None and target[1] is not None:
+                    target_id, target_metadata = target
+                    target_config = target_metadata.graph_config
+                    candidate_runtime = checkpoint_runtime or CheckpointRuntime()
+                    try:
+                        candidate_saver = candidate_runtime.open_sqlite(
+                            target_metadata.checkpoint_db or DEFAULT_CHECKPOINT_DB
+                        )
+                        candidate_agent = initialize_agent(
+                            target_config.model_name,
+                            "main_agent",
+                            target_config.structured_output,
+                            return_option,
+                            target_config.generate_report,
+                            target_config.recursion_limit,
+                            base_url=base_url,
+                            argo_user=argo_user,
+                            verbose=verbose,
+                            human_supervised=target_config.human_supervised,
+                            tools=tools,
+                            enable_deepagent=target_config.enable_deepagent,
+                            deepagent_workspace=target_config.deepagent_workspace,
+                            checkpointer=candidate_saver,
+                            reasoning_effort=target_config.reasoning_effort,
+                            max_retries=target_config.max_retries,
+                            terminal_tool_names=target_config.terminal_tool_names,
+                        )
+                        if candidate_agent is None:
+                            raise RuntimeError("Could not recreate the stored agent.")
+                        candidate_session = create_main_agent_session(
+                            candidate_agent,
+                            thread_id=target_id,
+                            checkpoint_db=(
+                                target_metadata.checkpoint_db or DEFAULT_CHECKPOINT_DB
+                            ),
+                        )
+                        restored = restore_main_agent_session(
+                            candidate_session,
+                            checkpoint_runtime=candidate_runtime,
+                        )
+                        if restored is None:
+                            raise RuntimeError("The stored thread could not be restored.")
+                    except Exception as exc:
+                        if checkpoint_runtime is None:
+                            candidate_runtime.close()
+                        console.print(f"[red]Could not restore session: {exc}[/red]")
+                        continue
+                    checkpoint_runtime = candidate_runtime
+                    checkpoint_saver = candidate_saver
+                    agent = candidate_agent
+                    main_session = candidate_session
+                    model = target_config.model_name
+                    workflow = "main_agent"
+                    checkpoint_db = target_metadata.checkpoint_db
+                    enable_deepagent = target_config.enable_deepagent
+                    deepagent_workspace = target_config.deepagent_workspace
+                    if restored.status == "failed":
+                        console.print(
+                            "[yellow]The restored operation can be continued with "
+                            "/retry.[/yellow]"
+                        )
+                    elif restored.assistant_response:
+                        format_response(restored, verbose=verbose)
+                    continue
                 if main_session is not None:
                     console.print(
-                        "[yellow]Persistent resume is not supported for the "
-                        "process-lifetime main_agent workflow.[/yellow]"
+                        "[red]The selected session is not a durable main-agent thread.[/red]"
                     )
                     continue
                 resume_query = Prompt.ask(
@@ -1195,7 +1412,14 @@ Example queries:
                         "workflow.[/yellow]"
                     )
                     continue
-                result = retry_main_agent_session(main_session, verbose=verbose)
+                if checkpoint_runtime is None:
+                    result = retry_main_agent_session(main_session, verbose=verbose)
+                else:
+                    result = retry_main_agent_session(
+                        main_session,
+                        verbose=verbose,
+                        checkpoint_runtime=checkpoint_runtime,
+                    )
                 if result:
                     format_response(result, verbose=verbose)
                     console.print(f"[dim]Thread: {main_session.thread_id}[/dim]")
@@ -1222,12 +1446,16 @@ Example queries:
                         if enable_deepagent and workflow == "main_agent"
                         else None
                     ),
+                    checkpointer=(checkpoint_saver if workflow == "main_agent" else None),
                 )
                 if new_agent:
                     model = new_model
                     agent = new_agent
                     main_session = (
-                        create_main_agent_session(agent)
+                        create_main_agent_session(
+                            agent,
+                            checkpoint_db=checkpoint_db or DEFAULT_CHECKPOINT_DB,
+                        )
                         if workflow == "main_agent"
                         else None
                     )
@@ -1239,6 +1467,11 @@ Example queries:
                     continue
                 new_workflow = resolve_workflow(argument)
                 if new_workflow in ALL_WORKFLOW_TYPES:
+                    if new_workflow == "main_agent" and checkpoint_runtime is None:
+                        checkpoint_runtime = CheckpointRuntime()
+                        checkpoint_saver = checkpoint_runtime.open_sqlite(
+                            checkpoint_db or DEFAULT_CHECKPOINT_DB
+                        )
                     new_agent = initialize_agent(
                         model,
                         new_workflow,
@@ -1258,12 +1491,18 @@ Example queries:
                             if enable_deepagent and new_workflow == "main_agent"
                             else None
                         ),
+                        checkpointer=(
+                            checkpoint_saver if new_workflow == "main_agent" else None
+                        ),
                     )
                     if new_agent:
                         workflow = new_workflow
                         agent = new_agent
                         main_session = (
-                            create_main_agent_session(agent)
+                            create_main_agent_session(
+                                agent,
+                                checkpoint_db=checkpoint_db or DEFAULT_CHECKPOINT_DB,
+                            )
                             if workflow == "main_agent"
                             else None
                         )
@@ -1278,11 +1517,19 @@ Example queries:
                 continue
 
             if main_session is not None:
-                result = run_main_agent_query(
-                    main_session,
-                    query,
-                    verbose=verbose,
-                )
+                if checkpoint_runtime is None:
+                    result = run_main_agent_query(
+                        main_session,
+                        query,
+                        verbose=verbose,
+                    )
+                else:
+                    result = run_main_agent_query(
+                        main_session,
+                        query,
+                        verbose=verbose,
+                        checkpoint_runtime=checkpoint_runtime,
+                    )
             else:
                 # Existing workflows use a fresh thread for each query.
                 result = run_query(agent, query, verbose=verbose)

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -1552,10 +1552,24 @@ Example queries:
                 new_workflow = resolve_workflow(argument)
                 if new_workflow in ALL_WORKFLOW_TYPES:
                     if new_workflow == "main_agent" and checkpoint_runtime is None:
-                        checkpoint_runtime = CheckpointRuntime()
-                        checkpoint_saver = checkpoint_runtime.open_sqlite(
-                            checkpoint_db or DEFAULT_CHECKPOINT_DB
-                        )
+                        candidate_runtime = None
+                        try:
+                            candidate_runtime = CheckpointRuntime()
+                            candidate_saver = candidate_runtime.open_sqlite(
+                                checkpoint_db or DEFAULT_CHECKPOINT_DB
+                            )
+                        except Exception as exc:
+                            if candidate_runtime is not None:
+                                candidate_runtime.close()
+                            checkpoint_runtime = None
+                            checkpoint_saver = None
+                            console.print(
+                                "[red]Could not open checkpoint database: "
+                                f"{exc}[/red]"
+                            )
+                            continue
+                        checkpoint_runtime = candidate_runtime
+                        checkpoint_saver = candidate_saver
                     new_agent = initialize_agent(
                         model,
                         new_workflow,

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -157,7 +157,17 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         "--resume",
         type=str,
         metavar="ID",
-        help="Resume from a previous session (injects context into new query)",
+        help=(
+            "Resume a prior session; main_agent restores exact checkpoints and "
+            "other workflows inject readable context"
+        ),
+    )
+    parser.add_argument(
+        "--checkpoint-db",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="SQLite checkpoint database for durable main_agent threads",
     )
     parser.add_argument(
         "-v",
@@ -367,6 +377,7 @@ def load_config(config_file: str) -> Dict[str, Any]:
                 "human_supervised": False,
                 "enable_deepagent": False,
                 "deepagent_workspace": None,
+                "checkpoint_db": None,
                 "verbose": False,
             },
             "api": {},
@@ -490,12 +501,6 @@ def _handle_run(args: argparse.Namespace) -> None:
         sys.exit(2)
 
     if args.workflow == "main_agent":
-        if getattr(args, "resume", None):
-            console.print(
-                "[red]--resume is not supported for the process-lifetime "
-                "main_agent workflow.[/red]"
-            )
-            sys.exit(2)
         if not getattr(args, "interactive", False):
             console.print(
                 "[red]main_agent requires interactive mode. Use "
@@ -539,6 +544,14 @@ def _handle_run(args: argparse.Namespace) -> None:
             tools=mcp_tools,
             enable_deepagent=enable_deepagent,
             deepagent_workspace=deepagent_workspace,
+            checkpoint_db=(
+                getattr(args, "checkpoint_db", None) or config.get("checkpoint_db")
+            ),
+            resume_session=(
+                getattr(args, "resume", None)
+                if args.workflow == "main_agent"
+                else None
+            ),
         )
         return
 

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -15,8 +15,10 @@ from langchain_core.messages import AIMessage, ToolMessage, convert_to_messages
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import GraphInterrupt
 
 from chemgraph.graphs.single_agent import construct_single_agent_graph
+from chemgraph.memory.subagent_recorder import SubagentRunRecorder
 
 
 DEFAULT_MAIN_AGENT_PROMPT = """\
@@ -99,15 +101,45 @@ def _preserve_terminal_tool_output(result: Any) -> Any:
     }
 
 
-def _adapt_subagent(spec: CompiledSubAgent) -> CompiledSubAgent:
+def _adapt_subagent(
+    spec: CompiledSubAgent,
+    recorder: SubagentRunRecorder | None = None,
+) -> CompiledSubAgent:
     runnable = spec["runnable"]
 
     def invoke(state: Any, config: RunnableConfig) -> Any:
-        return _preserve_terminal_tool_output(runnable.invoke(state, config=config))
+        run_id = recorder.start(spec["name"], state, config) if recorder else None
+        try:
+            result = runnable.invoke(state, config=config)
+        except GraphInterrupt:
+            if recorder and run_id:
+                recorder.interrupted(run_id)
+            raise
+        except Exception as exc:
+            if recorder and run_id:
+                recorder.failed(run_id, exc)
+            raise
+        result = _preserve_terminal_tool_output(result)
+        if recorder and run_id:
+            recorder.completed(run_id, result)
+        return result
 
     async def ainvoke(state: Any, config: RunnableConfig) -> Any:
-        result = await runnable.ainvoke(state, config=config)
-        return _preserve_terminal_tool_output(result)
+        run_id = recorder.start(spec["name"], state, config) if recorder else None
+        try:
+            result = await runnable.ainvoke(state, config=config)
+        except GraphInterrupt:
+            if recorder and run_id:
+                recorder.interrupted(run_id)
+            raise
+        except Exception as exc:
+            if recorder and run_id:
+                recorder.failed(run_id, exc)
+            raise
+        result = _preserve_terminal_tool_output(result)
+        if recorder and run_id:
+            recorder.completed(run_id, result)
+        return result
 
     return {
         "name": spec["name"],
@@ -118,6 +150,7 @@ def _adapt_subagent(spec: CompiledSubAgent) -> CompiledSubAgent:
 
 def _validate_subagents(
     subagents: Sequence[CompiledSubAgent],
+    recorder: SubagentRunRecorder | None = None,
 ) -> list[CompiledSubAgent]:
     if not subagents:
         raise ValueError("At least one subagent must be registered.")
@@ -147,7 +180,7 @@ def _validate_subagents(
                 f"Subagent {name!r} must provide invoke and ainvoke methods."
             )
         names.add(name)
-        validated.append(_adapt_subagent(spec))
+        validated.append(_adapt_subagent(spec, recorder))
     return validated
 
 
@@ -180,6 +213,7 @@ def construct_main_agent_graph(
     deepagent_recursion_limit: int = 50,
     system_prompt: str = DEFAULT_MAIN_AGENT_PROMPT,
     checkpointer: Any | None = None,
+    subagent_recorder: SubagentRunRecorder | None = None,
 ):
     """Construct a checkpointed supervisor with Deep Agents delegation."""
     if deepagent_recursion_limit <= 0:
@@ -243,7 +277,7 @@ def construct_main_agent_graph(
             }
         )
 
-    validated_subagents = _validate_subagents(registered_subagents)
+    validated_subagents = _validate_subagents(registered_subagents, subagent_recorder)
     supervisor_tools = list(main_tools or [])
     _validate_main_tools(supervisor_tools)
     middleware = SubAgentMiddleware(
@@ -255,7 +289,7 @@ def construct_main_agent_graph(
         tools=supervisor_tools,
         system_prompt=system_prompt,
         middleware=[middleware],
-        checkpointer=checkpointer or InMemorySaver(),
+        checkpointer=checkpointer if checkpointer is not None else InMemorySaver(),
         name="main_agent",
     )
 

--- a/src/chemgraph/memory/__init__.py
+++ b/src/chemgraph/memory/__init__.py
@@ -6,6 +6,21 @@ enabling users to review past sessions and resume from previous context.
 """
 
 from chemgraph.memory.store import SessionStore
-from chemgraph.memory.schemas import Session, SessionMessage, SessionSummary
+from chemgraph.memory.schemas import (
+    MainAgentGraphConfig,
+    MainAgentSessionMetadata,
+    Session,
+    SessionMessage,
+    SessionSummary,
+    SubagentRun,
+)
 
-__all__ = ["SessionStore", "Session", "SessionMessage", "SessionSummary"]
+__all__ = [
+    "MainAgentGraphConfig",
+    "MainAgentSessionMetadata",
+    "SessionStore",
+    "Session",
+    "SessionMessage",
+    "SessionSummary",
+    "SubagentRun",
+]

--- a/src/chemgraph/memory/durable.py
+++ b/src/chemgraph/memory/durable.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from chemgraph.memory.store import SessionStore
 
 
 def delete_durable_session(
     store: SessionStore,
     session_id: str,
-    *,
-    checkpointer: Any | None = None,
 ) -> bool:
     """Delete checkpoints first, then transactionally remove readable records."""
     session = store.get_session(session_id)
@@ -20,18 +16,12 @@ def delete_durable_session(
     if session.graph_config is None:
         return store.delete_session(session.session_id)
 
-    if checkpointer is not None:
-        raise RuntimeError(
-            "Caller-supplied async checkpointers must be deleted from their owner loop."
-        )
-    if session.checkpoint_backend not in {None, "AsyncSqliteSaver", "memory"}:
+    if session.checkpoint_backend == "memory":
+        return store.delete_session(session.session_id)
+    if session.checkpoint_backend not in {None, "AsyncSqliteSaver"}:
         raise RuntimeError(
             "This session uses an external checkpointer; delete it through the "
             "caller-owned saver before removing the session record."
-        )
-    if session.checkpoint_backend == "memory":
-        raise RuntimeError(
-            "The session refers to a process-local checkpointer that is no longer active."
         )
 
     from chemgraph.cli.checkpoint_runtime import CheckpointRuntime

--- a/src/chemgraph/memory/durable.py
+++ b/src/chemgraph/memory/durable.py
@@ -1,0 +1,48 @@
+"""Coordinated deletion across readable sessions and graph checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chemgraph.memory.store import SessionStore
+
+
+def delete_durable_session(
+    store: SessionStore,
+    session_id: str,
+    *,
+    checkpointer: Any | None = None,
+) -> bool:
+    """Delete checkpoints first, then transactionally remove readable records."""
+    session = store.get_session(session_id)
+    if session is None:
+        return False
+    if session.graph_config is None:
+        return store.delete_session(session.session_id)
+
+    if checkpointer is not None:
+        raise RuntimeError(
+            "Caller-supplied async checkpointers must be deleted from their owner loop."
+        )
+    if session.checkpoint_backend not in {None, "AsyncSqliteSaver", "memory"}:
+        raise RuntimeError(
+            "This session uses an external checkpointer; delete it through the "
+            "caller-owned saver before removing the session record."
+        )
+    if session.checkpoint_backend == "memory":
+        raise RuntimeError(
+            "The session refers to a process-local checkpointer that is no longer active."
+        )
+
+    from chemgraph.cli.checkpoint_runtime import CheckpointRuntime
+
+    runtime = CheckpointRuntime()
+    try:
+        saver = runtime.open_sqlite(session.checkpoint_db)
+        runtime.delete_thread(saver, session.session_id)
+    finally:
+        runtime.close()
+    return store.delete_session(session.session_id)
+
+
+__all__ = ["delete_durable_session"]

--- a/src/chemgraph/memory/schemas.py
+++ b/src/chemgraph/memory/schemas.py
@@ -3,7 +3,7 @@ Pydantic schemas for ChemGraph session memory.
 """
 
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -17,6 +17,67 @@ class SessionMessage(BaseModel):
         default=None, description="Tool name if role is 'tool'"
     )
     timestamp: datetime = Field(default_factory=datetime.now)
+    ordinal: Optional[int] = Field(
+        default=None, description="Stable position in the authoritative transcript"
+    )
+    message_id: Optional[str] = Field(
+        default=None, description="Canonical serialized-message identity"
+    )
+    serialization_type: Optional[str] = Field(
+        default=None, description="Serializer payload type tag"
+    )
+    serialized_payload: Optional[bytes] = Field(
+        default=None, description="Lossless serialized LangChain message"
+    )
+
+
+SessionStatus = Literal["new", "running", "waiting_for_user", "completed", "failed"]
+SubagentRunStatus = Literal[
+    "running", "waiting_for_user", "completed", "failed"
+]
+
+
+class MainAgentGraphConfig(BaseModel):
+    """Non-secret configuration needed to validate a durable graph topology."""
+
+    model_name: str
+    recursion_limit: int = 50
+    reasoning_effort: Optional[str] = None
+    structured_output: bool = False
+    generate_report: bool = False
+    max_retries: int = 1
+    human_supervised: bool = False
+    terminal_tool_names: tuple[str, ...] = ()
+    enable_deepagent: bool = False
+    deepagent_workspace: Optional[str] = None
+    subagent_names: tuple[str, ...] = ("chemgraph",)
+    tool_signatures: tuple[str, ...] = ()
+    package_version: str = ""
+    graph_schema_version: int = 1
+    topology_fingerprint: str = ""
+
+
+class MainAgentSessionMetadata(BaseModel):
+    """Durable metadata shared by a main-agent graph and session driver."""
+
+    graph_config: MainAgentGraphConfig
+    checkpoint_backend: str = "memory"
+    checkpoint_db: Optional[str] = None
+
+
+class SubagentRun(BaseModel):
+    """One direct supervisor-to-subagent invocation."""
+
+    run_id: str
+    root_session_id: str
+    agent_name: str
+    delegated_task: str
+    checkpoint_namespace: str
+    status: SubagentRunStatus
+    created_at: datetime
+    updated_at: datetime
+    error_text: Optional[str] = None
+    messages: list[SessionMessage] = Field(default_factory=list)
 
 
 class Session(BaseModel):
@@ -37,6 +98,17 @@ class Session(BaseModel):
         default=None, description="Path to session log directory"
     )
     query_count: int = Field(default=0, description="Number of user queries")
+    status: SessionStatus = "completed"
+    graph_config: Optional[MainAgentGraphConfig] = None
+    topology_fingerprint: Optional[str] = None
+    checkpoint_backend: Optional[str] = None
+    checkpoint_db: Optional[str] = None
+    child_runs: list[SubagentRun] = Field(default_factory=list)
+
+    @property
+    def child_run_count(self) -> int:
+        """Return the number of direct subagent invocations."""
+        return len(self.child_runs)
 
 
 class SessionSummary(BaseModel):
@@ -50,3 +122,5 @@ class SessionSummary(BaseModel):
     updated_at: datetime
     query_count: int
     message_count: int
+    status: SessionStatus = "completed"
+    child_run_count: int = 0

--- a/src/chemgraph/memory/serialization.py
+++ b/src/chemgraph/memory/serialization.py
@@ -1,0 +1,61 @@
+"""Lossless, strict serialization helpers for durable conversation messages."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage, convert_to_messages
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+
+from chemgraph.memory.schemas import SessionMessage
+
+
+_SERIALIZER = JsonPlusSerializer(
+    pickle_fallback=False,
+    allowed_msgpack_modules=None,
+)
+
+
+def _readable_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            item.get("text", json.dumps(item, default=str, sort_keys=True))
+            if isinstance(item, dict)
+            else str(item)
+            for item in content
+        )
+    return str(content)
+
+
+def serialize_message(message: Any, ordinal: int) -> SessionMessage:
+    """Project one LangChain message into readable and lossless storage fields."""
+    normalized: BaseMessage = convert_to_messages([message])[0]
+    serialization_type, payload = _SERIALIZER.dumps_typed(normalized)
+    identity = hashlib.sha256(
+        serialization_type.encode("utf-8") + b"\0" + payload
+    ).hexdigest()
+    content = _readable_content(normalized.content)
+    if not content and isinstance(normalized, AIMessage) and normalized.tool_calls:
+        names = ", ".join(str(call.get("name", "tool")) for call in normalized.tool_calls)
+        content = f"[tool calls: {names}]"
+    role = normalized.type
+    if role == "assistant":
+        role = "ai"
+    return SessionMessage(
+        role=role,
+        content=content,
+        tool_name=normalized.name if isinstance(normalized, ToolMessage) else None,
+        ordinal=ordinal,
+        message_id=identity,
+        serialization_type=serialization_type,
+        serialized_payload=payload,
+    )
+
+
+def serialize_messages(messages: list[Any]) -> list[SessionMessage]:
+    """Serialize an ordered LangChain message transcript."""
+    return [serialize_message(message, index) for index, message in enumerate(messages)]

--- a/src/chemgraph/memory/store.py
+++ b/src/chemgraph/memory/store.py
@@ -8,11 +8,21 @@ enabling session listing, resumption, and context injection.
 import logging
 import os
 import sqlite3
+import stat
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from chemgraph.memory.schemas import Session, SessionMessage, SessionSummary
+from chemgraph.memory.schemas import (
+    MainAgentGraphConfig,
+    MainAgentSessionMetadata,
+    Session,
+    SessionMessage,
+    SessionStatus,
+    SessionSummary,
+    SubagentRun,
+    SubagentRunStatus,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +39,12 @@ CREATE TABLE IF NOT EXISTS sessions (
     log_dir      TEXT,
     query_count  INTEGER NOT NULL DEFAULT 0,
     created_at   TEXT NOT NULL,
-    updated_at   TEXT NOT NULL
+    updated_at   TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'completed',
+    graph_config TEXT,
+    topology_fingerprint TEXT,
+    checkpoint_backend TEXT,
+    checkpoint_db TEXT
 );
 
 CREATE TABLE IF NOT EXISTS messages (
@@ -38,7 +53,37 @@ CREATE TABLE IF NOT EXISTS messages (
     role        TEXT NOT NULL,
     content     TEXT NOT NULL,
     tool_name   TEXT,
-    timestamp   TEXT NOT NULL
+    timestamp   TEXT NOT NULL,
+    ordinal     INTEGER,
+    message_id  TEXT,
+    serialization_type TEXT,
+    serialized_payload BLOB
+);
+
+CREATE TABLE IF NOT EXISTS subagent_runs (
+    run_id       TEXT PRIMARY KEY,
+    session_id   TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+    agent_name   TEXT NOT NULL,
+    delegated_task TEXT NOT NULL,
+    checkpoint_namespace TEXT NOT NULL,
+    status       TEXT NOT NULL,
+    error_text   TEXT,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subagent_messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id      TEXT NOT NULL REFERENCES subagent_runs(run_id) ON DELETE CASCADE,
+    role        TEXT NOT NULL,
+    content     TEXT NOT NULL,
+    tool_name   TEXT,
+    timestamp   TEXT NOT NULL,
+    ordinal     INTEGER NOT NULL,
+    message_id  TEXT NOT NULL,
+    serialization_type TEXT NOT NULL,
+    serialized_payload BLOB NOT NULL,
+    UNIQUE(run_id, ordinal)
 );
 
 CREATE INDEX IF NOT EXISTS idx_messages_session
@@ -46,7 +91,28 @@ CREATE INDEX IF NOT EXISTS idx_messages_session
 
 CREATE INDEX IF NOT EXISTS idx_sessions_updated
     ON sessions(updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_subagent_runs_session
+    ON subagent_runs(session_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_subagent_messages_run
+    ON subagent_messages(run_id, ordinal);
 """
+
+_SESSION_COLUMNS = {
+    "status": "TEXT NOT NULL DEFAULT 'completed'",
+    "graph_config": "TEXT",
+    "topology_fingerprint": "TEXT",
+    "checkpoint_backend": "TEXT",
+    "checkpoint_db": "TEXT",
+}
+
+_MESSAGE_COLUMNS = {
+    "ordinal": "INTEGER",
+    "message_id": "TEXT",
+    "serialization_type": "TEXT",
+    "serialized_payload": "BLOB",
+}
 
 
 class SessionStore:
@@ -67,18 +133,53 @@ class SessionStore:
         db_path : str, optional
             SQLite database path. Defaults to ``~/.chemgraph/sessions.db``.
         """
-        self.db_path = db_path or DEFAULT_DB_PATH
-        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+        self.db_path = os.path.abspath(os.path.expanduser(db_path or DEFAULT_DB_PATH))
+        parent = os.path.dirname(self.db_path) or os.curdir
+        parent_existed = os.path.exists(parent)
+        os.makedirs(parent, mode=0o700, exist_ok=True)
+        if not parent_existed or parent == os.path.abspath(DEFAULT_DB_DIR):
+            self._restrict_permissions(parent, 0o700)
         self._init_db()
+        self._restrict_permissions(self.db_path, 0o600)
 
     # ------------------------------------------------------------------
     # Database lifecycle
     # ------------------------------------------------------------------
 
     def _init_db(self):
-        """Create tables and indexes if they don't exist."""
+        """Create tables and migrate legacy databases in place."""
         with self._connect() as conn:
             conn.executescript(_SCHEMA_SQL)
+            self._add_missing_columns(conn, "sessions", _SESSION_COLUMNS)
+            self._add_missing_columns(conn, "messages", _MESSAGE_COLUMNS)
+            conn.executescript(_SCHEMA_SQL)
+            conn.execute("PRAGMA user_version = 1")
+
+    @staticmethod
+    def _add_missing_columns(
+        conn: sqlite3.Connection,
+        table: str,
+        definitions: dict[str, str],
+    ) -> None:
+        existing = {
+            row["name"] for row in conn.execute(f"PRAGMA table_info({table})")
+        }
+        for name, definition in definitions.items():
+            if name not in existing:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
+
+    @staticmethod
+    def _restrict_permissions(path: str, mode: int) -> None:
+        if os.name != "posix":
+            return
+        if not os.path.exists(path):
+            return
+        try:
+            current = stat.S_IMODE(os.stat(path).st_mode)
+            if current != mode:
+                os.chmod(path, mode)
+        except OSError:
+            logger.warning("Could not restrict permissions for %s", path)
 
     def _connect(self) -> sqlite3.Connection:
         """Return a new connection with WAL mode and FK enforcement."""
@@ -86,6 +187,9 @@ class SessionStore:
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA foreign_keys=ON")
         conn.row_factory = sqlite3.Row
+        self._restrict_permissions(self.db_path, 0o600)
+        self._restrict_permissions(self.db_path + "-wal", 0o600)
+        self._restrict_permissions(self.db_path + "-shm", 0o600)
         return conn
 
     # ------------------------------------------------------------------
@@ -99,6 +203,8 @@ class SessionStore:
         workflow_type: str,
         title: str = "",
         log_dir: Optional[str] = None,
+        status: SessionStatus = "completed",
+        session_metadata: MainAgentSessionMetadata | None = None,
     ) -> Session:
         """Create a new session record.
 
@@ -126,10 +232,28 @@ class SessionStore:
                 """
                 INSERT INTO sessions
                     (session_id, title, model_name, workflow_type, log_dir,
-                     query_count, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, 0, ?, ?)
+                     query_count, created_at, updated_at, status, graph_config,
+                     topology_fingerprint, checkpoint_backend, checkpoint_db)
+                VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
                 """,
-                (session_id, title, model_name, workflow_type, log_dir, now, now),
+                (
+                    session_id,
+                    title,
+                    model_name,
+                    workflow_type,
+                    log_dir,
+                    now,
+                    now,
+                    status,
+                    session_metadata.graph_config.model_dump_json()
+                    if session_metadata
+                    else None,
+                    session_metadata.graph_config.topology_fingerprint
+                    if session_metadata
+                    else None,
+                    session_metadata.checkpoint_backend if session_metadata else None,
+                    session_metadata.checkpoint_db if session_metadata else None,
+                ),
             )
         return Session(
             session_id=session_id,
@@ -139,6 +263,17 @@ class SessionStore:
             log_dir=log_dir,
             created_at=datetime.fromisoformat(now),
             updated_at=datetime.fromisoformat(now),
+            status=status,
+            graph_config=session_metadata.graph_config if session_metadata else None,
+            topology_fingerprint=(
+                session_metadata.graph_config.topology_fingerprint
+                if session_metadata
+                else None
+            ),
+            checkpoint_backend=(
+                session_metadata.checkpoint_backend if session_metadata else None
+            ),
+            checkpoint_db=session_metadata.checkpoint_db if session_metadata else None,
         )
 
     def save_messages(
@@ -167,8 +302,10 @@ class SessionStore:
         with self._connect() as conn:
             conn.executemany(
                 """
-                INSERT INTO messages (session_id, role, content, tool_name, timestamp)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO messages
+                    (session_id, role, content, tool_name, timestamp, ordinal,
+                     message_id, serialization_type, serialized_payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     (
@@ -177,6 +314,10 @@ class SessionStore:
                         m.content,
                         m.tool_name,
                         m.timestamp.isoformat(),
+                        m.ordinal,
+                        m.message_id,
+                        m.serialization_type,
+                        m.serialized_payload,
                     )
                     for m in messages
                 ],
@@ -194,6 +335,178 @@ class SessionStore:
                 f"UPDATE sessions SET {', '.join(update_fields)} WHERE session_id = ?",
                 update_params,
             )
+
+    def update_session_status(
+        self,
+        session_id: str,
+        status: SessionStatus,
+        *,
+        title: str | None = None,
+    ) -> None:
+        """Update durable session lifecycle metadata."""
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            if title:
+                conn.execute(
+                    "UPDATE sessions SET status = ?, title = ?, updated_at = ? "
+                    "WHERE session_id = ?",
+                    (status, title, now, session_id),
+                )
+            else:
+                conn.execute(
+                    "UPDATE sessions SET status = ?, updated_at = ? WHERE session_id = ?",
+                    (status, now, session_id),
+                )
+
+    def synchronize_messages(
+        self,
+        session_id: str,
+        messages: list[SessionMessage],
+    ) -> None:
+        """Reconcile readable storage with one authoritative graph transcript."""
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            stored = conn.execute(
+                "SELECT message_id FROM messages WHERE session_id = ? ORDER BY id",
+                (session_id,),
+            ).fetchall()
+            stored_ids = [row["message_id"] for row in stored]
+            incoming_ids = [message.message_id for message in messages]
+            is_prefix = (
+                all(stored_ids)
+                and len(stored_ids) <= len(incoming_ids)
+                and stored_ids == incoming_ids[: len(stored_ids)]
+            )
+            if is_prefix:
+                suffix = messages[len(stored_ids) :]
+            else:
+                conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+                suffix = messages
+
+            conn.executemany(
+                """
+                INSERT INTO messages
+                    (session_id, role, content, tool_name, timestamp, ordinal,
+                     message_id, serialization_type, serialized_payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        session_id,
+                        message.role,
+                        message.content,
+                        message.tool_name,
+                        message.timestamp.isoformat(),
+                        message.ordinal,
+                        message.message_id,
+                        message.serialization_type,
+                        message.serialized_payload,
+                    )
+                    for message in suffix
+                ],
+            )
+            query_count = sum(message.role == "human" for message in messages)
+            conn.execute(
+                "UPDATE sessions SET query_count = ?, updated_at = ? "
+                "WHERE session_id = ?",
+                (query_count, now, session_id),
+            )
+
+    def upsert_subagent_run(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        agent_name: str,
+        delegated_task: str,
+        checkpoint_namespace: str,
+        status: SubagentRunStatus,
+        error_text: str | None = None,
+    ) -> None:
+        """Idempotently create or update one direct subagent invocation."""
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO subagent_runs
+                    (run_id, session_id, agent_name, delegated_task,
+                     checkpoint_namespace, status, error_text, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    status = excluded.status,
+                    error_text = excluded.error_text,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    run_id,
+                    session_id,
+                    agent_name,
+                    delegated_task,
+                    checkpoint_namespace,
+                    status,
+                    error_text,
+                    now,
+                    now,
+                ),
+            )
+
+    def complete_subagent_run(
+        self,
+        run_id: str,
+        messages: list[SessionMessage],
+    ) -> None:
+        """Transactionally replace a child transcript and mark it completed."""
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            conn.execute("DELETE FROM subagent_messages WHERE run_id = ?", (run_id,))
+            conn.executemany(
+                """
+                INSERT INTO subagent_messages
+                    (run_id, role, content, tool_name, timestamp, ordinal,
+                     message_id, serialization_type, serialized_payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        run_id,
+                        message.role,
+                        message.content,
+                        message.tool_name,
+                        message.timestamp.isoformat(),
+                        message.ordinal,
+                        message.message_id,
+                        message.serialization_type,
+                        message.serialized_payload,
+                    )
+                    for message in messages
+                ],
+            )
+            conn.execute(
+                "UPDATE subagent_runs SET status = 'completed', error_text = NULL, "
+                "updated_at = ? WHERE run_id = ?",
+                (now, run_id),
+            )
+
+    def get_session_metadata(
+        self, session_id: str
+    ) -> tuple[str, MainAgentSessionMetadata | None] | None:
+        """Resolve a session ID and return its durable graph metadata."""
+        resolved_id = self._resolve_session_id(session_id)
+        if resolved_id is None:
+            return None
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT graph_config, checkpoint_backend, checkpoint_db "
+                "FROM sessions WHERE session_id = ?",
+                (resolved_id,),
+            ).fetchone()
+        if row is None or not row["graph_config"]:
+            return resolved_id, None
+        return resolved_id, MainAgentSessionMetadata(
+            graph_config=MainAgentGraphConfig.model_validate_json(row["graph_config"]),
+            checkpoint_backend=row["checkpoint_backend"] or "memory",
+            checkpoint_db=row["checkpoint_db"],
+        )
 
     def get_session(self, session_id: str) -> Optional[Session]:
         """Load a full session with all messages.
@@ -223,6 +536,17 @@ class SessionStore:
                 "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
                 (resolved_id,),
             ).fetchall()
+            run_rows = conn.execute(
+                "SELECT * FROM subagent_runs WHERE session_id = ? ORDER BY created_at",
+                (resolved_id,),
+            ).fetchall()
+            run_messages = {
+                run["run_id"]: conn.execute(
+                    "SELECT * FROM subagent_messages WHERE run_id = ? ORDER BY ordinal",
+                    (run["run_id"],),
+                ).fetchall()
+                for run in run_rows
+            }
 
         messages = [
             SessionMessage(
@@ -230,10 +554,46 @@ class SessionStore:
                 content=m["content"],
                 tool_name=m["tool_name"],
                 timestamp=datetime.fromisoformat(m["timestamp"]),
+                ordinal=m["ordinal"],
+                message_id=m["message_id"],
+                serialization_type=m["serialization_type"],
+                serialized_payload=m["serialized_payload"],
             )
             for m in msg_rows
         ]
 
+        child_runs = [
+            SubagentRun(
+                run_id=run["run_id"],
+                root_session_id=run["session_id"],
+                agent_name=run["agent_name"],
+                delegated_task=run["delegated_task"],
+                checkpoint_namespace=run["checkpoint_namespace"],
+                status=run["status"],
+                error_text=run["error_text"],
+                created_at=datetime.fromisoformat(run["created_at"]),
+                updated_at=datetime.fromisoformat(run["updated_at"]),
+                messages=[
+                    SessionMessage(
+                        role=message["role"],
+                        content=message["content"],
+                        tool_name=message["tool_name"],
+                        timestamp=datetime.fromisoformat(message["timestamp"]),
+                        ordinal=message["ordinal"],
+                        message_id=message["message_id"],
+                        serialization_type=message["serialization_type"],
+                        serialized_payload=message["serialized_payload"],
+                    )
+                    for message in run_messages[run["run_id"]]
+                ],
+            )
+            for run in run_rows
+        ]
+        graph_config = (
+            MainAgentGraphConfig.model_validate_json(row["graph_config"])
+            if row["graph_config"]
+            else None
+        )
         return Session(
             session_id=row["session_id"],
             title=row["title"],
@@ -244,6 +604,12 @@ class SessionStore:
             created_at=datetime.fromisoformat(row["created_at"]),
             updated_at=datetime.fromisoformat(row["updated_at"]),
             messages=messages,
+            status=row["status"],
+            graph_config=graph_config,
+            topology_fingerprint=row["topology_fingerprint"],
+            checkpoint_backend=row["checkpoint_backend"],
+            checkpoint_db=row["checkpoint_db"],
+            child_runs=child_runs,
         )
 
     def list_sessions(
@@ -270,7 +636,9 @@ class SessionStore:
                 """
                 SELECT s.*,
                        (SELECT COUNT(*) FROM messages m
-                        WHERE m.session_id = s.session_id) AS message_count
+                        WHERE m.session_id = s.session_id) AS message_count,
+                       (SELECT COUNT(*) FROM subagent_runs r
+                        WHERE r.session_id = s.session_id) AS child_run_count
                 FROM sessions s
                 ORDER BY s.updated_at DESC
                 LIMIT ? OFFSET ?
@@ -288,6 +656,8 @@ class SessionStore:
                 updated_at=datetime.fromisoformat(r["updated_at"]),
                 query_count=r["query_count"],
                 message_count=r["message_count"],
+                status=r["status"],
+                child_run_count=r["child_run_count"],
             )
             for r in rows
         ]

--- a/src/chemgraph/memory/store.py
+++ b/src/chemgraph/memory/store.py
@@ -487,6 +487,22 @@ class SessionStore:
                 (now, run_id),
             )
 
+    def update_subagent_run_status(
+        self,
+        run_id: str,
+        status: SubagentRunStatus,
+        *,
+        error_text: str | None = None,
+    ) -> None:
+        """Update child-run lifecycle metadata without replacing its transcript."""
+        now = datetime.now().isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE subagent_runs SET status = ?, error_text = ?, updated_at = ? "
+                "WHERE run_id = ?",
+                (status, error_text, now, run_id),
+            )
+
     def get_session_metadata(
         self, session_id: str
     ) -> tuple[str, MainAgentSessionMetadata | None] | None:

--- a/src/chemgraph/memory/store.py
+++ b/src/chemgraph/memory/store.py
@@ -152,7 +152,6 @@ class SessionStore:
             conn.executescript(_SCHEMA_SQL)
             self._add_missing_columns(conn, "sessions", _SESSION_COLUMNS)
             self._add_missing_columns(conn, "messages", _MESSAGE_COLUMNS)
-            conn.executescript(_SCHEMA_SQL)
             conn.execute("PRAGMA user_version = 1")
 
     @staticmethod

--- a/src/chemgraph/memory/subagent_recorder.py
+++ b/src/chemgraph/memory/subagent_recorder.py
@@ -1,0 +1,85 @@
+"""Persistence adapter for direct main-agent subgraph invocations."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from langgraph.errors import GraphInterrupt
+
+from chemgraph.memory.serialization import serialize_messages
+from chemgraph.memory.store import SessionStore
+
+
+_RUN_NAMESPACE = uuid.UUID("7ceaa8ee-c7ac-4efd-99e6-b8e3ad89de82")
+
+
+class SubagentRunRecorder:
+    """Record direct subagent lifecycle events in a :class:`SessionStore`."""
+
+    def __init__(self, store: SessionStore):
+        self.store = store
+
+    @staticmethod
+    def _identity(agent_name: str, state: Any, config: dict) -> tuple[str, str, str]:
+        configurable = config.get("configurable", {})
+        thread_id = str(configurable.get("thread_id", ""))
+        checkpoint_namespace = str(configurable.get("checkpoint_ns", ""))
+        if not thread_id or not checkpoint_namespace:
+            raise RuntimeError("Subagent recording requires thread and checkpoint IDs.")
+        run_id = str(
+            uuid.uuid5(
+                _RUN_NAMESPACE,
+                f"{thread_id}\0{checkpoint_namespace}\0{agent_name}",
+            )
+        )
+        messages = state.get("messages", []) if isinstance(state, dict) else []
+        task = str(getattr(messages[-1], "content", "")) if messages else ""
+        return run_id, thread_id, task
+
+    def start(self, agent_name: str, state: Any, config: dict) -> str:
+        run_id, thread_id, task = self._identity(agent_name, state, config)
+        checkpoint_namespace = str(config["configurable"]["checkpoint_ns"])
+        self.store.upsert_subagent_run(
+            run_id=run_id,
+            session_id=thread_id,
+            agent_name=agent_name,
+            delegated_task=task,
+            checkpoint_namespace=checkpoint_namespace,
+            status="running",
+        )
+        return run_id
+
+    def interrupted(self, run_id: str) -> None:
+        run = self._get_identity(run_id)
+        self.store.upsert_subagent_run(**run, status="waiting_for_user")
+
+    def failed(self, run_id: str, error: BaseException) -> None:
+        run = self._get_identity(run_id)
+        self.store.upsert_subagent_run(
+            **run,
+            status="failed",
+            error_text=repr(error),
+        )
+
+    def completed(self, run_id: str, result: Any) -> None:
+        messages = result.get("messages", []) if isinstance(result, dict) else []
+        self.store.complete_subagent_run(run_id, serialize_messages(list(messages)))
+
+    def _get_identity(self, run_id: str) -> dict[str, str]:
+        with self.store._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM subagent_runs WHERE run_id = ?", (run_id,)
+            ).fetchone()
+        if row is None:
+            raise RuntimeError(f"Subagent run {run_id!r} was not registered.")
+        return {
+            "run_id": row["run_id"],
+            "session_id": row["session_id"],
+            "agent_name": row["agent_name"],
+            "delegated_task": row["delegated_task"],
+            "checkpoint_namespace": row["checkpoint_namespace"],
+        }
+
+
+__all__ = ["GraphInterrupt", "SubagentRunRecorder"]

--- a/src/chemgraph/memory/subagent_recorder.py
+++ b/src/chemgraph/memory/subagent_recorder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -12,6 +13,7 @@ from chemgraph.memory.store import SessionStore
 
 
 _RUN_NAMESPACE = uuid.UUID("7ceaa8ee-c7ac-4efd-99e6-b8e3ad89de82")
+logger = logging.getLogger(__name__)
 
 
 class SubagentRunRecorder:
@@ -37,34 +39,79 @@ class SubagentRunRecorder:
         task = str(getattr(messages[-1], "content", "")) if messages else ""
         return run_id, thread_id, task
 
-    def start(self, agent_name: str, state: Any, config: dict) -> str:
-        run_id, thread_id, task = self._identity(agent_name, state, config)
-        checkpoint_namespace = str(config["configurable"]["checkpoint_ns"])
-        self.store.upsert_subagent_run(
-            run_id=run_id,
-            session_id=thread_id,
-            agent_name=agent_name,
-            delegated_task=task,
-            checkpoint_namespace=checkpoint_namespace,
-            status="running",
-        )
+    def start(self, agent_name: str, state: Any, config: dict) -> str | None:
+        try:
+            run_id, thread_id, task = self._identity(agent_name, state, config)
+            checkpoint_namespace = str(config["configurable"]["checkpoint_ns"])
+            self.store.upsert_subagent_run(
+                run_id=run_id,
+                session_id=thread_id,
+                agent_name=agent_name,
+                delegated_task=task,
+                checkpoint_namespace=checkpoint_namespace,
+                status="running",
+            )
+        except Exception:
+            logger.warning(
+                "Could not record the start of subagent %s.",
+                agent_name,
+                exc_info=True,
+            )
+            return None
         return run_id
 
     def interrupted(self, run_id: str) -> None:
-        run = self._get_identity(run_id)
-        self.store.upsert_subagent_run(**run, status="waiting_for_user")
+        try:
+            run = self._get_identity(run_id)
+            self.store.upsert_subagent_run(**run, status="waiting_for_user")
+        except Exception:
+            logger.warning(
+                "Could not record interruption of subagent run %s.",
+                run_id,
+                exc_info=True,
+            )
 
     def failed(self, run_id: str, error: BaseException) -> None:
-        run = self._get_identity(run_id)
-        self.store.upsert_subagent_run(
-            **run,
-            status="failed",
-            error_text=repr(error),
-        )
+        try:
+            run = self._get_identity(run_id)
+            self.store.upsert_subagent_run(
+                **run,
+                status="failed",
+                error_text=repr(error),
+            )
+        except Exception:
+            logger.warning(
+                "Could not record failure of subagent run %s.",
+                run_id,
+                exc_info=True,
+            )
 
     def completed(self, run_id: str, result: Any) -> None:
         messages = result.get("messages", []) if isinstance(result, dict) else []
-        self.store.complete_subagent_run(run_id, serialize_messages(list(messages)))
+        try:
+            serialized = serialize_messages(list(messages))
+            self.store.complete_subagent_run(run_id, serialized)
+        except Exception as exc:
+            logger.warning(
+                "Could not persist the transcript for completed subagent run %s.",
+                run_id,
+                exc_info=True,
+            )
+            try:
+                self.store.update_subagent_run_status(
+                    run_id,
+                    "completed",
+                    error_text=(
+                        "Readable transcript unavailable: "
+                        f"{type(exc).__name__}"
+                    ),
+                )
+            except Exception:
+                logger.warning(
+                    "Could not mark subagent run %s completed.",
+                    run_id,
+                    exc_info=True,
+                )
 
     def _get_identity(self, run_id: str) -> dict[str, str]:
         with self.store._connect() as conn:

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -17,6 +17,7 @@ from ase.io import read as ase_read
 
 from chemgraph.agent.llm_agent import HumanInputRequired
 from chemgraph.memory.store import SessionStore
+from chemgraph.memory.durable import delete_durable_session
 from chemgraph.models.supported_models import supported_argo_models
 from chemgraph.schemas.ase_input import (
     get_available_calculator_names,
@@ -402,7 +403,7 @@ def _render_session_sidebar() -> None:
                     help="Delete this session",
                 ):
                     try:
-                        store.delete_session(s.session_id)
+                        delete_durable_session(store, s.session_id)
                         # If we just deleted the active session, reset
                         if current_sid == s.session_id:
                             _start_new_chat()

--- a/tests/test_durable_main_agent.py
+++ b/tests/test_durable_main_agent.py
@@ -3,7 +3,7 @@
 import os
 import sqlite3
 import stat
-import time
+import threading
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -538,25 +538,38 @@ def test_local_database_files_are_private(tmp_path):
 def test_busy_runtime_shutdown_is_bounded_and_finishes_on_owner_thread(
     monkeypatch, caplog
 ):
+    owner_blocked = threading.Event()
+    release_owner = threading.Event()
+
     class BlockingConnection:
         async def close(self):
             import asyncio
 
-            asyncio.get_running_loop().call_soon(time.sleep, 0.15)
+            def block_owner():
+                owner_blocked.set()
+                release_owner.wait()
+
+            asyncio.get_running_loop().call_soon(block_owner)
 
     monkeypatch.setattr(checkpoint_runtime_module, "_CLOSE_TIMEOUT_SECONDS", 0.03)
     runtime = CheckpointRuntime()
     runtime._connections["blocking"] = BlockingConnection()
+    close_thread = threading.Thread(target=runtime.close)
 
-    started = time.monotonic()
-    runtime.close()
-    elapsed = time.monotonic() - started
+    try:
+        close_thread.start()
+        assert owner_blocked.wait(timeout=1.0)
+        close_thread.join(timeout=1.0)
 
-    assert elapsed < 0.12
-    assert runtime._thread.is_alive()
-    runtime._thread.join(timeout=0.5)
+        assert not close_thread.is_alive()
+        assert runtime._thread.is_alive()
+        assert "still running after shutdown" in caplog.text
+    finally:
+        release_owner.set()
+        close_thread.join(timeout=1.0)
+
+    runtime._thread.join(timeout=1.0)
     assert not runtime._thread.is_alive()
-    assert "still running after shutdown" in caplog.text
 
 
 def test_close_sqlite_releases_cached_saver(tmp_path):

--- a/tests/test_durable_main_agent.py
+++ b/tests/test_durable_main_agent.py
@@ -1,0 +1,384 @@
+"""Durable checkpoint and transcript tests for the main-agent workflow."""
+
+import os
+import sqlite3
+import stat
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from chemgraph.agent.main_session import (
+    IncompatibleCheckpointError,
+    MainAgentSession,
+    MissingCheckpointError,
+)
+from chemgraph.cli.checkpoint_runtime import CheckpointRuntime
+from chemgraph.graphs.main_agent import construct_main_agent_graph
+from chemgraph.memory.durable import delete_durable_session
+from chemgraph.memory.schemas import MainAgentGraphConfig, MainAgentSessionMetadata
+from chemgraph.memory.store import SessionStore
+from chemgraph.memory.subagent_recorder import SubagentRunRecorder
+from tests.test_main_agent import (
+    _ScriptedChatModel,
+    _answering_subgraph,
+    _interrupting_subgraph,
+    _subagent,
+    _task_call,
+)
+
+
+def _metadata(checkpoint_db, fingerprint="topology"):
+    return MainAgentSessionMetadata(
+        graph_config=MainAgentGraphConfig(
+            model_name="scripted",
+            topology_fingerprint=fingerprint,
+        ),
+        checkpoint_backend="AsyncSqliteSaver",
+        checkpoint_db=str(checkpoint_db),
+    )
+
+
+def _graph(model, saver, *, child=None, recorder=None):
+    return construct_main_agent_graph(
+        model,
+        subagents=[_subagent(child or _answering_subgraph("child"))],
+        checkpointer=saver,
+        subagent_recorder=recorder,
+    )
+
+
+def test_restart_restores_history_and_continues(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    metadata = _metadata(checkpoint_db)
+
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="first")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="durable-thread",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    runtime.run(lambda: session.run("first question"))
+    runtime.close()
+
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="second")]), saver)
+    restored = MainAgentSession(
+        graph,
+        thread_id="durable-thread",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    assert runtime.run(restored.restore).status == "completed"
+    result = runtime.run(lambda: restored.run("follow up"))
+    runtime.close()
+
+    assert result.assistant_response == "second"
+    saved = store.get_session("durable-thread")
+    assert [message.content for message in saved.messages if message.role == "human"] == [
+        "first question",
+        "follow up",
+    ]
+    assert saved.query_count == 2
+
+
+def test_restart_restores_subagent_interrupt_and_transcript(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    metadata = _metadata(checkpoint_db)
+
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(
+        _ScriptedChatModel(
+            responses=[AIMessage(content="", tool_calls=[_task_call("task-1")])]
+        ),
+        saver,
+        child=_interrupting_subgraph(),
+        recorder=SubagentRunRecorder(store),
+    )
+    session = MainAgentSession(
+        graph,
+        thread_id="interrupt-thread",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    waiting = runtime.run(lambda: session.run("calculate"))
+    assert waiting.status == "waiting_for_user"
+    assert store.get_session("interrupt-thread").child_runs[0].status == (
+        "waiting_for_user"
+    )
+    runtime.close()
+
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(
+        _ScriptedChatModel(responses=[AIMessage(content="used EMT")]),
+        saver,
+        child=_interrupting_subgraph(),
+        recorder=SubagentRunRecorder(store),
+    )
+    restored = MainAgentSession(
+        graph,
+        thread_id="interrupt-thread",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    assert runtime.run(restored.restore).status == "waiting_for_user"
+    completed = runtime.run(lambda: restored.resume("EMT"))
+    runtime.close()
+
+    assert completed.assistant_response == "used EMT"
+    saved = store.get_session("interrupt-thread")
+    assert len(saved.child_runs) == 1
+    assert saved.child_runs[0].status == "completed"
+    assert [message.role for message in saved.child_runs[0].messages] == [
+        "human",
+        "ai",
+    ]
+
+
+def test_restart_detects_failed_task_and_retry_is_idempotent(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    metadata = _metadata(checkpoint_db)
+
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[RuntimeError("temporary")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="failed-thread",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    with pytest.raises(RuntimeError, match="temporary"):
+        runtime.run(lambda: session.run("hello"))
+    runtime.close()
+
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="recovered")]), saver)
+    restored = MainAgentSession(
+        graph,
+        thread_id="failed-thread",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    assert runtime.run(restored.restore).status == "failed"
+    assert runtime.run(restored.retry).assistant_response == "recovered"
+    snapshot = runtime.run(lambda: graph.aget_state(restored.config))
+    runtime.close()
+
+    humans = [
+        message.content
+        for message in snapshot.values["messages"]
+        if isinstance(message, HumanMessage)
+    ]
+    assert humans == ["hello"]
+    assert store.get_session("failed-thread").query_count == 1
+
+
+def test_restore_rejects_topology_mismatch(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="done")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="mismatch",
+        session_store=store,
+        session_metadata=_metadata(checkpoint_db, "one"),
+    )
+    runtime.run(lambda: session.run("hello"))
+    incompatible = MainAgentSession(
+        graph,
+        thread_id="mismatch",
+        session_store=store,
+        session_metadata=_metadata(checkpoint_db, "two"),
+    )
+    with pytest.raises(IncompatibleCheckpointError):
+        runtime.run(incompatible.restore)
+    runtime.close()
+
+
+def test_restore_rejects_missing_checkpoint(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    metadata = _metadata(checkpoint_db)
+    store.create_session(
+        "missing",
+        "scripted",
+        "main_agent",
+        session_metadata=metadata,
+    )
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="missing",
+        session_store=store,
+        session_metadata=metadata,
+    )
+
+    with pytest.raises(MissingCheckpointError):
+        runtime.run(session.restore)
+    runtime.close()
+
+
+def test_parallel_direct_subagents_get_isolated_run_records(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    first = _task_call("first", "one")
+    second = _task_call("second", "two")
+    graph = _graph(
+        _ScriptedChatModel(
+            responses=[
+                AIMessage(content="", tool_calls=[first, second]),
+                AIMessage(content="complete"),
+            ]
+        ),
+        saver,
+        recorder=SubagentRunRecorder(store),
+    )
+    session = MainAgentSession(
+        graph,
+        thread_id="parallel",
+        session_store=store,
+        session_metadata=_metadata(checkpoint_db),
+    )
+
+    runtime.run(lambda: session.run("do both"))
+    runtime.close()
+
+    runs = store.get_session("parallel").child_runs
+    assert len(runs) == 2
+    assert {run.delegated_task for run in runs} == {"one", "two"}
+    assert len({run.run_id for run in runs}) == 2
+    assert all(run.status == "completed" for run in runs)
+
+
+def test_child_tool_transcript_is_lossless_and_replay_idempotent(tmp_path):
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    store.create_session(
+        "root",
+        "scripted",
+        "main_agent",
+        session_metadata=_metadata(tmp_path / "checkpoints.db"),
+    )
+    recorder = SubagentRunRecorder(store)
+    state = {"messages": [HumanMessage(content="calculate the energy")]}
+    config = {
+        "configurable": {
+            "thread_id": "root",
+            "checkpoint_ns": "task:opaque-namespace",
+        }
+    }
+    result = {
+        "messages": [
+            *state["messages"],
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "run_ase",
+                        "args": {"driver": "energy"},
+                        "id": "tool-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            ToolMessage(content='{"energy": -1.0}', tool_call_id="tool-1"),
+            AIMessage(content="The energy is -1.0 eV."),
+        ]
+    }
+
+    run_id = recorder.start("chemgraph", state, config)
+    recorder.completed(run_id, result)
+    recorder.completed(run_id, result)
+
+    runs = store.get_session("root").child_runs
+    assert len(runs) == 1
+    assert [message.role for message in runs[0].messages] == [
+        "human",
+        "ai",
+        "tool",
+        "ai",
+    ]
+    assert runs[0].messages[1].content == "[tool calls: run_ase]"
+    assert all(message.serialized_payload for message in runs[0].messages)
+    assert len({message.message_id for message in runs[0].messages}) == 4
+
+
+def test_delete_removes_session_children_and_checkpoints(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    metadata = _metadata(checkpoint_db)
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="done")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="delete-me",
+        session_store=store,
+        session_metadata=metadata,
+    )
+    runtime.run(lambda: session.run("hello"))
+    runtime.close()
+
+    assert delete_durable_session(store, "delete-me") is True
+    assert store.get_session("delete-me") is None
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    assert runtime.run(lambda: saver.aget({"configurable": {"thread_id": "delete-me"}})) is None
+    runtime.close()
+
+
+def test_legacy_session_database_migrates_in_place(tmp_path):
+    db_path = tmp_path / "legacy.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT '',
+                model_name TEXT NOT NULL, workflow_type TEXT NOT NULL,
+                log_dir TEXT, query_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(session_id),
+                role TEXT NOT NULL, content TEXT NOT NULL, tool_name TEXT,
+                timestamp TEXT NOT NULL
+            );
+            INSERT INTO sessions VALUES
+                ('legacy', 'Old', 'gpt', 'single_agent', NULL, 0,
+                 '2026-01-01T00:00:00', '2026-01-01T00:00:00');
+            """
+        )
+
+    migrated = SessionStore(str(db_path)).get_session("legacy")
+
+    assert migrated.status == "completed"
+    assert migrated.graph_config is None
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX modes are platform-specific")
+def test_local_database_files_are_private(tmp_path):
+    session_db = tmp_path / "sessions.db"
+    checkpoint_db = tmp_path / "checkpoints.db"
+    SessionStore(str(session_db))
+    runtime = CheckpointRuntime()
+    runtime.open_sqlite(str(checkpoint_db))
+    runtime.close()
+
+    assert stat.S_IMODE(session_db.stat().st_mode) == 0o600
+    assert stat.S_IMODE(checkpoint_db.stat().st_mode) == 0o600

--- a/tests/test_durable_main_agent.py
+++ b/tests/test_durable_main_agent.py
@@ -3,6 +3,7 @@
 import os
 import sqlite3
 import stat
+import time
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -12,6 +13,7 @@ from chemgraph.agent.main_session import (
     MainAgentSession,
     MissingCheckpointError,
 )
+from chemgraph.cli import checkpoint_runtime as checkpoint_runtime_module
 from chemgraph.cli.checkpoint_runtime import CheckpointRuntime
 from chemgraph.graphs.main_agent import construct_main_agent_graph
 from chemgraph.memory.durable import delete_durable_session
@@ -318,6 +320,136 @@ def test_child_tool_transcript_is_lossless_and_replay_idempotent(tmp_path):
     assert len({message.message_id for message in runs[0].messages}) == 4
 
 
+def test_unserializable_child_transcript_does_not_fail_completed_run(tmp_path):
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    store.create_session(
+        "root",
+        "scripted",
+        "main_agent",
+        session_metadata=_metadata(tmp_path / "checkpoints.db"),
+    )
+    recorder = SubagentRunRecorder(store)
+    state = {"messages": [HumanMessage(content="calculate")]}
+    config = {
+        "configurable": {
+            "thread_id": "root",
+            "checkpoint_ns": "task:unserializable",
+        }
+    }
+    run_id = recorder.start("chemgraph", state, config)
+
+    recorder.completed(
+        run_id,
+        {
+            "messages": [
+                ToolMessage(
+                    content="done",
+                    tool_call_id="tool-1",
+                    artifact=object(),
+                )
+            ]
+        },
+    )
+
+    run = store.get_session("root").child_runs[0]
+    assert run.status == "completed"
+    assert run.messages == []
+    assert run.error_text == "Readable transcript unavailable: TypeError"
+
+
+def test_readable_sync_failure_does_not_break_completed_turn(monkeypatch, tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="done")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="store-failure",
+        session_store=store,
+        session_metadata=_metadata(checkpoint_db),
+    )
+    monkeypatch.setattr(
+        store,
+        "synchronize_messages",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("store broke")),
+    )
+
+    result = runtime.run(lambda: session.run("hello"))
+    runtime.close()
+
+    assert result.status == "completed"
+    assert store.get_session("store-failure").status == "completed"
+
+
+def test_readable_registration_failure_does_not_prevent_turn(monkeypatch, tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    monkeypatch.setattr(
+        store,
+        "create_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("store broke")),
+    )
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[AIMessage(content="done")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="registration-failure",
+        session_store=store,
+        session_metadata=_metadata(checkpoint_db),
+    )
+
+    result = runtime.run(lambda: session.run("hello"))
+    runtime.close()
+
+    assert result.status == "completed"
+    assert store.get_session("registration-failure") is None
+
+
+def test_status_failure_does_not_mask_graph_error(monkeypatch, tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    runtime = CheckpointRuntime()
+    saver = runtime.open_sqlite(str(checkpoint_db))
+    graph = _graph(_ScriptedChatModel(responses=[RuntimeError("graph broke")]), saver)
+    session = MainAgentSession(
+        graph,
+        thread_id="original-error",
+        session_store=store,
+        session_metadata=_metadata(checkpoint_db),
+    )
+    session._ensure_registered("hello")
+    monkeypatch.setattr(
+        store,
+        "update_session_status",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("store broke")),
+    )
+
+    with pytest.raises(RuntimeError, match="graph broke"):
+        runtime.run(lambda: session.run("hello"))
+    runtime.close()
+
+
+def test_all_recorder_storage_failures_are_nonfatal():
+    class BrokenStore:
+        def upsert_subagent_run(self, **_kwargs):
+            raise RuntimeError("store broke")
+
+    recorder = SubagentRunRecorder(BrokenStore())
+    config = {
+        "configurable": {
+            "thread_id": "root",
+            "checkpoint_ns": "task:broken-store",
+        }
+    }
+
+    assert recorder.start("chemgraph", {"messages": []}, config) is None
+    recorder.interrupted("missing")
+    recorder.failed("missing", RuntimeError("graph broke"))
+    recorder.completed("missing", {"messages": []})
+
+
 def test_delete_removes_session_children_and_checkpoints(tmp_path):
     checkpoint_db = tmp_path / "checkpoints.db"
     store = SessionStore(str(tmp_path / "sessions.db"))
@@ -338,8 +470,27 @@ def test_delete_removes_session_children_and_checkpoints(tmp_path):
     assert store.get_session("delete-me") is None
     runtime = CheckpointRuntime()
     saver = runtime.open_sqlite(str(checkpoint_db))
-    assert runtime.run(lambda: saver.aget({"configurable": {"thread_id": "delete-me"}})) is None
+    assert runtime.run(
+        lambda: saver.aget({"configurable": {"thread_id": "delete-me"}})
+    ) is None
     runtime.close()
+
+
+def test_delete_removes_process_local_session_record(tmp_path):
+    store = SessionStore(str(tmp_path / "sessions.db"))
+    metadata = MainAgentSessionMetadata(
+        graph_config=MainAgentGraphConfig(model_name="scripted"),
+        checkpoint_backend="memory",
+    )
+    store.create_session(
+        "process-local",
+        "scripted",
+        "main_agent",
+        session_metadata=metadata,
+    )
+
+    assert delete_durable_session(store, "process-local") is True
+    assert store.get_session("process-local") is None
 
 
 def test_legacy_session_database_migrates_in_place(tmp_path):
@@ -382,3 +533,52 @@ def test_local_database_files_are_private(tmp_path):
 
     assert stat.S_IMODE(session_db.stat().st_mode) == 0o600
     assert stat.S_IMODE(checkpoint_db.stat().st_mode) == 0o600
+
+
+def test_busy_runtime_shutdown_is_bounded_and_finishes_on_owner_thread(
+    monkeypatch, caplog
+):
+    class BlockingConnection:
+        async def close(self):
+            import asyncio
+
+            asyncio.get_running_loop().call_soon(time.sleep, 0.15)
+
+    monkeypatch.setattr(checkpoint_runtime_module, "_CLOSE_TIMEOUT_SECONDS", 0.03)
+    runtime = CheckpointRuntime()
+    runtime._connections["blocking"] = BlockingConnection()
+
+    started = time.monotonic()
+    runtime.close()
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.12
+    assert runtime._thread.is_alive()
+    runtime._thread.join(timeout=0.5)
+    assert not runtime._thread.is_alive()
+    assert "still running after shutdown" in caplog.text
+
+
+def test_close_sqlite_releases_cached_saver(tmp_path):
+    checkpoint_db = tmp_path / "checkpoints.db"
+    runtime = CheckpointRuntime()
+    first = runtime.open_sqlite(str(checkpoint_db))
+
+    runtime.close_sqlite(str(checkpoint_db))
+    second = runtime.open_sqlite(str(checkpoint_db))
+    runtime.close()
+
+    assert second is not first
+
+
+def test_runtime_can_be_closed_from_owner_loop():
+    runtime = CheckpointRuntime()
+
+    async def close_runtime():
+        runtime.close()
+
+    runtime.run(close_runtime)
+    runtime._thread.join(timeout=0.5)
+
+    assert not runtime._thread.is_alive()
+    runtime.close()

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -110,6 +110,34 @@ def test_visualize_returns_ascii_graph():
     graph.draw_ascii.assert_called_once_with()
 
 
+def test_state_access_delegates_capability_and_uses_fresh_defaults():
+    class AsyncLookingWorkflow:
+        checkpointer = type("AsyncCustomSaver", (), {})()
+
+        def __init__(self):
+            self.sync_configs = []
+            self.async_configs = []
+
+        def get_state(self, config):
+            self.sync_configs.append(config)
+            return SimpleNamespace(values={"mode": "sync"})
+
+        async def aget_state(self, config):
+            self.async_configs.append(config)
+            return SimpleNamespace(values={"mode": "async"})
+
+    workflow = AsyncLookingWorkflow()
+    agent = object.__new__(ChemGraph)
+    agent.workflow = workflow
+
+    assert agent.get_state() == {"mode": "sync"}
+    first_config = workflow.sync_configs[0]
+    first_config["mutated"] = True
+    assert agent.get_state() == {"mode": "sync"}
+    assert "mutated" not in workflow.sync_configs[1]
+    assert asyncio.run(agent.aget_state()) == {"mode": "async"}
+
+
 def test_turn_event_callback_emits_llm_decision_for_tool_calls():
     events = []
     callback = _TurnEventCallback(

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -458,6 +458,72 @@ def test_interactive_slash_model_and_workflow_switches(monkeypatch):
     ]
 
 
+def test_workflow_switch_recovers_from_checkpoint_open_failure(monkeypatch):
+    class FakeRuntime:
+        def __init__(self, *, error=None):
+            self.error = error
+            self.closed = False
+            self.saver = SimpleNamespace()
+            self.opened_paths = []
+
+        def open_sqlite(self, path):
+            self.opened_paths.append(path)
+            if self.error is not None:
+                raise self.error
+            return self.saver
+
+        def close(self):
+            self.closed = True
+
+    failed_runtime = FakeRuntime(error=RuntimeError("database is locked"))
+    successful_runtime = FakeRuntime()
+    runtimes = iter([failed_runtime, successful_runtime])
+    initial_agent = SimpleNamespace(session_id="initial")
+    main_agent = SimpleNamespace()
+    agents = iter([initial_agent, main_agent])
+    initialization_calls = []
+    answers = iter(
+        [
+            "first-model",
+            "single_agent",
+            "/workflow main_agent",
+            "/workflow main_agent",
+            "quit",
+        ]
+    )
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "CheckpointRuntime", lambda: next(runtimes))
+
+    def fake_initialize(_model, workflow, *_args, **kwargs):
+        initialization_calls.append((workflow, kwargs["checkpointer"]))
+        return next(agents)
+
+    monkeypatch.setattr(commands, "initialize_agent", fake_initialize)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda *_args, **_kwargs: SimpleNamespace(thread_id="main", failed=False),
+    )
+
+    with console.capture() as capture:
+        commands.interactive_mode(workflow="single_agent", generate_report=False)
+
+    assert failed_runtime.closed is True
+    assert successful_runtime.closed is True
+    assert initialization_calls == [
+        ("single_agent", None),
+        ("main_agent", successful_runtime.saver),
+    ]
+    output = capture.get()
+    assert "Could not open checkpoint database: database is locked" in output
+    assert "Workflow changed to: main_agent" in output
+
+
 def test_resume_replaces_all_active_graph_settings(monkeypatch, tmp_path):
     target_config = MainAgentGraphConfig(
         model_name="argo:gpt-5.6-sol",

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -9,6 +9,8 @@ import toml
 from chemgraph.agent.main_session import MainAgentTurnResult, PendingInterrupt
 from chemgraph.cli import commands
 from chemgraph.cli.formatting import console
+from chemgraph.memory.schemas import MainAgentGraphConfig, MainAgentSessionMetadata
+from chemgraph.memory.store import SessionStore
 
 cli_main = importlib.import_module("chemgraph.cli.main")
 
@@ -454,6 +456,160 @@ def test_interactive_slash_model_and_workflow_switches(monkeypatch):
         ("Provider/Next-Model", "main_agent"),
         ("Provider/Next-Model", "single_agent"),
     ]
+
+
+def test_resume_replaces_all_active_graph_settings(monkeypatch, tmp_path):
+    target_config = MainAgentGraphConfig(
+        model_name="argo:gpt-5.6-sol",
+        structured_output=True,
+        generate_report=True,
+        human_supervised=True,
+        recursion_limit=77,
+        reasoning_effort="high",
+        max_retries=4,
+        terminal_tool_names=("finish",),
+        topology_fingerprint="target",
+    )
+    target_db = str(tmp_path / "target-checkpoints.db")
+    SessionStore().create_session(
+        "target-thread",
+        target_config.model_name,
+        "main_agent",
+        session_metadata=MainAgentSessionMetadata(
+            graph_config=target_config,
+            checkpoint_backend="AsyncSqliteSaver",
+            checkpoint_db=target_db,
+        ),
+    )
+    answers = iter(
+        [
+            "initial-model",
+            "main_agent",
+            "/resume target-thread",
+            "/workflow single_agent",
+            "quit",
+        ]
+    )
+    agents = iter([SimpleNamespace(), SimpleNamespace(), SimpleNamespace(session_id="new")])
+    initialization_calls = []
+    sessions = iter(
+        [
+            SimpleNamespace(thread_id="initial", failed=False),
+            SimpleNamespace(thread_id="target-thread", failed=False),
+        ]
+    )
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+
+    def fake_initialize(*args, **kwargs):
+        initialization_calls.append((args, kwargs))
+        return next(agents)
+
+    monkeypatch.setattr(commands, "initialize_agent", fake_initialize)
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda *_args, **_kwargs: next(sessions),
+    )
+    monkeypatch.setattr(
+        commands,
+        "restore_main_agent_session",
+        lambda *_args, **_kwargs: MainAgentTurnResult(
+            thread_id="target-thread",
+            status="completed",
+            assistant_response="",
+            interrupts=(),
+            state={},
+        ),
+    )
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent", generate_report=False)
+
+    resume_args, resume_kwargs = initialization_calls[1]
+    rebuild_args, rebuild_kwargs = initialization_calls[2]
+    assert resume_args[:6] == (
+        target_config.model_name,
+        "main_agent",
+        True,
+        "state",
+        True,
+        77,
+    )
+    assert rebuild_args[:6] == (
+        target_config.model_name,
+        "single_agent",
+        True,
+        "state",
+        True,
+        77,
+    )
+    for kwargs in (resume_kwargs, rebuild_kwargs):
+        assert kwargs["human_supervised"] is True
+        assert kwargs["reasoning_effort"] == "high"
+        assert kwargs["max_retries"] == 4
+        assert kwargs["terminal_tool_names"] == ("finish",)
+
+
+def test_startup_resume_distinguishes_process_local_session(monkeypatch):
+    SessionStore().create_session(
+        "process-local",
+        "scripted",
+        "main_agent",
+        session_metadata=MainAgentSessionMetadata(
+            graph_config=MainAgentGraphConfig(model_name="scripted"),
+            checkpoint_backend="memory",
+        ),
+    )
+    monkeypatch.setattr(
+        commands,
+        "initialize_agent",
+        lambda *_args, **_kwargs: pytest.fail("process-local session was initialized"),
+    )
+
+    with console.capture() as capture:
+        commands.interactive_mode(resume_session="process-local")
+
+    assert "process-local checkpoint" in capture.get()
+
+
+def test_interactive_eof_closes_checkpoint_runtime(monkeypatch):
+    class FakeRuntime:
+        def __init__(self):
+            self.closed = False
+
+        def open_sqlite(self, _path):
+            return SimpleNamespace()
+
+        def close(self):
+            self.closed = True
+
+    runtime = FakeRuntime()
+    answers = iter(["model", "main_agent"])
+
+    def prompt(*_args, **_kwargs):
+        try:
+            return next(answers)
+        except StopIteration as exc:
+            raise EOFError from exc
+
+    monkeypatch.setattr(commands, "CheckpointRuntime", lambda: runtime)
+    monkeypatch.setattr(commands.Prompt, "ask", prompt)
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: SimpleNamespace())
+    monkeypatch.setattr(
+        commands,
+        "create_main_agent_session",
+        lambda *_args, **_kwargs: SimpleNamespace(thread_id="main", failed=False),
+    )
+
+    with console.capture():
+        commands.interactive_mode(workflow="main_agent")
+
+    assert runtime.closed is True
 
 
 def test_interactive_deepagent_setting_survives_workflow_switches(monkeypatch):

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -13,6 +13,19 @@ from chemgraph.cli.formatting import console
 cli_main = importlib.import_module("chemgraph.cli.main")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_durable_databases(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        commands,
+        "DEFAULT_CHECKPOINT_DB",
+        str(tmp_path / "checkpoints.db"),
+    )
+    monkeypatch.setattr(
+        "chemgraph.memory.store.DEFAULT_DB_PATH",
+        str(tmp_path / "sessions.db"),
+    )
+
+
 def _turn_result(*interrupts: PendingInterrupt) -> MainAgentTurnResult:
     return MainAgentTurnResult(
         thread_id="main-thread",
@@ -196,6 +209,10 @@ def test_deepagent_cli_boolean_flags():
 
     assert parser.parse_args(["--deepagent"]).deepagent is True
     assert parser.parse_args(["--no-deepagent"]).deepagent is False
+    assert (
+        parser.parse_args(["--checkpoint-db", "/tmp/checkpoints.db"]).checkpoint_db
+        == "/tmp/checkpoints.db"
+    )
 
 
 def test_main_agent_query_failure_suggests_retry():
@@ -236,10 +253,10 @@ def test_interactive_main_agent_discards_session_on_quit(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: session,
+        lambda _agent, **_kwargs: session,
     )
 
-    def fake_run(active_session, query, verbose=False):
+    def fake_run(active_session, query, verbose=False, **_kwargs):
         assert active_session is session
         assert query == "calculate"
         assert verbose is False
@@ -267,12 +284,12 @@ def test_interactive_main_agent_retry_command(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: session,
+        lambda _agent, **_kwargs: session,
     )
 
     calls = []
 
-    def fake_retry(active_session, verbose=False):
+    def fake_retry(active_session, verbose=False, **_kwargs):
         calls.append((active_session, verbose))
         active_session.failed = False
         return _turn_result()
@@ -320,7 +337,7 @@ def test_interactive_show_prompt_reaches_main_agent(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: session,
+        lambda _agent, **_kwargs: session,
     )
     monkeypatch.setattr(
         commands,
@@ -328,7 +345,7 @@ def test_interactive_show_prompt_reaches_main_agent(monkeypatch):
         lambda _sid: pytest.fail("natural-language prompt called show_session"),
     )
 
-    def fake_run(active_session, query, verbose=False):
+    def fake_run(active_session, query, verbose=False, **_kwargs):
         calls.append((active_session, query, verbose))
         return _turn_result()
 
@@ -355,7 +372,7 @@ def test_interactive_slash_show_dispatches_to_session_command(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: session,
+        lambda _agent, **_kwargs: session,
     )
     monkeypatch.setattr(commands, "show_session", shown.append)
     monkeypatch.setattr(
@@ -426,7 +443,7 @@ def test_interactive_slash_model_and_workflow_switches(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: SimpleNamespace(thread_id="main", failed=False),
+        lambda _agent, **_kwargs: SimpleNamespace(thread_id="main", failed=False),
     )
 
     with console.capture():
@@ -473,7 +490,7 @@ def test_interactive_deepagent_setting_survives_workflow_switches(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: SimpleNamespace(thread_id="main", failed=False),
+        lambda _agent, **_kwargs: SimpleNamespace(thread_id="main", failed=False),
     )
 
     with console.capture():
@@ -507,7 +524,7 @@ def test_interactive_reports_invalid_slash_commands(monkeypatch):
     monkeypatch.setattr(
         commands,
         "create_main_agent_session",
-        lambda _agent: session,
+        lambda _agent, **_kwargs: session,
     )
 
     with console.capture() as capture:
@@ -556,12 +573,17 @@ def test_main_agent_requires_interactive_cli_mode():
     assert "requires interactive mode" in capture.get()
 
 
-def test_main_agent_rejects_persistent_resume():
-    with console.capture() as capture, pytest.raises(SystemExit) as exc_info:
-        cli_main._handle_run(_run_args(interactive=True, resume="old-thread"))
+def test_main_agent_dispatches_persistent_resume(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        cli_main,
+        "interactive_mode",
+        lambda **kwargs: captured.update(kwargs),
+    )
 
-    assert exc_info.value.code == 2
-    assert "--resume is not supported" in capture.get()
+    cli_main._handle_run(_run_args(interactive=True, resume="old-thread"))
+
+    assert captured["resume_session"] == "old-thread"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Persist exact main-agent supervisor state, pending interrupts, and retryable failures with a strict async SQLite LangGraph checkpointer.
- Store readable and lossless supervisor and direct-subagent transcripts with migration-safe session metadata, topology validation, and coordinated deletion.
- Add durable startup and in-REPL restore, retry support, checkpoint configuration, documentation, and regression coverage.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- ruff check src tests
- PYTHONPATH=src pytest -q tests/test_durable_main_agent.py tests/test_main_agent.py tests/test_main_agent_cli.py tests/test_memory.py tests/test_agent_session.py tests/test_ui_main_interface.py (153 passed)
- git diff --check

## Checklist

- [x] Branched from the latest main and targets main
- [x] PR is focused on one logical feature
- [x] Tracked source and tests pass Ruff checks
- [x] Added migration, restart, interrupt, retry, child-run, deletion, and permissions tests
- [x] Updated configuration and user documentation
- [ ] ruff check . passes (the workspace contains the unrelated untracked .cg_uma_env virtual environment)
- [ ] pytest tests/ -k not-tblite passes without optional-environment exclusions