### PR TITLE
Unify MLIP calculator and execution backend configuration

### DIFF
--- a/.github/workflows/dependency_tests.yml
+++ b/.github/workflows/dependency_tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        install_extras: [core, calculators, uma, ui, parsl, xanes, rag]
+        install_extras: [core, calculators, rootstock, nvalchemi_mace, uma, ui, parsl, xanes, rag]
 
     steps:
     - uses: actions/checkout@v4
@@ -81,6 +81,8 @@ jobs:
         # Mapping of extras to key packages they provide
         extra_packages = {
             'calculators': ['tblite'],
+            'rootstock': ['rootstock'],
+            'nvalchemi_mace': ['nvalchemi'],
             'uma': ['fairchem.core', 'e3nn'],
             'ui': ['streamlit', 'py3Dmol', 'plotly'],
             'parsl': ['parsl'],

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ available in that environment.
 | MACE | Core install | MACE-Polar medium is the default and supports molecular dipole moments; first use downloads ASL-licensed model weights |
 | TBLite / xTB | `pip install "chemgraph[calculators]"` | May require a Fortran toolchain when no wheel is available |
 | UMA / FAIRChem | `pip install "chemgraph[uma]"` | Use a separate environment from MACE if `e3nn` resolution conflicts |
+| NVIDIA ALCHEMI for MACE | `pip install "chemgraph[nvalchemi_mace]"` | CUDA-oriented batched MACE evaluation |
+| Rootstock | `pip install "chemgraph[rootstock]"` | Hosted model adapter exposed through an ASE calculator |
 | NWChem | Install the `nwchem` executable separately | Must be on `PATH` or configured through ASE |
 | ORCA | Install ORCA separately | Must be on `PATH` or configured through ASE |
 | AIMNet2 | Install `aimnet2calc` separately | Detected lazily when installed |

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -12,6 +12,8 @@ runtime; optional engines that cannot be imported or located are omitted.
 | MACE | Included in core ChemGraph | MACE-Polar medium is the default; supports energies, forces, and molecular dipole moments |
 | TBLite | `pip install "chemgraph[calculators]"` | Semiempirical calculations |
 | UMA / fairchem | `pip install "chemgraph[uma]"` in a separate environment | Advanced universal ML potential |
+| NVIDIA ALCHEMI | `pip install "chemgraph[nvalchemi_mace]"` | CUDA-oriented batched MACE evaluation |
+| Rootstock | `pip install "chemgraph[rootstock]"` | Hosted MACE, UMA, or AIMNet2 checkpoint through ASE |
 | AIMNet2 | Install its package/model dependencies separately | Supported molecular ML route when importable |
 | NWChem | Install/configure NWChem for ASE | External quantum chemistry |
 | ORCA | Install/configure ORCA for ASE | External quantum chemistry |
@@ -59,6 +61,25 @@ ChemGraph reports these dipole vectors in Debye.
 The UMA/fairchem stack can require an `e3nn` version that conflicts with MACE.
 Use a separate virtual environment for UMA rather than forcing incompatible
 versions into the core environment.
+
+## MLIP calculator backends
+
+The specialized `run_mlip` and `run_mlip_batch` tools keep the scientific model
+identity separate from the adapter that evaluates it. A request has one
+`model` object and one `calculator` object; `calculator.backend` selects `ase`,
+`nvalchemi`, or `rootstock`. Unsupported combinations fail during validation
+instead of silently dropping settings.
+
+| Calculator backend | Model families in the initial interface | Notes |
+| --- | --- | --- |
+| `ase` | MACE, UMA, AIMNet2 | General single-structure and reusable-calculator batch path |
+| `nvalchemi` | MACE-MP | Native CUDA batching; supports energy and FIRE optimization |
+| `rootstock` | MACE, UMA, AIMNet2 | Uses canonical hosted checkpoints and manages its calculator context across a batch |
+
+Execution placement is a separate concern. The same calculator request can be
+submitted by the MLIP MCP server through the local, Parsl, Ensemble Launcher,
+or Globus Compute execution backend. See [MCP servers](mcp_servers.md#mlip-server)
+for examples and remote filesystem requirements.
 
 ## External executables
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,6 +62,8 @@ Install only the integrations needed by your workflow:
 | --- | --- | --- |
 | `calculators` | `pip install "chemgraph[calculators]"` | TBLite |
 | `uma` | `pip install "chemgraph[uma]"` | UMA through fairchem-core |
+| `nvalchemi_mace` | `pip install "chemgraph[nvalchemi_mace]"` | NVIDIA ALCHEMI Toolkit with MACE support |
+| `rootstock` | `pip install "chemgraph[rootstock]"` | Rootstock-hosted model calculator |
 | `ui` | `pip install "chemgraph[ui]"` | Additional UI dependencies |
 | `rag` | `pip install "chemgraph[rag]"` | Document ingestion and vector stores |
 | `xanes` | `pip install "chemgraph[xanes]"` | XANES workflow dependencies |

--- a/docs/mcp_servers.md
+++ b/docs/mcp_servers.md
@@ -74,6 +74,89 @@ Start from the [general examples](https://github.com/argonne-lcf/ChemGraph/tree/
 [Parsl example](https://github.com/argonne-lcf/ChemGraph/tree/main/scripts/mcp_parsl_example),
 or [XANES examples](https://github.com/argonne-lcf/ChemGraph/tree/main/examples/xanes_mcp).
 
+## MLIP server
+
+The MLIP server exposes `run_mlip` and `run_mlip_batch` through the configured
+execution backend:
+
+```bash
+python -m chemgraph.mcp.run_mlip_mcp
+```
+
+Its request schema has one calculation envelope. The model identifies the
+scientific potential, while `calculator.backend` chooses the adapter that
+evaluates it. For example, ASE and NVIDIA ALCHEMI use the same MACE model
+shape:
+
+```json
+{
+  "params": {
+    "input_structure_file": "/data/water.xyz",
+    "output_results_file": "/data/water-result.json",
+    "driver": "energy",
+    "model": {
+      "family": "mace",
+      "checkpoint": "medium"
+    },
+    "calculator": {
+      "backend": "ase",
+      "device": "cpu"
+    }
+  }
+}
+```
+
+To route that scientific request through ALCHEMI, only the calculator object
+changes:
+
+```json
+{
+  "calculator": {
+    "backend": "nvalchemi",
+    "device": "cuda",
+    "dtype": "float32",
+    "compile_model": false,
+    "enable_cueq": false
+  }
+}
+```
+
+Rootstock is also selected as a calculator rather than represented as a model
+family:
+
+```json
+{
+  "model": {"family": "uma", "checkpoint": "organization/model"},
+  "calculator": {
+    "backend": "rootstock",
+    "cluster": "local",
+    "device": "cuda"
+  }
+}
+```
+
+The server-wide `[execution]` configuration independently controls where the
+whole tool call runs. It is not repeated inside the MLIP request:
+
+```toml
+[execution]
+backend = "parsl" # local, parsl, ensemble_launcher, or globus_compute
+system = "polaris"
+```
+
+`run_mlip_batch` submits the whole ordered batch as one execution task. The
+calculator/model is therefore loaded once and reused; `batch_size` and
+`max_atoms` control internal ALCHEMI chunks, not execution-backend fan-out.
+CUDA ASE and ALCHEMI requests add a one-GPU advisory resource hint. Backends
+may ignore advisory hints.
+
+With a non-shared filesystem such as a remote Globus Compute endpoint, the
+server does not copy or inline MLIP input files. Pre-stage structures, local
+checkpoints, and Rootstock weights (the transfer tools are exposed when Globus
+Transfer is configured), pass their remote paths, and use an absolute remote
+output path. Remote submissions return a `batch_id`; use `check_job_status` and
+`get_job_results` to retrieve the result.
+
 ## Artifacts and security
 
 Set `CHEMGRAPH_LOG_DIR` before starting a server to choose its log/artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,12 @@ codex = [
 calculators = [
     "tblite==0.4.0; python_version < '3.13' or platform_system != 'Darwin'",
 ]
+rootstock = [
+    "rootstock>=1.6,<2",
+]
+nvalchemi_mace = [
+    "nvalchemi-toolkit[mace]>=0.2,<0.3",
+]
 uma = [
     "fairchem-core==2.3.0",
     "e3nn>=0.5",

--- a/src/chemgraph/mcp/run_mlip_mcp.py
+++ b/src/chemgraph/mcp/run_mlip_mcp.py
@@ -1,31 +1,181 @@
-"""Standalone MCP server for runtime-selectable MLIP calculations."""
+"""Backend-aware MCP server for calculator-selectable MLIP calculations.
 
-from mcp.server.fastmcp import FastMCP
+The public request contains one scientific calculation configuration. The
+``calculator.backend`` field selects ASE, NVIDIA ALCHEMI, or Rootstock, while
+``[execution] backend`` in ``config.toml`` independently selects where this
+Python task runs (local, Parsl, Globus Compute, or EnsembleLauncher).
+"""
 
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from chemgraph.execution.base import TaskSpec
+from chemgraph.execution.config import get_transfer_manager
+from chemgraph.mcp.cg_fastmcp import CGFastMCP
 from chemgraph.mcp.server_utils import run_mcp_server
+from chemgraph.mcp.transfer_tools import register_transfer_tools
 from chemgraph.schemas.mlip_input import MLIPBatchInputSchema, MLIPInputSchema
+from chemgraph.tools.ase_core import _resolve_existing_path, _resolve_path
 from chemgraph.tools.run_mlip_core import run_mlip_batch_core, run_mlip_core
 
-mcp = FastMCP(
+logger = logging.getLogger(__name__)
+
+_JOBS_FILE = Path("~/.chemgraph/mlip_jobs.json").expanduser()
+
+mcp = CGFastMCP(
     name="ChemGraph MLIP Tools",
     instructions=(
-        "Run machine-learned interatomic-potential calculations through an "
-        "explicit ASE or NVIDIA ALCHEMI execution runtime."
+        "Run MLIP calculations using one request configuration. "
+        "calculator.backend selects ASE, NVIDIA ALCHEMI, or Rootstock; the "
+        "server's execution configuration independently selects local, Parsl, "
+        "Globus Compute, or EnsembleLauncher execution. A batch is submitted "
+        "as one backend task so its calculator or model can be reused. For "
+        "non-shared remote filesystems, pre-stage structures and local "
+        "checkpoint files, then provide remote absolute input and output paths."
     ),
 )
 
 
-@mcp.tool()
 def run_mlip(params: MLIPInputSchema) -> dict:
     """Run one MLIP energy calculation or fixed-cell geometry optimization."""
     return run_mlip_core(params)
 
 
-@mcp.tool()
 def run_mlip_batch(params: MLIPBatchInputSchema) -> dict:
-    """Run an ordered batch of MLIP calculations and write a JSON manifest."""
+    """Run an ordered MLIP batch as one execution-backend task."""
     return run_mlip_batch_core(params)
 
 
+def _backend_shares_fs() -> bool:
+    """Return whether the configured execution worker sees server-local files."""
+    backend = getattr(mcp, "_backend", None)
+    return getattr(backend, "shares_filesystem", True)
+
+
+def _resolved_local_structure(path: str) -> str | None:
+    """Return a server-local structure path, or ``None`` for a remote path."""
+    resolved = _resolve_existing_path(path)
+    return resolved if os.path.isfile(resolved) else None
+
+
+def _resolved_local_directory(path: str) -> str | None:
+    """Return a server-local input directory, including CHEMGRAPH_LOG_DIR."""
+    candidate = Path(path)
+    if candidate.is_dir():
+        return str(candidate.resolve())
+    resolved = Path(_resolve_path(path))
+    return str(resolved.resolve()) if resolved.is_dir() else None
+
+
+def _resolved_local_optional_file(path: str | None) -> str | None:
+    """Resolve an optional checkpoint-like value only when it is a local file."""
+    if not path:
+        return None
+    resolved = _resolve_existing_path(path)
+    return resolved if os.path.isfile(resolved) else None
+
+
+def _local_request_files(
+    params: MLIPInputSchema | MLIPBatchInputSchema,
+) -> list[str]:
+    """Collect files that would be inaccessible on a non-shared worker."""
+    local: list[str] = []
+    if isinstance(params, MLIPInputSchema):
+        structure = _resolved_local_structure(params.input_structure_file)
+        if structure is not None:
+            local.append(structure)
+    else:
+        for path in params.input_structure_files or []:
+            structure = _resolved_local_structure(path)
+            if structure is not None:
+                local.append(structure)
+        if params.input_structure_directory is not None:
+            directory = _resolved_local_directory(params.input_structure_directory)
+            if directory is not None:
+                local.append(directory)
+
+    checkpoint = _resolved_local_optional_file(params.model.checkpoint)
+    if checkpoint is not None:
+        local.append(checkpoint)
+    weights = getattr(params.calculator, "weights", None)
+    weights_file = _resolved_local_optional_file(weights)
+    if weights_file is not None:
+        local.append(weights_file)
+    return local
+
+
+def _validate_remote_paths(
+    params: MLIPInputSchema | MLIPBatchInputSchema,
+) -> None:
+    """Require explicit, pre-staged paths for non-shared execution backends."""
+    local_files = _local_request_files(params)
+    if local_files:
+        listed = ", ".join(local_files)
+        raise ValueError(
+            "The execution backend does not share the MCP server filesystem. "
+            "Pre-stage these inputs (for example with transfer_files) and pass "
+            f"their remote paths instead: {listed}"
+        )
+
+    if isinstance(params, MLIPInputSchema):
+        output_path = params.output_results_file
+        field_name = "output_results_file"
+    else:
+        output_path = params.output_results_directory
+        field_name = "output_results_directory"
+    if not os.path.isabs(output_path):
+        raise ValueError(
+            f"{field_name} must be an absolute path on a non-shared execution "
+            "backend."
+        )
+
+
+def _needs_execution_gpu(
+    params: MLIPInputSchema | MLIPBatchInputSchema,
+) -> bool:
+    """Return whether the outer execution task directly evaluates on CUDA."""
+    calculator = params.calculator
+    device = getattr(calculator, "device", None)
+    return calculator.backend != "rootstock" and bool(
+        device and device.lower().startswith("cuda")
+    )
+
+
+def _mlip_transport_hook(task: TaskSpec) -> TaskSpec:
+    """Validate remote paths and add a GPU resource hint before submission."""
+    if task.callable not in (run_mlip, run_mlip_batch):
+        return task
+
+    raw_params: Any = task.kwargs.get("params")
+    schema = (
+        MLIPInputSchema if task.callable is run_mlip else MLIPBatchInputSchema
+    )
+    params = schema.model_validate(raw_params)
+    if not _backend_shares_fs():
+        _validate_remote_paths(params)
+    if _needs_execution_gpu(params):
+        task.gpus_per_task = max(task.gpus_per_task, 1)
+    task.kwargs = {"params": params.model_dump(mode="json")}
+    return task
+
+
+mcp.set_pre_submit_hook(_mlip_transport_hook)
+mcp.tool(name="run_mlip")(run_mlip)
+mcp.tool(name="run_mlip_batch")(run_mlip_batch)
+mcp.init_backend(tracker_kwargs={"persist_file": _JOBS_FILE})
+
+_transfer_manager = get_transfer_manager()
+if _transfer_manager is not None:
+    register_transfer_tools(mcp, _transfer_manager)
+    logger.info("Registered Globus Transfer tools on MLIP MCP server.")
+
+
 if __name__ == "__main__":
-    run_mcp_server(mcp, default_port=9006)
+    try:
+        run_mcp_server(mcp, default_port=9006)
+    finally:
+        mcp.shutdown_backend()

--- a/src/chemgraph/mcp/run_mlip_mcp.py
+++ b/src/chemgraph/mcp/run_mlip_mcp.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
 
 from chemgraph.execution.base import TaskSpec
@@ -79,6 +79,11 @@ def _resolved_local_optional_file(path: str | None) -> str | None:
     return resolved if os.path.isfile(resolved) else None
 
 
+def _is_absolute_remote_path(path: str) -> bool:
+    """Recognize absolute worker paths independently of the server platform."""
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
+
+
 def _local_request_files(
     params: MLIPInputSchema | MLIPBatchInputSchema,
 ) -> list[str]:
@@ -127,7 +132,7 @@ def _validate_remote_paths(
     else:
         output_path = params.output_results_directory
         field_name = "output_results_directory"
-    if not os.path.isabs(output_path):
+    if not _is_absolute_remote_path(output_path):
         raise ValueError(
             f"{field_name} must be an absolute path on a non-shared execution "
             "backend."

--- a/src/chemgraph/mcp/run_mlip_mcp.py
+++ b/src/chemgraph/mcp/run_mlip_mcp.py
@@ -1,0 +1,31 @@
+"""Standalone MCP server for runtime-selectable MLIP calculations."""
+
+from mcp.server.fastmcp import FastMCP
+
+from chemgraph.mcp.server_utils import run_mcp_server
+from chemgraph.schemas.mlip_input import MLIPBatchInputSchema, MLIPInputSchema
+from chemgraph.tools.run_mlip_core import run_mlip_batch_core, run_mlip_core
+
+mcp = FastMCP(
+    name="ChemGraph MLIP Tools",
+    instructions=(
+        "Run machine-learned interatomic-potential calculations through an "
+        "explicit ASE or NVIDIA ALCHEMI execution runtime."
+    ),
+)
+
+
+@mcp.tool()
+def run_mlip(params: MLIPInputSchema) -> dict:
+    """Run one MLIP energy calculation or fixed-cell geometry optimization."""
+    return run_mlip_core(params)
+
+
+@mcp.tool()
+def run_mlip_batch(params: MLIPBatchInputSchema) -> dict:
+    """Run an ordered batch of MLIP calculations and write a JSON manifest."""
+    return run_mlip_batch_core(params)
+
+
+if __name__ == "__main__":
+    run_mcp_server(mcp, default_port=9006)

--- a/src/chemgraph/schemas/mlip_input.py
+++ b/src/chemgraph/schemas/mlip_input.py
@@ -1,0 +1,203 @@
+"""Schemas for runtime-selectable machine-learned interatomic potentials."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from chemgraph.schemas.atomsdata import AtomsData
+
+
+class _StrictModel(BaseModel):
+    """Base model that rejects misspelled runtime and model options."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ASEMLIPRuntimeConfig(_StrictModel):
+    """Execute MLIP calls through ASE calculators and optimizers."""
+
+    type: Literal["ase"] = "ase"
+    device: str = Field(default="cpu", description="Calculator device.")
+    dtype: Literal["float32", "float64"] = "float64"
+    optimizer: Literal["bfgs", "lbfgs", "gpmin", "fire", "mdmin"] = "bfgs"
+
+
+class NVAlchemiRuntimeConfig(_StrictModel):
+    """Execute MLIP calls through NVIDIA ALCHEMI Toolkit."""
+
+    type: Literal["nvalchemi"] = "nvalchemi"
+    device: str = Field(default="cuda", description="PyTorch device.")
+    dtype: Literal["float32", "float64"] = "float32"
+    optimizer: Literal["fire"] = "fire"
+    dt: float = Field(default=0.1, gt=0.0)
+    compile_model: bool = False
+    enable_cueq: bool = False
+
+
+MLIPRuntimeConfig = Annotated[
+    Union[ASEMLIPRuntimeConfig, NVAlchemiRuntimeConfig],
+    Field(discriminator="type"),
+]
+
+
+class MACEModelConfig(_StrictModel):
+    """MACE checkpoint usable by the ASE and NVIDIA ALCHEMI runtimes."""
+
+    provider: Literal["mace"] = "mace"
+    checkpoint: str = Field(
+        description="Named MACE checkpoint or path to a checkpoint file."
+    )
+    calculator_type: Literal["mace_mp", "mace_off", "mace_anicc"] = "mace_mp"
+    dispersion: bool = False
+    damping: str = "bj"
+    dispersion_xc: str = "pbe"
+    dispersion_cutoff: float = 21.167088422553647
+
+
+class UMAModelConfig(_StrictModel):
+    """UMA model configuration for the ASE runtime."""
+
+    provider: Literal["uma"] = "uma"
+    checkpoint: str = Field(description="Registered UMA model name.")
+    task_name: Literal["omol", "omat", "oc20", "odac", "omc"] = "omol"
+    inference_settings: Literal["default", "turbo"] = "default"
+    charge: int = 0
+    multiplicity: int = Field(default=1, ge=1)
+
+
+class AIMNet2ModelConfig(_StrictModel):
+    """AIMNet2 model configuration for the ASE runtime."""
+
+    provider: Literal["aimnet2"] = "aimnet2"
+    checkpoint: str = Field(description="AIMNet2 model alias or checkpoint path.")
+
+
+class RootstockModelConfig(_StrictModel):
+    """Rootstock-managed MLIP checkpoint exposed as an ASE calculator."""
+
+    provider: Literal["rootstock"] = "rootstock"
+    checkpoint: str
+    cluster: str | None = None
+    root: str | None = None
+    cache_root: str | None = None
+    setup_kwargs: dict[str, Any] = Field(default_factory=dict)
+    timeout: float = Field(default=600.0, gt=0.0)
+    weights: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_location(self) -> "RootstockModelConfig":
+        if self.cluster is not None and self.root is not None:
+            raise ValueError("Rootstock model cannot specify both cluster and root.")
+        return self
+
+
+MLIPModelConfig = Annotated[
+    Union[MACEModelConfig, UMAModelConfig, AIMNet2ModelConfig, RootstockModelConfig],
+    Field(discriminator="provider"),
+]
+
+
+class _MLIPCalculationConfig(_StrictModel):
+    """Options shared by single-structure and batch MLIP requests."""
+
+    driver: Literal["energy", "opt"] = "energy"
+    runtime: MLIPRuntimeConfig = Field(default_factory=ASEMLIPRuntimeConfig)
+    model: MLIPModelConfig
+    fmax: float = Field(default=0.01, gt=0.0)
+    steps: int = Field(default=1000, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_runtime_model_pair(self) -> "_MLIPCalculationConfig":
+        if self.model.provider == "rootstock" and self.runtime.type != "ase":
+            raise ValueError("Rootstock models require runtime.type='ase'.")
+        if self.runtime.type == "nvalchemi" and self.model.provider != "mace":
+            raise ValueError(
+                "NVIDIA ALCHEMI runtime supports only provider='mace' in v1."
+            )
+        return self
+
+
+class MLIPInputSchema(_MLIPCalculationConfig):
+    """Input for a single MLIP energy or fixed-cell optimization calculation."""
+
+    input_structure_file: str
+    output_results_file: str = "output.json"
+
+    @model_validator(mode="after")
+    def _validate_output_extension(self) -> "MLIPInputSchema":
+        if not self.output_results_file.lower().endswith(".json"):
+            raise ValueError("output_results_file must end with '.json'.")
+        return self
+
+
+class MLIPBatchInputSchema(_MLIPCalculationConfig):
+    """Input for a deterministic batch of MLIP calculations."""
+
+    input_structure_files: list[str] | None = None
+    input_structure_directory: str | None = None
+    output_results_directory: str = "mlip_results"
+    manifest_file: str = "batch_manifest.json"
+    batch_size: int = Field(default=16, ge=1)
+    max_atoms: int | None = Field(default=None, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_input_source(self) -> "MLIPBatchInputSchema":
+        sources = [
+            bool(self.input_structure_files),
+            self.input_structure_directory is not None,
+        ]
+        if sum(sources) != 1:
+            raise ValueError(
+                "Specify exactly one of input_structure_files or "
+                "input_structure_directory."
+            )
+        if not self.manifest_file.lower().endswith(".json"):
+            raise ValueError("manifest_file must end with '.json'.")
+        return self
+
+
+class MLIPOutputSchema(_StrictModel):
+    """Runtime-neutral result compatible with the existing ASE result envelope."""
+
+    schema_version: int = 1
+    input_structure_file: str
+    converged: bool = False
+    final_structure: AtomsData | None = None
+    simulation_input: dict[str, Any]
+    single_point_energy: float | None = None
+    energy_unit: str = "eV"
+    forces: list[list[float]] | None = None
+    force_unit: str = "eV/angstrom"
+    stress: list[list[float]] | None = None
+    stress_unit: str = "eV/angstrom^3"
+    runtime_info: dict[str, Any]
+    model_info: dict[str, Any]
+    success: bool = False
+    error: str = ""
+    wall_time: float | None = None
+
+
+class MLIPBatchItemSchema(_StrictModel):
+    """One ordered item in an MLIP batch manifest."""
+
+    index: int
+    input_structure_file: str
+    status: Literal["success", "failure"]
+    result_file: str
+    error: str = ""
+
+
+class MLIPBatchManifestSchema(_StrictModel):
+    """Persistent summary for an MLIP batch calculation."""
+
+    schema_version: int = 1
+    status: Literal["completed", "partial", "failure"]
+    runtime_info: dict[str, Any]
+    model_info: dict[str, Any]
+    total: int
+    succeeded: int
+    failed: int
+    wall_time: float
+    items: list[MLIPBatchItemSchema]

--- a/src/chemgraph/schemas/mlip_input.py
+++ b/src/chemgraph/schemas/mlip_input.py
@@ -1,4 +1,4 @@
-"""Schemas for runtime-selectable machine-learned interatomic potentials."""
+"""Schemas for calculator-selectable machine-learned interatomic potentials."""
 
 from __future__ import annotations
 
@@ -10,24 +10,33 @@ from chemgraph.schemas.atomsdata import AtomsData
 
 
 class _StrictModel(BaseModel):
-    """Base model that rejects misspelled runtime and model options."""
+    """Base model that rejects misspelled calculator and model options."""
 
     model_config = ConfigDict(extra="forbid")
 
 
-class ASEMLIPRuntimeConfig(_StrictModel):
-    """Execute MLIP calls through ASE calculators and optimizers."""
-
-    type: Literal["ase"] = "ase"
-    device: str = Field(default="cpu", description="Calculator device.")
-    dtype: Literal["float32", "float64"] = "float64"
-    optimizer: Literal["bfgs", "lbfgs", "gpmin", "fire", "mdmin"] = "bfgs"
+_ASEOptimizer = Literal["bfgs", "lbfgs", "gpmin", "fire", "mdmin"]
 
 
-class NVAlchemiRuntimeConfig(_StrictModel):
-    """Execute MLIP calls through NVIDIA ALCHEMI Toolkit."""
+class ASECalculatorConfig(_StrictModel):
+    """Evaluate a model through an ASE calculator and optimizer."""
 
-    type: Literal["nvalchemi"] = "nvalchemi"
+    backend: Literal["ase"] = "ase"
+    device: str | None = Field(
+        default=None,
+        description="Calculator device override when the selected model supports it.",
+    )
+    dtype: Literal["float32", "float64"] | None = Field(
+        default=None,
+        description="Calculator dtype override when the selected model supports it.",
+    )
+    optimizer: _ASEOptimizer = "bfgs"
+
+
+class NVAlchemiCalculatorConfig(_StrictModel):
+    """Evaluate a MACE model through NVIDIA ALCHEMI Toolkit."""
+
+    backend: Literal["nvalchemi"] = "nvalchemi"
     device: str = Field(default="cuda", description="PyTorch device.")
     dtype: Literal["float32", "float64"] = "float32"
     optimizer: Literal["fire"] = "fire"
@@ -36,66 +45,76 @@ class NVAlchemiRuntimeConfig(_StrictModel):
     enable_cueq: bool = False
 
 
-MLIPRuntimeConfig = Annotated[
-    Union[ASEMLIPRuntimeConfig, NVAlchemiRuntimeConfig],
-    Field(discriminator="type"),
-]
+class RootstockCalculatorConfig(_StrictModel):
+    """Evaluate a hosted model through a Rootstock ASE calculator."""
 
-
-class MACEModelConfig(_StrictModel):
-    """MACE checkpoint usable by the ASE and NVIDIA ALCHEMI runtimes."""
-
-    provider: Literal["mace"] = "mace"
-    checkpoint: str = Field(
-        description="Named MACE checkpoint or path to a checkpoint file."
-    )
-    calculator_type: Literal["mace_mp", "mace_off", "mace_anicc"] = "mace_mp"
-    dispersion: bool = False
-    damping: str = "bj"
-    dispersion_xc: str = "pbe"
-    dispersion_cutoff: float = 21.167088422553647
-
-
-class UMAModelConfig(_StrictModel):
-    """UMA model configuration for the ASE runtime."""
-
-    provider: Literal["uma"] = "uma"
-    checkpoint: str = Field(description="Registered UMA model name.")
-    task_name: Literal["omol", "omat", "oc20", "odac", "omc"] = "omol"
-    inference_settings: Literal["default", "turbo"] = "default"
-    charge: int = 0
-    multiplicity: int = Field(default=1, ge=1)
-
-
-class AIMNet2ModelConfig(_StrictModel):
-    """AIMNet2 model configuration for the ASE runtime."""
-
-    provider: Literal["aimnet2"] = "aimnet2"
-    checkpoint: str = Field(description="AIMNet2 model alias or checkpoint path.")
-
-
-class RootstockModelConfig(_StrictModel):
-    """Rootstock-managed MLIP checkpoint exposed as an ASE calculator."""
-
-    provider: Literal["rootstock"] = "rootstock"
-    checkpoint: str
+    backend: Literal["rootstock"] = "rootstock"
     cluster: str | None = None
     root: str | None = None
     cache_root: str | None = None
+    device: str = Field(default="cuda", description="Rootstock worker device.")
+    optimizer: _ASEOptimizer = "bfgs"
     setup_kwargs: dict[str, Any] = Field(default_factory=dict)
     timeout: float = Field(default=600.0, gt=0.0)
     weights: str | None = None
 
     @model_validator(mode="after")
-    def _validate_location(self) -> "RootstockModelConfig":
+    def _validate_location(self) -> "RootstockCalculatorConfig":
         if self.cluster is not None and self.root is not None:
-            raise ValueError("Rootstock model cannot specify both cluster and root.")
+            raise ValueError("Rootstock calculator cannot specify both cluster and root.")
         return self
 
 
+MLIPCalculatorConfig = Annotated[
+    Union[
+        ASECalculatorConfig,
+        NVAlchemiCalculatorConfig,
+        RootstockCalculatorConfig,
+    ],
+    Field(discriminator="backend"),
+]
+
+
+class MaceDispersionConfig(_StrictModel):
+    """D3 dispersion correction supported by the ASE MACE adapter."""
+
+    damping: str = "bj"
+    xc: str = "pbe"
+    cutoff: float = 21.167088422553647
+
+
+class MACEModelConfig(_StrictModel):
+    """Scientific identity and optional loader settings for a MACE model."""
+
+    family: Literal["mace"] = "mace"
+    checkpoint: str = Field(
+        description="Named MACE checkpoint or path to a checkpoint file."
+    )
+    calculator_type: Literal["mace_mp", "mace_off", "mace_anicc"] | None = None
+    dispersion: MaceDispersionConfig | None = None
+
+
+class UMAModelConfig(_StrictModel):
+    """Scientific identity and optional loader settings for a UMA model."""
+
+    family: Literal["uma"] = "uma"
+    checkpoint: str = Field(description="Registered UMA model name.")
+    task_name: Literal["omol", "omat", "oc20", "odac", "omc"] | None = None
+    inference_settings: Literal["default", "turbo"] | None = None
+    charge: int = 0
+    multiplicity: int = Field(default=1, ge=1)
+
+
+class AIMNet2ModelConfig(_StrictModel):
+    """Scientific identity for an AIMNet2 model."""
+
+    family: Literal["aimnet2"] = "aimnet2"
+    checkpoint: str = Field(description="AIMNet2 model alias or checkpoint path.")
+
+
 MLIPModelConfig = Annotated[
-    Union[MACEModelConfig, UMAModelConfig, AIMNet2ModelConfig, RootstockModelConfig],
-    Field(discriminator="provider"),
+    Union[MACEModelConfig, UMAModelConfig, AIMNet2ModelConfig],
+    Field(discriminator="family"),
 ]
 
 
@@ -103,18 +122,55 @@ class _MLIPCalculationConfig(_StrictModel):
     """Options shared by single-structure and batch MLIP requests."""
 
     driver: Literal["energy", "opt"] = "energy"
-    runtime: MLIPRuntimeConfig = Field(default_factory=ASEMLIPRuntimeConfig)
     model: MLIPModelConfig
+    calculator: MLIPCalculatorConfig = Field(default_factory=ASECalculatorConfig)
     fmax: float = Field(default=0.01, gt=0.0)
     steps: int = Field(default=1000, ge=1)
 
     @model_validator(mode="after")
-    def _validate_runtime_model_pair(self) -> "_MLIPCalculationConfig":
-        if self.model.provider == "rootstock" and self.runtime.type != "ase":
-            raise ValueError("Rootstock models require runtime.type='ase'.")
-        if self.runtime.type == "nvalchemi" and self.model.provider != "mace":
+    def _validate_calculator_model_pair(self) -> "_MLIPCalculationConfig":
+        model = self.model
+        calculator = self.calculator
+
+        if isinstance(calculator, ASECalculatorConfig):
+            if isinstance(model, UMAModelConfig) and calculator.dtype is not None:
+                raise ValueError("ASE UMA calculations do not support a dtype override.")
+            if isinstance(model, AIMNet2ModelConfig) and (
+                calculator.device is not None or calculator.dtype is not None
+            ):
+                raise ValueError(
+                    "ASE AIMNet2 calculations do not support device or dtype overrides."
+                )
+            return self
+
+        if isinstance(calculator, NVAlchemiCalculatorConfig):
+            if not isinstance(model, MACEModelConfig):
+                raise ValueError(
+                    "NVIDIA ALCHEMI supports only model.family='mace' in v1."
+                )
+            if model.calculator_type not in (None, "mace_mp"):
+                raise ValueError(
+                    "NVIDIA ALCHEMI supports only MACE-MP checkpoints in v1."
+                )
+            if model.dispersion is not None:
+                raise ValueError(
+                    "NVIDIA ALCHEMI does not support MACE dispersion settings in v1."
+                )
+            return self
+
+        if isinstance(model, MACEModelConfig) and (
+            model.calculator_type is not None or model.dispersion is not None
+        ):
             raise ValueError(
-                "NVIDIA ALCHEMI runtime supports only provider='mace' in v1."
+                "Rootstock resolves the MACE implementation from its canonical "
+                "checkpoint; omit calculator_type and dispersion."
+            )
+        if isinstance(model, UMAModelConfig) and (
+            model.task_name is not None or model.inference_settings is not None
+        ):
+            raise ValueError(
+                "Rootstock UMA loader settings must be supplied through "
+                "calculator.setup_kwargs."
             )
         return self
 
@@ -159,20 +215,21 @@ class MLIPBatchInputSchema(_MLIPCalculationConfig):
 
 
 class MLIPOutputSchema(_StrictModel):
-    """Runtime-neutral result compatible with the existing ASE result envelope."""
+    """Backend-neutral result compatible with the existing ASE result envelope."""
 
     schema_version: int = 1
     input_structure_file: str
     converged: bool = False
     final_structure: AtomsData | None = None
     simulation_input: dict[str, Any]
+    potential_energy: float | None = None
     single_point_energy: float | None = None
     energy_unit: str = "eV"
     forces: list[list[float]] | None = None
     force_unit: str = "eV/angstrom"
     stress: list[list[float]] | None = None
     stress_unit: str = "eV/angstrom^3"
-    runtime_info: dict[str, Any]
+    calculator_info: dict[str, Any]
     model_info: dict[str, Any]
     success: bool = False
     error: str = ""
@@ -194,7 +251,7 @@ class MLIPBatchManifestSchema(_StrictModel):
 
     schema_version: int = 1
     status: Literal["completed", "partial", "failure"]
-    runtime_info: dict[str, Any]
+    calculator_info: dict[str, Any]
     model_info: dict[str, Any]
     total: int
     succeeded: int

--- a/src/chemgraph/tools/run_mlip_core.py
+++ b/src/chemgraph/tools/run_mlip_core.py
@@ -1,0 +1,655 @@
+"""Plain-Python core for runtime-selectable MLIP calculations.
+
+This module owns all calculation, batching, lifecycle, and serialization
+logic. Framework wrappers in ``run_mlip_tools.py`` and ``run_mlip_mcp.py``
+only decorate and delegate to :func:`run_mlip_core` or
+:func:`run_mlip_batch_core`.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator, Sequence
+
+from chemgraph.schemas.mlip_input import (
+    AIMNet2ModelConfig,
+    ASEMLIPRuntimeConfig,
+    MACEModelConfig,
+    MLIPBatchInputSchema,
+    MLIPBatchItemSchema,
+    MLIPBatchManifestSchema,
+    MLIPInputSchema,
+    MLIPOutputSchema,
+    NVAlchemiRuntimeConfig,
+    RootstockModelConfig,
+    UMAModelConfig,
+)
+from chemgraph.tools.ase_core import (
+    _resolve_existing_path,
+    _resolve_path,
+    atoms_to_atomsdata,
+)
+
+
+def _resolved_input_file(path: str) -> str:
+    resolved = _resolve_existing_path(path)
+    if not os.path.isfile(resolved):
+        raise FileNotFoundError(f"Input structure file {path} does not exist.")
+    return resolved
+
+
+def _resolved_input_directory(path: str) -> Path:
+    candidate = Path(path)
+    if candidate.is_dir():
+        return candidate
+    log_candidate = Path(_resolve_path(path))
+    if log_candidate.is_dir():
+        return log_candidate
+    raise FileNotFoundError(f"Input structure directory {path} does not exist.")
+
+
+def _read_atoms(path: str):
+    from ase.io import read
+
+    try:
+        return read(path)
+    except Exception as exc:
+        raise ValueError(f"Cannot read {path} using ASE: {exc}") from exc
+
+
+def _write_result(result: MLIPOutputSchema, output_file: str) -> str:
+    resolved = _resolve_path(output_file)
+    output_path = Path(resolved)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(result.model_dump_json(indent=2), encoding="utf-8")
+    return str(output_path.resolve())
+
+
+def _failure_result(
+    params: MLIPInputSchema,
+    input_file: str,
+    error: Exception | str,
+    wall_time: float,
+) -> MLIPOutputSchema:
+    return MLIPOutputSchema(
+        input_structure_file=input_file,
+        simulation_input=params.model_dump(mode="json"),
+        runtime_info=params.runtime.model_dump(mode="json"),
+        model_info=params.model.model_dump(mode="json"),
+        success=False,
+        error=str(error),
+        wall_time=wall_time,
+    )
+
+
+def _success_result(
+    params: MLIPInputSchema,
+    input_file: str,
+    atoms,
+    energy: float,
+    forces: Any,
+    stress: Any,
+    converged: bool,
+    wall_time: float,
+) -> MLIPOutputSchema:
+    force_values = None if forces is None else forces.tolist()
+    stress_values = None if stress is None else stress.tolist()
+    return MLIPOutputSchema(
+        input_structure_file=input_file,
+        converged=converged,
+        final_structure=atoms_to_atomsdata(atoms),
+        simulation_input=params.model_dump(mode="json"),
+        single_point_energy=float(energy),
+        forces=force_values,
+        stress=stress_values,
+        runtime_info=params.runtime.model_dump(mode="json"),
+        model_info=params.model.model_dump(mode="json"),
+        success=True,
+        wall_time=wall_time,
+    )
+
+
+@contextmanager
+def _ase_calculator_context(
+    params: MLIPInputSchema,
+) -> Iterator[tuple[Any, dict[str, Any]]]:
+    """Create one ASE calculator and keep it alive for the surrounding batch."""
+    runtime = params.runtime
+    if not isinstance(runtime, ASEMLIPRuntimeConfig):
+        raise TypeError("ASE calculator requested for a non-ASE runtime.")
+
+    model = params.model
+    if isinstance(model, RootstockModelConfig):
+        try:
+            from rootstock import RootstockCalculator
+        except ImportError as exc:
+            raise ImportError(
+                "Rootstock provider requires the optional dependency. "
+                "Install ChemGraph with the 'rootstock' extra."
+            ) from exc
+
+        kwargs = {
+            "checkpoint": model.checkpoint,
+            "cluster": model.cluster,
+            "root": model.root,
+            "cache_root": model.cache_root,
+            "device": runtime.device,
+            "setup_kwargs": model.setup_kwargs,
+            "timeout": model.timeout,
+            "weights": model.weights,
+        }
+        kwargs = {key: value for key, value in kwargs.items() if value is not None}
+        with RootstockCalculator(**kwargs) as calculator:
+            yield calculator, {}
+        return
+
+    if isinstance(model, MACEModelConfig):
+        try:
+            from chemgraph.schemas.calculators.mace_calc import (
+                MaceCalc,
+                mace_loading_lock,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "MACE provider requires mace-torch to be installed."
+            ) from exc
+
+        config = MaceCalc(
+            calculator_type=model.calculator_type,
+            model=model.checkpoint,
+            device=runtime.device,
+            default_dtype=runtime.dtype,
+            dispersion=model.dispersion,
+            damping=model.damping,
+            dispersion_xc=model.dispersion_xc,
+            dispersion_cutoff=model.dispersion_cutoff,
+        )
+        with mace_loading_lock():
+            calculator = config.get_calculator()
+        yield calculator, {}
+        return
+
+    if isinstance(model, UMAModelConfig):
+        try:
+            from chemgraph.schemas.calculators.fairchem_calc import FAIRChemCalc
+        except ImportError as exc:
+            raise ImportError(
+                "UMA provider requires fairchem-core to be installed."
+            ) from exc
+
+        config = FAIRChemCalc(
+            model_name=model.checkpoint,
+            task_name=model.task_name,
+            inference_settings=model.inference_settings,
+            device=runtime.device,
+            charge=model.charge,
+            multiplicity=model.multiplicity,
+        )
+        yield config.get_calculator(), config.get_atoms_properties()
+        return
+
+    if isinstance(model, AIMNet2ModelConfig):
+        try:
+            from chemgraph.schemas.calculators.aimnet2_calc import AIMNET2Calc
+        except ImportError as exc:
+            raise ImportError(
+                "AIMNet2 provider requires aimnet2calc to be installed."
+            ) from exc
+
+        config = AIMNET2Calc(model=model.checkpoint)
+        yield config.get_calculator(), {}
+        return
+
+    raise ValueError(f"Unsupported ASE MLIP provider: {model.provider}")
+
+
+def _optional_stress(atoms):
+    if not atoms.pbc.any() or atoms.cell.rank != 3:
+        return None
+    try:
+        return atoms.get_stress(voigt=False)
+    except Exception:
+        return None
+
+
+def _run_ase_calculation(
+    params: MLIPInputSchema,
+    input_file: str,
+    atoms,
+    calculator: Any,
+    atoms_info: dict[str, Any],
+    start_time: float,
+) -> MLIPOutputSchema:
+    from ase.optimize import BFGS, FIRE, GPMin, LBFGS, MDMin
+
+    runtime = params.runtime
+    if not isinstance(runtime, ASEMLIPRuntimeConfig):
+        raise TypeError("ASE calculation requested for a non-ASE runtime.")
+
+    atoms.info.update(atoms_info)
+    atoms.calc = calculator
+    converged = True
+    if params.driver == "opt" and len(atoms) > 1:
+        optimizer_classes = {
+            "bfgs": BFGS,
+            "lbfgs": LBFGS,
+            "gpmin": GPMin,
+            "fire": FIRE,
+            "mdmin": MDMin,
+        }
+        optimizer = optimizer_classes[runtime.optimizer](atoms, logfile=None)
+        converged = bool(optimizer.run(fmax=params.fmax, steps=params.steps))
+
+    energy = float(atoms.get_potential_energy())
+    forces = atoms.get_forces()
+    stress = _optional_stress(atoms)
+    return _success_result(
+        params,
+        input_file,
+        atoms,
+        energy,
+        forces,
+        stress,
+        converged,
+        time.time() - start_time,
+    )
+
+
+def _load_nvalchemi_model(params: MLIPInputSchema):
+    runtime = params.runtime
+    model_config = params.model
+    if not isinstance(runtime, NVAlchemiRuntimeConfig) or not isinstance(
+        model_config, MACEModelConfig
+    ):
+        raise TypeError("Invalid NVIDIA ALCHEMI runtime/model configuration.")
+
+    try:
+        import torch
+        from nvalchemi.models.mace import MACEWrapper
+    except ImportError as exc:
+        raise ImportError(
+            "NVIDIA ALCHEMI runtime requires ChemGraph's 'nvalchemi_mace' "
+            "extra plus the CUDA-specific ALCHEMI dependencies."
+        ) from exc
+
+    dtype = getattr(torch, runtime.dtype)
+    wrapped = MACEWrapper.from_checkpoint(
+        model_config.checkpoint,
+        device=torch.device(runtime.device),
+        dtype=dtype,
+        enable_cueq=runtime.enable_cueq,
+        compile_model=runtime.compile_model,
+    )
+    wrapped.eval()
+    return wrapped
+
+
+def _atoms_to_nvalchemi_data(atoms, runtime: NVAlchemiRuntimeConfig):
+    try:
+        import torch
+        from nvalchemi.data import AtomicData
+    except ImportError as exc:
+        raise ImportError(
+            "NVIDIA ALCHEMI runtime requires ChemGraph's 'nvalchemi_mace' "
+            "extra plus the CUDA-specific ALCHEMI dependencies."
+        ) from exc
+
+    dtype = getattr(torch, runtime.dtype)
+    data = AtomicData.from_atoms(
+        atoms,
+        device=torch.device(runtime.device),
+        dtype=dtype,
+    )
+    data.forces = torch.zeros(data.num_nodes, 3, device=data.device, dtype=dtype)
+    data.energy = torch.zeros(1, 1, device=data.device, dtype=dtype)
+    data.velocities = torch.zeros(
+        data.num_nodes, 3, device=data.device, dtype=dtype
+    )
+    return data
+
+
+def _nvalchemi_result(
+    params: MLIPInputSchema,
+    input_file: str,
+    original_atoms,
+    data,
+    converged: bool,
+    start_time: float,
+) -> MLIPOutputSchema:
+    final_atoms = original_atoms.copy()
+    final_atoms.positions = data.positions.detach().cpu().numpy()
+    if data.cell is not None:
+        final_atoms.cell = data.cell.squeeze(0).detach().cpu().numpy()
+    if data.pbc is not None:
+        final_atoms.pbc = data.pbc.squeeze(0).detach().cpu().numpy()
+
+    energy = data.energy.detach().cpu().reshape(-1)[0].item()
+    forces = data.forces.detach().cpu().numpy() if data.forces is not None else None
+    stress = None
+    if data.stress is not None:
+        stress = data.stress.detach().cpu().reshape(-1, 3, 3)[0].numpy()
+    return _success_result(
+        params,
+        input_file,
+        final_atoms,
+        energy,
+        forces,
+        stress,
+        converged,
+        time.time() - start_time,
+    )
+
+
+def _run_nvalchemi_chunk(
+    model: Any,
+    entries: Sequence[tuple[MLIPInputSchema, str, Any, float]],
+) -> list[MLIPOutputSchema]:
+    try:
+        from nvalchemi.data import Batch
+        from nvalchemi.dynamics import BaseDynamics, ConvergenceHook, FIRE
+    except ImportError as exc:
+        raise ImportError(
+            "NVIDIA ALCHEMI runtime requires ChemGraph's 'nvalchemi_mace' "
+            "extra plus the CUDA-specific ALCHEMI dependencies."
+        ) from exc
+
+    params0 = entries[0][0]
+    runtime = params0.runtime
+    if not isinstance(runtime, NVAlchemiRuntimeConfig):
+        raise TypeError("NVIDIA ALCHEMI calculation received a non-ALCHEMI runtime.")
+
+    data_list = [
+        _atoms_to_nvalchemi_data(atoms, runtime) for _, _, atoms, _ in entries
+    ]
+    batch = Batch.from_data_list(data_list)
+    hooks = model.make_neighbor_hooks()
+    convergence = None
+    if params0.driver == "energy":
+        dynamics = BaseDynamics(model=model, hooks=hooks, n_steps=1)
+    else:
+        convergence = ConvergenceHook.from_fmax(params0.fmax)
+        dynamics = FIRE(
+            model=model,
+            dt=runtime.dt,
+            hooks=hooks,
+            convergence_hook=convergence,
+            n_steps=params0.steps,
+        )
+
+    with dynamics:
+        batch = dynamics.run(batch)
+
+    converged_indices = set(range(len(entries)))
+    if convergence is not None:
+        indices = convergence.evaluate(batch)
+        converged_indices = (
+            set() if indices is None else set(indices.detach().cpu().tolist())
+        )
+
+    final_data = batch.to_data_list()
+    return [
+        _nvalchemi_result(
+            params,
+            input_file,
+            atoms,
+            data,
+            index in converged_indices,
+            start_time,
+        )
+        for index, ((params, input_file, atoms, start_time), data) in enumerate(
+            zip(entries, final_data)
+        )
+    ]
+
+
+def _chunks_by_capacity(
+    entries: Sequence[tuple[MLIPInputSchema, str, Any, float]],
+    batch_size: int,
+    max_atoms: int | None,
+) -> Iterator[list[tuple[MLIPInputSchema, str, Any, float]]]:
+    chunk: list[tuple[MLIPInputSchema, str, Any, float]] = []
+    atom_count = 0
+    for entry in entries:
+        n_atoms = len(entry[2])
+        exceeds_atoms = max_atoms is not None and chunk and atom_count + n_atoms > max_atoms
+        if len(chunk) >= batch_size or exceeds_atoms:
+            yield chunk
+            chunk = []
+            atom_count = 0
+        chunk.append(entry)
+        atom_count += n_atoms
+    if chunk:
+        yield chunk
+
+
+def _execute_single_requests(
+    params_list: Sequence[MLIPInputSchema],
+    batch_size: int = 16,
+    max_atoms: int | None = None,
+) -> list[MLIPOutputSchema]:
+    results: list[MLIPOutputSchema | None] = [None] * len(params_list)
+    prepared: list[tuple[int, MLIPInputSchema, str, Any, float]] = []
+
+    for index, params in enumerate(params_list):
+        started = time.time()
+        input_file = params.input_structure_file
+        try:
+            input_file = _resolved_input_file(input_file)
+            atoms = _read_atoms(input_file)
+            prepared.append((index, params, input_file, atoms, started))
+        except Exception as exc:
+            results[index] = _failure_result(
+                params, input_file, exc, time.time() - started
+            )
+
+    if not prepared:
+        return [result for result in results if result is not None]
+
+    first_params = prepared[0][1]
+    if first_params.runtime.type == "ase":
+        try:
+            with _ase_calculator_context(first_params) as (calculator, atoms_info):
+                for index, params, input_file, atoms, started in prepared:
+                    try:
+                        results[index] = _run_ase_calculation(
+                            params,
+                            input_file,
+                            atoms,
+                            calculator,
+                            atoms_info,
+                            started,
+                        )
+                    except Exception as exc:
+                        results[index] = _failure_result(
+                            params, input_file, exc, time.time() - started
+                        )
+        except Exception as exc:
+            for index, params, input_file, _, started in prepared:
+                results[index] = _failure_result(
+                    params, input_file, exc, time.time() - started
+                )
+    else:
+        try:
+            model = _load_nvalchemi_model(first_params)
+            nvalchemi_entries = [
+                (params, input_file, atoms, started)
+                for _, params, input_file, atoms, started in prepared
+            ]
+            offset = 0
+            for chunk in _chunks_by_capacity(
+                nvalchemi_entries, batch_size, max_atoms
+            ):
+                try:
+                    chunk_results = _run_nvalchemi_chunk(model, chunk)
+                    if len(chunk_results) != len(chunk):
+                        raise RuntimeError(
+                            "NVIDIA ALCHEMI returned a different number of "
+                            "results than input structures."
+                        )
+                except Exception as exc:
+                    chunk_results = [
+                        _failure_result(
+                            params, input_file, exc, time.time() - started
+                        )
+                        for params, input_file, _, started in chunk
+                    ]
+                for chunk_index, result in enumerate(chunk_results):
+                    original_index = prepared[offset + chunk_index][0]
+                    results[original_index] = result
+                offset += len(chunk)
+        except Exception as exc:
+            for index, params, input_file, _, started in prepared:
+                results[index] = _failure_result(
+                    params, input_file, exc, time.time() - started
+                )
+
+    return [result for result in results if result is not None]
+
+
+def _tool_result(result: MLIPOutputSchema, result_file: str) -> dict[str, Any]:
+    if result.success:
+        return {
+            "status": "success",
+            "message": f"MLIP calculation completed. Results saved to {result_file}",
+            "output_results_file": result_file,
+            "single_point_energy": result.single_point_energy,
+            "unit": result.energy_unit,
+            "converged": result.converged,
+        }
+    return {
+        "status": "failure",
+        "error_type": "MLIPCalculationError",
+        "message": result.error,
+        "output_results_file": result_file,
+    }
+
+
+def run_mlip_core(params: MLIPInputSchema) -> dict[str, Any]:
+    """Run one MLIP calculation and persist a runtime-neutral JSON result."""
+    if not isinstance(params, MLIPInputSchema):
+        params = MLIPInputSchema.model_validate(params)
+    result = _execute_single_requests([params], batch_size=1)[0]
+    try:
+        result_file = _write_result(result, params.output_results_file)
+    except Exception as exc:
+        return {
+            "status": "failure",
+            "error_type": type(exc).__name__,
+            "message": f"Could not write MLIP result: {exc}",
+        }
+    return _tool_result(result, result_file)
+
+
+def _batch_input_files(params: MLIPBatchInputSchema) -> list[str]:
+    if params.input_structure_files is not None:
+        return list(params.input_structure_files)
+    directory = _resolved_input_directory(params.input_structure_directory or "")
+    return [str(path) for path in sorted(directory.iterdir()) if path.is_file()]
+
+
+def _single_params_for_batch_item(
+    batch_params: MLIPBatchInputSchema,
+    input_file: str,
+    output_file: str,
+) -> MLIPInputSchema:
+    return MLIPInputSchema(
+        input_structure_file=input_file,
+        output_results_file=output_file,
+        driver=batch_params.driver,
+        runtime=batch_params.runtime,
+        model=batch_params.model,
+        fmax=batch_params.fmax,
+        steps=batch_params.steps,
+    )
+
+
+def run_mlip_batch_core(params: MLIPBatchInputSchema) -> dict[str, Any]:
+    """Run an ordered MLIP batch and write per-item results plus a manifest."""
+    if not isinstance(params, MLIPBatchInputSchema):
+        params = MLIPBatchInputSchema.model_validate(params)
+
+    started = time.time()
+    output_directory = Path(_resolve_path(params.output_results_directory))
+    output_directory.mkdir(parents=True, exist_ok=True)
+    manifest_path = Path(params.manifest_file)
+    if not manifest_path.is_absolute():
+        manifest_path = output_directory / manifest_path
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        input_files = _batch_input_files(params)
+    except Exception as exc:
+        return {
+            "status": "failure",
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+
+    single_params = [
+        _single_params_for_batch_item(
+            params,
+            input_file,
+            str(output_directory / f"{index:05d}_{Path(input_file).stem}.json"),
+        )
+        for index, input_file in enumerate(input_files)
+    ]
+    results = _execute_single_requests(
+        single_params,
+        batch_size=params.batch_size,
+        max_atoms=params.max_atoms,
+    )
+
+    items: list[MLIPBatchItemSchema] = []
+    for index, (single, result) in enumerate(zip(single_params, results)):
+        try:
+            result_file = _write_result(result, single.output_results_file)
+        except Exception as exc:
+            result_file = str(Path(single.output_results_file).resolve())
+            result = _failure_result(
+                single,
+                result.input_structure_file,
+                f"Could not write MLIP result: {exc}",
+                result.wall_time or 0.0,
+            )
+        items.append(
+            MLIPBatchItemSchema(
+                index=index,
+                input_structure_file=result.input_structure_file,
+                status="success" if result.success else "failure",
+                result_file=result_file,
+                error=result.error,
+            )
+        )
+
+    succeeded = sum(item.status == "success" for item in items)
+    failed = len(items) - succeeded
+    if items and failed == 0:
+        status = "completed"
+    elif succeeded:
+        status = "partial"
+    else:
+        status = "failure"
+
+    manifest = MLIPBatchManifestSchema(
+        status=status,
+        runtime_info=params.runtime.model_dump(mode="json"),
+        model_info=params.model.model_dump(mode="json"),
+        total=len(items),
+        succeeded=succeeded,
+        failed=failed,
+        wall_time=time.time() - started,
+        items=items,
+    )
+    manifest_path.write_text(manifest.model_dump_json(indent=2), encoding="utf-8")
+    manifest_file = str(manifest_path.resolve())
+    return {
+        "status": status,
+        "manifest_file": manifest_file,
+        "total": len(items),
+        "succeeded": succeeded,
+        "failed": failed,
+        "message": f"MLIP batch {status}. Manifest saved to {manifest_file}",
+    }

--- a/src/chemgraph/tools/run_mlip_core.py
+++ b/src/chemgraph/tools/run_mlip_core.py
@@ -1,4 +1,4 @@
-"""Plain-Python core for runtime-selectable MLIP calculations.
+"""Plain-Python core for calculator-selectable MLIP calculations.
 
 This module owns all calculation, batching, lifecycle, and serialization
 logic. Framework wrappers in ``run_mlip_tools.py`` and ``run_mlip_mcp.py``
@@ -16,15 +16,15 @@ from typing import Any, Iterator, Sequence
 
 from chemgraph.schemas.mlip_input import (
     AIMNet2ModelConfig,
-    ASEMLIPRuntimeConfig,
+    ASECalculatorConfig,
     MACEModelConfig,
     MLIPBatchInputSchema,
     MLIPBatchItemSchema,
     MLIPBatchManifestSchema,
     MLIPInputSchema,
     MLIPOutputSchema,
-    NVAlchemiRuntimeConfig,
-    RootstockModelConfig,
+    NVAlchemiCalculatorConfig,
+    RootstockCalculatorConfig,
     UMAModelConfig,
 )
 from chemgraph.tools.ase_core import (
@@ -68,17 +68,39 @@ def _write_result(result: MLIPOutputSchema, output_file: str) -> str:
     return str(output_path.resolve())
 
 
+def _model_info(
+    params: MLIPInputSchema,
+    resolved: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "requested": params.model.model_dump(mode="json"),
+        "resolved": resolved or {},
+    }
+
+
+def _calculator_info(
+    params: MLIPInputSchema,
+    resolved: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "requested": params.calculator.model_dump(mode="json"),
+        "resolved": resolved or {},
+    }
+
+
 def _failure_result(
     params: MLIPInputSchema,
     input_file: str,
     error: Exception | str,
     wall_time: float,
+    calculator_resolved: dict[str, Any] | None = None,
+    model_resolved: dict[str, Any] | None = None,
 ) -> MLIPOutputSchema:
     return MLIPOutputSchema(
         input_structure_file=input_file,
         simulation_input=params.model_dump(mode="json"),
-        runtime_info=params.runtime.model_dump(mode="json"),
-        model_info=params.model.model_dump(mode="json"),
+        calculator_info=_calculator_info(params, calculator_resolved),
+        model_info=_model_info(params, model_resolved),
         success=False,
         error=str(error),
         wall_time=wall_time,
@@ -94,6 +116,8 @@ def _success_result(
     stress: Any,
     converged: bool,
     wall_time: float,
+    calculator_resolved: dict[str, Any] | None = None,
+    model_resolved: dict[str, Any] | None = None,
 ) -> MLIPOutputSchema:
     force_values = None if forces is None else forces.tolist()
     stress_values = None if stress is None else stress.tolist()
@@ -102,11 +126,12 @@ def _success_result(
         converged=converged,
         final_structure=atoms_to_atomsdata(atoms),
         simulation_input=params.model_dump(mode="json"),
+        potential_energy=float(energy),
         single_point_energy=float(energy),
         forces=force_values,
         stress=stress_values,
-        runtime_info=params.runtime.model_dump(mode="json"),
-        model_info=params.model.model_dump(mode="json"),
+        calculator_info=_calculator_info(params, calculator_resolved),
+        model_info=_model_info(params, model_resolved),
         success=True,
         wall_time=wall_time,
     )
@@ -115,37 +140,15 @@ def _success_result(
 @contextmanager
 def _ase_calculator_context(
     params: MLIPInputSchema,
-) -> Iterator[tuple[Any, dict[str, Any]]]:
+) -> Iterator[
+    tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+]:
     """Create one ASE calculator and keep it alive for the surrounding batch."""
-    runtime = params.runtime
-    if not isinstance(runtime, ASEMLIPRuntimeConfig):
-        raise TypeError("ASE calculator requested for a non-ASE runtime.")
+    calculator_config = params.calculator
+    if not isinstance(calculator_config, ASECalculatorConfig):
+        raise TypeError("ASE calculator requested for a non-ASE backend.")
 
     model = params.model
-    if isinstance(model, RootstockModelConfig):
-        try:
-            from rootstock import RootstockCalculator
-        except ImportError as exc:
-            raise ImportError(
-                "Rootstock provider requires the optional dependency. "
-                "Install ChemGraph with the 'rootstock' extra."
-            ) from exc
-
-        kwargs = {
-            "checkpoint": model.checkpoint,
-            "cluster": model.cluster,
-            "root": model.root,
-            "cache_root": model.cache_root,
-            "device": runtime.device,
-            "setup_kwargs": model.setup_kwargs,
-            "timeout": model.timeout,
-            "weights": model.weights,
-        }
-        kwargs = {key: value for key, value in kwargs.items() if value is not None}
-        with RootstockCalculator(**kwargs) as calculator:
-            yield calculator, {}
-        return
-
     if isinstance(model, MACEModelConfig):
         try:
             from chemgraph.schemas.calculators.mace_calc import (
@@ -154,22 +157,43 @@ def _ase_calculator_context(
             )
         except ImportError as exc:
             raise ImportError(
-                "MACE provider requires mace-torch to be installed."
+                "The MACE model family requires mace-torch to be installed."
             ) from exc
 
+        calculator_type = model.calculator_type or "mace_mp"
+        device = calculator_config.device or "cpu"
+        dtype = calculator_config.dtype or "float64"
+        dispersion = model.dispersion
         config = MaceCalc(
-            calculator_type=model.calculator_type,
+            calculator_type=calculator_type,
             model=model.checkpoint,
-            device=runtime.device,
-            default_dtype=runtime.dtype,
-            dispersion=model.dispersion,
-            damping=model.damping,
-            dispersion_xc=model.dispersion_xc,
-            dispersion_cutoff=model.dispersion_cutoff,
+            device=device,
+            default_dtype=dtype,
+            dispersion=dispersion is not None,
+            damping=dispersion.damping if dispersion is not None else "bj",
+            dispersion_xc=dispersion.xc if dispersion is not None else "pbe",
+            dispersion_cutoff=(
+                dispersion.cutoff if dispersion is not None else 21.167088422553647
+            ),
         )
         with mace_loading_lock():
             calculator = config.get_calculator()
-        yield calculator, {}
+        yield (
+            calculator,
+            {},
+            {
+                "backend": "ase",
+                "device": device,
+                "dtype": dtype,
+                "optimizer": calculator_config.optimizer,
+            },
+            {
+                "family": "mace",
+                "checkpoint": str(config.get_model_name_for_output()),
+                "calculator_type": calculator_type,
+                "dispersion": dispersion is not None,
+            },
+        )
         return
 
     if isinstance(model, UMAModelConfig):
@@ -177,18 +201,35 @@ def _ase_calculator_context(
             from chemgraph.schemas.calculators.fairchem_calc import FAIRChemCalc
         except ImportError as exc:
             raise ImportError(
-                "UMA provider requires fairchem-core to be installed."
+                "The UMA model family requires fairchem-core to be installed."
             ) from exc
 
+        device = calculator_config.device or "cpu"
+        task_name = model.task_name or "omol"
+        inference_settings = model.inference_settings or "default"
         config = FAIRChemCalc(
             model_name=model.checkpoint,
-            task_name=model.task_name,
-            inference_settings=model.inference_settings,
-            device=runtime.device,
+            task_name=task_name,
+            inference_settings=inference_settings,
+            device=device,
             charge=model.charge,
             multiplicity=model.multiplicity,
         )
-        yield config.get_calculator(), config.get_atoms_properties()
+        yield (
+            config.get_calculator(),
+            config.get_atoms_properties(),
+            {
+                "backend": "ase",
+                "device": device,
+                "optimizer": calculator_config.optimizer,
+            },
+            {
+                "family": "uma",
+                "checkpoint": model.checkpoint,
+                "task_name": task_name,
+                "inference_settings": inference_settings,
+            },
+        )
         return
 
     if isinstance(model, AIMNet2ModelConfig):
@@ -196,14 +237,75 @@ def _ase_calculator_context(
             from chemgraph.schemas.calculators.aimnet2_calc import AIMNET2Calc
         except ImportError as exc:
             raise ImportError(
-                "AIMNet2 provider requires aimnet2calc to be installed."
+                "The AIMNet2 model family requires aimnet2calc to be installed."
             ) from exc
 
         config = AIMNET2Calc(model=model.checkpoint)
-        yield config.get_calculator(), {}
+        yield (
+            config.get_calculator(),
+            {},
+            {"backend": "ase", "optimizer": calculator_config.optimizer},
+            {"family": "aimnet2", "checkpoint": model.checkpoint},
+        )
         return
 
-    raise ValueError(f"Unsupported ASE MLIP provider: {model.provider}")
+    raise ValueError(f"Unsupported ASE MLIP model family: {model.family}")
+
+
+@contextmanager
+def _rootstock_calculator_context(
+    params: MLIPInputSchema,
+) -> Iterator[
+    tuple[Any, dict[str, Any], dict[str, Any], dict[str, Any]]
+]:
+    """Create one Rootstock calculator and reuse its worker for a batch."""
+    calculator_config = params.calculator
+    if not isinstance(calculator_config, RootstockCalculatorConfig):
+        raise TypeError("Rootstock calculator requested for a different backend.")
+
+    try:
+        from rootstock import RootstockCalculator
+    except ImportError as exc:
+        raise ImportError(
+            "Rootstock calculator requires the optional dependency. "
+            "Install ChemGraph with the 'rootstock' extra."
+        ) from exc
+
+    model = params.model
+    kwargs = {
+        "checkpoint": model.checkpoint,
+        "cluster": calculator_config.cluster,
+        "root": calculator_config.root,
+        "cache_root": calculator_config.cache_root,
+        "device": calculator_config.device,
+        "setup_kwargs": calculator_config.setup_kwargs,
+        "timeout": calculator_config.timeout,
+        "weights": calculator_config.weights,
+    }
+    kwargs = {key: value for key, value in kwargs.items() if value is not None}
+    atoms_info = {}
+    if isinstance(model, UMAModelConfig):
+        atoms_info = {"charge": model.charge, "spin": model.multiplicity}
+
+    with RootstockCalculator(**kwargs) as calculator:
+        yield (
+            calculator,
+            atoms_info,
+            {
+                "backend": "rootstock",
+                "device": calculator_config.device,
+                "optimizer": calculator_config.optimizer,
+                "cluster": calculator_config.cluster,
+                "root": calculator_config.root,
+            },
+            {"family": model.family, "checkpoint": model.checkpoint},
+        )
+
+
+_ASE_CONTEXT_FACTORIES = {
+    "ase": _ase_calculator_context,
+    "rootstock": _rootstock_calculator_context,
+}
 
 
 def _optional_stress(atoms):
@@ -222,12 +324,16 @@ def _run_ase_calculation(
     calculator: Any,
     atoms_info: dict[str, Any],
     start_time: float,
+    calculator_resolved: dict[str, Any],
+    model_resolved: dict[str, Any],
 ) -> MLIPOutputSchema:
     from ase.optimize import BFGS, FIRE, GPMin, LBFGS, MDMin
 
-    runtime = params.runtime
-    if not isinstance(runtime, ASEMLIPRuntimeConfig):
-        raise TypeError("ASE calculation requested for a non-ASE runtime.")
+    calculator_config = params.calculator
+    if not isinstance(
+        calculator_config, (ASECalculatorConfig, RootstockCalculatorConfig)
+    ):
+        raise TypeError("ASE calculation requested for an incompatible backend.")
 
     atoms.info.update(atoms_info)
     atoms.calc = calculator
@@ -240,7 +346,7 @@ def _run_ase_calculation(
             "fire": FIRE,
             "mdmin": MDMin,
         }
-        optimizer = optimizer_classes[runtime.optimizer](atoms, logfile=None)
+        optimizer = optimizer_classes[calculator_config.optimizer](atoms, logfile=None)
         converged = bool(optimizer.run(fmax=params.fmax, steps=params.steps))
 
     energy = float(atoms.get_potential_energy())
@@ -255,52 +361,75 @@ def _run_ase_calculation(
         stress,
         converged,
         time.time() - start_time,
+        calculator_resolved,
+        model_resolved,
     )
 
 
 def _load_nvalchemi_model(params: MLIPInputSchema):
-    runtime = params.runtime
+    calculator_config = params.calculator
     model_config = params.model
-    if not isinstance(runtime, NVAlchemiRuntimeConfig) or not isinstance(
+    if not isinstance(calculator_config, NVAlchemiCalculatorConfig) or not isinstance(
         model_config, MACEModelConfig
     ):
-        raise TypeError("Invalid NVIDIA ALCHEMI runtime/model configuration.")
+        raise TypeError("Invalid NVIDIA ALCHEMI calculator/model configuration.")
 
     try:
         import torch
         from nvalchemi.models.mace import MACEWrapper
     except ImportError as exc:
         raise ImportError(
-            "NVIDIA ALCHEMI runtime requires ChemGraph's 'nvalchemi_mace' "
+            "NVIDIA ALCHEMI calculator support requires ChemGraph's "
+            "'nvalchemi_mace' "
             "extra plus the CUDA-specific ALCHEMI dependencies."
         ) from exc
 
-    dtype = getattr(torch, runtime.dtype)
+    dtype = getattr(torch, calculator_config.dtype)
     wrapped = MACEWrapper.from_checkpoint(
         model_config.checkpoint,
-        device=torch.device(runtime.device),
+        device=torch.device(calculator_config.device),
         dtype=dtype,
-        enable_cueq=runtime.enable_cueq,
-        compile_model=runtime.compile_model,
+        enable_cueq=calculator_config.enable_cueq,
+        compile_model=calculator_config.compile_model,
     )
     wrapped.eval()
-    return wrapped
+    return (
+        wrapped,
+        {
+            "backend": "nvalchemi",
+            "device": calculator_config.device,
+            "dtype": calculator_config.dtype,
+            "optimizer": calculator_config.optimizer,
+            "compile_model": calculator_config.compile_model,
+            "enable_cueq": calculator_config.enable_cueq,
+        },
+        {
+            "family": "mace",
+            "checkpoint": model_config.checkpoint,
+            "calculator_type": model_config.calculator_type or "mace_mp",
+            "dispersion": False,
+        },
+    )
 
 
-def _atoms_to_nvalchemi_data(atoms, runtime: NVAlchemiRuntimeConfig):
+def _atoms_to_nvalchemi_data(
+    atoms,
+    calculator_config: NVAlchemiCalculatorConfig,
+):
     try:
         import torch
         from nvalchemi.data import AtomicData
     except ImportError as exc:
         raise ImportError(
-            "NVIDIA ALCHEMI runtime requires ChemGraph's 'nvalchemi_mace' "
+            "NVIDIA ALCHEMI calculator support requires ChemGraph's "
+            "'nvalchemi_mace' "
             "extra plus the CUDA-specific ALCHEMI dependencies."
         ) from exc
 
-    dtype = getattr(torch, runtime.dtype)
+    dtype = getattr(torch, calculator_config.dtype)
     data = AtomicData.from_atoms(
         atoms,
-        device=torch.device(runtime.device),
+        device=torch.device(calculator_config.device),
         dtype=dtype,
     )
     data.forces = torch.zeros(data.num_nodes, 3, device=data.device, dtype=dtype)
@@ -318,6 +447,8 @@ def _nvalchemi_result(
     data,
     converged: bool,
     start_time: float,
+    calculator_resolved: dict[str, Any] | None = None,
+    model_resolved: dict[str, Any] | None = None,
 ) -> MLIPOutputSchema:
     final_atoms = original_atoms.copy()
     final_atoms.positions = data.positions.detach().cpu().numpy()
@@ -340,29 +471,37 @@ def _nvalchemi_result(
         stress,
         converged,
         time.time() - start_time,
+        calculator_resolved,
+        model_resolved,
     )
 
 
 def _run_nvalchemi_chunk(
     model: Any,
     entries: Sequence[tuple[MLIPInputSchema, str, Any, float]],
+    calculator_resolved: dict[str, Any] | None = None,
+    model_resolved: dict[str, Any] | None = None,
 ) -> list[MLIPOutputSchema]:
     try:
         from nvalchemi.data import Batch
         from nvalchemi.dynamics import BaseDynamics, ConvergenceHook, FIRE
     except ImportError as exc:
         raise ImportError(
-            "NVIDIA ALCHEMI runtime requires ChemGraph's 'nvalchemi_mace' "
+            "NVIDIA ALCHEMI calculator support requires ChemGraph's "
+            "'nvalchemi_mace' "
             "extra plus the CUDA-specific ALCHEMI dependencies."
         ) from exc
 
     params0 = entries[0][0]
-    runtime = params0.runtime
-    if not isinstance(runtime, NVAlchemiRuntimeConfig):
-        raise TypeError("NVIDIA ALCHEMI calculation received a non-ALCHEMI runtime.")
+    calculator_config = params0.calculator
+    if not isinstance(calculator_config, NVAlchemiCalculatorConfig):
+        raise TypeError(
+            "NVIDIA ALCHEMI calculation received a different calculator backend."
+        )
 
     data_list = [
-        _atoms_to_nvalchemi_data(atoms, runtime) for _, _, atoms, _ in entries
+        _atoms_to_nvalchemi_data(atoms, calculator_config)
+        for _, _, atoms, _ in entries
     ]
     batch = Batch.from_data_list(data_list)
     hooks = model.make_neighbor_hooks()
@@ -373,7 +512,7 @@ def _run_nvalchemi_chunk(
         convergence = ConvergenceHook.from_fmax(params0.fmax)
         dynamics = FIRE(
             model=model,
-            dt=runtime.dt,
+            dt=calculator_config.dt,
             hooks=hooks,
             convergence_hook=convergence,
             n_steps=params0.steps,
@@ -398,6 +537,8 @@ def _run_nvalchemi_chunk(
             data,
             index in converged_indices,
             start_time,
+            calculator_resolved,
+            model_resolved,
         )
         for index, ((params, input_file, atoms, start_time), data) in enumerate(
             zip(entries, final_data)
@@ -414,7 +555,9 @@ def _chunks_by_capacity(
     atom_count = 0
     for entry in entries:
         n_atoms = len(entry[2])
-        exceeds_atoms = max_atoms is not None and chunk and atom_count + n_atoms > max_atoms
+        exceeds_atoms = (
+            max_atoms is not None and chunk and atom_count + n_atoms > max_atoms
+        )
         if len(chunk) >= batch_size or exceeds_atoms:
             yield chunk
             chunk = []
@@ -449,9 +592,16 @@ def _execute_single_requests(
         return [result for result in results if result is not None]
 
     first_params = prepared[0][1]
-    if first_params.runtime.type == "ase":
+    backend = first_params.calculator.backend
+    if backend in _ASE_CONTEXT_FACTORIES:
+        context_factory = _ASE_CONTEXT_FACTORIES[backend]
         try:
-            with _ase_calculator_context(first_params) as (calculator, atoms_info):
+            with context_factory(first_params) as (
+                calculator,
+                atoms_info,
+                calculator_resolved,
+                model_resolved,
+            ):
                 for index, params, input_file, atoms, started in prepared:
                     try:
                         results[index] = _run_ase_calculation(
@@ -461,19 +611,28 @@ def _execute_single_requests(
                             calculator,
                             atoms_info,
                             started,
+                            calculator_resolved,
+                            model_resolved,
                         )
                     except Exception as exc:
                         results[index] = _failure_result(
-                            params, input_file, exc, time.time() - started
+                            params,
+                            input_file,
+                            exc,
+                            time.time() - started,
+                            calculator_resolved,
+                            model_resolved,
                         )
         except Exception as exc:
             for index, params, input_file, _, started in prepared:
                 results[index] = _failure_result(
                     params, input_file, exc, time.time() - started
                 )
-    else:
+    elif backend == "nvalchemi":
         try:
-            model = _load_nvalchemi_model(first_params)
+            model, calculator_resolved, model_resolved = _load_nvalchemi_model(
+                first_params
+            )
             nvalchemi_entries = [
                 (params, input_file, atoms, started)
                 for _, params, input_file, atoms, started in prepared
@@ -483,7 +642,12 @@ def _execute_single_requests(
                 nvalchemi_entries, batch_size, max_atoms
             ):
                 try:
-                    chunk_results = _run_nvalchemi_chunk(model, chunk)
+                    chunk_results = _run_nvalchemi_chunk(
+                        model,
+                        chunk,
+                        calculator_resolved,
+                        model_resolved,
+                    )
                     if len(chunk_results) != len(chunk):
                         raise RuntimeError(
                             "NVIDIA ALCHEMI returned a different number of "
@@ -492,7 +656,12 @@ def _execute_single_requests(
                 except Exception as exc:
                     chunk_results = [
                         _failure_result(
-                            params, input_file, exc, time.time() - started
+                            params,
+                            input_file,
+                            exc,
+                            time.time() - started,
+                            calculator_resolved,
+                            model_resolved,
                         )
                         for params, input_file, _, started in chunk
                     ]
@@ -505,6 +674,8 @@ def _execute_single_requests(
                 results[index] = _failure_result(
                     params, input_file, exc, time.time() - started
                 )
+    else:
+        raise ValueError(f"Unsupported calculator backend: {backend}")
 
     return [result for result in results if result is not None]
 
@@ -515,6 +686,7 @@ def _tool_result(result: MLIPOutputSchema, result_file: str) -> dict[str, Any]:
             "status": "success",
             "message": f"MLIP calculation completed. Results saved to {result_file}",
             "output_results_file": result_file,
+            "potential_energy": result.potential_energy,
             "single_point_energy": result.single_point_energy,
             "unit": result.energy_unit,
             "converged": result.converged,
@@ -528,7 +700,7 @@ def _tool_result(result: MLIPOutputSchema, result_file: str) -> dict[str, Any]:
 
 
 def run_mlip_core(params: MLIPInputSchema) -> dict[str, Any]:
-    """Run one MLIP calculation and persist a runtime-neutral JSON result."""
+    """Run one MLIP calculation and persist a backend-neutral JSON result."""
     if not isinstance(params, MLIPInputSchema):
         params = MLIPInputSchema.model_validate(params)
     result = _execute_single_requests([params], batch_size=1)[0]
@@ -559,8 +731,8 @@ def _single_params_for_batch_item(
         input_structure_file=input_file,
         output_results_file=output_file,
         driver=batch_params.driver,
-        runtime=batch_params.runtime,
         model=batch_params.model,
+        calculator=batch_params.calculator,
         fmax=batch_params.fmax,
         steps=batch_params.steps,
     )
@@ -613,6 +785,8 @@ def run_mlip_batch_core(params: MLIPBatchInputSchema) -> dict[str, Any]:
                 result.input_structure_file,
                 f"Could not write MLIP result: {exc}",
                 result.wall_time or 0.0,
+                result.calculator_info.get("resolved"),
+                result.model_info.get("resolved"),
             )
         items.append(
             MLIPBatchItemSchema(
@@ -633,10 +807,25 @@ def run_mlip_batch_core(params: MLIPBatchInputSchema) -> dict[str, Any]:
     else:
         status = "failure"
 
+    calculator_info = next(
+        (
+            result.calculator_info
+            for result in results
+            if result.calculator_info.get("resolved")
+        ),
+        {
+            "requested": params.calculator.model_dump(mode="json"),
+            "resolved": {},
+        },
+    )
+    model_info = next(
+        (result.model_info for result in results if result.model_info.get("resolved")),
+        {"requested": params.model.model_dump(mode="json"), "resolved": {}},
+    )
     manifest = MLIPBatchManifestSchema(
         status=status,
-        runtime_info=params.runtime.model_dump(mode="json"),
-        model_info=params.model.model_dump(mode="json"),
+        calculator_info=calculator_info,
+        model_info=model_info,
         total=len(items),
         succeeded=succeeded,
         failed=failed,

--- a/src/chemgraph/tools/run_mlip_tools.py
+++ b/src/chemgraph/tools/run_mlip_tools.py
@@ -1,0 +1,18 @@
+"""LangChain entry points for runtime-selectable MLIP calculations."""
+
+from langchain_core.tools import tool
+
+from chemgraph.schemas.mlip_input import MLIPBatchInputSchema, MLIPInputSchema
+from chemgraph.tools.run_mlip_core import run_mlip_batch_core, run_mlip_core
+
+
+@tool
+def run_mlip(params: MLIPInputSchema) -> dict:
+    """Run one MLIP energy calculation or fixed-cell geometry optimization."""
+    return run_mlip_core(params)
+
+
+@tool
+def run_mlip_batch(params: MLIPBatchInputSchema) -> dict:
+    """Run an ordered batch of MLIP calculations and write a JSON manifest."""
+    return run_mlip_batch_core(params)

--- a/src/chemgraph/tools/run_mlip_tools.py
+++ b/src/chemgraph/tools/run_mlip_tools.py
@@ -1,4 +1,4 @@
-"""LangChain entry points for runtime-selectable MLIP calculations."""
+"""LangChain entry points for calculator-selectable MLIP calculations."""
 
 from langchain_core.tools import tool
 

--- a/tests/test_run_mlip_core.py
+++ b/tests/test_run_mlip_core.py
@@ -32,7 +32,7 @@ def _single_params(input_file, output_file, **overrides):
     values = {
         "input_structure_file": str(input_file),
         "output_results_file": str(output_file),
-        "model": {"provider": "mace", "checkpoint": "unused.model"},
+        "model": {"family": "mace", "checkpoint": "unused.model"},
     }
     values.update(overrides)
     return MLIPInputSchema(**values)
@@ -43,26 +43,34 @@ def _emt_context(counter=None):
     def calculator_context(_params):
         if counter is not None:
             counter["entered"] += 1
-        yield EMT(), {}
+        yield (
+            EMT(),
+            {},
+            {"backend": "ase", "device": "cpu", "dtype": "float64"},
+            {"family": "mace", "checkpoint": "unused.model"},
+        )
 
     return calculator_context
 
 
-def test_run_mlip_ase_energy_writes_runtime_neutral_result(tmp_path, monkeypatch):
+def test_run_mlip_ase_energy_writes_backend_neutral_result(tmp_path, monkeypatch):
     input_file = tmp_path / "copper.xyz"
     output_file = tmp_path / "energy.json"
     _write_copper(input_file)
-    monkeypatch.setattr(core, "_ase_calculator_context", _emt_context())
+    monkeypatch.setitem(core._ASE_CONTEXT_FACTORIES, "ase", _emt_context())
 
     result = core.run_mlip_core(_single_params(input_file, output_file))
 
     assert result["status"] == "success"
+    assert result["potential_energy"] == result["single_point_energy"]
     assert result["single_point_energy"] is not None
     stored = json.loads(output_file.read_text())
     assert stored["success"] is True
     assert stored["simulation_input"]["driver"] == "energy"
-    assert stored["runtime_info"]["type"] == "ase"
-    assert stored["model_info"]["provider"] == "mace"
+    assert stored["calculator_info"]["requested"]["backend"] == "ase"
+    assert stored["calculator_info"]["resolved"]["device"] == "cpu"
+    assert stored["model_info"]["requested"]["family"] == "mace"
+    assert stored["potential_energy"] == stored["single_point_energy"]
     assert len(stored["forces"]) == 2
 
 
@@ -70,7 +78,7 @@ def test_run_mlip_ase_fixed_cell_optimization(tmp_path, monkeypatch):
     input_file = tmp_path / "copper.xyz"
     output_file = tmp_path / "opt.json"
     initial = _write_copper(input_file, distance=3.0)
-    monkeypatch.setattr(core, "_ase_calculator_context", _emt_context())
+    monkeypatch.setitem(core._ASE_CONTEXT_FACTORIES, "ase", _emt_context())
 
     params = _single_params(
         input_file,
@@ -94,14 +102,14 @@ def test_batch_reuses_calculator_and_records_partial_failure(tmp_path, monkeypat
     _write_copper(first)
     _write_copper(second, distance=2.7)
     counter = {"entered": 0}
-    monkeypatch.setattr(
-        core, "_ase_calculator_context", _emt_context(counter)
+    monkeypatch.setitem(
+        core._ASE_CONTEXT_FACTORIES, "ase", _emt_context(counter)
     )
 
     params = MLIPBatchInputSchema(
         input_structure_files=[str(first), str(missing), str(second)],
         output_results_directory=str(tmp_path / "results"),
-        model={"provider": "mace", "checkpoint": "unused.model"},
+        model={"family": "mace", "checkpoint": "unused.model"},
     )
     result = core.run_mlip_batch_core(params)
 
@@ -137,10 +145,16 @@ def test_nvalchemi_batch_loads_once_and_chunks_in_order(tmp_path, monkeypatch):
 
     def load_model(params):
         loaded.append(params.model.checkpoint)
-        return sentinel_model
+        return (
+            sentinel_model,
+            {"backend": "nvalchemi", "device": "cuda"},
+            {"family": "mace", "checkpoint": "model.pt"},
+        )
 
-    def run_chunk(model, entries):
+    def run_chunk(model, entries, calculator_resolved, model_resolved):
         assert model is sentinel_model
+        assert calculator_resolved["backend"] == "nvalchemi"
+        assert model_resolved["family"] == "mace"
         chunks.append([entry[1] for entry in entries])
         return [
             core._success_result(
@@ -162,8 +176,8 @@ def test_nvalchemi_batch_loads_once_and_chunks_in_order(tmp_path, monkeypatch):
         input_structure_files=input_files,
         output_results_directory=str(tmp_path / "results"),
         batch_size=2,
-        runtime={"type": "nvalchemi", "device": "cuda"},
-        model={"provider": "mace", "checkpoint": "model.pt"},
+        calculator={"backend": "nvalchemi", "device": "cuda"},
+        model={"family": "mace", "checkpoint": "model.pt"},
     )
 
     result = core.run_mlip_batch_core(params)
@@ -196,15 +210,25 @@ def test_rootstock_calculator_uses_context_manager(monkeypatch):
     params = MLIPInputSchema(
         input_structure_file="unused.xyz",
         model={
-            "provider": "rootstock",
+            "family": "mace",
             "checkpoint": "org/model",
+        },
+        calculator={
+            "backend": "rootstock",
             "cluster": "local",
         },
     )
 
-    with core._ase_calculator_context(params) as (calculator, atoms_info):
+    with core._rootstock_calculator_context(params) as (
+        calculator,
+        atoms_info,
+        calculator_resolved,
+        model_resolved,
+    ):
         assert calculator == "calculator"
         assert atoms_info == {}
+        assert calculator_resolved["backend"] == "rootstock"
+        assert model_resolved == {"family": "mace", "checkpoint": "org/model"}
 
     assert [event[0] for event in events] == ["init", "enter", "exit"]
     assert events[0][1]["checkpoint"] == "org/model"
@@ -223,7 +247,7 @@ def test_optional_backend_error_is_persisted_per_item(tmp_path, monkeypatch):
     params = _single_params(
         input_file,
         output_file,
-        runtime={"type": "nvalchemi"},
+        calculator={"backend": "nvalchemi"},
     )
 
     result = core.run_mlip_core(params)
@@ -234,27 +258,105 @@ def test_optional_backend_error_is_persisted_per_item(tmp_path, monkeypatch):
     assert "nvalchemi_mace" in stored["error"]
 
 
-def test_schema_rejects_unsupported_runtime_model_pairs():
-    with pytest.raises(ValidationError, match="supports only provider='mace'"):
+def test_schema_rejects_unsupported_calculator_model_pairs():
+    with pytest.raises(ValidationError, match="supports only model.family='mace'"):
         MLIPInputSchema(
             input_structure_file="input.xyz",
-            runtime={"type": "nvalchemi"},
-            model={"provider": "uma", "checkpoint": "uma-s-1p1"},
+            calculator={"backend": "nvalchemi"},
+            model={"family": "uma", "checkpoint": "uma-s-1p1"},
         )
 
-    with pytest.raises(ValidationError, match="require runtime.type='ase'"):
+    with pytest.raises(ValidationError, match="only MACE-MP"):
         MLIPInputSchema(
             input_structure_file="input.xyz",
-            runtime={"type": "nvalchemi"},
-            model={"provider": "rootstock", "checkpoint": "org/model"},
+            calculator={"backend": "nvalchemi"},
+            model={
+                "family": "mace",
+                "checkpoint": "model.pt",
+                "calculator_type": "mace_off",
+            },
         )
+
+    with pytest.raises(ValidationError, match="does not support MACE dispersion"):
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            calculator={"backend": "nvalchemi"},
+            model={
+                "family": "mace",
+                "checkpoint": "model.pt",
+                "dispersion": {},
+            },
+        )
+
+    with pytest.raises(ValidationError, match="omit calculator_type"):
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            calculator={"backend": "rootstock"},
+            model={
+                "family": "mace",
+                "checkpoint": "org/model",
+                "calculator_type": "mace_mp",
+            },
+        )
+
+    with pytest.raises(ValidationError, match="setup_kwargs"):
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            calculator={"backend": "rootstock"},
+            model={
+                "family": "uma",
+                "checkpoint": "org/model",
+                "task_name": "omol",
+            },
+        )
+
+    with pytest.raises(ValidationError, match="both cluster and root"):
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            calculator={
+                "backend": "rootstock",
+                "cluster": "local",
+                "root": "/remote/root",
+            },
+            model={"family": "aimnet2", "checkpoint": "org/model"},
+        )
+
+
+def test_schema_routes_one_config_to_calculator_adapters():
+    requests = [
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            model={"family": "uma", "checkpoint": "uma-s-1p1"},
+        ),
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            calculator={"backend": "nvalchemi"},
+            model={"family": "mace", "checkpoint": "model.pt"},
+        ),
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            calculator={"backend": "rootstock", "cluster": "local"},
+            model={"family": "aimnet2", "checkpoint": "org/model"},
+        ),
+    ]
+
+    assert [request.calculator.backend for request in requests] == [
+        "ase",
+        "nvalchemi",
+        "rootstock",
+    ]
+    assert [request.model.family for request in requests] == [
+        "uma",
+        "mace",
+        "aimnet2",
+    ]
 
 
 def test_relative_paths_resolve_through_chemgraph_log_dir(tmp_path, monkeypatch):
     input_file = tmp_path / "input.xyz"
     _write_copper(input_file)
     monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
-    monkeypatch.setattr(core, "_ase_calculator_context", _emt_context())
+    monkeypatch.setitem(core._ASE_CONTEXT_FACTORIES, "ase", _emt_context())
 
     result = core.run_mlip_core(
         _single_params("input.xyz", "nested/result.json")

--- a/tests/test_run_mlip_core.py
+++ b/tests/test_run_mlip_core.py
@@ -1,0 +1,264 @@
+import json
+import sys
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from ase import Atoms
+from ase.calculators.emt import EMT
+from ase.io import write
+from pydantic import ValidationError
+
+from chemgraph.schemas.mlip_input import (
+    MLIPBatchInputSchema,
+    MLIPInputSchema,
+)
+from chemgraph.tools import run_mlip_core as core
+
+
+def _write_copper(path, distance=2.5):
+    atoms = Atoms(
+        "Cu2",
+        positions=[[0.0, 0.0, 0.0], [distance, 0.0, 0.0]],
+        cell=[8.0, 8.0, 8.0],
+        pbc=False,
+    )
+    write(path, atoms)
+    return atoms
+
+
+def _single_params(input_file, output_file, **overrides):
+    values = {
+        "input_structure_file": str(input_file),
+        "output_results_file": str(output_file),
+        "model": {"provider": "mace", "checkpoint": "unused.model"},
+    }
+    values.update(overrides)
+    return MLIPInputSchema(**values)
+
+
+def _emt_context(counter=None):
+    @contextmanager
+    def calculator_context(_params):
+        if counter is not None:
+            counter["entered"] += 1
+        yield EMT(), {}
+
+    return calculator_context
+
+
+def test_run_mlip_ase_energy_writes_runtime_neutral_result(tmp_path, monkeypatch):
+    input_file = tmp_path / "copper.xyz"
+    output_file = tmp_path / "energy.json"
+    _write_copper(input_file)
+    monkeypatch.setattr(core, "_ase_calculator_context", _emt_context())
+
+    result = core.run_mlip_core(_single_params(input_file, output_file))
+
+    assert result["status"] == "success"
+    assert result["single_point_energy"] is not None
+    stored = json.loads(output_file.read_text())
+    assert stored["success"] is True
+    assert stored["simulation_input"]["driver"] == "energy"
+    assert stored["runtime_info"]["type"] == "ase"
+    assert stored["model_info"]["provider"] == "mace"
+    assert len(stored["forces"]) == 2
+
+
+def test_run_mlip_ase_fixed_cell_optimization(tmp_path, monkeypatch):
+    input_file = tmp_path / "copper.xyz"
+    output_file = tmp_path / "opt.json"
+    initial = _write_copper(input_file, distance=3.0)
+    monkeypatch.setattr(core, "_ase_calculator_context", _emt_context())
+
+    params = _single_params(
+        input_file,
+        output_file,
+        driver="opt",
+        steps=2,
+        fmax=0.01,
+    )
+    result = core.run_mlip_core(params)
+
+    assert result["status"] == "success"
+    stored = json.loads(output_file.read_text())
+    assert stored["simulation_input"]["driver"] == "opt"
+    assert stored["final_structure"]["cell"] == initial.cell.tolist()
+
+
+def test_batch_reuses_calculator_and_records_partial_failure(tmp_path, monkeypatch):
+    first = tmp_path / "first.xyz"
+    second = tmp_path / "second.xyz"
+    missing = tmp_path / "missing.xyz"
+    _write_copper(first)
+    _write_copper(second, distance=2.7)
+    counter = {"entered": 0}
+    monkeypatch.setattr(
+        core, "_ase_calculator_context", _emt_context(counter)
+    )
+
+    params = MLIPBatchInputSchema(
+        input_structure_files=[str(first), str(missing), str(second)],
+        output_results_directory=str(tmp_path / "results"),
+        model={"provider": "mace", "checkpoint": "unused.model"},
+    )
+    result = core.run_mlip_batch_core(params)
+
+    assert result["status"] == "partial"
+    assert result["succeeded"] == 2
+    assert result["failed"] == 1
+    assert counter["entered"] == 1
+    manifest = json.loads((tmp_path / "results" / "batch_manifest.json").read_text())
+    assert [item["index"] for item in manifest["items"]] == [0, 1, 2]
+    assert [item["status"] for item in manifest["items"]] == [
+        "success",
+        "failure",
+        "success",
+    ]
+    expected_results = [
+        "00000_first.json",
+        "00001_missing.json",
+        "00002_second.json",
+    ]
+    assert all((tmp_path / "results" / name).exists() for name in expected_results)
+
+
+def test_nvalchemi_batch_loads_once_and_chunks_in_order(tmp_path, monkeypatch):
+    input_files = []
+    for index in range(3):
+        input_file = tmp_path / f"input_{index}.xyz"
+        _write_copper(input_file, distance=2.5 + index * 0.1)
+        input_files.append(str(input_file))
+
+    loaded = []
+    chunks = []
+    sentinel_model = object()
+
+    def load_model(params):
+        loaded.append(params.model.checkpoint)
+        return sentinel_model
+
+    def run_chunk(model, entries):
+        assert model is sentinel_model
+        chunks.append([entry[1] for entry in entries])
+        return [
+            core._success_result(
+                params,
+                input_file,
+                atoms,
+                1.25,
+                np.zeros((len(atoms), 3)),
+                None,
+                True,
+                0.01,
+            )
+            for params, input_file, atoms, _ in entries
+        ]
+
+    monkeypatch.setattr(core, "_load_nvalchemi_model", load_model)
+    monkeypatch.setattr(core, "_run_nvalchemi_chunk", run_chunk)
+    params = MLIPBatchInputSchema(
+        input_structure_files=input_files,
+        output_results_directory=str(tmp_path / "results"),
+        batch_size=2,
+        runtime={"type": "nvalchemi", "device": "cuda"},
+        model={"provider": "mace", "checkpoint": "model.pt"},
+    )
+
+    result = core.run_mlip_batch_core(params)
+
+    assert result["status"] == "completed"
+    assert loaded == ["model.pt"]
+    assert [len(chunk) for chunk in chunks] == [2, 1]
+    assert chunks[0] + chunks[1] == input_files
+
+
+def test_rootstock_calculator_uses_context_manager(monkeypatch):
+    events = []
+
+    class FakeRootstockCalculator:
+        def __init__(self, **kwargs):
+            events.append(("init", kwargs))
+
+        def __enter__(self):
+            events.append(("enter", None))
+            return "calculator"
+
+        def __exit__(self, exc_type, exc, traceback):
+            events.append(("exit", None))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "rootstock",
+        SimpleNamespace(RootstockCalculator=FakeRootstockCalculator),
+    )
+    params = MLIPInputSchema(
+        input_structure_file="unused.xyz",
+        model={
+            "provider": "rootstock",
+            "checkpoint": "org/model",
+            "cluster": "local",
+        },
+    )
+
+    with core._ase_calculator_context(params) as (calculator, atoms_info):
+        assert calculator == "calculator"
+        assert atoms_info == {}
+
+    assert [event[0] for event in events] == ["init", "enter", "exit"]
+    assert events[0][1]["checkpoint"] == "org/model"
+    assert events[0][1]["cluster"] == "local"
+
+
+def test_optional_backend_error_is_persisted_per_item(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.xyz"
+    output_file = tmp_path / "result.json"
+    _write_copper(input_file)
+
+    def missing_backend(_params):
+        raise ImportError("Install ChemGraph with the 'nvalchemi_mace' extra.")
+
+    monkeypatch.setattr(core, "_load_nvalchemi_model", missing_backend)
+    params = _single_params(
+        input_file,
+        output_file,
+        runtime={"type": "nvalchemi"},
+    )
+
+    result = core.run_mlip_core(params)
+
+    assert result["status"] == "failure"
+    stored = json.loads(output_file.read_text())
+    assert stored["success"] is False
+    assert "nvalchemi_mace" in stored["error"]
+
+
+def test_schema_rejects_unsupported_runtime_model_pairs():
+    with pytest.raises(ValidationError, match="supports only provider='mace'"):
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            runtime={"type": "nvalchemi"},
+            model={"provider": "uma", "checkpoint": "uma-s-1p1"},
+        )
+
+    with pytest.raises(ValidationError, match="require runtime.type='ase'"):
+        MLIPInputSchema(
+            input_structure_file="input.xyz",
+            runtime={"type": "nvalchemi"},
+            model={"provider": "rootstock", "checkpoint": "org/model"},
+        )
+
+
+def test_relative_paths_resolve_through_chemgraph_log_dir(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.xyz"
+    _write_copper(input_file)
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(core, "_ase_calculator_context", _emt_context())
+
+    result = core.run_mlip_core(
+        _single_params("input.xyz", "nested/result.json")
+    )
+
+    assert result["status"] == "success"
+    assert (tmp_path / "nested" / "result.json").is_file()

--- a/tests/test_run_mlip_mcp.py
+++ b/tests/test_run_mlip_mcp.py
@@ -1,0 +1,48 @@
+import json
+
+import pytest
+from fastmcp import Client
+
+from chemgraph.mcp import run_mlip_mcp
+from chemgraph.schemas.mlip_input import MLIPBatchInputSchema, MLIPInputSchema
+
+
+@pytest.mark.asyncio
+async def test_run_mlip_mcp_exposes_standalone_tools(monkeypatch):
+    monkeypatch.setattr(
+        run_mlip_mcp,
+        "run_mlip_core",
+        lambda params: {"status": "single", "input": params.input_structure_file},
+    )
+    monkeypatch.setattr(
+        run_mlip_mcp,
+        "run_mlip_batch_core",
+        lambda params: {"status": "batch", "total": len(params.input_structure_files)},
+    )
+    single = MLIPInputSchema(
+        input_structure_file="input.xyz",
+        model={"provider": "mace", "checkpoint": "model.pt"},
+    )
+    batch = MLIPBatchInputSchema(
+        input_structure_files=["one.xyz", "two.xyz"],
+        model={"provider": "mace", "checkpoint": "model.pt"},
+    )
+
+    async with Client(run_mlip_mcp.mcp) as client:
+        tools = await client.list_tools()
+        single_result = await client.call_tool(
+            "run_mlip", {"params": single.model_dump(mode="json")}
+        )
+        batch_result = await client.call_tool(
+            "run_mlip_batch", {"params": batch.model_dump(mode="json")}
+        )
+
+    assert {tool.name for tool in tools} == {"run_mlip", "run_mlip_batch"}
+    assert json.loads(single_result.content[0].text) == {
+        "status": "single",
+        "input": "input.xyz",
+    }
+    assert json.loads(batch_result.content[0].text) == {
+        "status": "batch",
+        "total": 2,
+    }

--- a/tests/test_run_mlip_mcp.py
+++ b/tests/test_run_mlip_mcp.py
@@ -1,31 +1,57 @@
 import json
+from concurrent.futures import Future
+from types import SimpleNamespace
 
 import pytest
 from fastmcp import Client
 
+from chemgraph.execution.base import TaskSpec
+from chemgraph.execution.job_tracker import JobTracker
 from chemgraph.mcp import run_mlip_mcp
 from chemgraph.schemas.mlip_input import MLIPBatchInputSchema, MLIPInputSchema
 
 
+class _ImmediateBackend:
+    is_async_remote = False
+    shares_filesystem = True
+
+    def __init__(self):
+        self.submitted = []
+
+    def submit(self, task):
+        self.submitted.append(task)
+        future = Future()
+        future.set_result(task.callable(**task.kwargs))
+        return future
+
+
 @pytest.mark.asyncio
 async def test_run_mlip_mcp_exposes_standalone_tools(monkeypatch):
+    backend = _ImmediateBackend()
+    monkeypatch.setattr(run_mlip_mcp.mcp, "_backend", backend)
     monkeypatch.setattr(
         run_mlip_mcp,
         "run_mlip_core",
-        lambda params: {"status": "single", "input": params.input_structure_file},
+        lambda params: {
+            "status": "single",
+            "input": params["input_structure_file"],
+        },
     )
     monkeypatch.setattr(
         run_mlip_mcp,
         "run_mlip_batch_core",
-        lambda params: {"status": "batch", "total": len(params.input_structure_files)},
+        lambda params: {
+            "status": "batch",
+            "total": len(params["input_structure_files"]),
+        },
     )
     single = MLIPInputSchema(
         input_structure_file="input.xyz",
-        model={"provider": "mace", "checkpoint": "model.pt"},
+        model={"family": "mace", "checkpoint": "model.pt"},
     )
     batch = MLIPBatchInputSchema(
         input_structure_files=["one.xyz", "two.xyz"],
-        model={"provider": "mace", "checkpoint": "model.pt"},
+        model={"family": "mace", "checkpoint": "model.pt"},
     )
 
     async with Client(run_mlip_mcp.mcp) as client:
@@ -37,7 +63,14 @@ async def test_run_mlip_mcp_exposes_standalone_tools(monkeypatch):
             "run_mlip_batch", {"params": batch.model_dump(mode="json")}
         )
 
-    assert {tool.name for tool in tools} == {"run_mlip", "run_mlip_batch"}
+    assert {
+        "run_mlip",
+        "run_mlip_batch",
+        "check_job_status",
+        "get_job_results",
+        "list_jobs",
+        "cancel_job",
+    } <= {tool.name for tool in tools}
     assert json.loads(single_result.content[0].text) == {
         "status": "single",
         "input": "input.xyz",
@@ -46,3 +79,105 @@ async def test_run_mlip_mcp_exposes_standalone_tools(monkeypatch):
         "status": "batch",
         "total": 2,
     }
+    assert [task.callable.__name__ for task in backend.submitted] == [
+        "run_mlip",
+        "run_mlip_batch",
+    ]
+
+
+def test_mlip_remote_execution_requires_prestaged_inputs(tmp_path, monkeypatch):
+    input_file = tmp_path / "input.xyz"
+    input_file.write_text("local", encoding="utf-8")
+    monkeypatch.setattr(
+        run_mlip_mcp.mcp,
+        "_backend",
+        SimpleNamespace(shares_filesystem=False),
+    )
+    params = MLIPInputSchema(
+        input_structure_file=str(input_file),
+        output_results_file="/remote/results/output.json",
+        model={"family": "mace", "checkpoint": "named-model"},
+    )
+    task = TaskSpec(
+        task_id="single",
+        callable=run_mlip_mcp.run_mlip,
+        kwargs={"params": params.model_dump(mode="json")},
+    )
+
+    with pytest.raises(ValueError, match="Pre-stage these inputs"):
+        run_mlip_mcp._mlip_transport_hook(task)
+
+
+def test_mlip_remote_batch_stays_one_gpu_task(monkeypatch):
+    monkeypatch.setattr(
+        run_mlip_mcp.mcp,
+        "_backend",
+        SimpleNamespace(shares_filesystem=False),
+    )
+    params = MLIPBatchInputSchema(
+        input_structure_files=["/remote/input/one.xyz", "/remote/input/two.xyz"],
+        output_results_directory="/remote/results",
+        calculator={"backend": "nvalchemi"},
+        model={"family": "mace", "checkpoint": "remote-model"},
+    )
+    task = TaskSpec(
+        task_id="batch",
+        callable=run_mlip_mcp.run_mlip_batch,
+        kwargs={"params": params.model_dump(mode="json")},
+    )
+
+    routed = run_mlip_mcp._mlip_transport_hook(task)
+
+    assert routed is task
+    assert routed.gpus_per_task == 1
+    assert routed.callable is run_mlip_mcp.run_mlip_batch
+    assert list(routed.kwargs) == ["params"]
+
+
+def test_mlip_remote_execution_requires_absolute_output(monkeypatch):
+    monkeypatch.setattr(
+        run_mlip_mcp.mcp,
+        "_backend",
+        SimpleNamespace(shares_filesystem=False),
+    )
+    params = MLIPInputSchema(
+        input_structure_file="/remote/input.xyz",
+        output_results_file="output.json",
+        model={"family": "mace", "checkpoint": "named-model"},
+    )
+    task = TaskSpec(
+        task_id="single",
+        callable=run_mlip_mcp.run_mlip,
+        kwargs={"params": params.model_dump(mode="json")},
+    )
+
+    with pytest.raises(ValueError, match="must be an absolute path"):
+        run_mlip_mcp._mlip_transport_hook(task)
+
+
+@pytest.mark.asyncio
+async def test_run_mlip_mcp_returns_async_job_handle(monkeypatch):
+    backend = _ImmediateBackend()
+    backend.is_async_remote = True
+    monkeypatch.setattr(run_mlip_mcp.mcp, "_backend", backend)
+    monkeypatch.setattr(run_mlip_mcp.mcp, "_tracker", JobTracker())
+    monkeypatch.setattr(
+        run_mlip_mcp,
+        "run_mlip_core",
+        lambda params: {"status": "success"},
+    )
+    params = MLIPInputSchema(
+        input_structure_file="/remote/input.xyz",
+        output_results_file="/remote/output.json",
+        model={"family": "mace", "checkpoint": "named-model"},
+    )
+
+    async with Client(run_mlip_mcp.mcp) as client:
+        result = await client.call_tool(
+            "run_mlip", {"params": params.model_dump(mode="json")}
+        )
+
+    payload = json.loads(result.content[0].text)
+    assert payload["status"] == "submitted"
+    assert payload["n_tasks"] == 1
+    assert payload["batch_id"]

--- a/tests/test_run_mlip_mcp.py
+++ b/tests/test_run_mlip_mcp.py
@@ -155,6 +155,26 @@ def test_mlip_remote_execution_requires_absolute_output(monkeypatch):
         run_mlip_mcp._mlip_transport_hook(task)
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/remote/results/output.json",
+        "C:/remote/results/output.json",
+        r"\\worker\share\results\output.json",
+    ],
+)
+def test_remote_output_path_accepts_worker_platform_paths(path):
+    assert run_mlip_mcp._is_absolute_remote_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["output.json", "results/output.json", r"C:results\output.json"],
+)
+def test_remote_output_path_rejects_relative_paths(path):
+    assert not run_mlip_mcp._is_absolute_remote_path(path)
+
+
 @pytest.mark.asyncio
 async def test_run_mlip_mcp_returns_async_job_handle(monkeypatch):
     backend = _ImmediateBackend()

--- a/tests/test_run_mlip_tools.py
+++ b/tests/test_run_mlip_tools.py
@@ -1,0 +1,34 @@
+from chemgraph.schemas.mlip_input import MLIPBatchInputSchema, MLIPInputSchema
+from chemgraph.tools import run_mlip_tools
+
+
+def test_run_mlip_langchain_tool_delegates(monkeypatch):
+    params = MLIPInputSchema(
+        input_structure_file="input.xyz",
+        model={"provider": "mace", "checkpoint": "model.pt"},
+    )
+    monkeypatch.setattr(
+        run_mlip_tools,
+        "run_mlip_core",
+        lambda received: {"status": "single", "params": received},
+    )
+
+    result = run_mlip_tools.run_mlip.invoke({"params": params})
+
+    assert result == {"status": "single", "params": params}
+
+
+def test_run_mlip_batch_langchain_tool_delegates(monkeypatch):
+    params = MLIPBatchInputSchema(
+        input_structure_files=["input.xyz"],
+        model={"provider": "mace", "checkpoint": "model.pt"},
+    )
+    monkeypatch.setattr(
+        run_mlip_tools,
+        "run_mlip_batch_core",
+        lambda received: {"status": "batch", "params": received},
+    )
+
+    result = run_mlip_tools.run_mlip_batch.invoke({"params": params})
+
+    assert result == {"status": "batch", "params": params}

--- a/tests/test_run_mlip_tools.py
+++ b/tests/test_run_mlip_tools.py
@@ -5,7 +5,7 @@ from chemgraph.tools import run_mlip_tools
 def test_run_mlip_langchain_tool_delegates(monkeypatch):
     params = MLIPInputSchema(
         input_structure_file="input.xyz",
-        model={"provider": "mace", "checkpoint": "model.pt"},
+        model={"family": "mace", "checkpoint": "model.pt"},
     )
     monkeypatch.setattr(
         run_mlip_tools,
@@ -21,7 +21,7 @@ def test_run_mlip_langchain_tool_delegates(monkeypatch):
 def test_run_mlip_batch_langchain_tool_delegates(monkeypatch):
     params = MLIPBatchInputSchema(
         input_structure_files=["input.xyz"],
-        model={"provider": "mace", "checkpoint": "model.pt"},
+        model={"family": "mace", "checkpoint": "model.pt"},
     )
     monkeypatch.setattr(
         run_mlip_tools,


### PR DESCRIPTION
## Summary

- Use one scientific calculation envelope: `model` selects the potential while `calculator.backend` selects the ASE, NVIDIA ALCHEMI, or Rootstock adapter.
- Route the MLIP MCP tools through `CGFastMCP`, keeping the server-wide `[execution]` backend independent from calculator selection.
- Submit ordered batches as one execution task, provide CUDA GPU resource hints, validate paths for non-shared filesystems, and expose transfer tools when configured.
- Recognize POSIX and Windows worker paths independently of the MCP server platform.
- Persist model, calculator, and execution metadata and document the configuration and optional dependencies.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check` on all tracked Python files
- `pytest tests/ -k "not tblite"`: 763 passed, 30 skipped, 2 deselected
- `pytest tests/test_run_mlip_core.py tests/test_run_mlip_tools.py tests/test_run_mlip_mcp.py -q`: 22 passed
- `git diff --check origin/main...HEAD`
- No live scheduler, Globus Compute endpoint, model download, or GPU calculation was run; those paths are covered with hermetic backend and adapter tests.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change
- [x] `ruff check .` passes in a clean checkout
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added/updated tests for the change
- [x] Updated docs / README for the user-facing change