### PR TITLE
Add OCSR core, model registry, and agreement calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ vib*.traj
 
 # Kubernetes secrets (keep secrets.yaml.template, ignore actual secrets)
 k8s/secrets.yaml
+cg_logs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,8 @@ where = ["src/"]
 
 [tool.setuptools.package-data]
 "chemgraph.eval" = ["data/*.json"]
+"chemgraph.tools" = ["*.json"]
+"chemgraph.tools.ocsr_workers" = ["*.py", "*.sh", "*.txt"]
 "chemgraph.academy.campaigns" = [
     "example-*/*.json",
     "example-*/*.jsonc",

--- a/src/chemgraph/prompt/ocsr_prompt.py
+++ b/src/chemgraph/prompt/ocsr_prompt.py
@@ -1,0 +1,74 @@
+"""Prompts for the OCSR tool.
+
+Two distinct prompts that are easy to confuse:
+
+1. :data:`OCSR_SYSTEM_PROMPT` and :data:`OCSR_USER_PROMPT` go *inside* the tool, to the
+   vision model, and are vendored verbatim (see below).
+2. :data:`ocsr_agent_prompt` is the *orchestrator's* system prompt, used when binding
+   the tool to a ChemGraph agent. It is ours to write and the vision model never sees it.
+"""
+
+# ---------------------------------------------------------------------------
+# Vendored from the OCSR benchmark, bench/contract.py, at commit 6b7f022.
+#
+# Byte-identical on purpose. This is the exact prompt behind every published OCSR
+# accuracy number, so any edit here silently makes the tool's results incomparable
+# with the benchmark's, and the accuracies in the calibration table stop describing
+# what the tool does. Treat this block as data: if the prompt needs to change, the
+# committee has to be re-measured and the table refit.
+# ---------------------------------------------------------------------------
+
+OCSR_SYSTEM_PROMPT = (
+    "You are an expert chemist performing Optical Chemical Structure "
+    "Recognition (OCSR). You are shown a single image of one molecule's "
+    "2D structural diagram. Output the molecule as a single valid SMILES "
+    "string.\n"
+    "Rules:\n"
+    "- Respond with ONLY the SMILES string, on one line.\n"
+    "- Do not add commentary, labels, backticks, or explanation.\n"
+    "- If the drawing shows stereochemistry (wedge/dash bonds, cis/trans), "
+    "encode it in the SMILES (@/@@ and /\\).\n"
+    "- If you are unsure, give your single best guess as one SMILES string."
+)
+
+OCSR_USER_PROMPT = "What is the SMILES string for the molecule in this image?"
+
+
+# ---------------------------------------------------------------------------
+# The orchestrator's prompt. Mirrors prompt/molecular_docking_prompt.py in shape:
+# tell the agent what the tool is for and how to read its output, not how it works.
+# ---------------------------------------------------------------------------
+
+ocsr_agent_prompt = """You are a computational chemistry assistant that can read
+chemical structure diagrams from images.
+
+When the user supplies an image of a molecular structure, call `image_to_smiles` with
+its path. The tool reads the picture for you; you never see the image yourself.
+
+Always read `confidence` before you act on the answer:
+
+- `backend="ensemble"` gives a number: how often that voting pattern was right on
+  measured data. Above about 0.95 the SMILES is safe to act on. Below it the models
+  disagreed, so the drawing is hard: say so instead of presenting it as settled.
+- Every other backend gives `confidence: null`. One model cannot say how likely it
+  is to be right about this particular image, so nothing is quoted. Null means
+  unmeasured, which is different from the answer being wrong.
+- When the answer matters, `backend="ensemble"` is the only way to get a number.
+  If it returns null with a `committee_mismatch` reason, that machine has a partial
+  install and the message says which models are missing: report that to the user
+  rather than running it again.
+
+If `n_fragments` is greater than 1, the image contained more than one molecule, or a
+salt, or a reaction scheme. Ask the user which molecule they meant. Do not pass a
+multi-fragment SMILES to a geometry or energy calculation: the fragments are placed
+overlapping and the result is meaningless.
+
+Reading the image is the whole job. Report the SMILES to the user and say plainly how
+confident the tool was, then stop. If the user wants a geometry, an energy, or any
+other calculation on the molecule, say that the SMILES is ready for it and let them
+ask; the tools for that are not bound here.
+
+If a SMILES you propose yourself needs checking, `validate_smiles` reports what RDKit
+makes of it. You do not need it for a SMILES that came from `image_to_smiles`, whose
+return already carries `valid`, `formula` and `n_fragments`.
+"""

--- a/src/chemgraph/tools/ocsr_calibration_4model.json
+++ b/src/chemgraph/tools/ocsr_calibration_4model.json
@@ -1,0 +1,112 @@
+{
+  "committee": [
+    "decimer",
+    "molnextr",
+    "molscribe",
+    "ocsrglyph"
+  ],
+  "n_items": 722,
+  "scoring": "stereo_blind",
+  "abstention": "counts as a dissenting singleton vote; pattern parts always sum to the committee size",
+  "tie_break": "model-priority: decimer,molnextr,molscribe,ocsrglyph",
+  "min_n_for_point_estimate": 20,
+  "estimator": "Jeffreys: (k+0.5)/(n+1)",
+  "datasets": [
+    "eval100_random",
+    "eval100_minmax",
+    "eval100_stratified",
+    "pubchem"
+  ],
+  "model_performance": {
+    "decimer": {
+      "accuracy": 0.8989,
+      "k": 649,
+      "n": 722,
+      "ci": [
+        0.8753,
+        0.9193
+      ],
+      "abstention_rate": 0.0042
+    },
+    "molnextr": {
+      "accuracy": 0.8352,
+      "k": 603,
+      "n": 722,
+      "ci": [
+        0.8068,
+        0.8609
+      ],
+      "abstention_rate": 0.0429
+    },
+    "molscribe": {
+      "accuracy": 0.8241,
+      "k": 595,
+      "n": 722,
+      "ci": [
+        0.7951,
+        0.8505
+      ],
+      "abstention_rate": 0.054
+    },
+    "ocsrglyph": {
+      "accuracy": 0.7659,
+      "k": 553,
+      "n": 722,
+      "ci": [
+        0.734,
+        0.7957
+      ],
+      "abstention_rate": 0.0526
+    }
+  },
+  "patterns": {
+    "4": {
+      "k": 462,
+      "n": 462,
+      "p": 0.9989,
+      "ci": [
+        0.9946,
+        1.0
+      ]
+    },
+    "3/1": {
+      "k": 133,
+      "n": 135,
+      "p": 0.9816,
+      "ci": [
+        0.9533,
+        0.9969
+      ]
+    },
+    "2/1/1": {
+      "k": 46,
+      "n": 57,
+      "p": 0.8017,
+      "ci": [
+        0.6909,
+        0.8929
+      ]
+    },
+    "1/1/1/1": {
+      "k": 21,
+      "n": 56,
+      "p": 0.3772,
+      "ci": [
+        0.2571,
+        0.5055
+      ]
+    },
+    "2/2": {
+      "k": 7,
+      "n": 12,
+      "p": null,
+      "ci": [
+        0.3119,
+        0.8195
+      ]
+    }
+  },
+  "label_rule": "Where p is present, the consumer may quote it. Where p is null (n below min_n_for_point_estimate), no number is quoted: the label comes from the Jeffreys estimate (k+0.5)/(n+1), the same quantity p reports above the floor, so one rule covers the whole table.",
+  "model_performance_rule": "Per-model accuracy on the same n_items images, used when a backend runs one model and there is no agreement pattern to look up. 'accuracy' is the raw rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often the model returned no parseable SMILES.",
+  "note": "Valid ONLY for this exact four-model committee. Refit with chemgraph.tools.ocsr_calibrate for any other set."
+}

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -1,0 +1,924 @@
+"""Pure-Python OCSR helpers (no LangChain / MCP decorators).
+
+Optical Chemical Structure Recognition: read a molecule's 2D structure diagram
+from an image and return its SMILES. Used by the LangChain ``@tool`` wrappers in
+:mod:`chemgraph.tools.ocsr_tools`.
+
+Two families of backend. A vision LLM reads the picture directly; local specialist
+models (MolNexTR, MolScribe, DECIMER, OCSRGlyph) are purpose-built image-to-SMILES
+networks driven as subprocesses. Running several specialists and looking at how much
+they agree yields a calibrated confidence, which is the point of :func:`vote` and
+:func:`confidence`.
+
+RDKit is a core dependency and is imported lazily anyway, so this module imports and
+its tests collect on a host with no specialist environment and no network. A
+:func:`mock_ocsr` helper provides deterministic output for hermetic tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import math
+import os
+import re
+import stat
+
+logger = logging.getLogger(__name__)
+
+# Reject anything that is not one of these before base64-ing it to a remote endpoint.
+# Sniffed from the leading bytes, never from the file extension: the extension is
+# attacker-controlled and the whole point is to refuse a non-image renamed to .png.
+_MAGIC = {
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"\xff\xd8\xff": "image/jpeg",
+    b"GIF87a": "image/gif",
+    b"GIF89a": "image/gif",
+}
+_MAX_IMAGE_BYTES = 8_000_000
+
+# Confidence label cut-points, applied to the point estimate. Below the calibration
+# table's n floor these are prefixed "low_n_", because a 30-60 pp interval does not
+# deserve a decimal.
+_LABEL_BANDS = ((0.99, "unanimous"), (0.95, "strong"), (0.70, "weak"))
+
+# RDKit parsing is superlinear in string length: 20k characters costs about 9 s of
+# CPU and a megabyte-scale string is effectively unbounded. Model output is untrusted,
+# so cap it before RDKit sees it. Real SMILES are well under 1000 characters; the
+# longest in the OCSR benchmark is 224.
+_MAX_SMILES_CHARS = 4000
+
+_SMILES_LABEL_RE = re.compile(r"^\s*(?:smiles|answer|result)\s*[:=]\s*", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Image loading
+# ---------------------------------------------------------------------------
+
+
+def _sniff_mime(head: bytes) -> str | None:
+    """Return the MIME type implied by a file's leading bytes, or None.
+
+    WEBP needs a split check: "RIFF" then "WEBP" four bytes later.
+    """
+    for magic, mime in _MAGIC.items():
+        if head.startswith(magic):
+            return mime
+    if head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def load_image_bytes(image_path: str, max_bytes: int = _MAX_IMAGE_BYTES) -> tuple[bytes, str]:
+    """Read an image file safely and return ``(raw_bytes, mime_type)``.
+
+    Validates before reading rather than after. Reading first and checking later is
+    not equivalent: ``/dev/zero`` grows the buffer without bound, a FIFO blocks
+    forever in ``open()`` so no caller-side timeout fires, and a 50 GB regular file
+    is fully resident before any size check could reject it.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to a PNG, JPEG, GIF or WEBP file.
+    max_bytes : int, optional
+        Reject anything larger, by default 8 MB.
+
+    Returns
+    -------
+    tuple[bytes, str]
+        The file contents and its sniffed MIME type.
+
+    Raises
+    ------
+    FileNotFoundError
+        No such path.
+    ValueError
+        Not a regular file, too large, or not a recognized image format.
+    """
+    path = os.path.abspath(os.path.expanduser(image_path))
+    try:
+        st = os.lstat(path)  # lstat, so a symlink is judged on its own terms
+    except FileNotFoundError:
+        raise FileNotFoundError(f"no such image: {path}")
+
+    if not stat.S_ISREG(st.st_mode):
+        raise ValueError(
+            f"not a regular file: {path}. Directories, FIFOs, sockets and device "
+            f"files are refused (a FIFO would block forever, /dev/zero would not end)."
+        )
+    if st.st_size > max_bytes:
+        raise ValueError(f"image is {st.st_size} bytes, over the {max_bytes} limit: {path}")
+
+    with open(path, "rb") as fh:
+        data = fh.read(max_bytes + 1)  # +1 so a file that grew since lstat is caught
+    if len(data) > max_bytes:
+        raise ValueError(f"image grew past the {max_bytes} limit while reading: {path}")
+
+    mime = _sniff_mime(data[:16])
+    if mime is None:
+        raise ValueError(
+            f"not a recognized image (PNG/JPEG/GIF/WEBP) by content: {path}. "
+            f"The extension is not trusted; only the leading bytes are."
+        )
+    return data, mime
+
+
+def load_image_b64(image_path: str, max_bytes: int = _MAX_IMAGE_BYTES) -> tuple[str, str]:
+    """Read an image and return ``(base64_ascii, mime_type)`` for a data URL."""
+    data, mime = load_image_bytes(image_path, max_bytes=max_bytes)
+    return base64.b64encode(data).decode("ascii"), mime
+
+
+def extract_image_path(text: str) -> str | None:
+    """Pull the first usable image path out of a free-text query.
+
+    A candidate must both exist and pass the magic-byte check, so a text file named
+    ``notes.png`` is never selected.
+
+    Parameters
+    ----------
+    text : str
+        Natural-language query, e.g. "what is the SMILES in /data/mol.png?".
+
+    Returns
+    -------
+    str or None
+        Absolute path to the first real image mentioned, else None.
+    """
+    if not text:
+        return None
+    # The optional drive prefix keeps a Windows path whole: without it the match
+    # starts after "C:", and joining the remainder against the current drive points
+    # somewhere else entirely.
+    pattern = r"(?:[A-Za-z]:)?[\w./~\\-]+\.(?:png|jpe?g|gif|webp|bmp|tiff?)"
+    for token in re.findall(pattern, text, flags=re.IGNORECASE):
+        candidate = token.strip("'\"")
+        try:
+            load_image_bytes(candidate)
+        except Exception:
+            continue
+        return os.path.abspath(os.path.expanduser(candidate))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SMILES handling
+# ---------------------------------------------------------------------------
+
+
+def canonicalize(smiles: str | None, stereo: bool = False) -> str | None:
+    """Canonical SMILES, or None when the string does not parse.
+
+    Defaults to stereo-blind, matching how the OCSR benchmark scores: most reference
+    labels carry no stereochemistry, so comparing with it makes a model that correctly
+    reads a wedge bond look wrong.
+
+    Grouping predictions by this, rather than by raw string, is load-bearing for
+    :func:`vote`. DECIMER emits Kekule SMILES while the other specialists emit
+    aromatic, so raw-string comparison finds unanimity on 12 of 422 benchmark items
+    where canonical comparison finds it on 289.
+    """
+    if not smiles or len(smiles) > _MAX_SMILES_CHARS:
+        return None
+    from rdkit import Chem, RDLogger
+
+    RDLogger.DisableLog("rdApp.*")
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    if not stereo:
+        Chem.RemoveStereochemistry(mol)
+    return Chem.MolToSmiles(mol)
+
+
+def _looks_like_prose(s: str) -> bool:
+    """True if a string is a sentence rather than a SMILES.
+
+    Needed because RDKit is happy to parse prose. "I cannot process images." yields
+    a molecule: ``I`` is iodine and the parser stops at the space. Without this
+    guard a model's refusal is returned as a confident one-atom prediction.
+
+    Deliberately a syntactic check, not a model call. Asking an LLM "is this a
+    refusal?" would add a network round trip per prediction (four per ensemble call),
+    and would itself be a model that can refuse. Refusals and SMILES differ in form,
+    not in meaning, so form is enough.
+
+    Measured on real data: 0 false positives over 1916 unique specialist predictions,
+    and 100% recall over 2100 real reference SMILES wrapped in seven common LLM
+    phrasings (fenced, "SMILES:", "The SMILES string is", and so on).
+
+    Known limit: a refusal that happens to be a single organic-subset word would slip
+    through. None exists in practice, since refusals are sentences. If a model is ever
+    found to emit one, add it to an explicit denylist rather than reaching for a
+    classifier.
+    """
+    if " " in s.strip():
+        return True
+    # A SMILES is mostly non-alphanumeric structure or organic-subset letters. A word
+    # like "images" is all lowercase letters and no structural characters at all.
+    return s.isalpha() and s.islower() and not set(s) <= set("cnopsbrifhe")
+
+
+def extract_smiles(raw_text: str | None) -> str | None:
+    """Pull a SMILES out of a model's raw reply.
+
+    Handles a bare string, a fenced code block, and "The SMILES is: X" prose. Returns
+    None for a refusal ("I cannot process images"), which must not be mistaken for a
+    prediction. Does not validate; :func:`validate_smiles_core` does that.
+    """
+    if not raw_text or len(raw_text) > _MAX_SMILES_CHARS:
+        return None
+    text = re.sub(r"```[a-zA-Z]*\n?", "", raw_text).replace("```", "")
+    for line in text.splitlines():
+        cleaned = _SMILES_LABEL_RE.sub("", line).strip().strip("`\"'").strip()
+        if cleaned and not _looks_like_prose(cleaned) and canonicalize(cleaned) is not None:
+            return cleaned
+    for token in text.split():
+        cleaned = token.strip("`\"'").rstrip(".,;!?")
+        if (
+            len(cleaned) > 1
+            and not _looks_like_prose(cleaned)
+            and canonicalize(cleaned) is not None
+        ):
+            return cleaned
+    return None
+
+
+def validate_smiles_core(smiles: str) -> dict:
+    """Validate a SMILES with RDKit and report everything a caller can act on.
+
+    Never raises. An unparseable string yields ``valid=False`` with RDKit's own
+    sanitization message in ``errors``, which is the useful part: "Explicit valence
+    for atom # 3 N, 4, is greater than permitted" tells a model what to fix.
+
+    ``n_fragments`` above 1 means the string describes several disconnected molecules
+    (two structures in one image, a salt, a reaction scheme). That case parses,
+    sanitizes and canonicalizes cleanly, so nothing else catches it, and it corrupts
+    anything downstream: RDKit has no reason to separate disconnected fragments when
+    embedding, so they are placed overlapping (measured: 0.20 A closest approach,
+    0.00 A between centroids for ``CCO.CCN``), and an energy evaluation on that
+    geometry is meaningless while reporting success.
+
+    Returns
+    -------
+    dict
+        smiles, valid, canonical_smiles, formula, n_atoms, n_heavy_atoms,
+        elements, n_fragments, errors, rdkit_available
+    """
+    out = {
+        "smiles": smiles,
+        "valid": False,
+        "canonical_smiles": None,
+        "formula": None,
+        "n_atoms": 0,
+        "n_heavy_atoms": 0,
+        "elements": [],
+        "n_fragments": 0,
+        "errors": [],
+        "rdkit_available": True,
+    }
+    if not smiles or not isinstance(smiles, str):
+        out["errors"].append("empty or non-string SMILES")
+        return out
+    if len(smiles) > _MAX_SMILES_CHARS:
+        out["errors"].append(
+            f"SMILES is {len(smiles)} characters, over the {_MAX_SMILES_CHARS} limit; "
+            f"parsing cost grows superlinearly and real SMILES are far shorter"
+        )
+        return out
+
+    try:
+        from rdkit import Chem, RDLogger
+        from rdkit.Chem import rdMolDescriptors
+    except ImportError as e:  # pragma: no cover - rdkit is a core dependency
+        # Fail open. Failing closed would drive a validation retry loop until the
+        # recursion limit, spending a whole budget to produce nothing.
+        logger.warning("RDKit unavailable, skipping SMILES validation: %s", e)
+        out.update(rdkit_available=False, valid=True)
+        return out
+
+    RDLogger.DisableLog("rdApp.*")
+    if ">>" in smiles or ">" in smiles.replace("->", ""):
+        out["errors"].append(
+            "this looks like a reaction SMILES (contains '>'), not a single molecule"
+        )
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        # Re-parse without sanitizing to recover the specific complaint.
+        try:
+            raw = Chem.MolFromSmiles(smiles, sanitize=False)
+            if raw is not None:
+                Chem.SanitizeMol(raw)
+        except Exception as e:
+            out["errors"].append(str(e))
+        if not out["errors"]:
+            out["errors"].append("RDKit could not parse this SMILES")
+        return out
+
+    mol_h = Chem.AddHs(mol)
+    stereo_free = Chem.MolFromSmiles(smiles)
+    Chem.RemoveStereochemistry(stereo_free)
+    out.update(
+        valid=True,
+        canonical_smiles=Chem.MolToSmiles(stereo_free),
+        formula=rdMolDescriptors.CalcMolFormula(mol),
+        n_atoms=mol_h.GetNumAtoms(),
+        n_heavy_atoms=mol.GetNumAtoms(),
+        elements=sorted({a.GetSymbol() for a in mol_h.GetAtoms()}),
+        n_fragments=len(Chem.GetMolFrags(mol)),
+    )
+    if out["n_fragments"] > 1:
+        out["errors"].append(
+            f"this SMILES describes {out['n_fragments']} disconnected molecules; "
+            f"ask which one is meant before using it for a calculation"
+        )
+    return out
+
+
+def compare_smiles(smiles_a: str, smiles_b: str) -> dict:
+    """Report how two SMILES differ: same molecule, same skeleton, or unrelated."""
+    ca, cb = canonicalize(smiles_a), canonicalize(smiles_b)
+    out = {
+        "same_molecule": bool(ca and ca == cb),
+        "same_skeleton": False,
+        "same_formula": False,
+        "canonical_a": ca,
+        "canonical_b": cb,
+    }
+    if ca is None or cb is None:
+        return out
+    from rdkit import Chem
+    from rdkit.Chem import rdMolDescriptors
+
+    ma, mb = Chem.MolFromSmiles(smiles_a), Chem.MolFromSmiles(smiles_b)
+    out["same_skeleton"] = (
+        Chem.MolToInchiKey(ma).split("-")[0] == Chem.MolToInchiKey(mb).split("-")[0]
+    )
+    out["same_formula"] = rdMolDescriptors.CalcMolFormula(
+        ma
+    ) == rdMolDescriptors.CalcMolFormula(mb)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Consensus and calibrated confidence
+# ---------------------------------------------------------------------------
+
+
+def vote(results: list[dict], priority: list[str] | None = None) -> dict:
+    """Group specialist predictions and report the agreement pattern.
+
+    Predictions are canonicalized before grouping, so the same molecule written two
+    ways counts once. See :func:`canonicalize` for why that is not optional.
+
+    Distinguishes two things the caller must not conflate. ``committee`` is every
+    model that was asked, and must match the calibration table. ``voters`` is the
+    subset that returned a parseable SMILES.
+
+    An abstention counts as a dissenting vote, not as absence. A model that ran and
+    produced garbage contributes one singleton to the pattern, so the pattern's parts
+    always sum to the committee size: four models can only ever produce "4", "3/1",
+    "2/1/1", "2/2", or "1/1/1/1".
+
+    The alternative -- dropping abstainers and shrinking the pattern -- was measured
+    on 722 benchmark items and rejected. It split the same situations across eleven
+    buckets instead of five, pushing 12% of items below the sample floor where no
+    number can be quoted (2% under this rule). It also mislabelled the evidence: a
+    three-way agreement with one model unable to read the image at all was recorded
+    as "3", which reads like consensus, when the abstention is itself a signal that
+    the image is hard. Under this rule that item is "3/1", and the empirical accuracy
+    of the merged bucket bears this out.
+
+    Parameters
+    ----------
+    results : list[dict]
+        One entry per model: ``{"model", "smiles", "ok", "error", "infer_s"}``.
+        ``model`` is a bare name with no "local:" prefix.
+    priority : list[str], optional
+        Tie-break order, strongest model first. Defaults to the order given.
+
+    Returns
+    -------
+    dict
+        pattern, winner, votes, abstained, committee, voters
+    """
+    # Normalize the "local:" prefix here rather than trusting every caller. OCSR's
+    # LocalOCSRClient dispatches on ModelSpec names like "local:decimer", while the
+    # calibration table's committee is bare names. A mismatch does not raise: it makes
+    # check_committee report committee_mismatch, which nulls the confidence for every
+    # ensemble call. One missing removeprefix would turn the feature off permanently
+    # behind a plausible-looking error, so it is not left to the caller.
+    def _bare(name: str) -> str:
+        return name.removeprefix("local:")
+
+    committee = [_bare(r.get("model") or "") for r in results]
+    order = [_bare(m) for m in (priority or committee)]
+
+    groups: dict[str, list[str]] = {}
+    abstained: dict[str, str] = {}
+    # Counted separately from the dict: two results carrying the same model name, which
+    # `--models decimer,decimer` and the "local:" alias both produce, collapse to one
+    # dict key and would silently drop a singleton from the pattern.
+    n_abstained = 0
+    for r in results:
+        model = _bare(r.get("model") or "")
+        canon = canonicalize(r.get("smiles")) if r.get("ok", True) else None
+        if canon is None:
+            abstained[model] = str(r.get("smiles") or r.get("error") or "")[:80]
+            n_abstained += 1
+            continue
+        groups.setdefault(canon, []).append(model)
+
+    if not groups:
+        # Every model failed. There is no winner to be right about, but the item is
+        # not absent from the evidence either: it is the worst case of disagreement.
+        # Reporting it as all-singletons keeps it in the table, where it counts
+        # against that bucket, instead of vanishing and flattering every other row.
+        return {
+            "pattern": "/".join("1" * len(committee)) if committee else None,
+            "winner": None,
+            "votes": {},
+            "abstained": abstained,
+            "committee": committee,
+            "voters": [],
+        }
+
+    # Each abstainer is its own singleton: it agrees with nobody, including other
+    # abstainers, whose garbage output is unrelated.
+    counts = sorted(
+        [len(v) for v in groups.values()] + [1] * n_abstained, reverse=True
+    )
+    top = max(len(v) for v in groups.values())
+    tied = [smi for smi, models in groups.items() if len(models) == top]
+    if len(tied) > 1:
+        # Deterministic tie-break by model priority. This choice is load-bearing:
+        # it makes an all-different pattern report the strongest model's answer, so
+        # that bucket's accuracy in a calibration table is really that model's solo
+        # accuracy. Any table must record which rule was used.
+        #
+        # Resolved over the groups, so only models that actually voted can win. An
+        # earlier version scanned `results` and never re-checked ok, which let a model
+        # whose output failed to parse still decide the answer whenever its unusable
+        # string happened to canonicalize into a tied group. The winner would then be
+        # a SMILES from outside `voters`, and the bucket would not carry the solo
+        # accuracy the docstring above claims for it.
+        winner = next(
+            (smi for m in order for smi in tied if m in groups[smi]),
+            tied[0],
+        )
+    else:
+        winner = tied[0]
+
+    return {
+        "pattern": "/".join(str(c) for c in counts),
+        "winner": winner,
+        "votes": groups,
+        "abstained": abstained,
+        "committee": committee,
+        "voters": [m for models in groups.values() for m in models],
+    }
+
+
+def _label_for(p: float, low_n: bool = False) -> str:
+    """Map a probability to a coarse label, prefixed when the bucket is small."""
+    name = "conflicting"
+    for threshold, band in _LABEL_BANDS:
+        if p >= threshold:
+            name = band
+            break
+    return f"low_n_{name}" if low_n else name
+
+
+def confidence(pattern: str | None, table: dict) -> dict:
+    """Look up P(majority correct) for an agreement pattern.
+
+    Takes the table as an argument rather than reading a module global, so the tool
+    and the recalibration script share one code path.
+
+    Reports a point estimate only where the bucket cleared the table's sample floor.
+    Below it the 95% interval spans 30-60 pp, so a decimal would be false precision;
+    the label and the interval still carry the actionable part. An unknown pattern
+    gets no number at all rather than a guess.
+
+    Returns
+    -------
+    dict
+        p, label, n, ci, reason
+    """
+    if pattern is None:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_prediction"}
+
+    entry = (table.get("patterns") or {}).get(pattern)
+    if entry is None:
+        return {"p": None, "label": "unknown", "n": 0, "ci": None,
+                "reason": "unknown_pattern"}
+
+    p, n, ci = entry.get("p"), entry.get("n", 0), entry.get("ci")
+    if p is None:
+        # Below the floor we withhold the number but still owe a useful label, so it
+        # is derived from the Jeffreys estimate: the same quantity the `p` column
+        # reports above the floor, which keeps one rule across the whole table.
+        #
+        # The two obvious alternatives both mislead. The raw point estimate k/n calls
+        # a 7/7 bucket "unanimous", claiming certainty from seven items. The
+        # interval's lower bound calls that same bucket "conflicting", overstating
+        # the doubt: seven for seven is thin evidence, and it points one way.
+        # Jeffreys shrinks toward 0.5 in proportion to how thin the bucket is,
+        # putting 7/7 at 0.938 and so at low_n_weak, one band below the 0.95 cut.
+        k = entry.get("k")
+        est = ((k + 0.5) / (n + 1.0)) if (k is not None and n) else (ci[0] if ci else 0.0)
+        label = entry.get("label") or _label_for(est, low_n=True)
+        return {"p": None, "label": label, "n": n, "ci": ci,
+                "reason": "below_n_floor"}
+    return {"p": p, "label": entry.get("label") or _label_for(p), "n": n, "ci": ci,
+            "reason": None}
+
+
+def prior_confidence(model: str, table: dict | None = None) -> dict:
+    """Confidence for a single-model backend, from that model's measured solo accuracy.
+
+    A single model has no consensus to measure, so the agreement table does not apply.
+    Do **not** route a one-model result through :func:`vote` and :func:`confidence`:
+    that yields pattern "1", which a four-model table does not contain at all, so the
+    lookup misses and reports unknown_pattern. It would also trip
+    :func:`check_committee`. Use this instead.
+
+    Returns the same shape as :func:`confidence` so callers have one code path.
+
+    Every number here comes from the calibration table's ``model_performance`` section, never from
+    a constant in this file. Measurements belong with the data that produced them: a
+    user who refits on their own images gets priors for their images, and a stale
+    figure cannot outlive the table it was measured on. The registry in ocsr_models
+    describes what a model *is* (how to run it, how fast, what it needs); the table
+    records how well it *did*.
+
+    Passing ``table`` lets a caller that already loaded one avoid a second read.
+    """
+    bare = model.removeprefix("local:")
+    try:
+        t = table if table is not None else load_calibration()
+    except (OSError, ValueError, TypeError) as exc:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": f"calibration_unreadable: {type(exc).__name__}"}
+
+    entry = (t.get("model_performance") or {}).get(bare)
+    if not entry or entry.get("accuracy") is None:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_prior_for_model"}
+    p = entry["accuracy"]
+    return {"p": p, "label": _label_for(p), "n": entry.get("n", 0),
+            "ci": entry.get("ci"), "reason": None}
+
+
+def model_performance(model: str, table: dict | None = None) -> dict:
+    """Measured single-model performance from a calibration table, or {} if absent.
+
+    The one place to ask "how good is this model": accuracy, the k and n behind it,
+    a 95% interval, and how often it abstains. Nothing here is compiled into the
+    source, so a table refitted on other images reports that table's numbers.
+    """
+    try:
+        t = table if table is not None else load_calibration()
+    except (OSError, ValueError, TypeError):
+        return {}
+    return dict((t.get("model_performance") or {}).get(model.removeprefix("local:")) or {})
+
+
+def load_calibration(path: str | None = None) -> dict:
+    """Load a calibration table: explicit path, then env var, then the packaged default.
+
+    The packaged default describes the four-model committee on RDKit-rendered images
+    and is what makes ``backend="ensemble"`` work with no configuration. Anyone who
+    builds their own table with the recalibration script points at it here.
+
+    A table drives which answers get a confidence, so a malformed one is rejected on
+    load rather than silently producing wrong numbers deep in a run.
+    """
+    candidate = path or os.environ.get("CHEMGRAPH_OCSR_CALIBRATION")
+    if candidate:
+        resolved = os.path.expanduser(candidate)
+        # A FIFO here blocks open() forever with no caller-side timeout, the same
+        # reason load_image_bytes checks. Callers of this function have usually just
+        # spent real inference time and must not hang holding the result.
+        if not stat.S_ISREG(os.lstat(resolved).st_mode):
+            raise ValueError(f"calibration table is not a regular file: {resolved}")
+        with open(resolved) as fh:
+            return _validate_calibration(_load_json(fh, resolved), resolved)
+
+    from importlib import resources
+
+    # importlib.resources, not a __file__-relative path: the latter works under
+    # `pip install -e` and silently fails on a normal install.
+    ref = resources.files("chemgraph.tools").joinpath("ocsr_calibration_4model.json")
+    with ref.open() as fh:
+        return _validate_calibration(_load_json(fh, "packaged default"), "packaged default")
+
+
+def _load_json(fh, origin: str) -> object:
+    """json.load, with every failure normalised to ValueError.
+
+    Callers guard on (OSError, ValueError, TypeError) so that a bad table costs the
+    confidence and not the prediction. json.load can also raise RecursionError on a
+    deeply nested file, which slipped past all of them and discarded a completed
+    ensemble run.
+    """
+    try:
+        return json.load(fh)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"could not parse {origin}: {type(exc).__name__}") from None
+
+
+def _validate_calibration(table: object, origin: str) -> dict:
+    """Reject a table that cannot mean what a caller will assume it means."""
+    def bad(why: str) -> ValueError:
+        return ValueError(f"calibration table {origin!r} is unusable: {why}")
+
+    # Arithmetic below converts to float, and an int with hundreds of digits raises
+    # OverflowError, which is neither ValueError nor TypeError and so escaped every
+    # guard in the call chain.
+    def num(value: object, field: str) -> float:
+        try:
+            return float(value)
+        except (OverflowError, ValueError, TypeError):
+            raise bad(f"{field} is not a usable number: {value!r}") from None
+
+    if not isinstance(table, dict):
+        raise bad(f"top level is {type(table).__name__}, expected an object")
+    committee = table.get("committee")
+    if not isinstance(committee, list) or not all(isinstance(m, str) for m in committee):
+        raise bad("'committee' must be a list of model names")
+    # An empty committee disables check_committee, which only compares when both sides
+    # are non-empty, so every mismatch would pass and any table would apply anywhere.
+    if not committee:
+        raise bad("'committee' is empty, which would disable the committee check")
+    # check_committee compares sorted name lists, so a duplicate makes a table that
+    # can never match any real run and reports committee_mismatch forever.
+    if len(set(committee)) != len(committee):
+        raise bad(f"'committee' repeats a model: {committee}")
+    # A tie_break that does not parse, or that does not name exactly the committee,
+    # would fall back to the committee's arbitrary JSON order: the tool would vote one
+    # way and quote a number measured the other way, with nothing in the result to
+    # show it. Reject at load instead.
+    recorded = table.get("tie_break")
+    if recorded is not None:
+        order = _parse_tie_break(recorded)
+        if sorted(order) != sorted(committee):
+            raise bad(
+                f"'tie_break' must name exactly the committee, most accurate first. "
+                f"Committee: {committee}. Parsed from tie_break: {order}. Expected "
+                f"the form 'model-priority: a,b,c'."
+            )
+
+    patterns = table.get("patterns")
+    if not isinstance(patterns, dict) or not patterns:
+        raise bad("'patterns' must be a non-empty object")
+
+    size = len(committee)
+    for name, cell in patterns.items():
+        if not isinstance(cell, dict):
+            raise bad(f"pattern {name!r} is not an object")
+        try:
+            parts = [int(x) for x in str(name).split("/")]
+        except ValueError:
+            raise bad(f"pattern {name!r} is not slash-separated integers") from None
+        # int() accepts a leading minus and unicode digits, so the sum check below is
+        # not enough on its own: "2/-1" sums to 1 and would pass for a one-model
+        # committee. A part is a count of models agreeing, so it is at least 1.
+        if any(p < 1 for p in parts):
+            raise bad(f"pattern {name!r} has a part below 1; each part counts models")
+        # A pattern whose parts do not sum to the committee size means the table was
+        # fit under a different abstention rule; its buckets would not line up with
+        # what vote() produces, and every lookup would quietly miss or mismatch.
+        if sum(parts) != size:
+            raise bad(f"pattern {name!r} sums to {sum(parts)}, committee has {size} models")
+        k, n = cell.get("k"), cell.get("n")
+        if (isinstance(k, bool) or isinstance(n, bool)
+                or not isinstance(n, int) or n < 0
+                or not isinstance(k, int) or not 0 <= k <= n):
+            raise bad(f"pattern {name!r} has invalid k/n: {k!r}/{n!r}")
+        num(k, f"pattern {name!r} k")
+        num(n, f"pattern {name!r} n")
+        # A quotable number from no observations at all: (0+0.5)/(0+1) == 0.5 makes
+        # the consistency check below pass, so it has to be caught here.
+        if n == 0 and cell.get("p") is not None:
+            raise bad(f"pattern {name!r} quotes p over 0 observations")
+
+        # p, ci and label are what a caller acts on, so check them here. Left
+        # unchecked, a string p reached _label_for and raised TypeError deep inside a
+        # lookup, and a p that simply disagreed with its own k and n was returned as
+        # a confident answer with nothing to reveal the contradiction.
+        p = cell.get("p")
+        if p is not None:
+            if isinstance(p, bool) or not isinstance(p, (int, float)):
+                raise bad(f"pattern {name!r} has a non-numeric p: {p!r}")
+            if not 0.0 <= p <= 1.0:
+                raise bad(f"pattern {name!r} has p={p} outside [0, 1]")
+            expected = round((k + 0.5) / (n + 1.0), 4)
+            if abs(p - expected) > 5e-4:
+                raise bad(
+                    f"pattern {name!r} says p={p} but k/n = {k}/{n} gives {expected}. "
+                    f"Refit with chemgraph.tools.ocsr_calibrate instead of editing p."
+                )
+        ci = cell.get("ci")
+        if ci is not None:
+            ok = (isinstance(ci, list) and len(ci) == 2
+                  and all(isinstance(b, (int, float)) and not isinstance(b, bool)
+                          and math.isfinite(num(b, f"pattern {name!r} ci"))
+                          and 0.0 <= b <= 1.0
+                          for b in ci))
+            if not ok:
+                # json.loads accepts NaN and Infinity, and a NaN bound compares false
+                # against everything, so a low-n label would silently come out wrong.
+                raise bad(f"pattern {name!r} has a malformed ci: {ci!r}")
+            if ci[0] > ci[1]:
+                raise bad(f"pattern {name!r} has a reversed ci: {ci!r}")
+        label = cell.get("label")
+        if label is not None and not isinstance(label, str):
+            raise bad(f"pattern {name!r} has a non-string label: {label!r}")
+
+    # Checked here so prior_confidence and model_performance can read it without
+    # each guarding separately. A string accuracy used to reach _label_for and raise
+    # TypeError from inside a lookup, and mock_ocsr inherited the crash.
+    performance = table.get("model_performance")
+    if performance is not None:
+        if not isinstance(performance, dict):
+            raise bad("'model_performance' must be an object keyed by model name")
+        for name, entry in performance.items():
+            if not isinstance(entry, dict):
+                raise bad(f"model_performance.{name} is not an object")
+            accuracy = entry.get("accuracy")
+            if accuracy is None:
+                continue  # unmeasured is allowed; it reports no_prior_for_model
+            if isinstance(accuracy, bool) or not isinstance(accuracy, (int, float)):
+                raise bad(f"model_performance.{name} has a non-numeric accuracy")
+            if not 0.0 <= accuracy <= 1.0:
+                raise bad(f"model_performance.{name} has accuracy={accuracy} "
+                          f"outside [0, 1]")
+            count = entry.get("n")
+            if count is not None and (isinstance(count, bool)
+                                      or not isinstance(count, int) or count < 0):
+                raise bad(f"model_performance.{name} has an invalid n: {count!r}")
+            # An accuracy backed by nothing is worse than no accuracy: it reads as a
+            # real measurement and there is no field left to signal otherwise.
+            if count == 0:
+                raise bad(f"model_performance.{name} reports an accuracy over 0 "
+                          f"observations; drop the entry or set accuracy to null")
+    return table
+
+
+def tie_break_order(table: dict) -> list[str]:
+    """The model priority a table was fitted under, from its own tie_break field.
+
+    The order decides which answer wins a tie, so it decides what the all-different
+    bucket's accuracy actually measures. Using the registry's order instead of the
+    table's would attach a number measured for one model's answer to a different
+    model's answer, and check_committee cannot see it because it compares sorted
+    names.
+
+    A table with no tie_break falls back to its committee order, which is the best
+    available guess for a table written before the field existed. A table whose
+    tie_break is present but unusable never reaches here: _validate_calibration
+    rejects it, because falling back would silently vote one way while quoting a
+    number measured the other way.
+    """
+    order = _parse_tie_break(table.get("tie_break"))
+    return order if order is not None else list(table.get("committee") or [])
+
+
+def _parse_tie_break(value: object) -> list[str] | None:
+    """Model names from a tie_break string, or None when there is nothing to parse.
+
+    Returns None for an absent field and for one that does not parse, so a caller can
+    tell "no preference recorded" from "recorded something I cannot read".
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str) or "model-priority:" not in value:
+        return []  # present and unusable: an empty list, never a silent fallback
+    _, _, names = value.partition("model-priority:")
+    return [n.strip() for n in names.split(",") if n.strip()]
+
+
+def check_committee(vote_result: dict, table: dict) -> str | None:
+    """Return a reason string if the table does not describe this committee, else None.
+
+    Compares the models that were *asked*, not the ones that voted, since abstention
+    is normal and does not change which table applies.
+    """
+    ran = sorted(vote_result.get("committee") or [])
+    fit = sorted(table.get("committee") or [])
+    if not ran or not fit or ran == fit:
+        return None
+
+    # Name the missing models and how to get them. A partial install is the common
+    # case here, and "committee_mismatch: [...] vs [...]" tells a user their answer
+    # has no confidence without telling them what to do about it.
+    absent = [m for m in fit if m not in ran]
+    extra = [m for m in ran if m not in fit]
+    if absent and not extra:
+        # shlex.quote because these names come from a JSON file and the result is a
+        # command a user or an agent will copy and paste.
+        import shlex
+
+        install = "; ".join(
+            f"python -m chemgraph.tools.ocsr_setup {shlex.quote(m)}" for m in absent
+        )
+        return (
+            f"committee_mismatch: the table was fit on {fit} and this machine ran "
+            f"{ran}, so no calibrated number applies. Install the rest with: "
+            f"{install}; or refit for the models you have with "
+            f"python -m chemgraph.tools.ocsr_calibrate --labels YOUR_LABELS.csv "
+            f"--models {shlex.quote(','.join(ran))}"
+        )
+    if extra and not absent:
+        return (
+            f"committee_mismatch: the table was fit on {fit} and this machine ran "
+            f"the larger set {ran}. Vote only the committee the table describes with "
+            f"models_wanted={fit}."
+        )
+    # Both sets differ. Neither installing nor subsetting alone fixes it, so name the
+    # only two things that do.
+    return (
+        f"committee_mismatch: the table was fit on {fit} and this machine ran {ran}, "
+        f"which is a different set, so no calibrated number applies. Either install "
+        f"{', '.join(absent)} and vote the table's committee, or refit for what you "
+        f"have with python -m chemgraph.tools.ocsr_calibrate --labels YOUR_LABELS.csv "
+        f"--models {','.join(ran)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hermetic test helper
+# ---------------------------------------------------------------------------
+
+
+def build_result(**overrides) -> dict:
+    """Assemble the tool's return dict, with every contract key present.
+
+    One place builds this shape, so a backend cannot ship a partial dict and an agent
+    never has to test for a missing key. The docstring of ``image_to_smiles`` promises
+    these exact fields; changing the set means changing both together.
+
+    ``votes`` and ``abstained`` stay None outside ``backend="ensemble"``, where a
+    single model has nothing to report.
+    """
+    result = {
+        "ok": False,
+        "smiles": None,
+        "valid": False,
+        "formula": None,
+        "n_fragments": 0,
+        "confidence": None,
+        "confidence_label": "unavailable",
+        "confidence_unavailable_reason": None,
+        "agreement": None,
+        "basis": None,
+        "backend_used": None,
+        "model_used": None,
+        "cold_start": False,
+        "latency_s": 0.0,
+        "error": "",
+        "warning": "",
+        "votes": None,
+        "abstained": None,
+    }
+    unknown = set(overrides) - set(result)
+    if unknown:
+        raise KeyError(f"not part of the OCSR result contract: {sorted(unknown)}")
+    result.update(overrides)
+    return result
+
+
+def mock_ocsr(image_path: str, backend: str = "mock") -> dict:
+    """Deterministic stand-in for a real backend, for tests with no models installed.
+
+    Mirrors :func:`chemgraph.tools.docking_core.mock_docking`. Returns aspirin for
+    any input, so a test can assert on the plumbing without waiting for a model load.
+    Goes through :func:`build_result`, so a test written against it is testing the
+    real contract.
+
+    It reports no confidence, matching what a single model returns: one model cannot
+    say how likely it is to be right about a particular image. Returning a number
+    here would make the helper model a shape no backend produces, which is the one
+    thing a stand-in must not do.
+    """
+    smiles = "CC(=O)Oc1ccccc1C(=O)O"
+    v = validate_smiles_core(smiles)
+    return build_result(
+        ok=True,
+        smiles=smiles,
+        valid=v["valid"],
+        formula=v["formula"],
+        n_fragments=v["n_fragments"],
+        confidence=None,
+        confidence_label="unavailable",
+        confidence_unavailable_reason="single_model_has_no_per_image_confidence",
+        agreement="single",
+        backend_used=backend,
+        model_used="mock",
+    )

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -49,7 +49,17 @@ _LABEL_BANDS = ((0.99, "unanimous"), (0.95, "strong"), (0.70, "weak"))
 # longest in the OCSR benchmark is 224.
 _MAX_SMILES_CHARS = 4000
 
-_SMILES_LABEL_RE = re.compile(r"^\s*(?:smiles|answer|result)\s*[:=]\s*", re.IGNORECASE)
+# The optional quotes around the key let a JSON reply be read at the line level:
+# '"smiles": "CCO"' is the single most common structured form a vision LLM returns,
+# and reaching it here keeps the word-by-word fallback from matching an element
+# symbol out of an adjacent "elements" list first.
+# Matches a "smiles": "..." pair anywhere, so a one-line JSON reply is read from its
+# own field instead of from whatever token happens to parse first.
+_JSON_SMILES_RE = re.compile(r"[\"'](?:smiles)[\"']\s*:\s*[\"']([^\"']*)[\"']",
+                             re.IGNORECASE)
+
+_SMILES_LABEL_RE = re.compile(
+    r"^\s*[\"']?(?:smiles|answer|result)[\"']?\s*[:=]\s*", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +231,47 @@ def _looks_like_prose(s: str) -> bool:
     return s.isalpha() and s.islower() and not set(s) <= set("cnopsbrifhe")
 
 
+_WRAPPER_PAIRS = (("(", ")"), ("[", "]"), ("{", "}"), ("<", ">"))
+
+
+def _strip_wrappers(s: str) -> str:
+    """Peel markdown emphasis, quotes and balanced brackets off a candidate.
+
+    Emphasis is the dangerous case. ``*`` is RDKit's wildcard atom, so ``**CCO**``
+    parses as a valid five-atom molecule and would be returned as the prediction with
+    two extra atoms in it. Quotes and brackets only cost a match, since ``(CCO)``
+    fails to parse.
+
+    Brackets are peeled only when balanced across the whole string, because a SMILES
+    legitimately contains them: ``[Na+]`` and ``C(=O)O`` must survive unchanged.
+    """
+    s = s.strip()
+    while True:
+        before = s
+        s = s.strip("`\"'").strip()
+        while len(s) > 1 and s[0] == s[-1] == "*":
+            s = s[1:-1].strip()
+        for opener, closer in _WRAPPER_PAIRS:
+            if len(s) > 1 and s[0] == opener and s[-1] == closer:
+                inner = s[1:-1]
+                # Only unwrap an outer pair that encloses the whole string, so
+                # "C(=O)O" is left alone: its first "(" closes before the end.
+                depth = 0
+                encloses = True
+                for i, ch in enumerate(s):
+                    depth += (ch == opener) - (ch == closer)
+                    if depth == 0 and i < len(s) - 1:
+                        encloses = False
+                        break
+                # Keep the wrapped form when it is the one that parses: "[NH4+]" is
+                # a whole SMILES, and stripping its brackets leaves "NH4+", which is
+                # not. Unwrap only when doing so turns a non-molecule into one.
+                if encloses and canonicalize(s) is None:
+                    s = inner.strip()
+        if s == before:
+            return s
+
+
 def extract_smiles(raw_text: str | None) -> str | None:
     """Pull a SMILES out of a model's raw reply.
 
@@ -231,12 +282,19 @@ def extract_smiles(raw_text: str | None) -> str | None:
     if not raw_text or len(raw_text) > _MAX_SMILES_CHARS:
         return None
     text = re.sub(r"```[a-zA-Z]*\n?", "", raw_text).replace("```", "")
+    # A JSON object on one line never reaches the line-anchored label below, and the
+    # word-by-word fallback would take "C" out of an adjacent "elements" list first.
+    keyed = _JSON_SMILES_RE.search(text)
+    if keyed:
+        candidate = keyed.group(1).strip()
+        if candidate and not _looks_like_prose(candidate) and canonicalize(candidate):
+            return candidate
     for line in text.splitlines():
-        cleaned = _SMILES_LABEL_RE.sub("", line).strip().strip("`\"'").strip()
+        cleaned = _strip_wrappers(_SMILES_LABEL_RE.sub("", line))
         if cleaned and not _looks_like_prose(cleaned) and canonicalize(cleaned) is not None:
             return cleaned
     for token in text.split():
-        cleaned = token.strip("`\"'").rstrip(".,;!?")
+        cleaned = _strip_wrappers(token.rstrip(".,;!?"))
         if (
             len(cleaned) > 1
             and not _looks_like_prose(cleaned)

--- a/src/chemgraph/tools/ocsr_models.py
+++ b/src/chemgraph/tools/ocsr_models.py
@@ -1,0 +1,255 @@
+"""Which backends and models the OCSR tool can use, and which ones actually work.
+
+Two separate questions, and conflating them is how you end up shipping a default that
+nobody can run:
+
+  * Is a model *listed*? A registry entry means "offered", not "healthy right now".
+  * Does it *see the image*? A text-only model handed a picture does not say
+    "unsupported"; it confidently describes an image it never saw. The only way to
+    know is to ask it about a picture and check the answer.
+
+So the tables below carry a measured status, not just a name, and
+:func:`describe_backends` prints them for a user choosing a backend. Availability
+changes, so probe an endpoint before relying on it instead of trusting a
+date-stamped note here.
+"""
+
+from __future__ import annotations
+
+# --------------------------------------------------------------------------- #
+# The registry is data, not code: chemgraph/tools/ocsr_registry.json.
+#
+# Wiring in a new specialist means adding one entry there and dropping its worker
+# script into ocsr_workers/. Nothing in this module needs editing -- the backend name,
+# the installer, ensemble membership, and the printed listing are all derived from
+# that file. Point CHEMGRAPH_OCSR_REGISTRY at your own copy to add a model without
+# touching the installed package at all.
+#
+# No accuracy figures live here, for either family.
+#
+# Specialist accuracy belongs in the calibration table, beside the k, n and interval
+# that produced it, because it feeds the confidence a caller acts on and a refit has
+# to update every reported number at once.
+#
+# Vision LLMs get no accuracy at all. People use ChemGraph to run their own
+# benchmarks, on their own images, and a figure shipped here would answer the
+# question they came to ask, from a run they did not do and cannot inspect. What the
+# registry records instead is what a user cannot find out without trying: whether an
+# endpoint answers, and whether the model was seen to drive a tool call.
+# --------------------------------------------------------------------------- #
+_REGISTRY_ENV = "CHEMGRAPH_OCSR_REGISTRY"
+
+
+def load_registry(path: str | None = None) -> dict:
+    """Load the model registry: explicit path, then env var, then the packaged file."""
+    import json
+    import os
+
+    candidate = path or os.environ.get(_REGISTRY_ENV)
+    if candidate:
+        with open(os.path.expanduser(candidate)) as fh:
+            return _validate_registry(json.load(fh), os.path.expanduser(candidate))
+
+    from importlib import resources
+
+    ref = resources.files("chemgraph.tools").joinpath("ocsr_registry.json")
+    with ref.open() as fh:
+        return _validate_registry(json.load(fh), "packaged registry")
+
+
+def _validate_registry(reg: object, origin: str) -> dict:
+    """Reject a registry that would fail later in a confusing place."""
+    def bad(why: str) -> ValueError:
+        return ValueError(f"OCSR registry {origin!r} is unusable: {why}")
+
+    if not isinstance(reg, dict):
+        raise bad(f"top level is {type(reg).__name__}, expected an object")
+    specialists = reg.get("specialists")
+    if not isinstance(specialists, dict) or not specialists:
+        raise bad("'specialists' must be a non-empty object")
+    # Everything below is read during module import or by describe_backends, so a
+    # field of the wrong type takes down `import chemgraph.tools.ocsr_tools` with a
+    # traceback pointing at a dict comprehension in this file instead of at the line
+    # of JSON the user got wrong.
+    for name, m in specialists.items():
+        if not isinstance(m, dict):
+            raise bad(f"specialist {name!r} is not an object")
+        # Without a worker script the backend resolves and then dies at call time
+        # with a missing-file error that names an internal path, not the model.
+        if not isinstance(m.get("worker"), str) or not m["worker"]:
+            raise bad(f"specialist {name!r} needs a 'worker' script filename")
+        if not isinstance(m.get("latency_s"), (int, float)) or isinstance(
+            m.get("latency_s"), bool
+        ):
+            raise bad(f"specialist {name!r} needs a numeric 'latency_s'")
+        install = m.get("install")
+        if install is not None and not isinstance(install, dict):
+            raise bad(f"specialist {name!r} has a non-object 'install'")
+    llms = reg.get("vision_llms") or {}
+    if not isinstance(llms, dict):
+        raise bad("'vision_llms' must be an object")
+    for endpoint in ("alcf", "shim"):
+        entries = llms.get(endpoint)
+        if entries is None:
+            continue
+        if not isinstance(entries, dict):
+            raise bad(f"'vision_llms.{endpoint}' must be an object")
+        for name, m in entries.items():
+            if not isinstance(m, dict):
+                raise bad(f"vision_llms.{endpoint}.{name} is not an object")
+            if endpoint == "shim" and not isinstance(m.get("wire_name"), str):
+                raise bad(
+                    f"shim model {name!r} needs a 'wire_name': the shim rejects the "
+                    f"friendly spelling, so without it every call fails on the wire"
+                )
+    defaults = reg.get("defaults")
+    if defaults is not None and not isinstance(defaults, dict):
+        raise bad("'defaults' must be an object")
+    return reg
+
+
+_REGISTRY = load_registry()
+
+# Kept as module-level names because callers and tests already import them. Each is a
+# view of the registry file, so adding a model there adds it here.
+SPECIALIST_MODELS = {
+    name: {"latency_s": m.get("latency_s"), "note": m.get("note", "")}
+    for name, m in _REGISTRY["specialists"].items()
+}
+
+ALCF_VISION_MODELS = {
+    name: {"note": m.get("note", "")}
+    for name, m in (_REGISTRY.get("vision_llms", {}).get("alcf") or {}).items()
+}
+
+# Keys are the friendly spelling a user types; values are the wire name the shim
+# requires. Sending one the other's spelling fails mid-run with "Invalid model".
+SHIM_VISION_MODELS = {
+    name: m["wire_name"]
+    for name, m in (_REGISTRY.get("vision_llms", {}).get("shim") or {}).items()
+}
+
+_DEFAULTS = _REGISTRY.get("defaults") or {}
+
+# The default specialist must exist. Falling back to the first registered model rather
+# than to a name baked in here keeps a registry that drops 'decimer' working.
+DEFAULT_SPECIALIST = _DEFAULTS.get("specialist")
+if DEFAULT_SPECIALIST not in SPECIALIST_MODELS:
+    DEFAULT_SPECIALIST = next(iter(SPECIALIST_MODELS))
+
+DEFAULT_ALCF_MODEL = _DEFAULTS.get("alcf") or next(iter(ALCF_VISION_MODELS), None)
+DEFAULT_SHIM_MODEL = _DEFAULTS.get("shim") or next(iter(SHIM_VISION_MODELS), None)
+
+# Every registered specialist is also a backend name, so adding one to the registry
+# makes backend="<name>" work with no change here.
+BACKENDS = {
+    "auto": f"One fast, accurate specialist ({DEFAULT_SPECIALIST}). The default.",
+    "ensemble": (
+        f"All {len(SPECIALIST_MODELS)} specialists, voted, with a calibrated confidence."
+    ),
+    **{name: "That specialist alone." for name in SPECIALIST_MODELS},
+    "alcf": "A vision LLM on ALCF. Pick one with model=.",
+    "shim": "A vision LLM through the local Argo shim. Pick one with model=.",
+    "llm": "Whichever of alcf/shim is reachable; reports which in backend_used.",
+}
+
+
+def resolve_model(backend: str, model: str | None) -> str:
+    """Return the model name to send on the wire for a backend.
+
+    Accepts the friendly Argo spelling and translates it, so a caller never has to
+    remember that the shim wants ``claudeopus48`` rather than ``claude-opus-4.8``.
+
+    Raises
+    ------
+    ValueError
+        If the model is not known to be vision-capable on that backend. Refusing here
+        is deliberate: a text-only model given an image returns fluent text about a
+        picture it never saw, which is worse than an error.
+    """
+    if backend == "alcf":
+        name = model or DEFAULT_ALCF_MODEL
+        if name not in ALCF_VISION_MODELS:
+            raise ValueError(
+                f"{name!r} is not a known ALCF vision model. Choose from: "
+                f"{', '.join(ALCF_VISION_MODELS)}"
+            )
+        return name
+    if backend == "shim":
+        name = model or DEFAULT_SHIM_MODEL
+        if name in SHIM_VISION_MODELS:
+            return SHIM_VISION_MODELS[name]
+        if name in SHIM_VISION_MODELS.values():
+            return name  # already a wire name
+        raise ValueError(
+            f"{name!r} is not a known vision model on the Argo shim. Choose from: "
+            f"{', '.join(SHIM_VISION_MODELS)}"
+        )
+    if backend in SPECIALIST_MODELS:
+        return backend  # the backend name IS the model
+    raise ValueError(f"backend {backend!r} takes no model= argument")
+
+
+def describe_backends(calibration: str | None = None) -> str:
+    """Human-readable table of every backend and model, for the CLI and the docs.
+
+    Specialist accuracies are read from the calibration table, so this listing tracks
+    whatever table is in force rather than repeating figures compiled into the source.
+    Point it at a custom table to see that table's numbers.
+    """
+    from chemgraph.tools.ocsr_core import load_calibration
+
+    try:
+        table = load_calibration(calibration)
+    except (OSError, ValueError, TypeError):
+        table = {}
+    perf = table.get("model_performance") or {}
+    n_items = table.get("n_items")
+    committee = table.get("committee") or list(SPECIALIST_MODELS)
+
+    lines = ["OCSR backends (image -> SMILES)", ""]
+    lines.append("  Specialist models, local, no network:")
+    for name, m in SPECIALIST_MODELS.items():
+        acc = perf.get(name, {}).get("accuracy")
+        shown = f"{acc:.1%} exact" if acc is not None else "unmeasured "
+        lines.append(f"    {name:12s} {shown:12s} {m['latency_s']:>5.2f}s  {m['note']}")
+    ensemble = ", ".join(committee)
+    lines += [
+        "",
+        "  Ensemble:",
+        f"    ensemble     {ensemble}, voted, with a calibrated confidence",
+        "",
+        "  Vision LLMs on ALCF   (backend='alcf', model=<name>):",
+    ]
+    for name, m in ALCF_VISION_MODELS.items():
+        lines.append(f"    {name}")
+        # No accuracy column: whether the endpoint answers is the thing a user cannot
+        # discover without trying, and how well it reads their images is what they
+        # came here to measure.
+        if m.get("note"):
+            lines.append(f"      {m['note']}")
+    lines += ["", "  Vision LLMs via the Argo shim   (backend='shim', model=<name>):"]
+    shim_entries = _REGISTRY.get("vision_llms", {}).get("shim") or {}
+    for friendly, wire in SHIM_VISION_MODELS.items():
+        note = (shim_entries.get(friendly) or {}).get("note", "")
+        lines.append(f"    {friendly:28s} (sent as {wire:16s}) {note}".rstrip())
+    scope = f" on {n_items} images" if n_items else ""
+    lines += [
+        "",
+        f"  Specialist accuracy is exact-match, stereo-blind{scope}, read from the",
+        "  calibration table in force. It describes the model overall, so it is not",
+        "  reported as a confidence: only backend='ensemble' gives a number for the",
+        "  image in front of you.",
+        "",
+        "  No accuracy is quoted for the vision LLMs. Measure them on your own images",
+        "  with chemgraph.tools.ocsr_calibrate; a number from someone else's run",
+        "  answers a question you are better off asking of your own data.",
+        "  Specialist latency is warm; the first call also loads the model, which is",
+        "  5-25 s for most and 50-66 s for DECIMER (measured).",
+        "  A listed LLM may still be cold or down: probe before relying on one.",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(describe_backends())

--- a/src/chemgraph/tools/ocsr_registry.json
+++ b/src/chemgraph/tools/ocsr_registry.json
@@ -1,0 +1,132 @@
+{
+  "schema": 1,
+  "_comment": "Registry of OCSR models. To wire in a new specialist: add an entry under 'specialists' and drop its worker script into chemgraph/tools/ocsr_workers/. No Python change is needed -- the backend, the installer, the listing, and ensemble membership are all derived from this file. Measured accuracy lives in the calibration table, not here, next to the k and n that produced it; run chemgraph.tools.ocsr_calibrate to fit one.",
+  "specialists": {
+    "decimer": {
+      "latency_s": 0.73,
+      "note": "Most accurate single model. The default for backend='auto'.",
+      "worker": "decimer_infer.py",
+      "install": {
+        "script": "build_decimer.sh",
+        "weights": "~/.data/DECIMER-V2",
+        "env": "~/ocsr-decimer",
+        "python": "3.10",
+        "size_gb": 2.6,
+        "weights_gb": 0.66
+      },
+      "install_note": "The default backend. Install this one first; it is enough for backend='auto'."
+    },
+    "molnextr": {
+      "latency_s": 4.35,
+      "note": "Strong second. Slowest of the four.",
+      "worker": "molnextr_infer.py",
+      "install": {
+        "script": "build_molnextr.sh",
+        "weights": "~/ocsr-weights/molnextr/molnextr_best.pth",
+        "env": "~/ocsr-molnextr",
+        "python": "3.8",
+        "size_gb": 6.1,
+        "weights_gb": 1.1
+      },
+      "install_note": "Only needed for backend='ensemble'. Also clones a source tree to ~/opt."
+    },
+    "molscribe": {
+      "latency_s": 4.98,
+      "note": "Its worker runs with PYTHONNOUSERSITE=1: a user-site numpy 2 shadows the env and breaks torch 1.13 at model load.",
+      "worker": "molscribe_infer.py",
+      "install": {
+        "script": "build_molscribe.sh",
+        "weights": "~/ocsr-weights/molscribe/swin_base_char_aux_1m.pth",
+        "env": "~/ocsr-molscribe",
+        "python": "3.10",
+        "size_gb": 4.4,
+        "weights_gb": 1.1
+      },
+      "install_note": "Only needed for backend='ensemble'. Pins numpy<2; see the script."
+    },
+    "ocsrglyph": {
+      "latency_s": 0.3,
+      "note": "Fastest and lightest of the four. Useful when latency matters more.",
+      "worker": "ocsrglyph_infer.py",
+      "install": {
+        "script": "build_ocsrglyph.sh",
+        "weights": "~/ocsr-weights/ocsrglyph/model.pth",
+        "env": "~/ocsr-glyph",
+        "python": "3.11",
+        "size_gb": 1.8,
+        "weights_gb": 0.37
+      },
+      "install_note": "Only needed for backend='ensemble'. Lightest and fastest of the four."
+    }
+  },
+  "vision_llms": {
+    "alcf": {
+      "meta-llama/Llama-4-Maverick-17B-128E-Instruct": {
+        "note": "Its endpoint was cold every time it was probed on 2026-08-14; check before relying on it."
+      },
+      "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "note": ""
+      },
+      "google/gemma-4-31B-it": {
+        "note": "Sees images and drives tool calls; read the example correctly on 2026-08-14."
+      },
+      "google/gemma-3-27b-it": {
+        "note": ""
+      },
+      "google/gemma-4-26B-A4B-it": {
+        "note": "Not probed; check before relying on it."
+      },
+      "google/gemma-4-E4B-it": {
+        "note": "Sees images and drives tool calls on 2026-08-14, but read the example wrong."
+      },
+      "meta-llama/Llama-3.2-90B-Vision-Instruct": {
+        "note": "Sees images and drives tool calls on 2026-08-14, but read the example wrong. The one model ChemGraph's '# Vision Language Models' comment labels; do not assume it is the best choice."
+      }
+    },
+    "shim": {
+      "argo:claude-opus-5": {
+        "wire_name": "claudeopus5",
+        "note": "Read the example correctly on 2026-08-14. The default for backend='shim'."
+      },
+      "argo:claude-sonnet-5": {
+        "wire_name": "claudesonnet5",
+        "note": "Read the example correctly on 2026-08-14, and the fastest of these."
+      },
+      "argo:claude-opus-4.8": {
+        "wire_name": "claudeopus48",
+        "note": "Read the example correctly on 2026-08-14."
+      },
+      "argo:claude-opus-4.6": {
+        "wire_name": "claudeopus46"
+      },
+      "argo:claude-sonnet-4.6": {
+        "wire_name": "claudesonnet46"
+      },
+      "argo:gpt-5.5": {
+        "wire_name": "gpt55"
+      },
+      "argo:gpt-5.4": {
+        "wire_name": "gpt54"
+      },
+      "argo:gpt-4.1": {
+        "wire_name": "gpt41"
+      },
+      "argo:gpt-4o": {
+        "wire_name": "gpt4o",
+        "note": "Read the example correctly once and wrong once on 2026-08-14."
+      },
+      "argo:gemini-2.5-flash": {
+        "wire_name": "gemini25flash"
+      },
+      "argo:gpt-5.6-sol": {
+        "wire_name": "gpt56sol",
+        "note": "Read the example correctly on 2026-08-14."
+      }
+    }
+  },
+  "defaults": {
+    "specialist": "decimer",
+    "alcf": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    "shim": "argo:claude-opus-5"
+  }
+}

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -1,0 +1,570 @@
+"""Hermetic tests for the OCSR core helpers.
+
+No network, no conda envs, no model loads: everything here runs from RDKit and the
+packaged calibration table. Mirrors ``tests/test_docking_tools.py``, which is likewise
+hermetic by default.
+
+Several of these pin behaviour that is silent when broken. Those are marked in the test
+docstring with the consequence, because a reviewer tidying the code later needs to know
+what the assertion is protecting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from chemgraph.tools import ocsr_core as core
+
+
+# ---------------------------------------------------------------------------
+# Image loading and validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def png(tmp_path):
+    """A real 1-molecule PNG, rendered with RDKit so no fixture file is needed."""
+    from rdkit import Chem
+    from rdkit.Chem import Draw
+
+    path = tmp_path / "mol.png"
+    Draw.MolToImage(Chem.MolFromSmiles("CCO"), size=(120, 120)).save(path)
+    return path
+
+
+def test_load_image_bytes_round_trip(png):
+    import base64
+
+    data, mime = core.load_image_bytes(str(png))
+    assert mime == "image/png"
+    assert data.startswith(b"\x89PNG")
+    b64, mime64 = core.load_image_b64(str(png))
+    assert (mime64, base64.b64decode(b64)) == (mime, data)
+    with pytest.raises(FileNotFoundError):
+        core.load_image_bytes(str(png) + ".missing")
+
+
+def test_extract_image_path_only_picks_a_real_image(tmp_path, png):
+    """Pulling a path out of free text must verify it, not trust the extension.
+
+    ``png`` is a tmp_path fixture, so on Windows it carries a drive letter. A pattern
+    that cannot match ``C:`` returns the remainder joined against the current drive,
+    which points at a different filesystem location.
+    """
+    decoy = tmp_path / "notes.png"
+    decoy.write_text("not an image")
+    assert core.extract_image_path(f"read {png} please") == str(png)
+    assert core.extract_image_path(f"read {decoy} please") is None
+    assert core.extract_image_path("no image here") is None
+
+
+def test_mime_is_sniffed_not_taken_from_the_extension(tmp_path):
+    """A text file renamed .png must be refused.
+
+    Silent when broken: the bytes would be base64-ed to a remote endpoint.
+    """
+    fake = tmp_path / "notes.png"
+    fake.write_text("this is not an image")
+    with pytest.raises(ValueError, match="not a recognized image"):
+        core.load_image_bytes(str(fake))
+
+
+def test_oversized_file_is_refused_before_being_read(tmp_path):
+    big = tmp_path / "big.png"
+    big.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 5000)
+    with pytest.raises(ValueError, match="over the"):
+        core.load_image_bytes(str(big), max_bytes=1000)
+
+
+def test_directories_are_refused(tmp_path):
+    """A path that is not a regular file must be refused before it is opened."""
+    with pytest.raises(ValueError, match="not a regular file"):
+        core.load_image_bytes(str(tmp_path))
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo is POSIX-only")
+def test_fifos_are_refused(tmp_path):
+    """FIFOs and device files must not be opened.
+
+    Silent when broken: reading a FIFO blocks forever with no caller-side timeout,
+    and /dev/zero grows the buffer without bound.
+    """
+    fifo = tmp_path / "pipe.png"
+    os.mkfifo(fifo)
+    assert stat.S_ISFIFO(os.lstat(fifo).st_mode)
+    with pytest.raises(ValueError, match="not a regular file"):
+        core.load_image_bytes(str(fifo))
+
+
+# ---------------------------------------------------------------------------
+# SMILES handling
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_collapses_kekule_and_aromatic():
+    """DECIMER emits Kekule, the other specialists emit aromatic.
+
+    Silent when broken: vote() would group the same molecule as two answers, and
+    unanimity would drop from 289/422 benchmark items to 12/422. The confidence
+    feature stops working while still returning plausible numbers.
+    """
+    assert core.canonicalize("C1=CC=CC=C1") == core.canonicalize("c1ccccc1")
+    assert core.canonicalize("C(=O)(C(Br)(F)F)O") == core.canonicalize("O=C(O)C(F)(F)Br")
+    for junk in ["not a molecule", "", None]:
+        assert core.canonicalize(junk) is None
+
+
+def test_validate_smiles_core_on_a_good_molecule():
+    r = core.validate_smiles_core("CCO")
+    assert r["valid"] is True
+    assert r["formula"] == "C2H6O"
+    assert r["n_atoms"] == 9  # implicit hydrogens included
+    assert r["n_heavy_atoms"] == 3
+    assert r["n_fragments"] == 1
+    assert r["errors"] == []
+
+
+def test_validate_smiles_core_surfaces_the_rdkit_message():
+    """An invalid SMILES must carry RDKit's own complaint, not a generic failure.
+
+    That message is the whole value of the tool here: a model can act on
+    "Can't kekulize mol" but not on "invalid".
+    """
+    r = core.validate_smiles_core("c1ccccc1(C)(C)")
+    assert r["valid"] is False
+    assert any("kekulize" in e.lower() for e in r["errors"])
+
+
+def test_multi_fragment_is_flagged_but_still_valid():
+    """Two molecules in one image parse cleanly and would corrupt the downstream job.
+
+    Silent when broken: RDKit embeds disconnected fragments overlapping (measured
+    0.20 A closest approach, 0.00 A between centroids for CCO.CCN), so a geometry
+    optimization runs on an interpenetrating pair and reports success.
+    """
+    r = core.validate_smiles_core("CCO.CCN")
+    assert r["valid"] is True
+    assert r["n_fragments"] == 2
+    assert any("disconnected" in e for e in r["errors"])
+
+    salt = core.validate_smiles_core("[Na+].[Cl-]")
+    assert salt["n_fragments"] == 2
+
+
+def test_validate_smiles_core_never_raises():
+    for bad in ["", None, "?????", ">>", 42]:
+        r = core.validate_smiles_core(bad)  # type: ignore[arg-type]
+        assert r["valid"] is False
+        assert r["errors"]
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("CCO", "CCO"),
+        ("```\nCCO\n```", "CCO"),
+        ("```smiles\nc1ccccc1\n```", "c1ccccc1"),
+        ("SMILES: CC(=O)O", "CC(=O)O"),
+        ("The SMILES string is CC(=O)O", "CC(=O)O"),
+        ("N#Cc1no[nH]c1=O", "N#Cc1no[nH]c1=O"),
+    ],
+)
+def test_extract_smiles_finds_the_answer(raw, expected):
+    assert core.extract_smiles(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "refusal",
+    [
+        "I cannot process images.",
+        "I'm unable to view images.",
+        "Sorry, I can't see the image.",
+        "As a text-based model, I cannot analyze pictures.",
+        "No image was provided.",
+    ],
+)
+def test_extract_smiles_rejects_refusals(refusal):
+    """A refusal must not become a prediction.
+
+    Silent when broken: RDKit parses "I cannot process images." as iodine, because
+    I is an element and the parser stops at the space. The tool would report a
+    confident one-atom molecule for an image the model never saw.
+    """
+    assert core.extract_smiles(refusal) is None
+
+
+# ---------------------------------------------------------------------------
+# Consensus
+# ---------------------------------------------------------------------------
+
+
+def _results(*pairs):
+    return [{"model": m, "smiles": s, "ok": True} for m, s in pairs]
+
+
+def test_vote_unanimous_and_the_local_prefix():
+    """Four agreeing models are pattern "4", and "local:x" is the same model as "x"."""
+    v = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"),
+                           ("molscribe", "CCO"), ("ocsrglyph", "CCO")))
+    assert (v["pattern"], v["winner"]) == ("4", "CCO")
+    # Silent when broken: a "local:" name would not match the table's committee, so
+    # check_committee would null the confidence on every ensemble call.
+    v = core.vote(_results(("local:decimer", "CCO"), ("molnextr", "CCO")))
+    assert v["committee"] == ["decimer", "molnextr"]
+
+
+def test_vote_groups_by_canonical_form_not_string():
+    """Same molecule written two ways is one vote, not two."""
+    v = core.vote(_results(("decimer", "C(=O)(C(Br)(F)F)O"),
+                           ("molnextr", "O=C(O)C(F)(F)Br"),
+                           ("molscribe", "O=C(O)C(F)(F)Br"),
+                           ("ocsrglyph", "CC(C)(Br)C(=O)O")))
+    assert v["pattern"] == "3/1"
+    assert v["winner"] == core.canonicalize("O=C(O)C(F)(F)Br")
+
+
+def test_vote_treats_unparseable_output_as_a_dissenting_vote():
+    """A model that ran but produced junk contributes a singleton, not an absence.
+
+    The pattern stays "3/1" rather than collapsing to "3", because a model unable to
+    read the image is evidence about the image, not a smaller committee.
+    """
+    v = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"),
+                           ("molscribe", "CCO"), ("ocsrglyph", "@@@junk")))
+    assert v["pattern"] == "3/1"
+    assert v["committee"] == ["decimer", "molnextr", "molscribe", "ocsrglyph"]
+    assert v["voters"] == ["decimer", "molnextr", "molscribe"]
+    assert "ocsrglyph" in v["abstained"]
+
+
+def test_pattern_always_sums_to_the_committee_size():
+    """The invariant that makes a table's buckets mean one thing.
+
+    Every combination of agreement and abstention over four models must land in one
+    of five buckets, never in a shorter pattern that a smaller committee would give.
+    """
+    cases = [
+        (("CCO", "CCO", "CCO", "CCO"), "4"),
+        (("CCO", "CCO", "CCO", "@@@"), "3/1"),
+        (("CCO", "CCO", "@@@", "???"), "2/1/1"),
+        (("CCO", "CCO", "CCC", "CCC"), "2/2"),
+        (("CCO", "CCC", "@@@", "???"), "1/1/1/1"),
+        (("@@@", "???", "!!!", "###"), "1/1/1/1"),
+    ]
+    for smiles, expected in cases:
+        v = core.vote(_results(*zip(["decimer", "molnextr", "molscribe", "ocsrglyph"],
+                                    smiles)))
+        assert v["pattern"] == expected, smiles
+        assert sum(int(x) for x in v["pattern"].split("/")) == 4
+
+
+def test_vote_breaks_ties_by_model_priority():
+    v = core.vote(
+        _results(("decimer", "CCO"), ("molnextr", "CCN"),
+                 ("molscribe", "CCC"), ("ocsrglyph", "CCF")),
+        priority=["decimer", "molnextr", "molscribe", "ocsrglyph"],
+    )
+    assert v["pattern"] == "1/1/1/1"
+    assert v["winner"] == "CCO"  # decimer wins the four-way tie
+
+
+def test_vote_with_nobody_voting():
+    """Total failure is the all-singletons bucket, not a missing row.
+
+    Dropping the item would remove it from the calibration table and flatter every
+    other bucket. It happened once in 722 benchmark items: a fused polycyclic where
+    all four models emitted unparseable strings, two of them inventing metal atoms.
+    """
+    v = core.vote(_results(("decimer", "@@@"), ("molnextr", "???")))
+    assert v["pattern"] == "1/1"
+    assert v["winner"] is None
+    assert v["voters"] == []
+    assert len(v["abstained"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Calibration and confidence
+# ---------------------------------------------------------------------------
+
+
+def test_packaged_table_is_internally_consistent():
+    """Guards against a hand-edited table: the arithmetic must still close."""
+    t = core.load_calibration()
+    assert sum(c["n"] for c in t["patterns"].values()) == t["n_items"]
+    for name, c in t["patterns"].items():
+        assert sum(int(x) for x in name.split("/")) == len(t["committee"])
+        assert 0 <= c["k"] <= c["n"]
+        assert (c["p"] is None) == (c["n"] < t["min_n_for_point_estimate"])
+        if c["p"] is not None:
+            assert c["p"] == round((c["k"] + 0.5) / (c["n"] + 1), 4)
+        assert c["ci"][0] <= c["ci"][1]
+
+
+def test_check_committee_catches_a_mismatch():
+    t = core.load_calibration()
+    three = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"), ("molscribe", "CCO")))
+    assert "committee_mismatch" in core.check_committee(three, t)
+
+
+# ---------------------------------------------------------------------------
+# Single-model priors
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_specialist_has_a_prior():
+    """Registering a specialist must give it a confidence, not just a backend.
+
+    The prior reads from SPECIALIST_MODELS, so there is no second table to forget.
+    Values are the measured solo accuracies over the same 722 items.
+    """
+    from chemgraph.tools.ocsr_models import SPECIALIST_MODELS
+
+    n_items = core.load_calibration()["n_items"]
+    measured = core.load_calibration()["model_performance"]
+    assert set(SPECIALIST_MODELS) <= set(measured), (
+        "every registered specialist needs a model_performance entry in the "
+        "calibration table, or backend=<name> reports no confidence"
+    )
+    for model in SPECIALIST_MODELS:
+        c = core.prior_confidence(model)
+        assert c["p"] == measured[model]["accuracy"]
+        assert c["n"] == n_items  # from the table, not a constant in the source
+        assert c["reason"] is None
+        assert not c["label"].startswith("low_n_")
+
+
+def test_single_model_must_not_be_routed_through_vote():
+    """Documents the trap that prior_confidence exists to avoid.
+
+    A one-model vote yields pattern "1", which in the four-model table is the
+    all-different bucket: 8 items, 12.5% correct. Routing DECIMER's 89.9% through
+    it would attach the table's least reliable label to the most accurate model.
+    """
+    t = core.load_calibration()
+    v = core.vote(_results(("decimer", "CCO")))
+    assert v["pattern"] == "1"
+    assert core.confidence("1", t)["reason"] == "unknown_pattern"
+    from chemgraph.tools.ocsr_models import DEFAULT_SPECIALIST
+
+    assert core.prior_confidence(DEFAULT_SPECIALIST)["p"] is not None  # correct path
+
+
+# ---------------------------------------------------------------------------
+# The result contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_has_every_contract_key():
+    r = core.build_result()
+    assert len(r) == 18
+    for key in ["ok", "smiles", "valid", "formula", "n_fragments", "confidence",
+                "confidence_label", "confidence_unavailable_reason", "agreement",
+                "basis", "backend_used", "model_used", "cold_start", "latency_s",
+                "error", "warning", "votes", "abstained"]:
+        assert key in r
+
+
+def test_mock_ocsr_satisfies_the_contract():
+    """The hermetic stand-in must produce the shape a real single-model call does.
+
+    Otherwise tests written against it pass while the real path is broken. It used to
+    return a number with basis="prior", which is a shape no backend produces now that
+    a single model reports no per-image confidence.
+    """
+    r = core.mock_ocsr("/nonexistent.png")
+    assert set(r) == set(core.build_result())
+    assert r["ok"] is True
+    assert core.canonicalize(r["smiles"]) is not None
+    assert r["confidence"] is None
+    assert r["basis"] is None
+    assert r["confidence_unavailable_reason"] == (
+        "single_model_has_no_per_image_confidence")
+
+
+# ---------------------------------------------------------------------------
+# Extending the registry without touching Python
+# ---------------------------------------------------------------------------
+
+
+def test_an_abstaining_model_cannot_win_the_tie_break():
+    """Only a model that actually voted may decide the answer.
+
+    The tie-break used to scan every result without re-checking ok, so a model whose
+    output failed to parse still got consulted, and won whenever its unusable string
+    happened to canonicalize into a tied group. The returned SMILES then came from
+    outside `voters`, and the all-different bucket stopped carrying the strongest
+    model's solo accuracy that the calibration table assumes it does.
+    """
+    v = core.vote(
+        [{"model": "decimer", "ok": False, "smiles": "CCN"},
+         {"model": "molnextr", "ok": True, "smiles": "CCO"},
+         {"model": "molscribe", "ok": True, "smiles": "CCN"},
+         {"model": "ocsrglyph", "ok": True, "smiles": "CCF"}],
+        ["decimer", "molnextr", "molscribe", "ocsrglyph"],
+    )
+    assert v["winner"] == "CCO"  # top-priority *voter*, not the abstainer
+    assert "decimer" in v["abstained"]
+    winning_models = v["votes"][v["winner"]]
+    assert set(winning_models) <= set(v["voters"])
+
+
+@pytest.mark.parametrize("table, why", [
+    # A cell whose numbers contradict each other or cannot be read.
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "p": "high"}}},
+     "p is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "p": 2.5}}},
+     "p outside [0, 1]"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 0, "n": 100, "p": 0.99}}},
+     "p contradicts its own k and n"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 5, "n": 2}}}, "k exceeds n"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": "nope"}}},
+     "ci is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": [0.99, 0.1]}}},
+     "ci is reversed"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1,
+                                             "ci": [float("nan"), 1.0]}}},
+     "json.loads accepts NaN, which compares false against everything"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": [-0.5, 1.0]}}},
+     "a probability bound outside [0, 1]"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "label": 7}}},
+     "label is not a string"),
+    # A pattern name that cannot describe this committee.
+    ({"committee": ["a", "b"], "patterns": {"3": {"k": 1, "n": 2}}},
+     "pattern sums to more than the committee"),
+    ({"committee": ["a"], "patterns": {"0/1": {"k": 1, "n": 1}}},
+     "a zero part means a group with no models in it"),
+    ({"committee": ["a"], "patterns": {"2/-1": {"k": 1, "n": 1}}},
+     "int() accepts a minus sign, so this summed to 1 and passed the sum check"),
+    # A committee that can never match a real run.
+    ({"committee": [], "patterns": {"1": {"k": 1, "n": 1}}},
+     "empty committee would disable the mismatch guard entirely"),
+    ({"committee": ["a", "a"], "patterns": {"1/1": {"k": 1, "n": 1}}},
+     "a repeated model mismatches forever"),
+    ({"committee": ["a"], "patterns": {}}, "no patterns"),
+    ({"committee": "a,b", "patterns": {"2": {"k": 1, "n": 2}}},
+     "committee is a string, not a list"),
+    ([], "top level is not an object"),
+    # The model_performance section, which prior_confidence and mock_ocsr read.
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": "not-an-object"}, "section is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"decimer": {"accuracy": "90%"}}},
+     "accuracy is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"decimer": {"accuracy": 0.9, "n": 0}}},
+     "an accuracy backed by zero observations"),
+    ({"patterns": {"1": {"k": 1, "n": 2}}}, "no committee at all"),
+])
+def test_a_table_that_cannot_mean_what_it_says_is_rejected_at_load(
+        tmp_path, monkeypatch, table, why):
+    """A table decides which answers get a confidence, so it fails at load.
+
+    Every case here once loaded cleanly and then either raised a TypeError from deep
+    inside a lookup, naming neither the table nor the field, or returned a confident
+    number that contradicted the table's own k and n.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps(table))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration(str(custom))
+    # Same rejection whichever route the table arrives by.
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(custom))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration()
+
+
+@pytest.mark.parametrize("mutate, why", [
+    (lambda r: r["vision_llms"]["shim"].update({"x": {}}), "shim entry has no wire_name"),
+    (lambda r: r["vision_llms"]["shim"].update({"x": "y"}), "shim entry is a string"),
+    (lambda r: r["vision_llms"]["alcf"].update({"x": "y"}), "alcf entry is a string"),
+    (lambda r: r["specialists"]["decimer"].pop("latency_s"), "no latency_s"),
+    (lambda r: r.update({"defaults": []}), "defaults is a list"),
+    (lambda r: r["specialists"]["decimer"].update({"worker": 7}), "worker is a number"),
+])
+def test_a_registry_that_would_crash_at_import_is_rejected(tmp_path, mutate, why):
+    """The registry is read during module import, so a bad field breaks `import`.
+
+    Each of these used to surface as a KeyError or TypeError from inside a dict
+    comprehension in ocsr_models, taking down `import chemgraph.tools.ocsr_tools` with
+    a traceback that named neither the registry file nor the field at fault.
+    """
+    from importlib import resources
+
+    from chemgraph.tools.ocsr_models import _validate_registry
+
+    packaged = resources.files("chemgraph.tools").joinpath("ocsr_registry.json")
+    registry = json.loads(packaged.read_text())
+    mutate(registry)
+    with pytest.raises(ValueError, match="unusable"):
+        _validate_registry(registry, "test")
+
+
+def test_the_tie_break_follows_the_priority_it_is_given():
+    """Which model wins a tie decides what the all-different bucket measures.
+
+    Ordered so the answer differs from "first in the results list": a test where the
+    priority head is also the list head passes with the rule deleted entirely, which
+    is how this went uncovered. The calibration table records the priority it was
+    fitted under precisely because the number depends on it.
+    """
+    results = _results(("ocsrglyph", "CCC"), ("decimer", "CCO"))
+    assert core.vote(results, ["decimer", "ocsrglyph"])["winner"] == "CCO"
+    assert core.vote(results, ["ocsrglyph", "decimer"])["winner"] == "CCC"
+
+    # And the table's own recorded rule is what the ensemble must use.
+    table = core.load_calibration()
+    assert core.tie_break_order(table) == table["committee"]
+    assert core.tie_break_order({"committee": ["a", "b"]}) == ["a", "b"]
+
+
+def test_canonicalize_is_stereo_blind_by_default():
+    """Most reference labels carry no stereochemistry, so scoring with it marks a
+    model wrong for correctly reading a wedge bond, and splits one molecule into two
+    answers in vote()."""
+    chiral, flat = "C[C@H](N)C(=O)O", "CC(N)C(=O)O"
+    assert core.canonicalize(chiral) == core.canonicalize(flat)
+    assert core.canonicalize(chiral, stereo=True) != core.canonicalize(flat)
+
+
+def test_the_shipped_tie_break_matches_its_own_measured_accuracies():
+    """The packaged table's priority must be the ranking its own numbers imply.
+
+    The order decides who wins an even split, and the all-different bucket measures
+    how often that first model was right, so a priority that disagrees with the
+    accuracies in the same file would be measuring something nobody expects. This
+    order was written by hand before the fitter derived it; the assertion is what
+    keeps the two in step.
+    """
+    table = core.load_calibration()
+    performance = table["model_performance"]
+    by_accuracy = sorted(performance, key=lambda m: -performance[m]["accuracy"])
+    assert core.tie_break_order(table) == by_accuracy
+
+
+@pytest.mark.parametrize("tie_break, why", [
+    ("model priority: b,a", "a typo in the marker falls back to the committee order"),
+    (["b", "a"], "a JSON array is a plausible hand edit and does not parse"),
+    ("model-priority:", "an empty order"),
+    ("model-priority: zzz", "a name that is not in the committee"),
+    ("model-priority: a", "only part of the committee"),
+    ("model-priority: a,b,c", "a name too many"),
+])
+def test_an_unusable_tie_break_is_rejected_at_load(tie_break, why):
+    """Falling back silently would vote one way and quote a number measured another.
+
+    Every parse failure used to return the committee's arbitrary JSON order, so a
+    single mistyped character swapped which model's answer was returned while the
+    confidence stayed the same, with nothing in the result to reveal it.
+    """
+    table = {"committee": ["a", "b"], "tie_break": tie_break,
+             "patterns": {"1/1": {"k": 1, "n": 2}}}
+    with pytest.raises(ValueError, match="tie_break"):
+        core._validate_calibration(table, "test")
+
+    # Absent is fine: an older table falls back to its committee order.
+    core._validate_calibration(
+        {"committee": ["a", "b"], "patterns": {"1/1": {"k": 1, "n": 2}}}, "test")

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -568,3 +568,50 @@ def test_an_unusable_tie_break_is_rejected_at_load(tie_break, why):
     # Absent is fine: an older table falls back to its committee order.
     core._validate_calibration(
         {"committee": ["a", "b"], "patterns": {"1/1": {"k": 1, "n": 2}}}, "test")
+
+
+@pytest.mark.parametrize("raw, want", [
+    # Markdown emphasis is the dangerous wrapper: "*" is RDKit's wildcard atom, so
+    # "**CCO**" parses as a valid five-atom molecule and was returned as a prediction.
+    ("**CCO**", "CCO"),
+    ("The SMILES is **CC(=O)Oc1ccccc1C(=O)O**", "CC(=O)Oc1ccccc1C(=O)O"),
+    ("*CCO*", "CCO"),
+    ("The answer is `CCO`.", "CCO"),
+    # Parentheses and brackets only cost a match, since "(CCO)" fails to parse.
+    ("(CCO)", "CCO"),
+    ("This is aspirin (CC(=O)Oc1ccccc1C(=O)O).", "CC(=O)Oc1ccccc1C(=O)O"),
+    ("[CCO]", "CCO"),
+    # A JSON reply is the most common structured form, and the "elements" list
+    # beside it is full of strings that parse: "Cl" is a molecule.
+    ('{"elements": ["C", "H", "Cl"], "smiles": "CCCl"}', "CCCl"),
+    ('```json\n{\n  "elements": ["C", "O"],\n  "smiles": "CCO"\n}\n```', "CCO"),
+    # Brackets and parentheses are SMILES syntax and must survive untouched.
+    ("[NH4+]", "[NH4+]"),
+    ("[Na+].[Cl-]", "[Na+].[Cl-]"),
+    ("C(=O)O", "C(=O)O"),
+    ("[C@H](N)C", "[C@H](N)C"),
+    ("*CCO", "*CCO"),
+    ("**[Na+].[Cl-]**", "[Na+].[Cl-]"),
+])
+def test_wrappers_are_peeled_without_damaging_real_smiles(raw, want):
+    """A wrapped SMILES must come back unwrapped, and a real one untouched.
+
+    Silent when broken: emphasis markers are wildcard atoms, so the extracted string
+    stays a valid molecule with extra atoms in it, and every downstream check passes
+    while the answer is wrong.
+    """
+    assert core.extract_smiles(raw) == want
+
+
+def test_a_marked_up_refusal_is_not_a_molecule():
+    """A refusal wrapped in emphasis must not become a wildcard-atom molecule.
+
+    Measured on benchmark replies: an auth-error page yielded the SMILES "**", two
+    wildcard atoms. The LLM backend screens those by keyword before extraction, so
+    this is the guard for every other caller and for wording the screen misses.
+    """
+    denied = (
+        "⚠️ **IMPORTANT AUTHENTICATION NOTICE FROM ARGO** ⚠️\n\n"
+        "\U0001f6ab **ACCESS DENIED** \U0001f6ab\n\nThe username is not authorized."
+    )
+    assert core.extract_smiles(denied) is None


### PR DESCRIPTION
## Summary

Optical Chemical Structure Recognition turns a molecule supplied as a figure, scan
or screenshot into a SMILES. Without it the structure is transcribed by hand, which
is slow and error-prone for complex diagrams.

This PR does not install or run any OCSR model: no model environments, no
subprocesses, and no agent-facing tools. Those come in PRs 2 and 3. It contains only
the pure core layer, so the package imports and its tests collect without any
specialist model environments installed.

Agreement scores are empirically calibrated against 722 labelled benchmark images.
For each agreement bucket the table records how often the model majority was
correct, as k, n and a 95% Jeffreys interval. A bucket below n=20 gets a label and
no decimal, because even an apparently strong 18/20 has an interval spanning about
26 percentage points.

The model registry is data-driven. `ocsr_registry.json` defines the models, so
adding one is a JSON edit. Accuracy stays out of it and lives in the calibration
table beside the k and n that produced it.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

On this branch:

- `pytest tests/ -k "not tblite"`: 449 passed, 29 skipped, 2 deselected
  (70 new tests).
- `ruff check .`: passes.

Baseline `main` at c598807 has 19 pre-existing failures, in the durable main-agent
and memory modules. Merging c598807 into this branch reproduces the same 19
failures and no additional ones.

The shipped calibration table was rebuilt from the raw benchmark predictions and
reproduces every bucket's k and n exactly, independently of the code that reads it.

## Part of a 5-PR series

This is the first of five PRs that together add an OCSR capability. They are
intended to land in this order, each building on the last:

1. `feature/ocsr-core` (this PR): core types, model registry, and agreement
   calibration.
2. `feature/ocsr-specialist-envs`: installs the four specialist models.
3. `feature/ocsr-tools`: runs them as subprocesses behind two agent-facing tools.
4. `feature/ocsr-calibrate`: fits a confidence table from user-supplied images.
5. `feature/ocsr-workflow`: registers an `ocsr` workflow.

Split per CONTRIBUTING's guidance on incremental series: the whole feature is
about 6,200 lines and would be difficult to review as a single PR.

## Checklist

- [x] Branched off `main` and targets `main`
- [x] PR is focused on a single logical change
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added tests for the change
- [ ] Updated docs / README: deferred to PRs 3 and 5, where the user-facing
      surfaces land