### PR TITLE
Add OCSR calibration for custom model committees and datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ vib*.traj
 
 # Kubernetes secrets (keep secrets.yaml.template, ignore actual secrets)
 k8s/secrets.yaml
+cg_logs/

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,3 +88,43 @@ pip install -e ".[uma]"
 ```
 
 If resolution fails, install UMA in a separate environment dedicated to UMA workflows.
+
+## Optional OCSR install
+
+Reading a molecule structure diagram and returning a SMILES.
+
+**Nothing to install for the vision-LLM backends.** They need only RDKit, which
+ChemGraph already requires, so any existing installation already has them:
+
+```bash
+export ALCF_ACCESS_TOKEN=...          # or another supported vision provider
+```
+
+```python
+from chemgraph.tools.ocsr_tools import image_to_smiles_core as read
+read("molecule.png", backend="alcf")
+```
+
+### Adding the specialist models
+
+The four **specialist** OCSR models are usually more accurate than a general vision
+model on ordinary structure diagrams, but they cannot be pip dependencies: they need
+Python 3.8, 3.10, 3.10 and 3.11 respectively, and MolScribe's torch is built against
+numpy 1.x while ChemGraph pins 2.2.6. This is the same conflict as `uma` against
+`mace-torch` above, so the same answer applies: separate environments.
+
+They install **alongside** an existing ChemGraph, not into it. Nothing in your current
+environment is touched, no package is upgraded or removed, and any other extras you
+have keep working. Each model gets its own conda environment and is driven as a
+subprocess.
+
+```bash
+python -m chemgraph.tools.ocsr_setup --list      # models, disk cost, what is installed
+python -m chemgraph.tools.ocsr_setup decimer     # ~3.3 GB, enough for backend="auto"
+python -m chemgraph.tools.ocsr_setup --check     # verify
+```
+
+`decimer` alone covers the default backend. The other three are only used by
+`backend="ensemble"`, which votes across all four and returns a calibrated confidence;
+all of them together cost about 18 GB. Requires `conda` on PATH. Remove one by
+deleting its environment directory; nothing else refers to it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,8 @@ where = ["src/"]
 
 [tool.setuptools.package-data]
 "chemgraph.eval" = ["data/*.json"]
+"chemgraph.tools" = ["*.json"]
+"chemgraph.tools.ocsr_workers" = ["*.py", "*.sh", "*.txt"]
 "chemgraph.academy.campaigns" = [
     "example-*/*.json",
     "example-*/*.jsonc",

--- a/src/chemgraph/prompt/ocsr_prompt.py
+++ b/src/chemgraph/prompt/ocsr_prompt.py
@@ -1,0 +1,74 @@
+"""Prompts for the OCSR tool.
+
+Two distinct prompts that are easy to confuse:
+
+1. :data:`OCSR_SYSTEM_PROMPT` and :data:`OCSR_USER_PROMPT` go *inside* the tool, to the
+   vision model, and are vendored verbatim (see below).
+2. :data:`ocsr_agent_prompt` is the *orchestrator's* system prompt, used when binding
+   the tool to a ChemGraph agent. It is ours to write and the vision model never sees it.
+"""
+
+# ---------------------------------------------------------------------------
+# Vendored from the OCSR benchmark, bench/contract.py, at commit 6b7f022.
+#
+# Byte-identical on purpose. This is the exact prompt behind every published OCSR
+# accuracy number, so any edit here silently makes the tool's results incomparable
+# with the benchmark's, and the accuracies in the calibration table stop describing
+# what the tool does. Treat this block as data: if the prompt needs to change, the
+# committee has to be re-measured and the table refit.
+# ---------------------------------------------------------------------------
+
+OCSR_SYSTEM_PROMPT = (
+    "You are an expert chemist performing Optical Chemical Structure "
+    "Recognition (OCSR). You are shown a single image of one molecule's "
+    "2D structural diagram. Output the molecule as a single valid SMILES "
+    "string.\n"
+    "Rules:\n"
+    "- Respond with ONLY the SMILES string, on one line.\n"
+    "- Do not add commentary, labels, backticks, or explanation.\n"
+    "- If the drawing shows stereochemistry (wedge/dash bonds, cis/trans), "
+    "encode it in the SMILES (@/@@ and /\\).\n"
+    "- If you are unsure, give your single best guess as one SMILES string."
+)
+
+OCSR_USER_PROMPT = "What is the SMILES string for the molecule in this image?"
+
+
+# ---------------------------------------------------------------------------
+# The orchestrator's prompt. Mirrors prompt/molecular_docking_prompt.py in shape:
+# tell the agent what the tool is for and how to read its output, not how it works.
+# ---------------------------------------------------------------------------
+
+ocsr_agent_prompt = """You are a computational chemistry assistant that can read
+chemical structure diagrams from images.
+
+When the user supplies an image of a molecular structure, call `image_to_smiles` with
+its path. The tool reads the picture for you; you never see the image yourself.
+
+Always read `confidence` before you act on the answer:
+
+- `backend="ensemble"` gives a number: how often that voting pattern was right on
+  measured data. Above about 0.95 the SMILES is safe to act on. Below it the models
+  disagreed, so the drawing is hard: say so instead of presenting it as settled.
+- Every other backend gives `confidence: null`. One model cannot say how likely it
+  is to be right about this particular image, so nothing is quoted. Null means
+  unmeasured, which is different from the answer being wrong.
+- When the answer matters, `backend="ensemble"` is the only way to get a number.
+  If it returns null with a `committee_mismatch` reason, that machine has a partial
+  install and the message says which models are missing: report that to the user
+  rather than running it again.
+
+If `n_fragments` is greater than 1, the image contained more than one molecule, or a
+salt, or a reaction scheme. Ask the user which molecule they meant. Do not pass a
+multi-fragment SMILES to a geometry or energy calculation: the fragments are placed
+overlapping and the result is meaningless.
+
+Reading the image is the whole job. Report the SMILES to the user and say plainly how
+confident the tool was, then stop. If the user wants a geometry, an energy, or any
+other calculation on the molecule, say that the SMILES is ready for it and let them
+ask; the tools for that are not bound here.
+
+If a SMILES you propose yourself needs checking, `validate_smiles` reports what RDKit
+makes of it. You do not need it for a SMILES that came from `image_to_smiles`, whose
+return already carries `valid`, `formula` and `n_fragments`.
+"""

--- a/src/chemgraph/prompt/ocsr_prompt.py
+++ b/src/chemgraph/prompt/ocsr_prompt.py
@@ -35,6 +35,32 @@ OCSR_USER_PROMPT = "What is the SMILES string for the molecule in this image?"
 
 
 # ---------------------------------------------------------------------------
+# The structured alternative. Not vendored, and free to change: it is deliberately
+# outside the block above so the legacy benchmark prompt stays byte-identical.
+#
+# A model asked for one bare SMILES still returns markdown, prose and JSON, and
+# extract_smiles has to guess which. Asking for JSON makes the answer a named field.
+# The confidence table was fitted under the benchmark prompt, so a run using this one
+# reports agreement measured elsewhere; refit with ocsr_calibrate to get numbers that
+# describe your own setup.
+# ---------------------------------------------------------------------------
+
+OCSR_STRUCTURED_SYSTEM_PROMPT = (
+    "You are an expert chemist performing Optical Chemical Structure "
+    "Recognition (OCSR). You are shown a single image of one molecule's "
+    "2D structural diagram.\n"
+    "Reply with a single JSON object and nothing else:\n"
+    '{"smiles": "<the SMILES string>"}\n'
+    "Rules:\n"
+    "- No markdown, no code fences, no commentary outside the JSON.\n"
+    "- If the drawing shows stereochemistry (wedge/dash bonds, cis/trans), "
+    "encode it in the SMILES (@/@@ and /\\).\n"
+    "- If you are unsure, give your single best guess as one SMILES string.\n"
+    '- If the image is not a molecule, reply {"smiles": null}.'
+)
+
+
+# ---------------------------------------------------------------------------
 # The orchestrator's prompt. Mirrors prompt/molecular_docking_prompt.py in shape:
 # tell the agent what the tool is for and how to read its output, not how it works.
 # ---------------------------------------------------------------------------

--- a/src/chemgraph/tools/ocsr_backends.py
+++ b/src/chemgraph/tools/ocsr_backends.py
@@ -1,0 +1,318 @@
+"""Backends that actually run a model, for the OCSR tool.
+
+Split from :mod:`chemgraph.tools.ocsr_core` so that core stays pure: core imports and
+its tests run on a host with no network, no credentials and no conda environments.
+Everything here touches a socket or a subprocess.
+
+Two families:
+
+* :func:`smiles_from_llm` posts a base64 image to an OpenAI-compatible vision endpoint
+  (ALCF, or a local Argo shim).
+* :func:`smiles_from_specialist` drives one of the purpose-built OCSR networks
+  (MolNexTR, MolScribe, DECIMER, OCSRGlyph) as a subprocess.
+
+Both return the same narrow dict and **never raise**::
+
+    {"ok", "smiles", "raw", "model_used", "cold_start", "latency_s", "error"}
+
+``ocsr_tools`` maps that onto the public 18-key contract. ``raw`` is dropped there
+rather than returned, since ``build_result`` rejects keys outside the contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from chemgraph.tools import ocsr_core as core
+from chemgraph.tools import ocsr_models as models
+
+logger = logging.getLogger(__name__)
+
+ALCF_BASE_URL = "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1"
+SHIM_BASE_URL = "http://127.0.0.1:11216/argoapi/v1"
+
+# Phrases that mark an HTTP 200 body as a gateway notice rather than a model answer.
+# The Argo shim returns ACCESS DENIED with a 200 when the `user` field is a placeholder,
+# and an OCSR answer is a short SMILES with no prose, so any of these means failure.
+_ERROR_MASQUERADE = (
+    "access denied", "not authorized", "unauthorized",
+    "invalid or missing", "api key", "authentication",
+)
+
+
+def _narrow(ok=False, smiles=None, raw="", model_used=None,
+            cold_start=False, latency_s=0.0, error="") -> dict:
+    """The shape both backends return. Keeps the two paths honest with each other."""
+    return {"ok": ok, "smiles": smiles, "raw": raw, "model_used": model_used,
+            "cold_start": cold_start, "latency_s": round(latency_s, 3), "error": error}
+
+
+# ---------------------------------------------------------------------------
+# Vision LLM
+# ---------------------------------------------------------------------------
+
+
+def _llm_credentials(backend: str) -> tuple[str, str, dict | None]:
+    """Resolve (base_url, api_key, extra_headers) for one endpoint.
+
+    Per-backend rather than a chained ``or``: with both ALCF_ACCESS_TOKEN and
+    OPENAI_API_KEY set, which is common, a fallback chain would make one endpoint
+    unreachable.
+    """
+    if backend == "alcf":
+        key = os.environ.get("ALCF_ACCESS_TOKEN")
+        if not key:
+            raise RuntimeError(
+                "ALCF_ACCESS_TOKEN is not set. Mint one with "
+                "`python inference_auth_token.py get_access_token`."
+            )
+        return ALCF_BASE_URL, key, None
+
+    if backend == "shim":
+        key = os.environ.get("ARGO_SHIM_API_KEY")
+        if not key:
+            raise RuntimeError(
+                "ARGO_SHIM_API_KEY is not set. The Argo shim gates on an x-api-key "
+                "header; the key rotates when the shim restarts."
+            )
+        # openai>=2 also reads OPENAI_CUSTOM_HEADERS, but pass it explicitly so the
+        # call does not depend on the caller's environment being set up first.
+        return SHIM_BASE_URL, key, {"x-api-key": key}
+
+    raise RuntimeError(f"{backend!r} is not an LLM backend")
+
+
+def _pick_reachable_llm() -> str:
+    """For backend='llm': shim if its key is present, else ALCF.
+
+    Deliberately checks credentials rather than probing the network. A probe costs a
+    round trip on every call and would still race with an endpoint going cold.
+    """
+    if os.environ.get("ARGO_SHIM_API_KEY"):
+        return "shim"
+    return "alcf"
+
+
+def smiles_from_llm(image_bytes: bytes, mime: str, backend: str,
+                    model: str | None = None, timeout_s: float = 90.0,
+                    prompt_mode: str = "legacy_benchmark") -> dict:
+    """Read a structure image with a vision LLM.
+
+    Parameters
+    ----------
+    image_bytes, mime
+        From :func:`chemgraph.tools.ocsr_core.load_image_bytes`, so the bytes were
+        validated before anything was sent anywhere.
+    backend
+        ``"alcf"``, ``"shim"``, or ``"llm"`` to pick whichever is configured.
+    model
+        Endpoint-specific name. ``None`` takes that endpoint's default. The two
+        endpoints use different formats and :func:`ocsr_models.resolve_model`
+        translates, so a caller can pass the friendly ``argo:claude-opus-4.8``.
+    prompt_mode
+        ``"legacy_benchmark"``, the default, sends the vendored prompt behind every
+        number in the shipped calibration table. ``"structured"`` asks for a JSON
+        object with a ``smiles`` field, which removes the guesswork from parsing at
+        the cost of a prompt the shipped table was not fitted under; refit with
+        ``ocsr_calibrate`` to get confidence numbers that describe it.
+    """
+    import base64
+
+    start = time.monotonic()
+    if prompt_mode not in ("legacy_benchmark", "structured"):
+        return _narrow(error=f"unknown prompt_mode {prompt_mode!r}. "
+                             f"Choose 'legacy_benchmark' or 'structured'.")
+    if backend == "llm":
+        backend = _pick_reachable_llm()
+
+    try:
+        base_url, key, headers = _llm_credentials(backend)
+        wire = models.resolve_model(backend, model)
+    except (RuntimeError, ValueError) as e:
+        return _narrow(error=str(e), latency_s=time.monotonic() - start)
+
+    try:
+        from openai import OpenAI
+
+        from chemgraph.prompt import ocsr_prompt
+
+        system = (ocsr_prompt.OCSR_STRUCTURED_SYSTEM_PROMPT
+                  if prompt_mode == "structured" else ocsr_prompt.OCSR_SYSTEM_PROMPT)
+
+        client = OpenAI(base_url=base_url, api_key=key, timeout=timeout_s,
+                        max_retries=0, default_headers=headers)
+        b64 = base64.b64encode(image_bytes).decode("ascii")
+        resp = client.chat.completions.create(
+            model=wire,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": [
+                    {"type": "text", "text": ocsr_prompt.OCSR_USER_PROMPT},
+                    {"type": "image_url",
+                     "image_url": {"url": f"data:{mime};base64,{b64}"}},
+                ]},
+            ],
+            max_tokens=256,
+        )
+        raw = (resp.choices[0].message.content or "").strip()
+    except Exception as e:
+        msg = f"{type(e).__name__}: {e}"
+        if "not ready" in msg or "internal_endpoint_error" in msg:
+            msg = (f"the {backend} endpoint for {wire} is cold (503). It says nothing "
+                   f"about the model; try again shortly or pick another model.")
+        return _narrow(model_used=wire, error=msg[:400],
+                       latency_s=time.monotonic() - start)
+
+    elapsed = time.monotonic() - start
+
+    if any(m in raw.lower() for m in _ERROR_MASQUERADE):
+        return _narrow(raw=raw, model_used=wire, latency_s=elapsed,
+                       error=f"the endpoint returned an auth notice, not an answer: {raw[:160]}")
+
+    smiles = core.extract_smiles(raw)
+    if smiles is None:
+        return _narrow(raw=raw, model_used=wire, latency_s=elapsed,
+                       error="the model replied but no SMILES could be extracted")
+    return _narrow(ok=True, smiles=smiles, raw=raw, model_used=wire, latency_s=elapsed)
+
+
+# ---------------------------------------------------------------------------
+# Local specialist models
+# ---------------------------------------------------------------------------
+
+
+_client = None
+
+
+def _specialist_client():
+    """The in-tree worker client, or None when nothing is installed here.
+
+    Uses :mod:`chemgraph.tools.ocsr_worker_client`, which ships with ChemGraph: no
+    private repo, no ``sys.path`` surgery, no external checkout. It owns worker
+    lifetime, the idle reaper and the temp-image handling, so this function is only
+    a lazily-built singleton.
+    """
+    global _client
+    if _client is not None:
+        return _client
+    try:
+        from chemgraph.tools.ocsr_setup import load_install
+        from chemgraph.tools.ocsr_worker_client import OCSRWorkerClient
+
+        config = load_install()
+        if not config:
+            return None
+        _client = OCSRWorkerClient(config)
+        return _client
+    except BaseException as e:  # never let a config problem kill the caller
+        logger.warning("specialist client unavailable: %s: %s", type(e).__name__, e)
+        return None
+
+
+def available_specialists() -> list[str]:
+    """Names whose conda env exists on this host. Cheap: stat only, never spawns."""
+    try:
+        from chemgraph.tools.ocsr_setup import load_install
+    except Exception:
+        return []
+    out = []
+    for name, entry in (load_install() or {}).items():
+        py = os.path.expandvars(os.path.expanduser(entry.get("python_bin", "")))
+        if py and os.path.exists(py):
+            out.append(name)
+    return out
+
+
+def _setup_hint() -> str:
+    """Tell the caller how to fix a missing install, in a command that actually runs.
+
+    Built at call time from the registry: the model name is whichever specialist the
+    registry marks as the default, and ocsr_setup takes it as a bare positional. A
+    hardcoded string got both wrong at once, naming an `install` subcommand that does
+    not exist and a model that a custom registry need not contain. This message is
+    returned into an agent's context, so a command that exits 2 costs a retry loop.
+    """
+    from chemgraph.tools.ocsr_models import DEFAULT_SPECIALIST
+
+    return (
+        "No local OCSR models are installed. Install one with "
+        f"`python -m chemgraph.tools.ocsr_setup {DEFAULT_SPECIALIST}`, or use a "
+        "vision LLM with backend='alcf'."
+    )
+
+
+def smiles_from_specialist(name: str, image_bytes: bytes,
+                           timeout_s: float | None = None) -> dict:
+    """Read a structure image with one local specialist model.
+
+    The first call for a given model loads it: 5-25 s for most, 50-66 s for DECIMER,
+    measured on a busy shared machine; later calls are 0.3-5 s. ``cold_start`` in the
+    return says which happened, so an agent can reason about cost instead of guessing.
+    """
+    start = time.monotonic()
+    bare = name.removeprefix("local:")
+
+    installed = available_specialists()
+    if bare not in installed:
+        # Name the command for the model that is missing. Appending the generic hint
+        # unconditionally asserted "no local models are installed" right after
+        # listing two of them, and pointed at a model the user already had.
+        if installed:
+            detail = (f"{bare!r} is not installed. Installed: "
+                      f"{', '.join(installed)}. Install it with: "
+                      f"python -m chemgraph.tools.ocsr_setup {bare}")
+        else:
+            detail = _setup_hint()
+        return _narrow(model_used=bare, cold_start=True, error=detail,
+                       latency_s=time.monotonic() - start)
+
+    client = _specialist_client()
+    if client is None:
+        return _narrow(model_used=bare, cold_start=True, error=_setup_hint(),
+                       latency_s=time.monotonic() - start)
+
+    # predict() never raises and already reports cold_start and infer_s.
+    r = client.predict(bare, image_bytes, timeout_s=timeout_s)
+    cold = r.get("cold_start", False)
+    elapsed = r.get("infer_s", time.monotonic() - start)
+
+    if not r["ok"]:
+        return _narrow(model_used=bare, cold_start=cold, latency_s=elapsed,
+                       error=r.get("error", "the model returned no SMILES"))
+
+    # The worker protocol sets ok = bool(smiles): it means "the model returned a
+    # string", not "the string is a molecule". 3.8% of real specialist predictions do
+    # not parse on average and 5.4% for the worst of the four, and a further class is
+    # prose. Gate on extract_smiles, the same check the LLM path uses: it rejects both
+    # kinds, and rejects a refusal like
+    # "I cannot process images" that RDKit would otherwise read as iodine.
+    #
+    # Without this the caller gets ok=True with the model's 0.899 prior attached to
+    # a string that is not a molecule, and formula=None / n_fragments=0 means the
+    # multi-fragment guard cannot fire either.
+    smiles = core.extract_smiles(r.get("smiles"))
+    if smiles is None:
+        return _narrow(
+            model_used=bare, cold_start=cold, latency_s=elapsed,
+            raw=str(r.get("smiles") or "")[:200],
+            error=(f"{bare} returned a string RDKit cannot read as a molecule: "
+                   f"{str(r.get('smiles'))[:80]!r}"),
+        )
+
+    return _narrow(ok=True, smiles=smiles, model_used=bare,
+                   cold_start=cold, latency_s=elapsed)
+
+
+def _reset_client() -> None:
+    """Drop the singleton so a test can force a fresh one."""
+    global _client
+    if _client is not None:
+        try:
+            _client.close()
+        except Exception:
+            pass
+    _client = None
+
+

--- a/src/chemgraph/tools/ocsr_calibrate.py
+++ b/src/chemgraph/tools/ocsr_calibrate.py
@@ -1,0 +1,466 @@
+"""Fit a confidence table for your own committee, on your own labelled images.
+
+The table that ships with ChemGraph describes four specific models on RDKit-rendered
+diagrams. It is the right default, but it is not a law of nature: a different set of
+models, or a different kind of image (scans, photographs, journal crops), has a
+different relationship between agreement and correctness. This module measures that
+relationship for whatever you actually run.
+
+    python -m chemgraph.tools.ocsr_calibrate \\
+        --labels my_data/labels.csv \\
+        --models decimer,molnextr,molscribe \\
+        --out my_calibration.json
+
+Then use it, voting the committee the table describes:
+
+    image_to_smiles_core(img, backend="ensemble",
+                         models_wanted=["decimer", "molnextr", "molscribe"],
+                         calibration="my_calibration.json")
+    # or, for a whole session:
+    export CHEMGRAPH_OCSR_CALIBRATION=my_calibration.json
+
+``models_wanted`` matters whenever the table covers fewer models than are installed:
+the ensemble runs everything it finds otherwise, and a table fit on three models
+says nothing about what four of them agreeing means.
+
+The method is the one in the shipped table and is deliberately unclever: run every
+model on every image, group predictions that are the same molecule, note the vote
+pattern, and count how often the majority was right. No independence assumption, so
+correlated errors between models are already priced in by construction.
+
+You need labelled images, which is the catch: the reference SMILES has to come from
+somewhere. If you have none, `--validate` against the shipped table is the cheaper
+question, since detecting "this table is wrong for my images" takes far fewer labels
+than fitting a new one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from datetime import date
+
+from chemgraph.tools import ocsr_backends as backends
+from chemgraph.tools import ocsr_core as core
+
+# Below this many observations a bucket gets a label and an interval but no point
+# estimate. At n=20 the 95% interval is 41 points wide at the midpoint and 26 even
+# for a lopsided 18/20; quoting a decimal for a bucket of 7 would be false precision,
+# and the shipped table follows the same rule.
+DEFAULT_MIN_N = 20
+
+
+def _jeffreys(k: int, n: int) -> float:
+    """Posterior mean under Beta(0.5, 0.5). Keeps a perfect bucket below 1.0."""
+    return (k + 0.5) / (n + 1.0)
+
+
+def _interval(k: int, n: int, alpha: float = 0.05) -> list[float]:
+    """Jeffreys 95% credible interval, or a Wilson fallback without scipy."""
+    try:
+        from scipy.stats import beta
+
+        lo = 0.0 if k == 0 else float(beta.ppf(alpha / 2, k + 0.5, n - k + 0.5))
+        hi = 1.0 if k == n else float(beta.ppf(1 - alpha / 2, k + 0.5, n - k + 0.5))
+        return [round(lo, 4), round(hi, 4)]
+    except ImportError:
+        import math
+
+        z = 1.959963984540054
+        p, d = k / n, 1 + z * z / n
+        centre = (p + z * z / (2 * n)) / d
+        half = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / d
+        return [round(max(0.0, centre - half), 4), round(min(1.0, centre + half), 4)]
+
+
+def read_labels(path: str) -> list[tuple[str, str]]:
+    """Read ``image_path,smiles`` pairs from a CSV.
+
+    Accepts a header or not, and resolves relative image paths against the CSV's own
+    directory so a labels file can travel with its images.
+    """
+    base = os.path.dirname(os.path.abspath(path))
+    rows: list[tuple[str, str]] = []
+    with open(path, newline="") as fh:
+        for row in csv.reader(fh):
+            if len(row) < 2:
+                continue
+            img, smiles = row[0].strip(), row[1].strip()
+            if not img or not smiles:
+                continue
+            if img.lower() in ("image_path", "image", "path", "file", "filename"):
+                continue  # header
+            if not os.path.isabs(img):
+                img = os.path.join(base, img)
+            rows.append((img, smiles))
+    return rows
+
+
+def collect(labels: list[tuple[str, str]], models: list[str],
+            verbose: bool = True) -> list[tuple[list[dict], str]]:
+    """Run every model over every image. Returns (results, reference) per image.
+
+    The slow part: one model load per model, then one inference per image per model.
+    Failures are kept as ``ok=False`` entries rather than dropped, because a model
+    that fails on hard images is part of what the agreement pattern is measuring.
+    """
+    out = []
+    for i, (image_path, reference) in enumerate(labels, 1):
+        try:
+            image_bytes, _ = core.load_image_bytes(image_path)
+        except Exception as e:
+            if verbose:
+                print(f"  [{i}/{len(labels)}] skipped {image_path}: {e}", file=sys.stderr)
+            continue
+
+        results = []
+        for name in models:
+            r = backends.smiles_from_specialist(name, image_bytes)
+            results.append({"model": name, "smiles": r["smiles"], "ok": r["ok"],
+                            "error": r["error"], "infer_s": r["latency_s"]})
+        out.append((results, reference))
+        if verbose and (i % 10 == 0 or i == len(labels)):
+            print(f"  {i}/{len(labels)} images", file=sys.stderr)
+    return out
+
+
+def fit_calibration(rows: list[tuple[list[dict], str]], models: list[str],
+                    min_n: int = DEFAULT_MIN_N, dataset: str = "",
+                    scoring: str = "stereo_blind",
+                    tie_break: list[str] | None = None) -> dict:
+    """Turn (per-image results, reference) pairs into a calibration table.
+
+    Correctness is judged the way :func:`ocsr_core.canonicalize` compares, which is
+    stereo-blind by default: most reference labels carry no stereochemistry, so
+    scoring with it would mark a model wrong for correctly reading a wedge bond.
+
+    ``tie_break`` is the model priority that decides an evenly split committee, and
+    it is recorded in the table because the numbers depend on it: the all-different
+    bucket measures how often the *first* model was right. Defaults to ranking the
+    committee by the solo accuracy measured here, so a caller who never thinks about
+    order still gets the strongest model breaking ties. The order of ``models`` is
+    deliberately not used for this: it is a set of names, and treating it as a
+    ranking would bake a caller's arbitrary typing order into their table.
+    """
+    buckets: dict[str, list[int]] = {}
+    # Per-model tallies alongside the committee ones: [correct, scored, abstained].
+    # These become the table's model_performance section, which is what a single-model
+    # backend reports as its confidence. Fitting them here rather than leaving them to
+    # a separate run is what makes a refit update every number the tool reports.
+    solo: dict[str, list[int]] = {m: [0, 0, 0] for m in models}
+
+    # Two passes: score every model first, so an unspecified tie-break can rank the
+    # committee by what the data says rather than by argument order.
+    if tie_break is None:
+        scored: dict[str, list[int]] = {m: [0, 0] for m in models}
+        for results, reference in rows:
+            ref = core.canonicalize(reference)
+            if ref is None:
+                continue
+            for r in results:
+                name = str(r.get("model", "")).removeprefix("local:")
+                if name not in scored:
+                    continue
+                scored[name][1] += 1
+                predicted = (core.canonicalize(r.get("smiles"))
+                             if r.get("ok", True) else None)
+                if predicted == ref:
+                    scored[name][0] += 1
+        order = sorted(models, key=lambda m: (-(scored[m][0] / scored[m][1])
+                                              if scored[m][1] else 0.0, m))
+    else:
+        order = list(tie_break)
+        if sorted(order) != sorted(models):
+            raise ValueError(
+                f"tie_break must name exactly the committee, most accurate first. "
+                f"Committee: {sorted(models)}. Got: {sorted(order)}."
+            )
+
+    for results, reference in rows:
+        ref = core.canonicalize(reference)
+        if ref is None:
+            continue  # an unparseable reference cannot judge anything
+        for r in results:
+            name = str(r.get("model", "")).removeprefix("local:")
+            tally = solo.get(name)
+            if tally is None:
+                continue
+            tally[1] += 1
+            predicted = core.canonicalize(r.get("smiles")) if r.get("ok", True) else None
+            if predicted is None:
+                tally[2] += 1
+            elif predicted == ref:
+                tally[0] += 1
+        v = core.vote(results, priority=order)
+        if v["pattern"] is None:
+            continue  # nobody voted; no pattern to attribute this to
+        entry = buckets.setdefault(v["pattern"], [0, 0])
+        entry[1] += 1
+        if v["winner"] == ref:
+            entry[0] += 1
+
+    patterns = {}
+    for pattern, (k, n) in sorted(buckets.items(), key=lambda kv: -kv[1][1]):
+        cell: dict = {"k": k, "n": n, "ci": _interval(k, n)}
+        if n >= min_n:
+            cell["p"] = round(_jeffreys(k, n), 4)
+            cell["label"] = core._label_for(cell["p"])
+        else:
+            # No stored label below the floor: the consumer derives one from the
+            # Jeffreys estimate, which is the same rule confidence() applies.
+            cell["p"] = None
+        patterns[pattern] = cell
+
+    performance = {
+        name: {
+            "accuracy": round(k / n, 4),
+            "k": k,
+            "n": n,
+            "ci": _interval(k, n),
+            "abstention_rate": round(abstained / n, 4),
+        }
+        for name, (k, n, abstained) in solo.items()
+        if n
+    }
+
+    return {
+        "committee": list(models),
+        "n_items": sum(n for _, n in buckets.values()),
+        "dataset": dataset,
+        "scoring": scoring,
+        "model_performance": performance,
+        "model_performance_rule": (
+            "Per-model accuracy over the same images, used when a backend runs one "
+            "model and there is no agreement pattern to look up. 'accuracy' is the raw "
+            "rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often "
+            "the model returned no parseable SMILES."
+        ),
+        "tie_break": "model-priority: " + ",".join(order),
+        "created": date.today().isoformat(),
+        "min_n_for_point_estimate": min_n,
+        "estimator": "Jeffreys: (k+0.5)/(n+1)",
+        "label_rule": (
+            "Where p is present, the consumer may quote it. Where p is null (n below min_n_for_point_estimate), no number is quoted: the label comes from the Jeffreys estimate (k+0.5)/(n+1), the same quantity p reports above the floor, so one rule covers the whole table."
+        ),
+        "patterns": patterns,
+    }
+
+
+def report(table: dict, min_n: int) -> str:
+    """A human-readable summary, including what is too thin to quote."""
+    lines = [
+        f"committee : {', '.join(table['committee'])}",
+        f"images    : {table['n_items']}",
+        f"scoring   : {table['scoring']}",
+        "",
+        f"{'pattern':10s} {'k/n':>9s} {'P(correct)':>11s} {'95% CI':>16s}  label",
+    ]
+    thin = []
+    for pattern, cell in table["patterns"].items():
+        k, n = cell["k"], cell["n"]
+        # Every displayed field comes from confidence(), the same call image_to_smiles
+        # makes, so this report cannot drift from what the tool will say. Reading
+        # cell["label"] and cell["ci"] directly crashed with a bare KeyError on the
+        # shipped table, whose above-floor cells store no label, and on any table the
+        # validator accepts without a ci.
+        verdict = core.confidence(pattern, table)
+        if verdict["p"] is None:
+            thin.append((pattern, n))
+        p_str = "  --" if verdict["p"] is None else f"{verdict['p']:.3f}"
+        ci = verdict["ci"]
+        ci_str = f"[{ci[0]:.3f}, {ci[1]:.3f}]" if ci else "(no interval)"
+        lines.append(f"{pattern:10s} {f'{k}/{n}':>9s} {p_str:>11s} "
+                     f"{ci_str:>16s}  {verdict['label']}")
+    if thin:
+        lines += ["", f"Too thin to quote a number (n < {min_n}): " +
+                  ", ".join(f"{p} (n={n})" for p, n in thin)]
+        lines.append("These still get a label from the Jeffreys estimate.")
+    return "\n".join(lines)
+
+
+def validate(rows: list[tuple[list[dict], str]], models: list[str],
+             table: dict) -> str:
+    """Compare an existing table's predictions against measured outcomes.
+
+    Far cheaper than refitting: 20-40 labelled images is enough to notice that a
+    table is badly wrong for your images, where fitting a new one needs a few
+    hundred. This is the question most users actually have.
+    """
+    # Vote by the rule the table was fitted under, so the comparison is like for
+    # like. Using any other order would measure a different quantity than the one
+    # the table's numbers describe.
+    order = core.tie_break_order(table) or list(models)
+    seen: dict[str, list[int]] = {}
+    for results, reference in rows:
+        ref = core.canonicalize(reference)
+        if ref is None:
+            continue
+        v = core.vote(results, priority=order)
+        if v["pattern"] is None:
+            continue
+        e = seen.setdefault(v["pattern"], [0, 0])
+        e[1] += 1
+        if v["winner"] == ref:
+            e[0] += 1
+
+    lines = [f"{'pattern':10s} {'yours':>12s} {'table says':>11s} {'gap':>8s}"]
+    worst = 0.0
+    # Tracked separately from `worst`: a bucket that matches the table exactly leaves
+    # worst at 0.0, and overloading that to mean "nothing was judged" reported the
+    # best possible outcome as a failure to gather data.
+    judged = False
+    for pattern, (k, n) in sorted(seen.items(), key=lambda kv: -kv[1][1]):
+        c = core.confidence(pattern, table)
+        observed = k / n
+        if c["p"] is None:
+            lines.append(f"{pattern:10s} {f'{k}/{n}':>12s} {'(no number)':>11s} "
+                         f"{'':>8s}")
+            continue
+        gap = observed - c["p"]
+        if n >= 10:
+            judged = True
+            worst = max(worst, abs(gap))
+        lines.append(f"{pattern:10s} {f'{k}/{n} = {100*observed:.0f}%':>12s} "
+                     f"{100*c['p']:10.0f}% {100*gap:+7.0f} pp")
+
+    lines.append("")
+    if not judged:
+        lines.append("Not enough data in any bucket (n >= 10) to judge. Add more labels.")
+    elif worst < 0.10:
+        lines.append(f"Largest gap {100*worst:.0f} pp. The shipped table looks usable "
+                     f"for your images.")
+    else:
+        lines.append(f"Largest gap {100*worst:.0f} pp. The shipped table does NOT "
+                     f"describe your images well; consider fitting your own.")
+    lines.append("Gaps on small buckets are mostly noise: 10 images cannot "
+                 "distinguish 90% from 70%.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="python -m chemgraph.tools.ocsr_calibrate",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--labels", required=True,
+                   help="CSV of image_path,smiles (relative paths resolve to its directory)")
+    p.add_argument("--models", default=None,
+                   help=("comma-separated committee; default is every installed "
+                         "model. Order does not matter here."))
+    p.add_argument("--tie-break", default=None, metavar="MODELS",
+                   help=("comma-separated models, most accurate first, deciding who "
+                         "wins when the committee splits evenly. Defaults to the "
+                         "most accurate first, measured on your own images."))
+    p.add_argument("--out", default=None, help="where to write the table")
+    p.add_argument("--validate", action="store_true",
+                   help="check the shipped table against your images instead of fitting")
+    p.add_argument("--min-n", type=int, default=DEFAULT_MIN_N,
+                   help=f"observations needed for a point estimate (default {DEFAULT_MIN_N})")
+    args = p.parse_args(argv)
+
+    installed = backends.available_specialists()
+    models = ([m.strip() for m in args.models.split(",")] if args.models else installed)
+    missing = [m for m in models if m not in installed]
+    if missing:
+        print(f"not installed: {', '.join(missing)}. Installed: "
+              f"{', '.join(installed) or 'none'}.\n"
+              f"Install with: python -m chemgraph.tools.ocsr_setup <model>",
+              file=sys.stderr)
+        return 2
+    if not models:
+        print("no specialist models installed; nothing to calibrate", file=sys.stderr)
+        return 2
+    if len(set(models)) != len(models):
+        # Checked here rather than at the pre-write validator, which would reject it
+        # only after running every model over every image.
+        print(f"--models repeats a model: {','.join(models)}", file=sys.stderr)
+        return 2
+
+    if args.validate and args.tie_break is not None:
+        # Checked with the other argument validation, not after collect() has spent
+        # minutes of inference that the return would discard.
+        print("--tie-break has no effect with --validate, which votes by the order "
+              "recorded in the table it is checking", file=sys.stderr)
+        return 2
+
+    tie_break = None
+    if args.tie_break is not None:
+        tie_break = [m.strip() for m in args.tie_break.split(",") if m.strip()]
+        if sorted(tie_break) != sorted(models):
+            print(f"--tie-break must list exactly the committee, in your preferred "
+                  f"order. Committee: {','.join(models)}. Got: {','.join(tie_break)}.",
+                  file=sys.stderr)
+            return 2
+
+    if not os.path.isfile(os.path.expanduser(args.labels)):
+        print(f"no such labels file: {args.labels}. Expected a CSV of "
+              f"image_path,smiles.", file=sys.stderr)
+        return 2
+    labels = read_labels(args.labels)
+    if not labels:
+        print(f"no usable rows in {args.labels}; expected image_path,smiles",
+              file=sys.stderr)
+        return 2
+
+    if not args.validate and len(labels) < 100:
+        print(f"note: {len(labels)} images is thin for fitting a table. Most buckets "
+              f"will be under the n={args.min_n} floor and get a label but no number. "
+              f"About 300 is a sensible minimum; --validate is the better question "
+              f"below that.\n", file=sys.stderr)
+
+    print(f"running {len(models)} model(s) over {len(labels)} images; the first call "
+          f"per model loads it (5-66 s)", file=sys.stderr)
+    rows = collect(labels, models)
+    if not rows:
+        print("no images could be read", file=sys.stderr)
+        return 1
+
+    if args.validate:
+        print(validate(rows, models, core.load_calibration()))
+        return 0
+
+    table = fit_calibration(rows, models, min_n=args.min_n,
+                            dataset=os.path.abspath(args.labels),
+                            tie_break=tie_break)
+
+    # Check the table against the loader before writing it. The committee comes from
+    # --models while the patterns come from whatever the rows actually held, so the
+    # two can disagree: a model that never produced a row, a row naming a model not in
+    # --models, or ragged rows all yield patterns that do not sum to the committee
+    # size. Writing first and failing at load leaves the user holding a file this tool
+    # told them to use.
+    try:
+        core._validate_calibration(table, args.out or "the fitted table")
+    except ValueError as exc:
+        print(f"\nthe fitted table is not self-consistent, so it was not written:\n"
+              f"  {exc}\n"
+              f"  Every model in --models must appear in every row, and no row may "
+              f"name a model outside it.", file=sys.stderr)
+        return 1
+
+    print(report(table, args.min_n))
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(table, fh, indent=2)
+        installed = backends.available_specialists()
+        subset = [m for m in installed if m not in models]
+        names = ", ".join(repr(m) for m in models)
+        wanted = f"models_wanted=[{names}], " if subset else ""
+        print(f"\nwrote {args.out}\nUse it with: "
+              f"image_to_smiles_core(img, backend='ensemble', {wanted}"
+              f"calibration='{args.out}')")
+        if subset:
+            print(f"  models_wanted is needed here: {', '.join(subset)} "
+                  f"{'is' if len(subset) == 1 else 'are'} also installed, and the "
+                  f"ensemble would otherwise vote {'it' if len(subset) == 1 else 'them'} too.")
+    else:
+        print("\n(no --out given, table not saved)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/chemgraph/tools/ocsr_calibration_4model.json
+++ b/src/chemgraph/tools/ocsr_calibration_4model.json
@@ -1,0 +1,112 @@
+{
+  "committee": [
+    "decimer",
+    "molnextr",
+    "molscribe",
+    "ocsrglyph"
+  ],
+  "n_items": 722,
+  "scoring": "stereo_blind",
+  "abstention": "counts as a dissenting singleton vote; pattern parts always sum to the committee size",
+  "tie_break": "model-priority: decimer,molnextr,molscribe,ocsrglyph",
+  "min_n_for_point_estimate": 20,
+  "estimator": "Jeffreys: (k+0.5)/(n+1)",
+  "datasets": [
+    "eval100_random",
+    "eval100_minmax",
+    "eval100_stratified",
+    "pubchem"
+  ],
+  "model_performance": {
+    "decimer": {
+      "accuracy": 0.8989,
+      "k": 649,
+      "n": 722,
+      "ci": [
+        0.8753,
+        0.9193
+      ],
+      "abstention_rate": 0.0042
+    },
+    "molnextr": {
+      "accuracy": 0.8352,
+      "k": 603,
+      "n": 722,
+      "ci": [
+        0.8068,
+        0.8609
+      ],
+      "abstention_rate": 0.0429
+    },
+    "molscribe": {
+      "accuracy": 0.8241,
+      "k": 595,
+      "n": 722,
+      "ci": [
+        0.7951,
+        0.8505
+      ],
+      "abstention_rate": 0.054
+    },
+    "ocsrglyph": {
+      "accuracy": 0.7659,
+      "k": 553,
+      "n": 722,
+      "ci": [
+        0.734,
+        0.7957
+      ],
+      "abstention_rate": 0.0526
+    }
+  },
+  "patterns": {
+    "4": {
+      "k": 462,
+      "n": 462,
+      "p": 0.9989,
+      "ci": [
+        0.9946,
+        1.0
+      ]
+    },
+    "3/1": {
+      "k": 133,
+      "n": 135,
+      "p": 0.9816,
+      "ci": [
+        0.9533,
+        0.9969
+      ]
+    },
+    "2/1/1": {
+      "k": 46,
+      "n": 57,
+      "p": 0.8017,
+      "ci": [
+        0.6909,
+        0.8929
+      ]
+    },
+    "1/1/1/1": {
+      "k": 21,
+      "n": 56,
+      "p": 0.3772,
+      "ci": [
+        0.2571,
+        0.5055
+      ]
+    },
+    "2/2": {
+      "k": 7,
+      "n": 12,
+      "p": null,
+      "ci": [
+        0.3119,
+        0.8195
+      ]
+    }
+  },
+  "label_rule": "Where p is present, the consumer may quote it. Where p is null (n below min_n_for_point_estimate), no number is quoted: the label comes from the Jeffreys estimate (k+0.5)/(n+1), the same quantity p reports above the floor, so one rule covers the whole table.",
+  "model_performance_rule": "Per-model accuracy on the same n_items images, used when a backend runs one model and there is no agreement pattern to look up. 'accuracy' is the raw rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often the model returned no parseable SMILES.",
+  "note": "Valid ONLY for this exact four-model committee. Refit with chemgraph.tools.ocsr_calibrate for any other set."
+}

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -1,0 +1,924 @@
+"""Pure-Python OCSR helpers (no LangChain / MCP decorators).
+
+Optical Chemical Structure Recognition: read a molecule's 2D structure diagram
+from an image and return its SMILES. Used by the LangChain ``@tool`` wrappers in
+:mod:`chemgraph.tools.ocsr_tools`.
+
+Two families of backend. A vision LLM reads the picture directly; local specialist
+models (MolNexTR, MolScribe, DECIMER, OCSRGlyph) are purpose-built image-to-SMILES
+networks driven as subprocesses. Running several specialists and looking at how much
+they agree yields a calibrated confidence, which is the point of :func:`vote` and
+:func:`confidence`.
+
+RDKit is a core dependency and is imported lazily anyway, so this module imports and
+its tests collect on a host with no specialist environment and no network. A
+:func:`mock_ocsr` helper provides deterministic output for hermetic tests.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import math
+import os
+import re
+import stat
+
+logger = logging.getLogger(__name__)
+
+# Reject anything that is not one of these before base64-ing it to a remote endpoint.
+# Sniffed from the leading bytes, never from the file extension: the extension is
+# attacker-controlled and the whole point is to refuse a non-image renamed to .png.
+_MAGIC = {
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"\xff\xd8\xff": "image/jpeg",
+    b"GIF87a": "image/gif",
+    b"GIF89a": "image/gif",
+}
+_MAX_IMAGE_BYTES = 8_000_000
+
+# Confidence label cut-points, applied to the point estimate. Below the calibration
+# table's n floor these are prefixed "low_n_", because a 30-60 pp interval does not
+# deserve a decimal.
+_LABEL_BANDS = ((0.99, "unanimous"), (0.95, "strong"), (0.70, "weak"))
+
+# RDKit parsing is superlinear in string length: 20k characters costs about 9 s of
+# CPU and a megabyte-scale string is effectively unbounded. Model output is untrusted,
+# so cap it before RDKit sees it. Real SMILES are well under 1000 characters; the
+# longest in the OCSR benchmark is 224.
+_MAX_SMILES_CHARS = 4000
+
+_SMILES_LABEL_RE = re.compile(r"^\s*(?:smiles|answer|result)\s*[:=]\s*", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Image loading
+# ---------------------------------------------------------------------------
+
+
+def _sniff_mime(head: bytes) -> str | None:
+    """Return the MIME type implied by a file's leading bytes, or None.
+
+    WEBP needs a split check: "RIFF" then "WEBP" four bytes later.
+    """
+    for magic, mime in _MAGIC.items():
+        if head.startswith(magic):
+            return mime
+    if head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def load_image_bytes(image_path: str, max_bytes: int = _MAX_IMAGE_BYTES) -> tuple[bytes, str]:
+    """Read an image file safely and return ``(raw_bytes, mime_type)``.
+
+    Validates before reading rather than after. Reading first and checking later is
+    not equivalent: ``/dev/zero`` grows the buffer without bound, a FIFO blocks
+    forever in ``open()`` so no caller-side timeout fires, and a 50 GB regular file
+    is fully resident before any size check could reject it.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to a PNG, JPEG, GIF or WEBP file.
+    max_bytes : int, optional
+        Reject anything larger, by default 8 MB.
+
+    Returns
+    -------
+    tuple[bytes, str]
+        The file contents and its sniffed MIME type.
+
+    Raises
+    ------
+    FileNotFoundError
+        No such path.
+    ValueError
+        Not a regular file, too large, or not a recognized image format.
+    """
+    path = os.path.abspath(os.path.expanduser(image_path))
+    try:
+        st = os.lstat(path)  # lstat, so a symlink is judged on its own terms
+    except FileNotFoundError:
+        raise FileNotFoundError(f"no such image: {path}")
+
+    if not stat.S_ISREG(st.st_mode):
+        raise ValueError(
+            f"not a regular file: {path}. Directories, FIFOs, sockets and device "
+            f"files are refused (a FIFO would block forever, /dev/zero would not end)."
+        )
+    if st.st_size > max_bytes:
+        raise ValueError(f"image is {st.st_size} bytes, over the {max_bytes} limit: {path}")
+
+    with open(path, "rb") as fh:
+        data = fh.read(max_bytes + 1)  # +1 so a file that grew since lstat is caught
+    if len(data) > max_bytes:
+        raise ValueError(f"image grew past the {max_bytes} limit while reading: {path}")
+
+    mime = _sniff_mime(data[:16])
+    if mime is None:
+        raise ValueError(
+            f"not a recognized image (PNG/JPEG/GIF/WEBP) by content: {path}. "
+            f"The extension is not trusted; only the leading bytes are."
+        )
+    return data, mime
+
+
+def load_image_b64(image_path: str, max_bytes: int = _MAX_IMAGE_BYTES) -> tuple[str, str]:
+    """Read an image and return ``(base64_ascii, mime_type)`` for a data URL."""
+    data, mime = load_image_bytes(image_path, max_bytes=max_bytes)
+    return base64.b64encode(data).decode("ascii"), mime
+
+
+def extract_image_path(text: str) -> str | None:
+    """Pull the first usable image path out of a free-text query.
+
+    A candidate must both exist and pass the magic-byte check, so a text file named
+    ``notes.png`` is never selected.
+
+    Parameters
+    ----------
+    text : str
+        Natural-language query, e.g. "what is the SMILES in /data/mol.png?".
+
+    Returns
+    -------
+    str or None
+        Absolute path to the first real image mentioned, else None.
+    """
+    if not text:
+        return None
+    # The optional drive prefix keeps a Windows path whole: without it the match
+    # starts after "C:", and joining the remainder against the current drive points
+    # somewhere else entirely.
+    pattern = r"(?:[A-Za-z]:)?[\w./~\\-]+\.(?:png|jpe?g|gif|webp|bmp|tiff?)"
+    for token in re.findall(pattern, text, flags=re.IGNORECASE):
+        candidate = token.strip("'\"")
+        try:
+            load_image_bytes(candidate)
+        except Exception:
+            continue
+        return os.path.abspath(os.path.expanduser(candidate))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SMILES handling
+# ---------------------------------------------------------------------------
+
+
+def canonicalize(smiles: str | None, stereo: bool = False) -> str | None:
+    """Canonical SMILES, or None when the string does not parse.
+
+    Defaults to stereo-blind, matching how the OCSR benchmark scores: most reference
+    labels carry no stereochemistry, so comparing with it makes a model that correctly
+    reads a wedge bond look wrong.
+
+    Grouping predictions by this, rather than by raw string, is load-bearing for
+    :func:`vote`. DECIMER emits Kekule SMILES while the other specialists emit
+    aromatic, so raw-string comparison finds unanimity on 12 of 422 benchmark items
+    where canonical comparison finds it on 289.
+    """
+    if not smiles or len(smiles) > _MAX_SMILES_CHARS:
+        return None
+    from rdkit import Chem, RDLogger
+
+    RDLogger.DisableLog("rdApp.*")
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    if not stereo:
+        Chem.RemoveStereochemistry(mol)
+    return Chem.MolToSmiles(mol)
+
+
+def _looks_like_prose(s: str) -> bool:
+    """True if a string is a sentence rather than a SMILES.
+
+    Needed because RDKit is happy to parse prose. "I cannot process images." yields
+    a molecule: ``I`` is iodine and the parser stops at the space. Without this
+    guard a model's refusal is returned as a confident one-atom prediction.
+
+    Deliberately a syntactic check, not a model call. Asking an LLM "is this a
+    refusal?" would add a network round trip per prediction (four per ensemble call),
+    and would itself be a model that can refuse. Refusals and SMILES differ in form,
+    not in meaning, so form is enough.
+
+    Measured on real data: 0 false positives over 1916 unique specialist predictions,
+    and 100% recall over 2100 real reference SMILES wrapped in seven common LLM
+    phrasings (fenced, "SMILES:", "The SMILES string is", and so on).
+
+    Known limit: a refusal that happens to be a single organic-subset word would slip
+    through. None exists in practice, since refusals are sentences. If a model is ever
+    found to emit one, add it to an explicit denylist rather than reaching for a
+    classifier.
+    """
+    if " " in s.strip():
+        return True
+    # A SMILES is mostly non-alphanumeric structure or organic-subset letters. A word
+    # like "images" is all lowercase letters and no structural characters at all.
+    return s.isalpha() and s.islower() and not set(s) <= set("cnopsbrifhe")
+
+
+def extract_smiles(raw_text: str | None) -> str | None:
+    """Pull a SMILES out of a model's raw reply.
+
+    Handles a bare string, a fenced code block, and "The SMILES is: X" prose. Returns
+    None for a refusal ("I cannot process images"), which must not be mistaken for a
+    prediction. Does not validate; :func:`validate_smiles_core` does that.
+    """
+    if not raw_text or len(raw_text) > _MAX_SMILES_CHARS:
+        return None
+    text = re.sub(r"```[a-zA-Z]*\n?", "", raw_text).replace("```", "")
+    for line in text.splitlines():
+        cleaned = _SMILES_LABEL_RE.sub("", line).strip().strip("`\"'").strip()
+        if cleaned and not _looks_like_prose(cleaned) and canonicalize(cleaned) is not None:
+            return cleaned
+    for token in text.split():
+        cleaned = token.strip("`\"'").rstrip(".,;!?")
+        if (
+            len(cleaned) > 1
+            and not _looks_like_prose(cleaned)
+            and canonicalize(cleaned) is not None
+        ):
+            return cleaned
+    return None
+
+
+def validate_smiles_core(smiles: str) -> dict:
+    """Validate a SMILES with RDKit and report everything a caller can act on.
+
+    Never raises. An unparseable string yields ``valid=False`` with RDKit's own
+    sanitization message in ``errors``, which is the useful part: "Explicit valence
+    for atom # 3 N, 4, is greater than permitted" tells a model what to fix.
+
+    ``n_fragments`` above 1 means the string describes several disconnected molecules
+    (two structures in one image, a salt, a reaction scheme). That case parses,
+    sanitizes and canonicalizes cleanly, so nothing else catches it, and it corrupts
+    anything downstream: RDKit has no reason to separate disconnected fragments when
+    embedding, so they are placed overlapping (measured: 0.20 A closest approach,
+    0.00 A between centroids for ``CCO.CCN``), and an energy evaluation on that
+    geometry is meaningless while reporting success.
+
+    Returns
+    -------
+    dict
+        smiles, valid, canonical_smiles, formula, n_atoms, n_heavy_atoms,
+        elements, n_fragments, errors, rdkit_available
+    """
+    out = {
+        "smiles": smiles,
+        "valid": False,
+        "canonical_smiles": None,
+        "formula": None,
+        "n_atoms": 0,
+        "n_heavy_atoms": 0,
+        "elements": [],
+        "n_fragments": 0,
+        "errors": [],
+        "rdkit_available": True,
+    }
+    if not smiles or not isinstance(smiles, str):
+        out["errors"].append("empty or non-string SMILES")
+        return out
+    if len(smiles) > _MAX_SMILES_CHARS:
+        out["errors"].append(
+            f"SMILES is {len(smiles)} characters, over the {_MAX_SMILES_CHARS} limit; "
+            f"parsing cost grows superlinearly and real SMILES are far shorter"
+        )
+        return out
+
+    try:
+        from rdkit import Chem, RDLogger
+        from rdkit.Chem import rdMolDescriptors
+    except ImportError as e:  # pragma: no cover - rdkit is a core dependency
+        # Fail open. Failing closed would drive a validation retry loop until the
+        # recursion limit, spending a whole budget to produce nothing.
+        logger.warning("RDKit unavailable, skipping SMILES validation: %s", e)
+        out.update(rdkit_available=False, valid=True)
+        return out
+
+    RDLogger.DisableLog("rdApp.*")
+    if ">>" in smiles or ">" in smiles.replace("->", ""):
+        out["errors"].append(
+            "this looks like a reaction SMILES (contains '>'), not a single molecule"
+        )
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        # Re-parse without sanitizing to recover the specific complaint.
+        try:
+            raw = Chem.MolFromSmiles(smiles, sanitize=False)
+            if raw is not None:
+                Chem.SanitizeMol(raw)
+        except Exception as e:
+            out["errors"].append(str(e))
+        if not out["errors"]:
+            out["errors"].append("RDKit could not parse this SMILES")
+        return out
+
+    mol_h = Chem.AddHs(mol)
+    stereo_free = Chem.MolFromSmiles(smiles)
+    Chem.RemoveStereochemistry(stereo_free)
+    out.update(
+        valid=True,
+        canonical_smiles=Chem.MolToSmiles(stereo_free),
+        formula=rdMolDescriptors.CalcMolFormula(mol),
+        n_atoms=mol_h.GetNumAtoms(),
+        n_heavy_atoms=mol.GetNumAtoms(),
+        elements=sorted({a.GetSymbol() for a in mol_h.GetAtoms()}),
+        n_fragments=len(Chem.GetMolFrags(mol)),
+    )
+    if out["n_fragments"] > 1:
+        out["errors"].append(
+            f"this SMILES describes {out['n_fragments']} disconnected molecules; "
+            f"ask which one is meant before using it for a calculation"
+        )
+    return out
+
+
+def compare_smiles(smiles_a: str, smiles_b: str) -> dict:
+    """Report how two SMILES differ: same molecule, same skeleton, or unrelated."""
+    ca, cb = canonicalize(smiles_a), canonicalize(smiles_b)
+    out = {
+        "same_molecule": bool(ca and ca == cb),
+        "same_skeleton": False,
+        "same_formula": False,
+        "canonical_a": ca,
+        "canonical_b": cb,
+    }
+    if ca is None or cb is None:
+        return out
+    from rdkit import Chem
+    from rdkit.Chem import rdMolDescriptors
+
+    ma, mb = Chem.MolFromSmiles(smiles_a), Chem.MolFromSmiles(smiles_b)
+    out["same_skeleton"] = (
+        Chem.MolToInchiKey(ma).split("-")[0] == Chem.MolToInchiKey(mb).split("-")[0]
+    )
+    out["same_formula"] = rdMolDescriptors.CalcMolFormula(
+        ma
+    ) == rdMolDescriptors.CalcMolFormula(mb)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Consensus and calibrated confidence
+# ---------------------------------------------------------------------------
+
+
+def vote(results: list[dict], priority: list[str] | None = None) -> dict:
+    """Group specialist predictions and report the agreement pattern.
+
+    Predictions are canonicalized before grouping, so the same molecule written two
+    ways counts once. See :func:`canonicalize` for why that is not optional.
+
+    Distinguishes two things the caller must not conflate. ``committee`` is every
+    model that was asked, and must match the calibration table. ``voters`` is the
+    subset that returned a parseable SMILES.
+
+    An abstention counts as a dissenting vote, not as absence. A model that ran and
+    produced garbage contributes one singleton to the pattern, so the pattern's parts
+    always sum to the committee size: four models can only ever produce "4", "3/1",
+    "2/1/1", "2/2", or "1/1/1/1".
+
+    The alternative -- dropping abstainers and shrinking the pattern -- was measured
+    on 722 benchmark items and rejected. It split the same situations across eleven
+    buckets instead of five, pushing 12% of items below the sample floor where no
+    number can be quoted (2% under this rule). It also mislabelled the evidence: a
+    three-way agreement with one model unable to read the image at all was recorded
+    as "3", which reads like consensus, when the abstention is itself a signal that
+    the image is hard. Under this rule that item is "3/1", and the empirical accuracy
+    of the merged bucket bears this out.
+
+    Parameters
+    ----------
+    results : list[dict]
+        One entry per model: ``{"model", "smiles", "ok", "error", "infer_s"}``.
+        ``model`` is a bare name with no "local:" prefix.
+    priority : list[str], optional
+        Tie-break order, strongest model first. Defaults to the order given.
+
+    Returns
+    -------
+    dict
+        pattern, winner, votes, abstained, committee, voters
+    """
+    # Normalize the "local:" prefix here rather than trusting every caller. OCSR's
+    # LocalOCSRClient dispatches on ModelSpec names like "local:decimer", while the
+    # calibration table's committee is bare names. A mismatch does not raise: it makes
+    # check_committee report committee_mismatch, which nulls the confidence for every
+    # ensemble call. One missing removeprefix would turn the feature off permanently
+    # behind a plausible-looking error, so it is not left to the caller.
+    def _bare(name: str) -> str:
+        return name.removeprefix("local:")
+
+    committee = [_bare(r.get("model") or "") for r in results]
+    order = [_bare(m) for m in (priority or committee)]
+
+    groups: dict[str, list[str]] = {}
+    abstained: dict[str, str] = {}
+    # Counted separately from the dict: two results carrying the same model name, which
+    # `--models decimer,decimer` and the "local:" alias both produce, collapse to one
+    # dict key and would silently drop a singleton from the pattern.
+    n_abstained = 0
+    for r in results:
+        model = _bare(r.get("model") or "")
+        canon = canonicalize(r.get("smiles")) if r.get("ok", True) else None
+        if canon is None:
+            abstained[model] = str(r.get("smiles") or r.get("error") or "")[:80]
+            n_abstained += 1
+            continue
+        groups.setdefault(canon, []).append(model)
+
+    if not groups:
+        # Every model failed. There is no winner to be right about, but the item is
+        # not absent from the evidence either: it is the worst case of disagreement.
+        # Reporting it as all-singletons keeps it in the table, where it counts
+        # against that bucket, instead of vanishing and flattering every other row.
+        return {
+            "pattern": "/".join("1" * len(committee)) if committee else None,
+            "winner": None,
+            "votes": {},
+            "abstained": abstained,
+            "committee": committee,
+            "voters": [],
+        }
+
+    # Each abstainer is its own singleton: it agrees with nobody, including other
+    # abstainers, whose garbage output is unrelated.
+    counts = sorted(
+        [len(v) for v in groups.values()] + [1] * n_abstained, reverse=True
+    )
+    top = max(len(v) for v in groups.values())
+    tied = [smi for smi, models in groups.items() if len(models) == top]
+    if len(tied) > 1:
+        # Deterministic tie-break by model priority. This choice is load-bearing:
+        # it makes an all-different pattern report the strongest model's answer, so
+        # that bucket's accuracy in a calibration table is really that model's solo
+        # accuracy. Any table must record which rule was used.
+        #
+        # Resolved over the groups, so only models that actually voted can win. An
+        # earlier version scanned `results` and never re-checked ok, which let a model
+        # whose output failed to parse still decide the answer whenever its unusable
+        # string happened to canonicalize into a tied group. The winner would then be
+        # a SMILES from outside `voters`, and the bucket would not carry the solo
+        # accuracy the docstring above claims for it.
+        winner = next(
+            (smi for m in order for smi in tied if m in groups[smi]),
+            tied[0],
+        )
+    else:
+        winner = tied[0]
+
+    return {
+        "pattern": "/".join(str(c) for c in counts),
+        "winner": winner,
+        "votes": groups,
+        "abstained": abstained,
+        "committee": committee,
+        "voters": [m for models in groups.values() for m in models],
+    }
+
+
+def _label_for(p: float, low_n: bool = False) -> str:
+    """Map a probability to a coarse label, prefixed when the bucket is small."""
+    name = "conflicting"
+    for threshold, band in _LABEL_BANDS:
+        if p >= threshold:
+            name = band
+            break
+    return f"low_n_{name}" if low_n else name
+
+
+def confidence(pattern: str | None, table: dict) -> dict:
+    """Look up P(majority correct) for an agreement pattern.
+
+    Takes the table as an argument rather than reading a module global, so the tool
+    and the recalibration script share one code path.
+
+    Reports a point estimate only where the bucket cleared the table's sample floor.
+    Below it the 95% interval spans 30-60 pp, so a decimal would be false precision;
+    the label and the interval still carry the actionable part. An unknown pattern
+    gets no number at all rather than a guess.
+
+    Returns
+    -------
+    dict
+        p, label, n, ci, reason
+    """
+    if pattern is None:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_prediction"}
+
+    entry = (table.get("patterns") or {}).get(pattern)
+    if entry is None:
+        return {"p": None, "label": "unknown", "n": 0, "ci": None,
+                "reason": "unknown_pattern"}
+
+    p, n, ci = entry.get("p"), entry.get("n", 0), entry.get("ci")
+    if p is None:
+        # Below the floor we withhold the number but still owe a useful label, so it
+        # is derived from the Jeffreys estimate: the same quantity the `p` column
+        # reports above the floor, which keeps one rule across the whole table.
+        #
+        # The two obvious alternatives both mislead. The raw point estimate k/n calls
+        # a 7/7 bucket "unanimous", claiming certainty from seven items. The
+        # interval's lower bound calls that same bucket "conflicting", overstating
+        # the doubt: seven for seven is thin evidence, and it points one way.
+        # Jeffreys shrinks toward 0.5 in proportion to how thin the bucket is,
+        # putting 7/7 at 0.938 and so at low_n_weak, one band below the 0.95 cut.
+        k = entry.get("k")
+        est = ((k + 0.5) / (n + 1.0)) if (k is not None and n) else (ci[0] if ci else 0.0)
+        label = entry.get("label") or _label_for(est, low_n=True)
+        return {"p": None, "label": label, "n": n, "ci": ci,
+                "reason": "below_n_floor"}
+    return {"p": p, "label": entry.get("label") or _label_for(p), "n": n, "ci": ci,
+            "reason": None}
+
+
+def prior_confidence(model: str, table: dict | None = None) -> dict:
+    """Confidence for a single-model backend, from that model's measured solo accuracy.
+
+    A single model has no consensus to measure, so the agreement table does not apply.
+    Do **not** route a one-model result through :func:`vote` and :func:`confidence`:
+    that yields pattern "1", which a four-model table does not contain at all, so the
+    lookup misses and reports unknown_pattern. It would also trip
+    :func:`check_committee`. Use this instead.
+
+    Returns the same shape as :func:`confidence` so callers have one code path.
+
+    Every number here comes from the calibration table's ``model_performance`` section, never from
+    a constant in this file. Measurements belong with the data that produced them: a
+    user who refits on their own images gets priors for their images, and a stale
+    figure cannot outlive the table it was measured on. The registry in ocsr_models
+    describes what a model *is* (how to run it, how fast, what it needs); the table
+    records how well it *did*.
+
+    Passing ``table`` lets a caller that already loaded one avoid a second read.
+    """
+    bare = model.removeprefix("local:")
+    try:
+        t = table if table is not None else load_calibration()
+    except (OSError, ValueError, TypeError) as exc:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": f"calibration_unreadable: {type(exc).__name__}"}
+
+    entry = (t.get("model_performance") or {}).get(bare)
+    if not entry or entry.get("accuracy") is None:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_prior_for_model"}
+    p = entry["accuracy"]
+    return {"p": p, "label": _label_for(p), "n": entry.get("n", 0),
+            "ci": entry.get("ci"), "reason": None}
+
+
+def model_performance(model: str, table: dict | None = None) -> dict:
+    """Measured single-model performance from a calibration table, or {} if absent.
+
+    The one place to ask "how good is this model": accuracy, the k and n behind it,
+    a 95% interval, and how often it abstains. Nothing here is compiled into the
+    source, so a table refitted on other images reports that table's numbers.
+    """
+    try:
+        t = table if table is not None else load_calibration()
+    except (OSError, ValueError, TypeError):
+        return {}
+    return dict((t.get("model_performance") or {}).get(model.removeprefix("local:")) or {})
+
+
+def load_calibration(path: str | None = None) -> dict:
+    """Load a calibration table: explicit path, then env var, then the packaged default.
+
+    The packaged default describes the four-model committee on RDKit-rendered images
+    and is what makes ``backend="ensemble"`` work with no configuration. Anyone who
+    builds their own table with the recalibration script points at it here.
+
+    A table drives which answers get a confidence, so a malformed one is rejected on
+    load rather than silently producing wrong numbers deep in a run.
+    """
+    candidate = path or os.environ.get("CHEMGRAPH_OCSR_CALIBRATION")
+    if candidate:
+        resolved = os.path.expanduser(candidate)
+        # A FIFO here blocks open() forever with no caller-side timeout, the same
+        # reason load_image_bytes checks. Callers of this function have usually just
+        # spent real inference time and must not hang holding the result.
+        if not stat.S_ISREG(os.lstat(resolved).st_mode):
+            raise ValueError(f"calibration table is not a regular file: {resolved}")
+        with open(resolved) as fh:
+            return _validate_calibration(_load_json(fh, resolved), resolved)
+
+    from importlib import resources
+
+    # importlib.resources, not a __file__-relative path: the latter works under
+    # `pip install -e` and silently fails on a normal install.
+    ref = resources.files("chemgraph.tools").joinpath("ocsr_calibration_4model.json")
+    with ref.open() as fh:
+        return _validate_calibration(_load_json(fh, "packaged default"), "packaged default")
+
+
+def _load_json(fh, origin: str) -> object:
+    """json.load, with every failure normalised to ValueError.
+
+    Callers guard on (OSError, ValueError, TypeError) so that a bad table costs the
+    confidence and not the prediction. json.load can also raise RecursionError on a
+    deeply nested file, which slipped past all of them and discarded a completed
+    ensemble run.
+    """
+    try:
+        return json.load(fh)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"could not parse {origin}: {type(exc).__name__}") from None
+
+
+def _validate_calibration(table: object, origin: str) -> dict:
+    """Reject a table that cannot mean what a caller will assume it means."""
+    def bad(why: str) -> ValueError:
+        return ValueError(f"calibration table {origin!r} is unusable: {why}")
+
+    # Arithmetic below converts to float, and an int with hundreds of digits raises
+    # OverflowError, which is neither ValueError nor TypeError and so escaped every
+    # guard in the call chain.
+    def num(value: object, field: str) -> float:
+        try:
+            return float(value)
+        except (OverflowError, ValueError, TypeError):
+            raise bad(f"{field} is not a usable number: {value!r}") from None
+
+    if not isinstance(table, dict):
+        raise bad(f"top level is {type(table).__name__}, expected an object")
+    committee = table.get("committee")
+    if not isinstance(committee, list) or not all(isinstance(m, str) for m in committee):
+        raise bad("'committee' must be a list of model names")
+    # An empty committee disables check_committee, which only compares when both sides
+    # are non-empty, so every mismatch would pass and any table would apply anywhere.
+    if not committee:
+        raise bad("'committee' is empty, which would disable the committee check")
+    # check_committee compares sorted name lists, so a duplicate makes a table that
+    # can never match any real run and reports committee_mismatch forever.
+    if len(set(committee)) != len(committee):
+        raise bad(f"'committee' repeats a model: {committee}")
+    # A tie_break that does not parse, or that does not name exactly the committee,
+    # would fall back to the committee's arbitrary JSON order: the tool would vote one
+    # way and quote a number measured the other way, with nothing in the result to
+    # show it. Reject at load instead.
+    recorded = table.get("tie_break")
+    if recorded is not None:
+        order = _parse_tie_break(recorded)
+        if sorted(order) != sorted(committee):
+            raise bad(
+                f"'tie_break' must name exactly the committee, most accurate first. "
+                f"Committee: {committee}. Parsed from tie_break: {order}. Expected "
+                f"the form 'model-priority: a,b,c'."
+            )
+
+    patterns = table.get("patterns")
+    if not isinstance(patterns, dict) or not patterns:
+        raise bad("'patterns' must be a non-empty object")
+
+    size = len(committee)
+    for name, cell in patterns.items():
+        if not isinstance(cell, dict):
+            raise bad(f"pattern {name!r} is not an object")
+        try:
+            parts = [int(x) for x in str(name).split("/")]
+        except ValueError:
+            raise bad(f"pattern {name!r} is not slash-separated integers") from None
+        # int() accepts a leading minus and unicode digits, so the sum check below is
+        # not enough on its own: "2/-1" sums to 1 and would pass for a one-model
+        # committee. A part is a count of models agreeing, so it is at least 1.
+        if any(p < 1 for p in parts):
+            raise bad(f"pattern {name!r} has a part below 1; each part counts models")
+        # A pattern whose parts do not sum to the committee size means the table was
+        # fit under a different abstention rule; its buckets would not line up with
+        # what vote() produces, and every lookup would quietly miss or mismatch.
+        if sum(parts) != size:
+            raise bad(f"pattern {name!r} sums to {sum(parts)}, committee has {size} models")
+        k, n = cell.get("k"), cell.get("n")
+        if (isinstance(k, bool) or isinstance(n, bool)
+                or not isinstance(n, int) or n < 0
+                or not isinstance(k, int) or not 0 <= k <= n):
+            raise bad(f"pattern {name!r} has invalid k/n: {k!r}/{n!r}")
+        num(k, f"pattern {name!r} k")
+        num(n, f"pattern {name!r} n")
+        # A quotable number from no observations at all: (0+0.5)/(0+1) == 0.5 makes
+        # the consistency check below pass, so it has to be caught here.
+        if n == 0 and cell.get("p") is not None:
+            raise bad(f"pattern {name!r} quotes p over 0 observations")
+
+        # p, ci and label are what a caller acts on, so check them here. Left
+        # unchecked, a string p reached _label_for and raised TypeError deep inside a
+        # lookup, and a p that simply disagreed with its own k and n was returned as
+        # a confident answer with nothing to reveal the contradiction.
+        p = cell.get("p")
+        if p is not None:
+            if isinstance(p, bool) or not isinstance(p, (int, float)):
+                raise bad(f"pattern {name!r} has a non-numeric p: {p!r}")
+            if not 0.0 <= p <= 1.0:
+                raise bad(f"pattern {name!r} has p={p} outside [0, 1]")
+            expected = round((k + 0.5) / (n + 1.0), 4)
+            if abs(p - expected) > 5e-4:
+                raise bad(
+                    f"pattern {name!r} says p={p} but k/n = {k}/{n} gives {expected}. "
+                    f"Refit with chemgraph.tools.ocsr_calibrate instead of editing p."
+                )
+        ci = cell.get("ci")
+        if ci is not None:
+            ok = (isinstance(ci, list) and len(ci) == 2
+                  and all(isinstance(b, (int, float)) and not isinstance(b, bool)
+                          and math.isfinite(num(b, f"pattern {name!r} ci"))
+                          and 0.0 <= b <= 1.0
+                          for b in ci))
+            if not ok:
+                # json.loads accepts NaN and Infinity, and a NaN bound compares false
+                # against everything, so a low-n label would silently come out wrong.
+                raise bad(f"pattern {name!r} has a malformed ci: {ci!r}")
+            if ci[0] > ci[1]:
+                raise bad(f"pattern {name!r} has a reversed ci: {ci!r}")
+        label = cell.get("label")
+        if label is not None and not isinstance(label, str):
+            raise bad(f"pattern {name!r} has a non-string label: {label!r}")
+
+    # Checked here so prior_confidence and model_performance can read it without
+    # each guarding separately. A string accuracy used to reach _label_for and raise
+    # TypeError from inside a lookup, and mock_ocsr inherited the crash.
+    performance = table.get("model_performance")
+    if performance is not None:
+        if not isinstance(performance, dict):
+            raise bad("'model_performance' must be an object keyed by model name")
+        for name, entry in performance.items():
+            if not isinstance(entry, dict):
+                raise bad(f"model_performance.{name} is not an object")
+            accuracy = entry.get("accuracy")
+            if accuracy is None:
+                continue  # unmeasured is allowed; it reports no_prior_for_model
+            if isinstance(accuracy, bool) or not isinstance(accuracy, (int, float)):
+                raise bad(f"model_performance.{name} has a non-numeric accuracy")
+            if not 0.0 <= accuracy <= 1.0:
+                raise bad(f"model_performance.{name} has accuracy={accuracy} "
+                          f"outside [0, 1]")
+            count = entry.get("n")
+            if count is not None and (isinstance(count, bool)
+                                      or not isinstance(count, int) or count < 0):
+                raise bad(f"model_performance.{name} has an invalid n: {count!r}")
+            # An accuracy backed by nothing is worse than no accuracy: it reads as a
+            # real measurement and there is no field left to signal otherwise.
+            if count == 0:
+                raise bad(f"model_performance.{name} reports an accuracy over 0 "
+                          f"observations; drop the entry or set accuracy to null")
+    return table
+
+
+def tie_break_order(table: dict) -> list[str]:
+    """The model priority a table was fitted under, from its own tie_break field.
+
+    The order decides which answer wins a tie, so it decides what the all-different
+    bucket's accuracy actually measures. Using the registry's order instead of the
+    table's would attach a number measured for one model's answer to a different
+    model's answer, and check_committee cannot see it because it compares sorted
+    names.
+
+    A table with no tie_break falls back to its committee order, which is the best
+    available guess for a table written before the field existed. A table whose
+    tie_break is present but unusable never reaches here: _validate_calibration
+    rejects it, because falling back would silently vote one way while quoting a
+    number measured the other way.
+    """
+    order = _parse_tie_break(table.get("tie_break"))
+    return order if order is not None else list(table.get("committee") or [])
+
+
+def _parse_tie_break(value: object) -> list[str] | None:
+    """Model names from a tie_break string, or None when there is nothing to parse.
+
+    Returns None for an absent field and for one that does not parse, so a caller can
+    tell "no preference recorded" from "recorded something I cannot read".
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str) or "model-priority:" not in value:
+        return []  # present and unusable: an empty list, never a silent fallback
+    _, _, names = value.partition("model-priority:")
+    return [n.strip() for n in names.split(",") if n.strip()]
+
+
+def check_committee(vote_result: dict, table: dict) -> str | None:
+    """Return a reason string if the table does not describe this committee, else None.
+
+    Compares the models that were *asked*, not the ones that voted, since abstention
+    is normal and does not change which table applies.
+    """
+    ran = sorted(vote_result.get("committee") or [])
+    fit = sorted(table.get("committee") or [])
+    if not ran or not fit or ran == fit:
+        return None
+
+    # Name the missing models and how to get them. A partial install is the common
+    # case here, and "committee_mismatch: [...] vs [...]" tells a user their answer
+    # has no confidence without telling them what to do about it.
+    absent = [m for m in fit if m not in ran]
+    extra = [m for m in ran if m not in fit]
+    if absent and not extra:
+        # shlex.quote because these names come from a JSON file and the result is a
+        # command a user or an agent will copy and paste.
+        import shlex
+
+        install = "; ".join(
+            f"python -m chemgraph.tools.ocsr_setup {shlex.quote(m)}" for m in absent
+        )
+        return (
+            f"committee_mismatch: the table was fit on {fit} and this machine ran "
+            f"{ran}, so no calibrated number applies. Install the rest with: "
+            f"{install}; or refit for the models you have with "
+            f"python -m chemgraph.tools.ocsr_calibrate --labels YOUR_LABELS.csv "
+            f"--models {shlex.quote(','.join(ran))}"
+        )
+    if extra and not absent:
+        return (
+            f"committee_mismatch: the table was fit on {fit} and this machine ran "
+            f"the larger set {ran}. Vote only the committee the table describes with "
+            f"models_wanted={fit}."
+        )
+    # Both sets differ. Neither installing nor subsetting alone fixes it, so name the
+    # only two things that do.
+    return (
+        f"committee_mismatch: the table was fit on {fit} and this machine ran {ran}, "
+        f"which is a different set, so no calibrated number applies. Either install "
+        f"{', '.join(absent)} and vote the table's committee, or refit for what you "
+        f"have with python -m chemgraph.tools.ocsr_calibrate --labels YOUR_LABELS.csv "
+        f"--models {','.join(ran)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hermetic test helper
+# ---------------------------------------------------------------------------
+
+
+def build_result(**overrides) -> dict:
+    """Assemble the tool's return dict, with every contract key present.
+
+    One place builds this shape, so a backend cannot ship a partial dict and an agent
+    never has to test for a missing key. The docstring of ``image_to_smiles`` promises
+    these exact fields; changing the set means changing both together.
+
+    ``votes`` and ``abstained`` stay None outside ``backend="ensemble"``, where a
+    single model has nothing to report.
+    """
+    result = {
+        "ok": False,
+        "smiles": None,
+        "valid": False,
+        "formula": None,
+        "n_fragments": 0,
+        "confidence": None,
+        "confidence_label": "unavailable",
+        "confidence_unavailable_reason": None,
+        "agreement": None,
+        "basis": None,
+        "backend_used": None,
+        "model_used": None,
+        "cold_start": False,
+        "latency_s": 0.0,
+        "error": "",
+        "warning": "",
+        "votes": None,
+        "abstained": None,
+    }
+    unknown = set(overrides) - set(result)
+    if unknown:
+        raise KeyError(f"not part of the OCSR result contract: {sorted(unknown)}")
+    result.update(overrides)
+    return result
+
+
+def mock_ocsr(image_path: str, backend: str = "mock") -> dict:
+    """Deterministic stand-in for a real backend, for tests with no models installed.
+
+    Mirrors :func:`chemgraph.tools.docking_core.mock_docking`. Returns aspirin for
+    any input, so a test can assert on the plumbing without waiting for a model load.
+    Goes through :func:`build_result`, so a test written against it is testing the
+    real contract.
+
+    It reports no confidence, matching what a single model returns: one model cannot
+    say how likely it is to be right about a particular image. Returning a number
+    here would make the helper model a shape no backend produces, which is the one
+    thing a stand-in must not do.
+    """
+    smiles = "CC(=O)Oc1ccccc1C(=O)O"
+    v = validate_smiles_core(smiles)
+    return build_result(
+        ok=True,
+        smiles=smiles,
+        valid=v["valid"],
+        formula=v["formula"],
+        n_fragments=v["n_fragments"],
+        confidence=None,
+        confidence_label="unavailable",
+        confidence_unavailable_reason="single_model_has_no_per_image_confidence",
+        agreement="single",
+        backend_used=backend,
+        model_used="mock",
+    )

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -49,7 +49,17 @@ _LABEL_BANDS = ((0.99, "unanimous"), (0.95, "strong"), (0.70, "weak"))
 # longest in the OCSR benchmark is 224.
 _MAX_SMILES_CHARS = 4000
 
-_SMILES_LABEL_RE = re.compile(r"^\s*(?:smiles|answer|result)\s*[:=]\s*", re.IGNORECASE)
+# The optional quotes around the key let a JSON reply be read at the line level:
+# '"smiles": "CCO"' is the single most common structured form a vision LLM returns,
+# and reaching it here keeps the word-by-word fallback from matching an element
+# symbol out of an adjacent "elements" list first.
+# Matches a "smiles": "..." pair anywhere, so a one-line JSON reply is read from its
+# own field instead of from whatever token happens to parse first.
+_JSON_SMILES_RE = re.compile(r"[\"'](?:smiles)[\"']\s*:\s*[\"']([^\"']*)[\"']",
+                             re.IGNORECASE)
+
+_SMILES_LABEL_RE = re.compile(
+    r"^\s*[\"']?(?:smiles|answer|result)[\"']?\s*[:=]\s*", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -221,6 +231,47 @@ def _looks_like_prose(s: str) -> bool:
     return s.isalpha() and s.islower() and not set(s) <= set("cnopsbrifhe")
 
 
+_WRAPPER_PAIRS = (("(", ")"), ("[", "]"), ("{", "}"), ("<", ">"))
+
+
+def _strip_wrappers(s: str) -> str:
+    """Peel markdown emphasis, quotes and balanced brackets off a candidate.
+
+    Emphasis is the dangerous case. ``*`` is RDKit's wildcard atom, so ``**CCO**``
+    parses as a valid five-atom molecule and would be returned as the prediction with
+    two extra atoms in it. Quotes and brackets only cost a match, since ``(CCO)``
+    fails to parse.
+
+    Brackets are peeled only when balanced across the whole string, because a SMILES
+    legitimately contains them: ``[Na+]`` and ``C(=O)O`` must survive unchanged.
+    """
+    s = s.strip()
+    while True:
+        before = s
+        s = s.strip("`\"'").strip()
+        while len(s) > 1 and s[0] == s[-1] == "*":
+            s = s[1:-1].strip()
+        for opener, closer in _WRAPPER_PAIRS:
+            if len(s) > 1 and s[0] == opener and s[-1] == closer:
+                inner = s[1:-1]
+                # Only unwrap an outer pair that encloses the whole string, so
+                # "C(=O)O" is left alone: its first "(" closes before the end.
+                depth = 0
+                encloses = True
+                for i, ch in enumerate(s):
+                    depth += (ch == opener) - (ch == closer)
+                    if depth == 0 and i < len(s) - 1:
+                        encloses = False
+                        break
+                # Keep the wrapped form when it is the one that parses: "[NH4+]" is
+                # a whole SMILES, and stripping its brackets leaves "NH4+", which is
+                # not. Unwrap only when doing so turns a non-molecule into one.
+                if encloses and canonicalize(s) is None:
+                    s = inner.strip()
+        if s == before:
+            return s
+
+
 def extract_smiles(raw_text: str | None) -> str | None:
     """Pull a SMILES out of a model's raw reply.
 
@@ -231,12 +282,19 @@ def extract_smiles(raw_text: str | None) -> str | None:
     if not raw_text or len(raw_text) > _MAX_SMILES_CHARS:
         return None
     text = re.sub(r"```[a-zA-Z]*\n?", "", raw_text).replace("```", "")
+    # A JSON object on one line never reaches the line-anchored label below, and the
+    # word-by-word fallback would take "C" out of an adjacent "elements" list first.
+    keyed = _JSON_SMILES_RE.search(text)
+    if keyed:
+        candidate = keyed.group(1).strip()
+        if candidate and not _looks_like_prose(candidate) and canonicalize(candidate):
+            return candidate
     for line in text.splitlines():
-        cleaned = _SMILES_LABEL_RE.sub("", line).strip().strip("`\"'").strip()
+        cleaned = _strip_wrappers(_SMILES_LABEL_RE.sub("", line))
         if cleaned and not _looks_like_prose(cleaned) and canonicalize(cleaned) is not None:
             return cleaned
     for token in text.split():
-        cleaned = token.strip("`\"'").rstrip(".,;!?")
+        cleaned = _strip_wrappers(token.rstrip(".,;!?"))
         if (
             len(cleaned) > 1
             and not _looks_like_prose(cleaned)

--- a/src/chemgraph/tools/ocsr_models.py
+++ b/src/chemgraph/tools/ocsr_models.py
@@ -1,0 +1,255 @@
+"""Which backends and models the OCSR tool can use, and which ones actually work.
+
+Two separate questions, and conflating them is how you end up shipping a default that
+nobody can run:
+
+  * Is a model *listed*? A registry entry means "offered", not "healthy right now".
+  * Does it *see the image*? A text-only model handed a picture does not say
+    "unsupported"; it confidently describes an image it never saw. The only way to
+    know is to ask it about a picture and check the answer.
+
+So the tables below carry a measured status, not just a name, and
+:func:`describe_backends` prints them for a user choosing a backend. Availability
+changes, so probe an endpoint before relying on it instead of trusting a
+date-stamped note here.
+"""
+
+from __future__ import annotations
+
+# --------------------------------------------------------------------------- #
+# The registry is data, not code: chemgraph/tools/ocsr_registry.json.
+#
+# Wiring in a new specialist means adding one entry there and dropping its worker
+# script into ocsr_workers/. Nothing in this module needs editing -- the backend name,
+# the installer, ensemble membership, and the printed listing are all derived from
+# that file. Point CHEMGRAPH_OCSR_REGISTRY at your own copy to add a model without
+# touching the installed package at all.
+#
+# No accuracy figures live here, for either family.
+#
+# Specialist accuracy belongs in the calibration table, beside the k, n and interval
+# that produced it, because it feeds the confidence a caller acts on and a refit has
+# to update every reported number at once.
+#
+# Vision LLMs get no accuracy at all. People use ChemGraph to run their own
+# benchmarks, on their own images, and a figure shipped here would answer the
+# question they came to ask, from a run they did not do and cannot inspect. What the
+# registry records instead is what a user cannot find out without trying: whether an
+# endpoint answers, and whether the model was seen to drive a tool call.
+# --------------------------------------------------------------------------- #
+_REGISTRY_ENV = "CHEMGRAPH_OCSR_REGISTRY"
+
+
+def load_registry(path: str | None = None) -> dict:
+    """Load the model registry: explicit path, then env var, then the packaged file."""
+    import json
+    import os
+
+    candidate = path or os.environ.get(_REGISTRY_ENV)
+    if candidate:
+        with open(os.path.expanduser(candidate)) as fh:
+            return _validate_registry(json.load(fh), os.path.expanduser(candidate))
+
+    from importlib import resources
+
+    ref = resources.files("chemgraph.tools").joinpath("ocsr_registry.json")
+    with ref.open() as fh:
+        return _validate_registry(json.load(fh), "packaged registry")
+
+
+def _validate_registry(reg: object, origin: str) -> dict:
+    """Reject a registry that would fail later in a confusing place."""
+    def bad(why: str) -> ValueError:
+        return ValueError(f"OCSR registry {origin!r} is unusable: {why}")
+
+    if not isinstance(reg, dict):
+        raise bad(f"top level is {type(reg).__name__}, expected an object")
+    specialists = reg.get("specialists")
+    if not isinstance(specialists, dict) or not specialists:
+        raise bad("'specialists' must be a non-empty object")
+    # Everything below is read during module import or by describe_backends, so a
+    # field of the wrong type takes down `import chemgraph.tools.ocsr_tools` with a
+    # traceback pointing at a dict comprehension in this file instead of at the line
+    # of JSON the user got wrong.
+    for name, m in specialists.items():
+        if not isinstance(m, dict):
+            raise bad(f"specialist {name!r} is not an object")
+        # Without a worker script the backend resolves and then dies at call time
+        # with a missing-file error that names an internal path, not the model.
+        if not isinstance(m.get("worker"), str) or not m["worker"]:
+            raise bad(f"specialist {name!r} needs a 'worker' script filename")
+        if not isinstance(m.get("latency_s"), (int, float)) or isinstance(
+            m.get("latency_s"), bool
+        ):
+            raise bad(f"specialist {name!r} needs a numeric 'latency_s'")
+        install = m.get("install")
+        if install is not None and not isinstance(install, dict):
+            raise bad(f"specialist {name!r} has a non-object 'install'")
+    llms = reg.get("vision_llms") or {}
+    if not isinstance(llms, dict):
+        raise bad("'vision_llms' must be an object")
+    for endpoint in ("alcf", "shim"):
+        entries = llms.get(endpoint)
+        if entries is None:
+            continue
+        if not isinstance(entries, dict):
+            raise bad(f"'vision_llms.{endpoint}' must be an object")
+        for name, m in entries.items():
+            if not isinstance(m, dict):
+                raise bad(f"vision_llms.{endpoint}.{name} is not an object")
+            if endpoint == "shim" and not isinstance(m.get("wire_name"), str):
+                raise bad(
+                    f"shim model {name!r} needs a 'wire_name': the shim rejects the "
+                    f"friendly spelling, so without it every call fails on the wire"
+                )
+    defaults = reg.get("defaults")
+    if defaults is not None and not isinstance(defaults, dict):
+        raise bad("'defaults' must be an object")
+    return reg
+
+
+_REGISTRY = load_registry()
+
+# Kept as module-level names because callers and tests already import them. Each is a
+# view of the registry file, so adding a model there adds it here.
+SPECIALIST_MODELS = {
+    name: {"latency_s": m.get("latency_s"), "note": m.get("note", "")}
+    for name, m in _REGISTRY["specialists"].items()
+}
+
+ALCF_VISION_MODELS = {
+    name: {"note": m.get("note", "")}
+    for name, m in (_REGISTRY.get("vision_llms", {}).get("alcf") or {}).items()
+}
+
+# Keys are the friendly spelling a user types; values are the wire name the shim
+# requires. Sending one the other's spelling fails mid-run with "Invalid model".
+SHIM_VISION_MODELS = {
+    name: m["wire_name"]
+    for name, m in (_REGISTRY.get("vision_llms", {}).get("shim") or {}).items()
+}
+
+_DEFAULTS = _REGISTRY.get("defaults") or {}
+
+# The default specialist must exist. Falling back to the first registered model rather
+# than to a name baked in here keeps a registry that drops 'decimer' working.
+DEFAULT_SPECIALIST = _DEFAULTS.get("specialist")
+if DEFAULT_SPECIALIST not in SPECIALIST_MODELS:
+    DEFAULT_SPECIALIST = next(iter(SPECIALIST_MODELS))
+
+DEFAULT_ALCF_MODEL = _DEFAULTS.get("alcf") or next(iter(ALCF_VISION_MODELS), None)
+DEFAULT_SHIM_MODEL = _DEFAULTS.get("shim") or next(iter(SHIM_VISION_MODELS), None)
+
+# Every registered specialist is also a backend name, so adding one to the registry
+# makes backend="<name>" work with no change here.
+BACKENDS = {
+    "auto": f"One fast, accurate specialist ({DEFAULT_SPECIALIST}). The default.",
+    "ensemble": (
+        f"All {len(SPECIALIST_MODELS)} specialists, voted, with a calibrated confidence."
+    ),
+    **{name: "That specialist alone." for name in SPECIALIST_MODELS},
+    "alcf": "A vision LLM on ALCF. Pick one with model=.",
+    "shim": "A vision LLM through the local Argo shim. Pick one with model=.",
+    "llm": "Whichever of alcf/shim is reachable; reports which in backend_used.",
+}
+
+
+def resolve_model(backend: str, model: str | None) -> str:
+    """Return the model name to send on the wire for a backend.
+
+    Accepts the friendly Argo spelling and translates it, so a caller never has to
+    remember that the shim wants ``claudeopus48`` rather than ``claude-opus-4.8``.
+
+    Raises
+    ------
+    ValueError
+        If the model is not known to be vision-capable on that backend. Refusing here
+        is deliberate: a text-only model given an image returns fluent text about a
+        picture it never saw, which is worse than an error.
+    """
+    if backend == "alcf":
+        name = model or DEFAULT_ALCF_MODEL
+        if name not in ALCF_VISION_MODELS:
+            raise ValueError(
+                f"{name!r} is not a known ALCF vision model. Choose from: "
+                f"{', '.join(ALCF_VISION_MODELS)}"
+            )
+        return name
+    if backend == "shim":
+        name = model or DEFAULT_SHIM_MODEL
+        if name in SHIM_VISION_MODELS:
+            return SHIM_VISION_MODELS[name]
+        if name in SHIM_VISION_MODELS.values():
+            return name  # already a wire name
+        raise ValueError(
+            f"{name!r} is not a known vision model on the Argo shim. Choose from: "
+            f"{', '.join(SHIM_VISION_MODELS)}"
+        )
+    if backend in SPECIALIST_MODELS:
+        return backend  # the backend name IS the model
+    raise ValueError(f"backend {backend!r} takes no model= argument")
+
+
+def describe_backends(calibration: str | None = None) -> str:
+    """Human-readable table of every backend and model, for the CLI and the docs.
+
+    Specialist accuracies are read from the calibration table, so this listing tracks
+    whatever table is in force rather than repeating figures compiled into the source.
+    Point it at a custom table to see that table's numbers.
+    """
+    from chemgraph.tools.ocsr_core import load_calibration
+
+    try:
+        table = load_calibration(calibration)
+    except (OSError, ValueError, TypeError):
+        table = {}
+    perf = table.get("model_performance") or {}
+    n_items = table.get("n_items")
+    committee = table.get("committee") or list(SPECIALIST_MODELS)
+
+    lines = ["OCSR backends (image -> SMILES)", ""]
+    lines.append("  Specialist models, local, no network:")
+    for name, m in SPECIALIST_MODELS.items():
+        acc = perf.get(name, {}).get("accuracy")
+        shown = f"{acc:.1%} exact" if acc is not None else "unmeasured "
+        lines.append(f"    {name:12s} {shown:12s} {m['latency_s']:>5.2f}s  {m['note']}")
+    ensemble = ", ".join(committee)
+    lines += [
+        "",
+        "  Ensemble:",
+        f"    ensemble     {ensemble}, voted, with a calibrated confidence",
+        "",
+        "  Vision LLMs on ALCF   (backend='alcf', model=<name>):",
+    ]
+    for name, m in ALCF_VISION_MODELS.items():
+        lines.append(f"    {name}")
+        # No accuracy column: whether the endpoint answers is the thing a user cannot
+        # discover without trying, and how well it reads their images is what they
+        # came here to measure.
+        if m.get("note"):
+            lines.append(f"      {m['note']}")
+    lines += ["", "  Vision LLMs via the Argo shim   (backend='shim', model=<name>):"]
+    shim_entries = _REGISTRY.get("vision_llms", {}).get("shim") or {}
+    for friendly, wire in SHIM_VISION_MODELS.items():
+        note = (shim_entries.get(friendly) or {}).get("note", "")
+        lines.append(f"    {friendly:28s} (sent as {wire:16s}) {note}".rstrip())
+    scope = f" on {n_items} images" if n_items else ""
+    lines += [
+        "",
+        f"  Specialist accuracy is exact-match, stereo-blind{scope}, read from the",
+        "  calibration table in force. It describes the model overall, so it is not",
+        "  reported as a confidence: only backend='ensemble' gives a number for the",
+        "  image in front of you.",
+        "",
+        "  No accuracy is quoted for the vision LLMs. Measure them on your own images",
+        "  with chemgraph.tools.ocsr_calibrate; a number from someone else's run",
+        "  answers a question you are better off asking of your own data.",
+        "  Specialist latency is warm; the first call also loads the model, which is",
+        "  5-25 s for most and 50-66 s for DECIMER (measured).",
+        "  A listed LLM may still be cold or down: probe before relying on one.",
+    ]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(describe_backends())

--- a/src/chemgraph/tools/ocsr_registry.json
+++ b/src/chemgraph/tools/ocsr_registry.json
@@ -1,0 +1,132 @@
+{
+  "schema": 1,
+  "_comment": "Registry of OCSR models. To wire in a new specialist: add an entry under 'specialists' and drop its worker script into chemgraph/tools/ocsr_workers/. No Python change is needed -- the backend, the installer, the listing, and ensemble membership are all derived from this file. Measured accuracy lives in the calibration table, not here, next to the k and n that produced it; run chemgraph.tools.ocsr_calibrate to fit one.",
+  "specialists": {
+    "decimer": {
+      "latency_s": 0.73,
+      "note": "Most accurate single model. The default for backend='auto'.",
+      "worker": "decimer_infer.py",
+      "install": {
+        "script": "build_decimer.sh",
+        "weights": "~/.data/DECIMER-V2",
+        "env": "~/ocsr-decimer",
+        "python": "3.10",
+        "size_gb": 2.6,
+        "weights_gb": 0.66
+      },
+      "install_note": "The default backend. Install this one first; it is enough for backend='auto'."
+    },
+    "molnextr": {
+      "latency_s": 4.35,
+      "note": "Strong second. Slowest of the four.",
+      "worker": "molnextr_infer.py",
+      "install": {
+        "script": "build_molnextr.sh",
+        "weights": "~/ocsr-weights/molnextr/molnextr_best.pth",
+        "env": "~/ocsr-molnextr",
+        "python": "3.8",
+        "size_gb": 6.1,
+        "weights_gb": 1.1
+      },
+      "install_note": "Only needed for backend='ensemble'. Also clones a source tree to ~/opt."
+    },
+    "molscribe": {
+      "latency_s": 4.98,
+      "note": "Its worker runs with PYTHONNOUSERSITE=1: a user-site numpy 2 shadows the env and breaks torch 1.13 at model load.",
+      "worker": "molscribe_infer.py",
+      "install": {
+        "script": "build_molscribe.sh",
+        "weights": "~/ocsr-weights/molscribe/swin_base_char_aux_1m.pth",
+        "env": "~/ocsr-molscribe",
+        "python": "3.10",
+        "size_gb": 4.4,
+        "weights_gb": 1.1
+      },
+      "install_note": "Only needed for backend='ensemble'. Pins numpy<2; see the script."
+    },
+    "ocsrglyph": {
+      "latency_s": 0.3,
+      "note": "Fastest and lightest of the four. Useful when latency matters more.",
+      "worker": "ocsrglyph_infer.py",
+      "install": {
+        "script": "build_ocsrglyph.sh",
+        "weights": "~/ocsr-weights/ocsrglyph/model.pth",
+        "env": "~/ocsr-glyph",
+        "python": "3.11",
+        "size_gb": 1.8,
+        "weights_gb": 0.37
+      },
+      "install_note": "Only needed for backend='ensemble'. Lightest and fastest of the four."
+    }
+  },
+  "vision_llms": {
+    "alcf": {
+      "meta-llama/Llama-4-Maverick-17B-128E-Instruct": {
+        "note": "Its endpoint was cold every time it was probed on 2026-08-14; check before relying on it."
+      },
+      "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+        "note": ""
+      },
+      "google/gemma-4-31B-it": {
+        "note": "Sees images and drives tool calls; read the example correctly on 2026-08-14."
+      },
+      "google/gemma-3-27b-it": {
+        "note": ""
+      },
+      "google/gemma-4-26B-A4B-it": {
+        "note": "Not probed; check before relying on it."
+      },
+      "google/gemma-4-E4B-it": {
+        "note": "Sees images and drives tool calls on 2026-08-14, but read the example wrong."
+      },
+      "meta-llama/Llama-3.2-90B-Vision-Instruct": {
+        "note": "Sees images and drives tool calls on 2026-08-14, but read the example wrong. The one model ChemGraph's '# Vision Language Models' comment labels; do not assume it is the best choice."
+      }
+    },
+    "shim": {
+      "argo:claude-opus-5": {
+        "wire_name": "claudeopus5",
+        "note": "Read the example correctly on 2026-08-14. The default for backend='shim'."
+      },
+      "argo:claude-sonnet-5": {
+        "wire_name": "claudesonnet5",
+        "note": "Read the example correctly on 2026-08-14, and the fastest of these."
+      },
+      "argo:claude-opus-4.8": {
+        "wire_name": "claudeopus48",
+        "note": "Read the example correctly on 2026-08-14."
+      },
+      "argo:claude-opus-4.6": {
+        "wire_name": "claudeopus46"
+      },
+      "argo:claude-sonnet-4.6": {
+        "wire_name": "claudesonnet46"
+      },
+      "argo:gpt-5.5": {
+        "wire_name": "gpt55"
+      },
+      "argo:gpt-5.4": {
+        "wire_name": "gpt54"
+      },
+      "argo:gpt-4.1": {
+        "wire_name": "gpt41"
+      },
+      "argo:gpt-4o": {
+        "wire_name": "gpt4o",
+        "note": "Read the example correctly once and wrong once on 2026-08-14."
+      },
+      "argo:gemini-2.5-flash": {
+        "wire_name": "gemini25flash"
+      },
+      "argo:gpt-5.6-sol": {
+        "wire_name": "gpt56sol",
+        "note": "Read the example correctly on 2026-08-14."
+      }
+    }
+  },
+  "defaults": {
+    "specialist": "decimer",
+    "alcf": "meta-llama/Llama-4-Maverick-17B-128E-Instruct",
+    "shim": "argo:claude-opus-5"
+  }
+}

--- a/src/chemgraph/tools/ocsr_setup.py
+++ b/src/chemgraph/tools/ocsr_setup.py
@@ -1,0 +1,296 @@
+"""Install the specialist OCSR models, one isolated environment per model.
+
+    python -m chemgraph.tools.ocsr_setup --list
+    python -m chemgraph.tools.ocsr_setup decimer
+    python -m chemgraph.tools.ocsr_setup --check
+
+ChemGraph already accepts that some dependencies cannot share an environment:
+`docs/installation.md` tells users to keep UMA and MACE apart because their `e3nn`
+requirements conflict. The four OCSR specialists are the same situation, four times
+over and worse. They need Python 3.8, 3.10, 3.10 and 3.11, and MolScribe's torch 1.13
+is compiled against numpy 1.x while ChemGraph pins numpy 2.2.6. There is no single
+environment that holds all of them, so each gets its own and is driven as a
+subprocess.
+
+This module automates what the UMA note leaves to the reader. It does not invent a
+packaging mechanism: it runs the build script for one model, which creates a conda
+env, pip-installs pinned versions, and fetches weights from HuggingFace. Everything
+it needs ships with ChemGraph; nothing is fetched from a private repository.
+
+Nothing here runs automatically. Installing all four is a decision the user makes
+explicitly, so this is a command they type, never something a tool call triggers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from importlib import resources
+
+# What to install and where, read from the same registry that defines the backends.
+# A specialist added to ocsr_registry.json is installable here with no edit, and there
+# is no second list to fall out of step with the first.
+def _install_specs() -> dict:
+    from chemgraph.tools.ocsr_models import load_registry
+
+    out = {}
+    for name, m in load_registry()["specialists"].items():
+        install = dict(m.get("install") or {})
+        if not install.get("script"):
+            continue  # a model with no build script is not installable by this tool
+        install["note"] = m.get("install_note", m.get("note", ""))
+        out[name] = install
+    return out
+
+
+MODELS = _install_specs()
+
+_INSTALL_JSON = "~/.chemgraph/ocsr_install.json"
+_INSTALL_ENV = "CHEMGRAPH_OCSR_INSTALL"
+
+
+def load_install(path: str | None = None) -> dict:
+    """Where each model is installed: explicit path, env var, user file, then defaults.
+
+    The user file is what :func:`_record_install` writes, so a model installed through
+    ``ocsr_setup`` is found with no further configuration. The packaged fallback is
+    derived from :data:`MODELS` rather than shipped as JSON, since every path in it is
+    per-user and a wheel cannot know them.
+    """
+    candidate = path or os.environ.get(_INSTALL_ENV) or _INSTALL_JSON
+    with contextlib.suppress(FileNotFoundError, json.JSONDecodeError):
+        with open(os.path.expanduser(candidate)) as fh:
+            return json.load(fh)
+    return {
+        name: {
+            "python_bin": _env_python(name),
+            "weights_path": os.path.expanduser(m["weights"]),
+            "device": "cpu",
+            "startup_timeout_s": m.get("startup_timeout_s", 300),
+            "timeout_s": m.get("timeout_s", 120),
+        }
+        for name, m in MODELS.items()
+    }
+
+
+def _script_path(name: str) -> str:
+    """Absolute path to a build script, extracting it from the wheel if needed.
+
+    Raises FileNotFoundError if the registry names a script that is not there.
+    ``importlib.resources`` only composes a path, so without this check a typo'd
+    registry entry returns a plausible-looking path and fails later as an opaque
+    "bash: no such file", after the caller has already printed a download size and
+    asked for confirmation.
+    """
+    script = MODELS[name]["script"]
+    ref = resources.files("chemgraph.tools.ocsr_workers").joinpath(script)
+    if not ref.is_file():
+        raise FileNotFoundError(
+            f"the registry entry for {name!r} names build script {script!r}, but "
+            f"chemgraph/tools/ocsr_workers/{script} does not exist. Add the script, "
+            f"or correct 'install.script' in ocsr_registry.json."
+        )
+    with resources.as_file(ref) as p:
+        return str(p)
+
+
+def _env_python(name: str) -> str:
+    return os.path.expanduser(os.path.join(MODELS[name]["env"], "bin", "python"))
+
+
+def cmd_list() -> int:
+    """Print what is available, what it costs, and what is already installed.
+
+    Accuracy comes from the calibration table rather than this module, so the listing
+    reports whatever table is in force. A model with no measured accuracy prints a
+    dash: unmeasured is not the same as zero.
+    """
+    from chemgraph.tools.ocsr_core import load_calibration
+    from chemgraph.tools.ocsr_models import DEFAULT_SPECIALIST
+
+    try:
+        performance = load_calibration().get("model_performance") or {}
+    except (OSError, ValueError, TypeError):
+        performance = {}
+
+    print("Specialist OCSR models. Each installs into its own conda environment.\n")
+    print(f"  {'model':11s} {'python':7s} {'disk':>7s} {'accuracy':>9s}  {'status':12s}")
+    for name, m in MODELS.items():
+        total = m["size_gb"] + m["weights_gb"]
+        status = "installed" if os.path.exists(_env_python(name)) else "not installed"
+        accuracy = performance.get(name, {}).get("accuracy")
+        shown = f"{accuracy:8.1%}" if accuracy is not None else f"{'--':>8s}"
+        print(f"  {name:11s} {m['python']:7s} {total:6.1f}G {shown}  {status:12s}")
+    total_all = sum(m["size_gb"] + m["weights_gb"] for m in MODELS.values())
+    print(f"\n  {DEFAULT_SPECIALIST} alone is enough for backend='auto'.")
+    print(f"  All {len(MODELS)} ({total_all:.1f} GB) are only needed for "
+          f"backend='ensemble'.")
+    print("\n  Install one with:  python -m chemgraph.tools.ocsr_setup <model>")
+    return 0
+
+
+def _missing_registry_files(name: str) -> list[str]:
+    """Files the registry promises for a model but that are not in the package.
+
+    Distinguishes a broken registry entry from an uninstalled model. Since the
+    registry is user-editable data, a typo in a filename is an expected mistake, not
+    a developer bug -- and without this it surfaces 45 seconds into a build as
+    "bash: no such file", or worse, as a model that resolves as a backend and then
+    fails at first call.
+    """
+    from chemgraph.tools.ocsr_models import load_registry
+
+    spec = load_registry()["specialists"].get(name) or {}
+    workers = resources.files("chemgraph.tools.ocsr_workers")
+    missing = []
+    for key in ("worker", ("install", "script")):
+        if isinstance(key, tuple):
+            filename = (spec.get(key[0]) or {}).get(key[1])
+        else:
+            filename = spec.get(key)
+        if filename and not workers.joinpath(filename).is_file():
+            missing.append(filename)
+    return missing
+
+
+def cmd_check() -> int:
+    """Verify what is actually usable, and say what to run for anything missing."""
+    ok = True
+    broken_registry = False
+    print(f"  {'model':11s} {'env':38s} {'status'}")
+    for name in MODELS:
+        absent = _missing_registry_files(name)
+        if absent:
+            # Report this before the env check: telling the user to install a model
+            # whose build script does not exist sends them into a 45 s failure.
+            print(f"  {name:11s} {MODELS[name]['env']:38s} "
+                  f"REGISTRY ERROR: no such file: {', '.join(absent)}")
+            ok = False
+            broken_registry = True
+            continue
+        py = _env_python(name)
+        if not os.path.exists(py):
+            print(f"  {name:11s} {MODELS[name]['env']:38s} not installed")
+            ok = False
+            continue
+        # The interpreter existing is not the same as it working: a user-site package
+        # can shadow the env and break an import that only fails at model load.
+        probe = subprocess.run(
+            [py, "-c", "import sys; print(sys.version_info[:2])"],
+            capture_output=True, text=True, timeout=60,
+            env={**os.environ, "PYTHONNOUSERSITE": "1"},
+        )
+        if probe.returncode != 0:
+            print(f"  {name:11s} {MODELS[name]['env']:38s} BROKEN ({probe.stderr.strip()[:40]})")
+            ok = False
+        else:
+            print(f"  {name:11s} {MODELS[name]['env']:38s} ok  python {probe.stdout.strip()}")
+    if broken_registry:
+        print("\n  A REGISTRY ERROR is not something installing will fix: the entry in")
+        print("  ocsr_registry.json names a file that is not in chemgraph/tools/")
+        print("  ocsr_workers/. Add the file, or correct the name in the registry.")
+    if ok:
+        return 0
+    if not broken_registry:
+        print("\n  Install a missing model with:")
+        print("    python -m chemgraph.tools.ocsr_setup <model>")
+    return 1
+
+
+def cmd_install(name: str, yes: bool = False) -> int:
+    """Run one model's build script, after saying what it will cost."""
+    m = MODELS[name]
+    script = _script_path(name)
+    total = m["size_gb"] + m["weights_gb"]
+
+    print(f"Installing {name}")
+    print(f"  environment  {m['env']}  (conda, python {m['python']})")
+    print(f"  weights      ~{m['weights_gb']:.1f} GB from HuggingFace")
+    print(f"  total disk   ~{total:.1f} GB")
+    print(f"  script       {script}")
+    print(f"\n  {m['note']}")
+
+    if not shutil.which("conda"):
+        print("\nconda not found. Install miniforge, or load your site's conda module:")
+        print("  https://github.com/conda-forge/miniforge")
+        return 1
+
+    if not yes:
+        try:
+            if input("\nProceed? [y/N] ").strip().lower() not in ("y", "yes"):
+                print("Nothing was installed.")
+                return 1
+        except EOFError:
+            print("\nNot a terminal; re-run with --yes to install non-interactively.")
+            return 1
+
+    print()
+    rc = subprocess.call(["bash", script])
+    if rc != 0:
+        print(f"\nBuild failed (exit {rc}). The script's output above says why.")
+        return rc
+
+    _record_install(name)
+    print(f"\n{name} installed. Verify with:")
+    print("  python -m chemgraph.tools.ocsr_setup --check")
+    return 0
+
+
+def _record_install(name: str) -> None:
+    """Note where this model landed, so the tool finds it without a hardcoded path."""
+    path = os.path.expanduser(_INSTALL_JSON)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    try:
+        with open(path) as fh:
+            data = json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        data = {}
+    # Everything a worker needs to start. Three of the four declare --weights as
+    # required, so recording only python_bin would produce a config that dies at
+    # argparse 0.3 s into the spawn.
+    m = MODELS[name]
+    data[name] = {
+        "python_bin": _env_python(name),
+        "weights_path": os.path.expanduser(m["weights"]),
+        "device": "cpu",
+        "startup_timeout_s": m.get("startup_timeout_s", 300),
+        "timeout_s": m.get("timeout_s", 120),
+    }
+    with open(path, "w") as fh:
+        json.dump(data, fh, indent=2)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The CLI's argument parser.
+
+    Separate from main() so a test can check that the command this package tells
+    users to run is a command this package accepts.
+    """
+    p = argparse.ArgumentParser(
+        prog="python -m chemgraph.tools.ocsr_setup",
+        description="Install specialist OCSR models into isolated environments.",
+    )
+    p.add_argument("model", nargs="?", choices=sorted(MODELS), help="model to install")
+    p.add_argument("--list", action="store_true", help="show models, sizes and status")
+    p.add_argument("--check", action="store_true", help="verify installed environments")
+    p.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.check:
+        return cmd_check()
+    if args.list or not args.model:
+        return cmd_list()
+    return cmd_install(args.model, yes=args.yes)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/chemgraph/tools/ocsr_tools.py
+++ b/src/chemgraph/tools/ocsr_tools.py
@@ -1,0 +1,455 @@
+"""LangChain ``@tool`` wrappers for OCSR: read a structure image, return a SMILES.
+
+Each tool delegates to a plain function so a human or a test can call the same logic
+without an agent: ``image_to_smiles`` is a ``StructuredTool`` and is not callable
+directly, ``image_to_smiles_core`` is. Same split as
+:mod:`chemgraph.tools.docking_tools` over :mod:`chemgraph.tools.docking_core`.
+
+Layering, so it is clear where to add things:
+
+* :mod:`ocsr_core` is pure: validation, canonicalization, voting, the confidence table.
+  No network, no subprocesses.
+* :mod:`ocsr_backends` runs models. Never raises; returns a narrow dict.
+* this module dispatches on ``backend=``, assembles the public 18-key contract, and
+  is the only place that catches everything.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.tools import tool
+
+from chemgraph.tools import ocsr_backends as backends
+from chemgraph.tools import ocsr_core as core
+from chemgraph.tools import ocsr_models as models
+
+logger = logging.getLogger(__name__)
+
+# Derived from the registry, so a specialist added to ocsr_registry.json becomes a
+# usable backend here without an edit. Read at call time rather than bound once, so a
+# test or a user pointing CHEMGRAPH_OCSR_REGISTRY at another file is honoured.
+_LLM_BACKENDS = ("alcf", "shim", "llm")
+
+
+def _specialists() -> tuple[str, ...]:
+    return tuple(models.SPECIALIST_MODELS)
+
+
+def _default_single() -> str:
+    return models.DEFAULT_SPECIALIST
+
+
+def _prior_with(model_name: str, calibration: str | None) -> dict:
+    """A single model's prior, read from the table the caller named.
+
+    Without threading `calibration` through, prior_confidence loads the packaged
+    default, so a user who refit on their own images got their own numbers from the
+    ensemble and someone else's from every single-model backend, the 'auto' default
+    included, with nothing in the result to show it.
+
+    An unreadable path is reported rather than silently falling back, since falling
+    back would answer with the very numbers the caller was trying to replace.
+    """
+    try:
+        table = core.load_calibration(calibration)
+    except (OSError, ValueError, TypeError) as exc:
+        return {"p": None, "label": "unavailable",
+                "reason": f"calibration_unreadable: {type(exc).__name__}"}
+    return core.prior_confidence(model_name, table)
+
+
+def _finish(narrow: dict, *, agreement: str, basis: str | None,
+            backend_used: str, conf: dict | None = None,
+            votes: dict | None = None, abstained: dict | None = None) -> dict:
+    """Turn a backend's narrow dict plus a confidence verdict into the contract.
+
+    One place assembles the 18 keys, so a backend cannot ship a partial result and an
+    agent never has to test for a missing field. ``raw`` is dropped here rather than
+    returned: it is useful in a log, not in an agent's context.
+    """
+    if not narrow["ok"]:
+        return core.build_result(
+            ok=False, error=narrow["error"], backend_used=backend_used,
+            model_used=narrow["model_used"], cold_start=narrow["cold_start"],
+            latency_s=narrow["latency_s"], agreement=agreement,
+            confidence_unavailable_reason="no_prediction",
+        )
+
+    v = core.validate_smiles_core(narrow["smiles"])
+    warning = ""
+    if v["n_fragments"] > 1:
+        warning = (f"this image gave {v['n_fragments']} disconnected molecules; ask "
+                   f"which one is meant before using it for a calculation")
+
+    conf = conf or {"p": None, "label": "unavailable", "reason": "no_prior_for_model"}
+    return core.build_result(
+        ok=True,
+        smiles=narrow["smiles"],
+        valid=v["valid"],
+        formula=v["formula"],
+        n_fragments=v["n_fragments"],
+        confidence=conf["p"],
+        confidence_label=conf["label"],
+        confidence_unavailable_reason=conf.get("reason"),
+        agreement=agreement,
+        basis=basis,
+        backend_used=backend_used,
+        model_used=narrow["model_used"],
+        cold_start=narrow["cold_start"],
+        latency_s=narrow["latency_s"],
+        warning=warning,
+        votes=votes,
+        abstained=abstained,
+    )
+
+
+def _run_ensemble(image_bytes: bytes, calibration: str | None,
+                  models_wanted: list[str] | None = None) -> dict:
+    """Vote a committee of specialists and attach a calibrated confidence.
+
+    Runs every installed specialist unless ``models_wanted`` names a subset. A subset
+    is worth supporting because the committee is what a table describes: someone who
+    has all four installed but fitted a table on two of them can only get a number by
+    running exactly those two.
+    """
+    installed = backends.available_specialists()
+    if not installed:
+        return core.build_result(
+            ok=False, backend_used="none",
+            error=backends._setup_hint(),
+            confidence_unavailable_reason="no_specialists_installed",
+        )
+
+    if models_wanted is not None:
+        # A bare string iterates per character, and a non-string element blows up the
+        # join below with a TypeError that names neither the argument nor the valid
+        # names. An empty list is a caller who filtered down to nothing, which must
+        # not silently become "run everything".
+        if isinstance(models_wanted, str) or not isinstance(
+            models_wanted, (list, tuple, set, frozenset)
+        ):
+            return core.build_result(
+                ok=False, backend_used="ensemble",
+                error=(f"models_wanted must be a list of specialist names, got "
+                       f"{type(models_wanted).__name__}. Choose from: "
+                       f"{', '.join(_specialists())}"),
+            )
+        models_wanted = list(models_wanted)
+        if not models_wanted:
+            return core.build_result(
+                ok=False, backend_used="ensemble",
+                error=(f"models_wanted is empty. Omit it to vote every installed "
+                       f"specialist, or name some of: {', '.join(_specialists())}"),
+            )
+        unknown = [m for m in models_wanted if m not in _specialists()]
+        if unknown:
+            return core.build_result(
+                ok=False, backend_used="ensemble",
+                error=(f"not OCSR specialists: "
+                       f"{', '.join(repr(m) for m in unknown)}. Choose from: "
+                       f"{', '.join(_specialists())}"),
+            )
+        absent = [m for m in models_wanted if m not in installed]
+        if absent:
+            return core.build_result(
+                ok=False, backend_used="ensemble",
+                error=(f"requested but not installed: {', '.join(absent)}. Install "
+                       f"with: " + "; ".join(
+                           f"python -m chemgraph.tools.ocsr_setup {m}"
+                           for m in absent)),
+                confidence_unavailable_reason="no_specialists_installed",
+            )
+        installed = [m for m in installed if m in models_wanted]
+
+    results, cold, total = [], False, 0.0
+    for name in installed:
+        r = backends.smiles_from_specialist(name, image_bytes)
+        cold = cold or r["cold_start"]
+        total += r["latency_s"]
+        results.append({"model": name, "smiles": r["smiles"],
+                        "ok": r["ok"], "error": r["error"], "infer_s": r["latency_s"]})
+
+    # Load before voting: the table records the model priority it was fitted under,
+    # and that order decides which answer wins a tie. Voting by the registry's order
+    # instead would attach a number measured for one model's answer to a different
+    # model's answer, which check_committee cannot detect because it compares sorted
+    # names. A typo in the path must still not throw the prediction away, so an
+    # unreadable table falls back to the registry order and reports no confidence.
+    try:
+        table = core.load_calibration(calibration)
+    except Exception as exc:
+        table = None
+        unreadable = f"calibration_unreadable: {type(exc).__name__}"
+    else:
+        unreadable = None
+
+    priority = core.tie_break_order(table) if table else list(_specialists())
+    v = core.vote(results, priority=priority)
+    if v["winner"] is None:
+        return core.build_result(
+            ok=False, backend_used="ensemble", cold_start=cold, latency_s=total,
+            error="every specialist failed or returned an unparseable SMILES",
+            abstained=v["abstained"],
+            confidence_unavailable_reason="no_prediction",
+        )
+
+    if unreadable:
+        mismatch = None
+        conf = {"p": None, "label": "unavailable", "reason": unreadable}
+    else:
+        mismatch = core.check_committee(v, table)
+        if mismatch:
+            # Do not silently drop the confidence: the caller asked for the ensemble
+            # precisely to get a number, and a partial install is invisible otherwise.
+            conf = {"p": None, "label": "unavailable", "reason": mismatch}
+        else:
+            conf = core.confidence(v["pattern"], table)
+
+    narrow = {"ok": True, "smiles": v["winner"], "raw": "",
+              "model_used": "+".join(v["voters"]), "cold_start": cold,
+              "latency_s": round(total, 3), "error": ""}
+    out = _finish(narrow, agreement=v["pattern"],
+                  basis="agreement" if conf.get("p") is not None else None,
+                  backend_used="ensemble", conf=conf,
+                  votes=v["votes"], abstained=v["abstained"])
+    if not out["warning"]:
+        # Surface both in warning, not only in the reason: an unreadable path looked
+        # identical to a legitimate no-number result in anything that prints the
+        # result, and the reason alone named a Python exception class.
+        out["warning"] = mismatch or (
+            f"the calibration table at {calibration!r} could not be read, so this "
+            f"answer carries no confidence" if unreadable else ""
+        )
+    return out
+
+
+def image_to_smiles_core(image_path: str, backend: str = "auto",
+                         model: str | None = None,
+                         calibration: str | None = None,
+                         models_wanted: list[str] | None = None,
+                         report_solo_accuracy: bool = False,
+                         prompt_mode: str = "legacy_benchmark") -> dict:
+    """Read a molecule's 2D structure diagram and return its SMILES.
+
+    The plain-Python entry point. ``image_to_smiles`` is the agent-facing wrapper.
+    Never raises: every failure comes back as ``ok=False`` with an actionable ``error``.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to a PNG, JPEG, GIF or WEBP of one molecule's structure.
+    backend : str
+        See :data:`chemgraph.tools.ocsr_models.BACKENDS`.
+    model : str, optional
+        Which model, for ``alcf`` and ``shim``. Ignored for the specialists, whose
+        backend name is the model.
+    calibration : str, optional
+        Path to a calibration table, overriding the packaged default.
+    models_wanted : list[str], optional
+        For ``backend="ensemble"``, run only these specialists. The committee is what
+        a calibration table describes, so a table fit on two models yields a number
+        only when exactly those two vote.
+    report_solo_accuracy : bool, optional
+        For a single-specialist backend, return that model's overall benchmark
+        accuracy as ``confidence``. Off by default: it is a property of the model on
+        someone else's images and says nothing about this one. Only the ensemble
+        produces a per-image number.
+    prompt_mode : str, optional
+        For a vision LLM backend. ``"legacy_benchmark"``, the default, sends the
+        vendored prompt behind every number in the shipped calibration table.
+        ``"structured"`` asks for a JSON object with a ``smiles`` field, so the answer
+        arrives in a named field; refit with ``ocsr_calibrate`` for confidence numbers
+        that describe a structured run.
+
+    Returns
+    -------
+    dict
+        The 18-key contract; see :func:`chemgraph.tools.ocsr_core.build_result`.
+    """
+    # Check the backend name before touching the filesystem, so a typo is reported as
+    # a typo rather than as whatever happens to be wrong with the path. Guarded for
+    # hashability first: a list or dict here raised TypeError straight out of the
+    # function, past the catch-all below, breaking the never-raise promise.
+    if not isinstance(backend, str) or backend not in models.BACKENDS:
+        return core.build_result(
+            ok=False, backend_used=backend,
+            error=(f"unknown backend {backend!r}. Choose one of: "
+                   f"{', '.join(models.BACKENDS)}"),
+        )
+
+    try:
+        image_bytes, mime = core.load_image_bytes(image_path)
+    except (OSError, ValueError, TypeError) as e:
+        # OSError, not just FileNotFoundError: an agent-synthesized path routinely
+        # produces PermissionError, NotADirectoryError ("some/file.txt/x.png") or
+        # ENAMETOOLONG, and the docstring promises this returns rather than raises.
+        # TypeError covers image_path=None from a direct Python call.
+        return core.build_result(ok=False, error=str(e), backend_used=backend)
+
+    try:
+        if backend == "auto":
+            installed = backends.available_specialists()
+            if _default_single() in installed:
+                backend = _default_single()
+            elif installed:
+                # Some other specialist is installed. Saying "no local models are
+                # installed" here was false, and the tool docstring tells an agent to
+                # answer that by going to a vision LLM, so a compliant agent
+                # abandoned a working local model that is more accurate.
+                backend = next(
+                    name for name in _specialists() if name in installed
+                )
+                logger.info(
+                    "backend='auto': %s is not installed, using %s",
+                    _default_single(), backend,
+                )
+            else:
+                return core.build_result(
+                    ok=False, backend_used="none",
+                    error=(f"{backends._setup_hint()} (backend='auto' uses "
+                           f"{_default_single()})"),
+                    confidence_unavailable_reason="no_specialists_installed",
+                )
+
+        if backend == "ensemble":
+            return _run_ensemble(image_bytes, calibration, models_wanted)
+
+        if backend in _specialists():
+            narrow = backends.smiles_from_specialist(backend, image_bytes)
+            # Pass the table through. Without it prior_confidence loads the packaged
+            # default, so a user who refit on their own images got their numbers from
+            # the ensemble and someone else's from every single-model backend, which
+            # includes the 'auto' default, with nothing in the result to show it.
+            conf = (_prior_with(backend, calibration) if report_solo_accuracy
+                    else {"p": None, "label": "unavailable",
+                          "reason": "single_model_has_no_per_image_confidence"})
+            return _finish(narrow, agreement="single",
+                           basis="prior" if report_solo_accuracy else None,
+                           backend_used=backend, conf=conf)
+
+        if backend in _LLM_BACKENDS:
+            narrow = backends.smiles_from_llm(image_bytes, mime, backend, model,
+                                              prompt_mode=prompt_mode)
+            used = narrow["model_used"]
+            resolved = backend
+            if backend == "llm":
+                # report which endpoint actually answered, not the alias
+                resolved = "shim" if used in models.SHIM_VISION_MODELS.values() else "alcf"
+            return _finish(narrow, agreement="single", basis=None,
+                           backend_used=resolved)
+
+        # Unreachable: BACKENDS was checked above. Kept so a new entry added to
+        # BACKENDS without a branch here fails loudly instead of silently.
+        return core.build_result(
+            ok=False, backend_used=backend,
+            error=f"backend {backend!r} is listed but not implemented",
+        )
+    except Exception as e:  # the never-raise invariant, belt and braces
+        logger.exception("unexpected OCSR failure")
+        return core.build_result(ok=False, backend_used=backend,
+                                 error=f"{type(e).__name__}: {e}")
+
+
+@tool
+def image_to_smiles(image_path: str, backend: str = "auto",
+                    model: str | None = None) -> dict:
+    """Read a molecule's 2D structure diagram from an image and return its SMILES.
+
+    Use this when the user supplies an image file of a chemical structure.
+
+    Backends. Use 'auto' unless you have a reason not to; it is the default and is
+    right for almost every question. Switch only in these cases:
+      - the answer will drive an expensive calculation (a geometry optimization, a
+        DFT job): use 'ensemble', which runs every installed specialist and returns
+        a sharper confidence, at the cost of being slower.
+      - 'auto' returned ok=False saying no local models are installed: use 'alcf'.
+      - the user named a specific model: pass its name as the backend, or use
+        backend='alcf'/'shim' with model=. The error message on an unknown backend
+        lists every name this installation accepts; do not guess from memory.
+
+    Do NOT try backends in a loop. If one fails because nothing is installed, the
+    others in that family fail the same way, and each attempt can cost 45 seconds.
+    The error says which family works on this machine; believe it.
+
+    ALWAYS read `confidence` before acting on the answer:
+
+      - backend='ensemble' returns a number, and `basis` is 'agreement'. It is how
+        often this exact agreement pattern gave the right answer on measured data.
+        Above about 0.95 the answer is safe to feed to an expensive calculation;
+        below it, say so to the user or ask them to check the structure.
+      - Every other backend returns confidence=null with a reason. A single model
+        cannot say how likely IT is to be right about THIS image, so nothing is
+        quoted. Null means unmeasured here, and never that the answer is bad.
+      - If the answer matters, use backend='ensemble', the only one that produces a
+        per-image number.
+
+    `confidence_label` is the coarse version and is the safer thing to reason with,
+    because a bare number can look more precise than it is. It is 'unanimous',
+    'strong', 'weak' or 'conflicting' when a number was produced; the same four
+    prefixed 'low_n_' when the bucket is too small to quote one, which still tells
+    you which way the evidence points; and 'unavailable' when no measurement applies
+    at all.
+
+    A null `confidence` means the confidence machinery failed, not that the answer is
+    good; `confidence_unavailable_reason` says why.
+
+    If `n_fragments` is greater than 1 the image contained more than one molecule (or
+    a salt, or a reaction scheme). Ask the user which one they meant rather than
+    passing the SMILES to a geometry or energy calculation.
+
+    Timing. The first call in a session loads models: about 55-65 s for DECIMER and
+    5-20 s for the others, so a cold 'ensemble' can take well over a minute of wall
+    time. Later calls take about 0.7 s ('auto') or 3-5 s ('ensemble'). `cold_start`
+    says whether a load happened; `latency_s` counts inference only and excludes that
+    load, so on a cold call the wall time is much larger than the number reported.
+
+    Specialists are purpose-built and usually more accurate than a general vision
+    model, but fail on unusual drawing styles, Markush structures, and reaction
+    schemes.
+
+    Parameters
+    ----------
+    image_path : str
+        Path to a PNG or JPEG showing ONE molecule's 2D structure.
+    backend : str, optional
+        'auto', 'ensemble', a specialist name, 'alcf', 'shim', or 'llm'.
+    model : str, optional
+        Which vision model, for 'alcf' and 'shim'.
+
+    Returns
+    -------
+    dict
+        Always present: ok, smiles, valid, formula, n_fragments, confidence,
+        confidence_label, confidence_unavailable_reason, agreement, basis,
+        backend_used, model_used, cold_start, latency_s, error, warning.
+        Only for backend='ensemble': votes, abstained.
+    """
+    return image_to_smiles_core(image_path, backend=backend, model=model)
+
+
+@tool
+def validate_smiles(smiles: str) -> dict:
+    """Check whether a SMILES string is chemically valid, and say what is wrong.
+
+    Use this after proposing a SMILES and before giving a final answer. If `valid` is
+    false, read `errors`: it carries RDKit's own message, for example "Explicit
+    valence for atom # 3 N, 4, is greater than permitted", which tells you what to
+    correct. Also returns the molecular formula and atom counts so you can check them
+    against the image.
+
+    `n_fragments` greater than 1 means the string describes more than one
+    disconnected molecule, which is usually a salt or two structures read as one.
+
+    Parameters
+    ----------
+    smiles : str
+        The candidate SMILES string.
+
+    Returns
+    -------
+    dict
+        smiles, valid, canonical_smiles, formula, n_atoms, n_heavy_atoms, elements,
+        n_fragments, errors, rdkit_available.
+    """
+    return core.validate_smiles_core(smiles)

--- a/src/chemgraph/tools/ocsr_worker_client.py
+++ b/src/chemgraph/tools/ocsr_worker_client.py
@@ -1,0 +1,432 @@
+"""Drive the specialist OCSR workers: spawn, talk, tear down.
+
+Each specialist model lives in its own conda environment (see
+:mod:`chemgraph.tools.ocsr_setup`) and runs as a subprocess speaking the JSON line
+protocol in :mod:`chemgraph.tools.ocsr_workers._protocol`. This module is the parent
+side of that conversation.
+
+Workers are expensive to start (50-66 s for DECIMER, measured, dominated by loading
+TensorFlow and the weights) and cheap to reuse (0.5-5 s per image). So one worker per
+model is started on first use and kept, with an idle reaper closing it after a period
+of inactivity rather than holding a multi-gigabyte process for the life of a CLI
+session.
+
+Ported from the OCSR benchmark's ``local_client._Worker``, which has driven thousands
+of rows, with three deliberate changes: it takes image bytes rather than a
+``BenchItem``, it returns a plain dict rather than a ``Prediction``, and the read loop
+no longer blocks past its deadline (see :meth:`_Worker._read_until`).
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import io
+import json
+import logging
+import os
+import selectors
+import subprocess
+import tempfile
+import threading
+import time
+from importlib import resources
+
+logger = logging.getLogger(__name__)
+
+# Long enough for a cold TensorFlow import plus weights off a shared filesystem;
+# DECIMER measured 66 s on an idle machine and can be slower under load.
+DEFAULT_STARTUP_TIMEOUT_S = 300.0
+DEFAULT_INFER_TIMEOUT_S = 120.0
+# Interactive sessions should not sit on ~2 GB and a torch process indefinitely.
+_MAX_LOG_BYTES = 5 * 1024 * 1024
+
+# Longest single protocol line we will buffer. Messages are small JSON objects, so
+# anything past this means the worker is emitting a stream with no newline in it, and
+# waiting for one would grow the parent's memory until the deadline (measured: about
+# 1.8 GB over the 300 s startup budget).
+_MAX_LINE_BYTES = 1024 * 1024
+
+
+def _die_with_parent() -> None:
+    """Ask the kernel to SIGTERM this child when its parent dies.
+
+    ``atexit`` and the ``BaseException`` handler both need the parent to keep
+    running, so neither covers SIGKILL, an OOM kill, or a job teardown. A worker
+    already blocked on stdin sees EOF and exits on its own, but one still loading
+    its model is not reading yet, and that window is up to 66 s during which several GB
+    would be stranded on a shared node with nothing to reap it.
+
+    Linux only, and best effort: any failure here must not stop the spawn.
+    """
+    with contextlib.suppress(Exception):
+        import ctypes
+        import signal
+
+        ctypes.CDLL("libc.so.6", use_errno=True).prctl(1, signal.SIGTERM)  # PR_SET_PDEATHSIG
+
+DEFAULT_IDLE_TIMEOUT_S = 600.0
+
+_WORKER_PACKAGE = "chemgraph.tools.ocsr_workers"
+
+# Set once, so the whole ocsr_workers directory is on disk for the life of the process
+# rather than per spawn. The workers do `sys.path.insert(0, dirname(__file__))` and then
+# `import _protocol`, so the script and its sibling must be extracted together; pulling
+# out a single file would leave the import dangling under a zipimport.
+_workers_dir: str | None = None
+_workers_stack = contextlib.ExitStack()
+atexit.register(_workers_stack.close)
+
+
+def workers_dir() -> str:
+    """Filesystem path to the packaged worker scripts, materializing them if needed.
+
+    Copies the whole directory rather than calling ``as_file`` on it. Two reasons,
+    both invisible under an editable install and fatal under a wheel: ``as_file`` on
+    a *directory* traversable raises ``IsADirectoryError`` from a zip, and extracting
+    a single file would leave ``_protocol.py`` behind, which the workers import by
+    sitting next to it.
+    """
+    global _workers_dir
+    if _workers_dir is None:
+        pkg = resources.files(_WORKER_PACKAGE)
+        direct = getattr(pkg, "_paths", None) or pkg
+        if isinstance(direct, os.PathLike) or os.path.isdir(str(pkg)):
+            _workers_dir = str(pkg)          # normal filesystem install
+        else:
+            out = _workers_stack.enter_context(tempfile.TemporaryDirectory(
+                prefix="chemgraph_ocsr_workers_"))
+            for entry in pkg.iterdir():
+                if entry.is_file():
+                    with open(os.path.join(out, entry.name), "wb") as fh:
+                        fh.write(entry.read_bytes())
+            _workers_dir = out
+    return _workers_dir
+
+
+def worker_script(model: str) -> str:
+    """Path to one model's `*_infer.py`."""
+    return os.path.join(workers_dir(), f"{model}_infer.py")
+
+
+class WorkerError(RuntimeError):
+    """A worker could not be started, or died, or did not answer in time."""
+
+
+class _Worker:
+    """One model's subprocess: start it, ask it for SMILES, shut it down."""
+
+    def __init__(self, model: str, cfg: dict):
+        self.model = model
+        self.cfg = cfg
+        self.proc: subprocess.Popen | None = None
+        self.lock = threading.Lock()
+        self.last_used = time.monotonic()
+        self._log_fh = None
+        self._buf = ""   # partial line carried across reads, see _read_until
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        script = worker_script(self.model)
+        if not os.path.exists(script):
+            raise WorkerError(f"no worker script for {self.model!r} at {script}")
+
+        python_bin = os.path.expanduser(os.path.expandvars(self.cfg["python_bin"]))
+        if not os.path.exists(python_bin):
+            raise WorkerError(
+                f"{self.model} is not installed ({python_bin} does not exist). "
+                f"Install it with: python -m chemgraph.tools.ocsr_setup {self.model}"
+            )
+
+        cmd = [python_bin, script, "--device", str(self.cfg.get("device", "cpu"))]
+        weights = self.cfg.get("weights_path")
+        if weights:
+            cmd += ["--weights", os.path.expanduser(os.path.expandvars(weights))]
+        # OCSRGlyph sets its own torch thread count and would ignore the environment,
+        # so it takes the cap on the command line instead.
+        threads = int(self.cfg.get("threads", 4))
+        if self.model == "ocsrglyph":
+            cmd += ["--threads", str(threads)]
+
+        log_dir = os.path.expanduser("~/.chemgraph/ocsr_logs")
+        os.makedirs(log_dir, exist_ok=True)
+        # A real logfile, never DEVNULL: a worker that dies during import writes its
+        # traceback to stderr, and without this the parent only sees a timeout.
+        #
+        # Truncate at spawn if it has grown past the cap. This bounds what a chatty
+        # worker accumulates across sessions; it does not stop one already running,
+        # which would need the parent to relay every line. The log exists only to
+        # recover an import traceback, so a few MB is ample.
+        log_path = os.path.join(log_dir, f"{self.model}.log")
+        with contextlib.suppress(OSError):
+            if os.path.getsize(log_path) > _MAX_LOG_BYTES:
+                os.truncate(log_path, 0)
+        self._log_fh = open(log_path, "a")
+
+        env = {
+            **os.environ,
+            # The worker envs are conda envs, not venvs, so ~/.local/lib/pythonX.Y
+            # takes priority over their own site-packages. That silently broke
+            # MolScribe once: a user-site torch shadowed the env's and torchvision
+            # failed to import inside the subprocess, where nobody could see it.
+            "PYTHONNOUSERSITE": "1",
+            # Four workers at library defaults is 224 threads on a 104-core shared
+            # machine. Cap them.
+            "OMP_NUM_THREADS": str(threads),
+            "MKL_NUM_THREADS": str(threads),
+            "OPENBLAS_NUM_THREADS": str(threads),
+            "TF_NUM_INTRAOP_THREADS": str(threads),
+        }
+
+        logger.info("starting OCSR worker %s (first call loads the model)", self.model)
+        # stdout is deliberately NOT text-wrapped: _read_until does its own framing
+        # with os.read, and a TextIOWrapper in front of it would hide bytes from the
+        # selector. stdin is wrapped for convenience since we only ever write to it.
+        self.proc = subprocess.Popen(
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=self._log_fh, bufsize=0, env=env,
+            preexec_fn=_die_with_parent,
+        )
+        self.stdin = io.TextIOWrapper(self.proc.stdin, encoding="utf-8", write_through=True)
+        timeout = float(self.cfg.get("startup_timeout_s", DEFAULT_STARTUP_TIMEOUT_S))
+        try:
+            msg = self._read_until("ready", timeout)
+        except BaseException:
+            # A worker that never says `ready` is not registered with the client, so
+            # nothing downstream would ever reap it. Left alone that leaks a ~2 GB
+            # process per failed startup, outliving the interpreter.
+            self.close()
+            raise
+        logger.info("OCSR worker %s ready in %.1fs", self.model, msg.get("load_s", 0.0))
+
+    def alive(self) -> bool:
+        return self.proc is not None and self.proc.poll() is None
+
+    def close(self) -> None:
+        """Ask the worker to quit, then insist.
+
+        The escalation is not defensive padding. A TensorFlow worker can take well
+        over ten seconds to unwind after acknowledging `quit`, so a bare `wait()`
+        either hangs the caller or, if the caller gives up first, leaks a multi-
+        gigabyte process.
+        """
+        if self.proc is None:
+            return
+        try:
+            if self.proc.poll() is None:
+                with contextlib.suppress(Exception):
+                    self.stdin.write(json.dumps({"cmd": "quit"}) + "\n")
+                    self.stdin.flush()
+                try:
+                    self.proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self.proc.terminate()
+                    try:
+                        self.proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        self.proc.kill()
+        finally:
+            if self._log_fh is not None:
+                with contextlib.suppress(Exception):
+                    self._log_fh.close()
+                self._log_fh = None
+            self.proc = None
+
+    # -- protocol ----------------------------------------------------------
+
+    def _read_until(self, event: str, timeout_s: float, req_id: str | None = None) -> dict:
+        """Read protocol lines until `event` arrives, honouring a real deadline.
+
+        Two failure modes have to be handled at once, and fixing one naively breaks
+        the other.
+
+        The benchmark's version looped `while time.monotonic() < deadline:` around a
+        bare `readline()`, which blocks indefinitely on a pipe. The deadline was only
+        consulted *between* lines, so a worker that went quiet hung the caller for
+        ever. That never surfaced there because the failures seen were crashes, where
+        EOF makes `readline` return immediately.
+
+        The obvious fix, selecting on the pipe before each `readline()`, is also
+        wrong: it selects on the *file descriptor* while reading through a buffered
+        `TextIOWrapper`. When a worker emits chatter and its result in one write, both
+        land in the buffer on the first read, the fd then has nothing left, and select
+        blocks until the deadline with the answer already in hand. MolNexTR does
+        exactly this (it prints `chiral_center_ids` before its result), so the bug
+        would have hit a real model while passing every test on DECIMER, whose stdout
+        is clean.
+
+        So: no buffered reader. Read raw bytes with `os.read` and split lines here,
+        keeping a leftover buffer across iterations. Non-protocol lines are skipped;
+        the models print to stdout despite the worker's redirection.
+        """
+        fd = self.proc.stdout.fileno()
+        sel = selectors.DefaultSelector()
+        sel.register(fd, selectors.EVENT_READ)
+        deadline = time.monotonic() + timeout_s
+        pending: list[str] = []
+        try:
+            while True:
+                while pending:
+                    line = pending.pop(0)
+                    try:
+                        msg = json.loads(line)
+                    except (ValueError, TypeError):
+                        continue
+                    if not isinstance(msg, dict):
+                        continue
+                    if msg.get("event") == "error":
+                        raise WorkerError(
+                            f"{self.model}: {msg.get('error', 'unknown error')}"
+                        )
+                    if msg.get("event") == event and (
+                        req_id is None or msg.get("id") == req_id
+                    ):
+                        return msg
+
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise WorkerError(
+                        f"{self.model} did not send {event!r} within {timeout_s:.0f}s "
+                        f"(see ~/.chemgraph/ocsr_logs/{self.model}.log)"
+                    )
+                if not sel.select(timeout=remaining):
+                    continue
+                chunk = os.read(fd, 65536)
+                if not chunk:
+                    raise WorkerError(
+                        f"{self.model} exited while waiting for {event!r} "
+                        f"(see ~/.chemgraph/ocsr_logs/{self.model}.log)"
+                    )
+                self._buf += chunk.decode("utf-8", errors="replace")
+                *complete, self._buf = self._buf.split("\n")
+                if len(self._buf) > _MAX_LINE_BYTES:
+                    raise WorkerError(
+                        f"{self.model} sent {len(self._buf)} bytes with no newline; "
+                        f"the protocol is line-based, so this worker is not speaking it"
+                    )
+                pending.extend(complete)
+        finally:
+            sel.close()
+
+    def infer(self, req_id: str, image_path: str, timeout_s: float) -> dict:
+        """Send one image, return the worker's raw result dict."""
+        if not self.alive():
+            raise WorkerError(f"{self.model} is not running")
+        self.stdin.write(
+            json.dumps({"cmd": "infer", "id": req_id, "image_path": image_path}) + "\n"
+        )
+        self.stdin.flush()
+        self.last_used = time.monotonic()
+        try:
+            return self._read_until("result", timeout_s, req_id=req_id)
+        finally:
+            # Stamp on completion too, not only on send: a long inference should
+            # count as "used" when it finishes, or the reaper sees a stale timestamp
+            # the moment the call returns.
+            self.last_used = time.monotonic()
+
+
+class OCSRWorkerClient:
+    """Keeps one worker per model alive, and reaps them when idle."""
+
+    def __init__(self, config: dict, idle_timeout_s: float = DEFAULT_IDLE_TIMEOUT_S):
+        self.config = config
+        self.idle_timeout_s = idle_timeout_s
+        self._workers: dict[str, _Worker] = {}
+        self._spawn_lock = threading.Lock()
+        self._tmp_dir = tempfile.mkdtemp(prefix="chemgraph_ocsr_")
+        os.chmod(self._tmp_dir, 0o700)
+        atexit.register(self.close)
+
+    def _get(self, model: str) -> _Worker:
+        with self._spawn_lock:
+            self._reap_idle()
+            w = self._workers.get(model)
+            if w is not None and w.alive():
+                return w
+            if model not in self.config:
+                raise WorkerError(
+                    f"no configuration for {model!r}. Known: {sorted(self.config)}"
+                )
+            w = _Worker(model, self.config[model])
+            w.start()
+            self._workers[model] = w
+            return w
+
+    def _reap_idle(self) -> None:
+        """Close workers that have gone unused. Never one that is mid-inference.
+
+        ``last_used`` is stamped when a request is *sent*, so a call that runs longer
+        than the idle timeout would otherwise look idle and be closed out from under
+        itself. The per-worker lock is the authority on whether one is busy: take it
+        without blocking, and skip the worker if we cannot.
+        """
+        now = time.monotonic()
+        for name, w in list(self._workers.items()):
+            if not (w.alive() and (now - w.last_used) > self.idle_timeout_s):
+                continue
+            if not w.lock.acquire(blocking=False):
+                continue  # in flight, and its own timeout governs it
+            try:
+                logger.info("closing idle OCSR worker %s", name)
+                w.close()
+                self._workers.pop(name, None)
+            finally:
+                w.lock.release()
+
+    def predict(self, model: str, image_bytes: bytes, timeout_s: float | None = None) -> dict:
+        """Run one image through one model. Never raises.
+
+        Takes bytes rather than a path so the file the worker opens is the one the
+        caller validated, closing the window where a path could be swapped in
+        between. The protocol needs a filename, so the bytes are written to a
+        private temp file for the duration of the call.
+
+        Returns ``{"ok", "smiles", "error", "infer_s", "cold_start"}``.
+        """
+        cfg = self.config.get(model, {})
+        if timeout_s is None:
+            timeout_s = float(cfg.get("timeout_s", DEFAULT_INFER_TIMEOUT_S))
+
+        was_running = model in self._workers and self._workers[model].alive()
+        path = os.path.join(self._tmp_dir, f"{model}_{os.getpid()}_{time.monotonic_ns()}.png")
+        t0 = time.monotonic()
+        try:
+            with open(path, "wb") as fh:
+                fh.write(image_bytes)
+            worker = self._get(model)
+            with worker.lock:
+                msg = worker.infer(str(time.monotonic_ns()), path, timeout_s)
+            return {
+                "ok": bool(msg.get("ok")),
+                "smiles": msg.get("smiles"),
+                "error": msg.get("error", "") or "",
+                "infer_s": float(msg.get("infer_s", 0.0)),
+                "cold_start": not was_running,
+            }
+        except BaseException as e:
+            # BaseException, not Exception: a KeyboardInterrupt during a 60 s model
+            # load must still tear the worker down rather than leave it orphaned.
+            self._drop(model)
+            if isinstance(e, KeyboardInterrupt):
+                raise
+            return {"ok": False, "smiles": None, "error": f"{type(e).__name__}: {e}",
+                    "infer_s": time.monotonic() - t0, "cold_start": not was_running}
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(path)
+
+    def _drop(self, model: str) -> None:
+        w = self._workers.pop(model, None)
+        if w is not None:
+            with contextlib.suppress(Exception):
+                w.close()
+
+    def close(self) -> None:
+        for name in list(self._workers):
+            self._drop(name)
+        with contextlib.suppress(Exception):
+            import shutil
+
+            shutil.rmtree(self._tmp_dir, ignore_errors=True)

--- a/src/chemgraph/tools/ocsr_workers/__init__.py
+++ b/src/chemgraph/tools/ocsr_workers/__init__.py
@@ -1,0 +1,16 @@
+"""Specialist OCSR worker processes and the scripts that build their environments.
+
+Each worker is a standalone script run by its OWN Python interpreter, not this one.
+The four models have mutually incompatible requirements (four Python versions, and a
+numpy<2 pin for MolScribe against ChemGraph's numpy 2.x), so each lives in its own
+conda environment and is driven over a JSON line protocol on stdin/stdout. See
+:mod:`chemgraph.tools.ocsr_worker_client` for the parent side.
+
+Nothing here is imported by ChemGraph. The `*_infer.py` files are package data that
+happens to be Python: they are executed as `<their-env-python> <path> --device cpu`,
+and importing one into this interpreter would fail on the missing torch or TensorFlow.
+
+The `build_*.sh` scripts create those environments and fetch weights. They are not run
+automatically; installing 17.7 GB across four Python versions is a decision the user
+makes once, explicitly. See `examples/ocsr/README.md`.
+"""

--- a/src/chemgraph/tools/ocsr_workers/_protocol.py
+++ b/src/chemgraph/tools/ocsr_workers/_protocol.py
@@ -1,0 +1,148 @@
+"""Shared line-protocol helpers for the local OCSR specialist workers.
+
+STDLIB ONLY. This module is imported by worker scripts that run inside each
+model's own conda env (MolNexTR: py3.8; MolScribe/DECIMER: py3.10), so it must
+not depend on anything outside the standard library.
+
+Protocol (one JSON object per line, ``\\n``-terminated, UTF-8):
+
+  worker -> client, once at startup:
+      {"event": "ready", "model": "...", "backend": "xpu|cuda|cpu", "load_s": 1.2}
+  client -> worker, one per image:
+      {"cmd": "infer", "id": "gen_000001", "image_path": "/tmp/....png"}
+  worker -> client, one response per request (same id echoed):
+      {"event": "result", "id": "gen_000001", "smiles": "CCO", "ok": true,
+       "infer_s": 0.4}
+      {"event": "result", "id": "gen_000001", "smiles": null, "ok": false,
+       "error": "..."}
+  client -> worker, to shut down:
+      {"cmd": "quit"}
+
+The single hard rule for a worker: **stdout carries ONLY protocol lines**. Any
+model/library chatter must go to stderr, or it corrupts the stream. Use
+``redirect_c_stdout_to_stderr`` around model load, and emit all protocol lines
+via ``emit`` (which writes to the saved real stdout and flushes).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, Iterator, Optional
+
+
+# The real stdout fd is captured at import time so protocol lines always reach
+# the client even after we redirect Python-level sys.stdout during model load.
+_REAL_STDOUT_FD = os.dup(1)
+_real_stdout = os.fdopen(_REAL_STDOUT_FD, "w", buffering=1, encoding="utf-8")
+
+
+def emit(obj: Dict[str, Any]) -> None:
+    """Write one protocol JSON object to the real stdout and flush."""
+    _real_stdout.write(json.dumps(obj) + "\n")
+    _real_stdout.flush()
+
+
+def emit_ready(model: str, backend: str, load_s: float) -> None:
+    emit({"event": "ready", "model": model, "backend": backend, "load_s": round(load_s, 3)})
+
+
+def emit_result(
+    item_id: str,
+    smiles: Optional[str],
+    ok: bool,
+    infer_s: float = 0.0,
+    error: str = "",
+) -> None:
+    rec: Dict[str, Any] = {
+        "event": "result",
+        "id": item_id,
+        "smiles": smiles,
+        "ok": bool(ok),
+        "infer_s": round(infer_s, 4),
+    }
+    if error:
+        rec["error"] = str(error)[:500]
+    emit(rec)
+
+
+@contextlib.contextmanager
+def redirect_c_stdout_to_stderr() -> Iterator[None]:
+    """Redirect BOTH Python- and C-level stdout to stderr for the block.
+
+    Model loads (torch/TF) print banners at the C level that ``sys.stdout``
+    reassignment alone cannot capture; we dup stderr onto fd 1 so nothing lands
+    on the protocol stream. The real stdout stays available via ``emit`` (it
+    writes through the fd saved at import, not fd 1).
+    """
+    sys.stdout.flush()
+    saved_fd = os.dup(1)
+    try:
+        os.dup2(2, 1)  # fd 1 (stdout) -> fd 2 (stderr)
+        old_py_stdout = sys.stdout
+        sys.stdout = sys.stderr
+        try:
+            yield
+        finally:
+            sys.stdout = old_py_stdout
+    finally:
+        sys.stdout.flush()
+        os.dup2(saved_fd, 1)
+        os.close(saved_fd)
+
+
+def log(msg: str) -> None:
+    """Diagnostic line -> stderr (captured to the per-worker logfile)."""
+    print(f"[worker] {msg}", file=sys.stderr, flush=True)
+
+
+def serve(model_name: str, infer_fn: Callable[[str], Optional[str]]) -> int:
+    """Run the request loop until EOF or a ``quit`` command.
+
+    ``infer_fn`` takes an image path and returns a SMILES string (or None). It
+    MUST NOT be responsible for protocol I/O; this loop handles reading requests
+    and emitting results, and it never lets a per-image exception kill the loop.
+    Returns a process exit code.
+    """
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except Exception:
+            log(f"ignoring non-JSON request line: {line[:120]!r}")
+            continue
+
+        cmd = req.get("cmd")
+        if cmd == "quit":
+            log("received quit")
+            return 0
+        if cmd != "infer":
+            log(f"unknown cmd: {cmd!r}")
+            continue
+
+        item_id = req.get("id", "")
+        image_path = req.get("image_path", "")
+        start = time.monotonic()
+        try:
+            smiles = infer_fn(image_path)
+            emit_result(
+                item_id,
+                smiles or None,
+                ok=bool(smiles),
+                infer_s=time.monotonic() - start,
+                error="" if smiles else "empty prediction",
+            )
+        except Exception as e:  # one bad image must not kill the worker
+            emit_result(
+                item_id,
+                None,
+                ok=False,
+                infer_s=time.monotonic() - start,
+                error=f"{type(e).__name__}: {e}",
+            )
+    return 0

--- a/src/chemgraph/tools/ocsr_workers/build_decimer.sh
+++ b/src/chemgraph/tools/ocsr_workers/build_decimer.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Build the DECIMER conda env + pre-fetch Zenodo weights (Aurora UAN or any host with conda).
+# DECIMER is TensorFlow-based (py3.10). CPU by default (Aurora GPUs are Intel).
+set -eo pipefail
+
+# --- host setup -------------------------------------------------------------
+# Written for and tested on an ALCF Aurora UAN node, where conda comes from a
+# module and outbound traffic needs the site proxy. Every line is guarded so the
+# script also runs on an ordinary machine that already has conda on PATH.
+#
+# The proxy guard matters more than it looks: proxy.alcf.anl.gov is reachable
+# only from inside ANL, so exporting it elsewhere makes every pip and
+# HuggingFace fetch HANG rather than fail.
+[ -f /usr/share/lmod/lmod/init/bash ] && source /usr/share/lmod/lmod/init/bash >/dev/null 2>&1
+if type module >/dev/null 2>&1; then
+  module load oneapi/release/2025.3.1 >/dev/null 2>&1 || true
+  module load miniforge3/25.11.0-1 >/dev/null 2>&1 || true
+fi
+case "$(hostname -f 2>/dev/null)" in
+  *.alcf.anl.gov)
+    export https_proxy=http://proxy.alcf.anl.gov:3128
+    export http_proxy=http://proxy.alcf.anl.gov:3128
+    export no_proxy=localhost,127.0.0.1
+    ;;
+esac
+command -v conda >/dev/null 2>&1 || {
+  echo "conda not found. Install miniforge (https://github.com/conda-forge/miniforge)" >&2
+  echo "or load your site's conda module, then re-run this script." >&2
+  exit 1
+}
+# ----------------------------------------------------------------------------
+
+ENV=$HOME/ocsr-decimer
+PY=$ENV/bin/python
+
+# An interrupted build leaves a half-populated env that the "is python present?"
+# guard below would then treat as complete, so the next run skips straight to
+# inference and fails somewhere far less legible. Remove it on failure, but only if
+# this run is the one that created it.
+_ocsr_created_env=0
+_ocsr_build_cleanup() {
+  if [ "$_ocsr_created_env" = "1" ]; then
+    echo "[decimer] build interrupted; removing the incomplete env $ENV" >&2
+    rm -rf "$ENV"
+  fi
+}
+trap _ocsr_build_cleanup ERR INT TERM
+
+echo "[decimer] === create env (py3.10) ==="
+if [ ! -x "$PY" ]; then
+  _ocsr_created_env=1
+  conda create -p "$ENV" python=3.10 -y
+fi
+
+echo "[decimer] === pip install decimer (pulls tensorflow) ==="
+"$PY" -m pip install --quiet --upgrade pip
+"$PY" -m pip install --quiet decimer
+
+echo "[decimer] === warm-up: pre-download Zenodo weights ==="
+# First predict_SMILES() downloads the model into ~/.data/DECIMER-V2. Do it here
+# on the UAN node (with proxy) so the benchmark never pays the download.
+# Render a trivial molecule image to feed the warm-up call.
+"$PY" - <<'PYEOF'
+import os, tempfile
+# Make a tiny PNG with PIL (DECIMER pulls pillow); content need not be a real molecule
+# for the download to happen, but a blank image is enough to trigger model build.
+from PIL import Image
+img = Image.new("RGB", (224, 224), "white")
+fd, path = tempfile.mkstemp(suffix=".png"); os.close(fd)
+img.save(path)
+print("warming up DECIMER (downloads weights on first call)...")
+from DECIMER import predict_SMILES
+smi = predict_SMILES(path)
+print("warmup prediction:", repr(smi))
+os.unlink(path)
+PYEOF
+
+echo "[decimer] === verify ==="
+ls -la "$HOME/.data/DECIMER-V2" 2>/dev/null | head || echo "[decimer] NOTE: weights dir not at ~/.data/DECIMER-V2 (check DECIMER default cache)"
+echo "[decimer] DONE"
+
+trap - ERR INT TERM

--- a/src/chemgraph/tools/ocsr_workers/build_molnextr.sh
+++ b/src/chemgraph/tools/ocsr_workers/build_molnextr.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Build the MolNexTR conda env + download weights (Aurora UAN or any host with conda).
+# MolNexTR pins old deps (OpenNMT-py==2.2.0, timm==0.4.12, albumentations==1.1.0)
+# that want py3.8 + an older torch. CPU-only (Aurora GPUs are Intel, not CUDA).
+set -eo pipefail
+
+# --- host setup -------------------------------------------------------------
+# Written for and tested on an ALCF Aurora UAN node, where conda comes from a
+# module and outbound traffic needs the site proxy. Every line is guarded so the
+# script also runs on an ordinary machine that already has conda on PATH.
+#
+# The proxy guard matters more than it looks: proxy.alcf.anl.gov is reachable
+# only from inside ANL, so exporting it elsewhere makes every pip and
+# HuggingFace fetch HANG rather than fail.
+[ -f /usr/share/lmod/lmod/init/bash ] && source /usr/share/lmod/lmod/init/bash >/dev/null 2>&1
+if type module >/dev/null 2>&1; then
+  module load oneapi/release/2025.3.1 >/dev/null 2>&1 || true
+  module load miniforge3/25.11.0-1 >/dev/null 2>&1 || true
+fi
+case "$(hostname -f 2>/dev/null)" in
+  *.alcf.anl.gov)
+    export https_proxy=http://proxy.alcf.anl.gov:3128
+    export http_proxy=http://proxy.alcf.anl.gov:3128
+    export no_proxy=localhost,127.0.0.1
+    ;;
+esac
+command -v conda >/dev/null 2>&1 || {
+  echo "conda not found. Install miniforge (https://github.com/conda-forge/miniforge)" >&2
+  echo "or load your site's conda module, then re-run this script." >&2
+  exit 1
+}
+# ----------------------------------------------------------------------------
+
+ENV=$HOME/ocsr-molnextr
+SRC=$HOME/opt/MolNexTR
+WDIR=$HOME/ocsr-weights/molnextr
+PY=$ENV/bin/python
+
+# An interrupted build leaves a half-populated env that the "is python present?"
+# guard below would then treat as complete, so the next run skips straight to
+# inference and fails somewhere far less legible. Remove it on failure, but only if
+# this run is the one that created it.
+_ocsr_created_env=0
+_ocsr_build_cleanup() {
+  if [ "$_ocsr_created_env" = "1" ]; then
+    echo "[molnextr] build interrupted; removing the incomplete env $ENV" >&2
+    rm -rf "$ENV"
+  fi
+}
+trap _ocsr_build_cleanup ERR INT TERM
+
+echo "[molnextr] === create env (py3.8) ==="
+if [ ! -x "$PY" ]; then
+  _ocsr_created_env=1
+  conda create -p "$ENV" python=3.8 -y
+fi
+
+echo "[molnextr] === clone repo (pinned commit) ==="
+if [ ! -d "$SRC/.git" ]; then
+  git clone https://github.com/CYF2000127/MolNexTR "$SRC"
+fi
+# Pinned so a rebuild reproduces the accuracy this model is documented with (83.5%
+# exact). An unpinned clone would silently track upstream main, and a changed
+# prediction does not raise, it just moves the number.
+git -C "$SRC" checkout -q 6f6502b4ed9733dba8b1ee45d2da474576683194
+
+echo "[molnextr] === pip install (CPU torch + pinned deps) ==="
+"$PY" -m pip install --quiet --upgrade "pip<24" setuptools wheel
+# torch 1.12.1 CPU: last line that plays well with OpenNMT-py 2.2.0 / timm 0.4.12 on py3.8.
+"$PY" -m pip install --quiet torch==1.12.1 torchvision==0.13.1 --index-url https://download.pytorch.org/whl/cpu
+# Repo requirements (pinned versions inside requirements.txt).
+"$PY" -m pip install --quiet -r "$SRC/requirements.txt"
+# Install the package itself so `import MolNexTR` works.
+"$PY" -m pip install --quiet -e "$SRC" || echo "[molnextr] WARN: pip install -e failed; will import from repo dir via PYTHONPATH"
+# huggingface_hub for the weights download (not a repo dep).
+"$PY" -m pip install --quiet huggingface_hub
+# CRITICAL (same lesson as MolScribe): torch 1.12 + rdkit are numpy-1.x builds;
+# numpy 2.x makes torch.from_numpy raise "Numpy is not available". Force numpy<2
+# as the LAST pip step so nothing pulls numpy 2 back in.
+"$PY" -m pip install --quiet "numpy<2"
+
+echo "[molnextr] === download weights (1.13 GB) ==="
+mkdir -p "$WDIR"
+"$PY" - <<PYEOF
+from huggingface_hub import hf_hub_download
+p = hf_hub_download('CYF200127/MolNexTR', 'molnextr_best.pth',
+                    repo_type='dataset', local_dir='$WDIR')
+print('weights ->', p)
+PYEOF
+
+echo "[molnextr] === verify import ==="
+PYTHONPATH="$SRC:$PYTHONPATH" "$PY" -c "import torch; import MolNexTR; print('MolNexTR import OK, torch', torch.__version__)" \
+  || echo "[molnextr] WARN: import check failed; inspect worker import path"
+echo "[molnextr] DONE"
+
+trap - ERR INT TERM

--- a/src/chemgraph/tools/ocsr_workers/build_molscribe.sh
+++ b/src/chemgraph/tools/ocsr_workers/build_molscribe.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Build the MolScribe conda env + download weights (Aurora UAN or any host with conda).
+# Self-contained: loads the module chain + proxy every run (module state does
+# not persist across shells). Idempotent-ish: skips env create if it exists.
+set -eo pipefail
+
+# --- host setup -------------------------------------------------------------
+# Written for and tested on an ALCF Aurora UAN node, where conda comes from a
+# module and outbound traffic needs the site proxy. Every line is guarded so the
+# script also runs on an ordinary machine that already has conda on PATH.
+#
+# The proxy guard matters more than it looks: proxy.alcf.anl.gov is reachable
+# only from inside ANL, so exporting it elsewhere makes every pip and
+# HuggingFace fetch HANG rather than fail.
+[ -f /usr/share/lmod/lmod/init/bash ] && source /usr/share/lmod/lmod/init/bash >/dev/null 2>&1
+if type module >/dev/null 2>&1; then
+  module load oneapi/release/2025.3.1 >/dev/null 2>&1 || true
+  module load miniforge3/25.11.0-1 >/dev/null 2>&1 || true
+fi
+case "$(hostname -f 2>/dev/null)" in
+  *.alcf.anl.gov)
+    export https_proxy=http://proxy.alcf.anl.gov:3128
+    export http_proxy=http://proxy.alcf.anl.gov:3128
+    export no_proxy=localhost,127.0.0.1
+    ;;
+esac
+command -v conda >/dev/null 2>&1 || {
+  echo "conda not found. Install miniforge (https://github.com/conda-forge/miniforge)" >&2
+  echo "or load your site's conda module, then re-run this script." >&2
+  exit 1
+}
+# ----------------------------------------------------------------------------
+
+ENV=$HOME/ocsr-molscribe
+WDIR=$HOME/ocsr-weights/molscribe
+PY=$ENV/bin/python
+
+# An interrupted build leaves a half-populated env that the "is python present?"
+# guard below would then treat as complete, so the next run skips straight to
+# inference and fails somewhere far less legible. Remove it on failure, but only if
+# this run is the one that created it.
+_ocsr_created_env=0
+_ocsr_build_cleanup() {
+  if [ "$_ocsr_created_env" = "1" ]; then
+    echo "[molscribe] build interrupted; removing the incomplete env $ENV" >&2
+    rm -rf "$ENV"
+  fi
+}
+trap _ocsr_build_cleanup ERR INT TERM
+
+echo "[molscribe] === create env (py3.10) ==="
+if [ ! -x "$PY" ]; then
+  _ocsr_created_env=1
+  conda create -p "$ENV" python=3.10 -y
+fi
+
+echo "[molscribe] === pip install (torch + MolScribe) ==="
+"$PY" -m pip install --quiet --upgrade pip
+"$PY" -m pip install --quiet MolScribe
+# MolScribe pulls a CUDA torch build; it runs on CPU fine (cuda.is_available()=False
+# on Aurora's Intel GPUs). huggingface_hub is needed for the weights download but
+# is not a MolScribe dependency, so add it explicitly.
+"$PY" -m pip install --quiet huggingface_hub
+# CRITICAL: torch/rdkit here are compiled against numpy 1.x. numpy 2.x makes
+# torch.from_numpy raise "Numpy is not available" at inference time. opencv>=4.11
+# drags numpy 2 back in, so pin opencv 4.10 (last that accepts numpy<2) and force
+# numpy 1.26. Order matters: this MUST be the last pip step.
+"$PY" -m pip install --quiet "opencv-python==4.10.0.84" "opencv-python-headless==4.10.0.84" "numpy==1.26.4"
+
+echo "[molscribe] === download weights ==="
+mkdir -p "$WDIR"
+"$PY" - <<PYEOF
+from huggingface_hub import hf_hub_download
+p = hf_hub_download('yujieq/MolScribe', 'swin_base_char_aux_1m.pth', local_dir='$WDIR')
+print('weights ->', p)
+PYEOF
+
+echo "[molscribe] === verify import ==="
+"$PY" -c "import torch, molscribe; print('molscribe import OK, torch', torch.__version__)"
+echo "[molscribe] DONE"
+
+trap - ERR INT TERM

--- a/src/chemgraph/tools/ocsr_workers/build_ocsrglyph.sh
+++ b/src/chemgraph/tools/ocsr_workers/build_ocsrglyph.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Build the OCSRGlyph conda env + download weights (Aurora UAN or any host with conda).
+# Self-contained: loads the module chain + proxy every run (module state does
+# not persist across shells). Idempotent: skips env create, clone, and the
+# weights download if they already exist.
+set -eo pipefail
+
+# --- host setup -------------------------------------------------------------
+# Written for and tested on an ALCF Aurora UAN node, where conda comes from a
+# module and outbound traffic needs the site proxy. Every line is guarded so the
+# script also runs on an ordinary machine that already has conda on PATH.
+#
+# The proxy guard matters more than it looks: proxy.alcf.anl.gov is reachable
+# only from inside ANL, so exporting it elsewhere makes every pip and
+# HuggingFace fetch HANG rather than fail.
+[ -f /usr/share/lmod/lmod/init/bash ] && source /usr/share/lmod/lmod/init/bash >/dev/null 2>&1
+if type module >/dev/null 2>&1; then
+  module load oneapi/release/2025.3.1 >/dev/null 2>&1 || true
+  module load miniforge3/25.11.0-1 >/dev/null 2>&1 || true
+fi
+case "$(hostname -f 2>/dev/null)" in
+  *.alcf.anl.gov)
+    export https_proxy=http://proxy.alcf.anl.gov:3128
+    export http_proxy=http://proxy.alcf.anl.gov:3128
+    export no_proxy=localhost,127.0.0.1
+    ;;
+esac
+command -v conda >/dev/null 2>&1 || {
+  echo "conda not found. Install miniforge (https://github.com/conda-forge/miniforge)" >&2
+  echo "or load your site's conda module, then re-run this script." >&2
+  exit 1
+}
+# ----------------------------------------------------------------------------
+# Keep ~/.local/lib/pythonX.Y/site-packages off sys.path so a stray user-site
+# install can never shadow this env's torch.
+export PYTHONNOUSERSITE=1
+
+ENV=$HOME/ocsr-glyph
+SRC=$HOME/opt/glyph
+WDIR=$HOME/ocsr-weights/ocsrglyph
+PY=$ENV/bin/python
+
+# An interrupted build leaves a half-populated env that the "is python present?"
+# guard below would then treat as complete, so the next run skips straight to
+# inference and fails somewhere far less legible. Remove it on failure, but only if
+# this run is the one that created it.
+_ocsr_created_env=0
+_ocsr_build_cleanup() {
+  if [ "$_ocsr_created_env" = "1" ]; then
+    echo "[ocsrglyph] build interrupted; removing the incomplete env $ENV" >&2
+    rm -rf "$ENV"
+  fi
+}
+trap _ocsr_build_cleanup ERR INT TERM
+
+echo "[ocsrglyph] === create env (py3.11) ==="
+# py3.11: glyph's pyproject sets requires-python >=3.11.
+if [ ! -x "$PY" ]; then
+  _ocsr_created_env=1
+  conda create -p "$ENV" python=3.11 -y
+fi
+"$PY" -m pip install --quiet --upgrade pip
+
+echo "[ocsrglyph] === pip install CPU torch + torchvision (ordering matters) ==="
+# CRITICAL ORDERING: torch AND torchvision together from the CPU index FIRST.
+# timm depends on torchvision; if torchvision is absent when timm installs, pip
+# pulls it from PyPI and drags in torch 2.13+cu130 plus ~15 nvidia-* CUDA
+# packages (verified failure mode, not hypothetical). Aurora GPUs are Intel, so
+# a CUDA torch is pure bloat here.
+"$PY" -m pip install --quiet torch==2.9.1 torchvision==0.24.1 \
+    --index-url https://download.pytorch.org/whl/cpu
+
+echo "[ocsrglyph] === pip install glyph runtime deps ==="
+"$PY" -m pip install --quiet "timm>=1.0" "rdkit>=2024.3.1" "SmilesPE>=0.0.3" \
+    "pyarrow>=15.0" "Pillow>=10.3" "PyYAML>=6.0" "tqdm>=4.66" \
+    "huggingface-hub>=0.24" "typer>=0.20"
+
+echo "[ocsrglyph] === clone + install glyph (pinned commit) ==="
+if [ ! -d "$SRC/.git" ]; then
+  git clone https://github.com/EdisonScientific/glyph "$SRC"
+fi
+git -C "$SRC" checkout -q 0bf782f863d26b041ace157668928ef07c38b972
+# --no-deps: deps are installed above with the CPU torch already pinned in
+# place; letting pip resolve the pyproject here would re-open the CUDA trap.
+"$PY" -m pip install --quiet --no-deps -e "$SRC"
+
+echo "[ocsrglyph] === guard: no CUDA packages ==="
+# Guard: the ordering trap above must not have fired.
+if "$PY" -m pip list 2>/dev/null | grep -qi nvidia; then
+  echo "ERROR: nvidia-* packages present; torch install order was wrong" >&2
+  exit 1
+fi
+
+echo "[ocsrglyph] === download weights (357 MB) ==="
+mkdir -p "$WDIR"
+if [ -f "$WDIR/model.pth" ]; then
+  echo "[ocsrglyph] weights already present -> $WDIR/model.pth (skipping)"
+else
+  "$PY" - <<PYEOF
+from huggingface_hub import hf_hub_download
+p = hf_hub_download('EdisonScientific/OCSRGlyph', 'model.pth', local_dir='$WDIR')
+print('weights ->', p)
+PYEOF
+fi
+
+echo "[ocsrglyph] === verify import ==="
+"$PY" -c "import torch, timm; from glyph.ocsr.predict import OCSRPredictor; print('OK', torch.__version__, timm.__version__)"
+echo "[ocsrglyph] DONE"
+
+trap - ERR INT TERM

--- a/src/chemgraph/tools/ocsr_workers/decimer_infer.py
+++ b/src/chemgraph/tools/ocsr_workers/decimer_infer.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""DECIMER OCSR worker, run INSIDE the DECIMER conda env (py3.10 + tensorflow).
+
+Loads the DECIMER model once (first call triggers the Zenodo weight download if
+not cached), then serves image->SMILES requests over the line protocol in
+``_protocol.py``. Launched as a subprocess by
+``chemgraph.tools.ocsr_worker_client``; never imported by ChemGraph itself.
+
+    python decimer_infer.py [--weights /path/DECIMER-V2] [--device auto]
+
+Model API (per the DECIMER repo):
+    from DECIMER import predict_SMILES
+    smiles = predict_SMILES(image_path)
+
+Weights auto-download to ~/.data/DECIMER-V2 on first use. ``--weights`` is
+advisory: if given, it is exported as the DECIMER data dir so a pre-fetched
+cache is reused instead of re-downloading (helpful on egress-less compute nodes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _protocol as P  # noqa: E402
+
+
+def _select_backend(want: str) -> str:
+    """Best-effort TF device selection; CPU is the safe default on Aurora.
+
+    TF picks GPUs automatically when a compatible plugin is present. When the
+    caller asks for cpu (or no GPU is visible) we hide GPUs so TF stays on CPU.
+    Returns the backend label for the ready line.
+    """
+    want = (want or "auto").lower()
+    if want == "cpu":
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+        return "cpu"
+    try:
+        import tensorflow as tf
+
+        gpus = tf.config.list_physical_devices("GPU")
+        if gpus:
+            return "gpu"
+    except Exception:
+        pass
+    return "cpu"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--weights", default="")
+    ap.add_argument("--device", default="auto")
+    args = ap.parse_args()
+
+    # Point DECIMER at a pre-fetched cache if provided (avoids re-download).
+    if args.weights:
+        parent = os.path.dirname(args.weights.rstrip("/")) or args.weights
+        os.environ.setdefault("DECIMER_DATA_DIR", args.weights)
+        os.environ.setdefault("XDG_DATA_HOME", parent)
+
+    start = time.monotonic()
+    with P.redirect_c_stdout_to_stderr():
+        backend = _select_backend(args.device)
+        from DECIMER import predict_SMILES
+
+        # Warm up so the (slow) model build happens before we report ready.
+        _ = predict_SMILES  # ensure symbol resolved
+    P.emit_ready("decimer", backend, time.monotonic() - start)
+
+    def infer(image_path: str):
+        return predict_SMILES(image_path)
+
+    return P.serve("decimer", infer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chemgraph/tools/ocsr_workers/molnextr_infer.py
+++ b/src/chemgraph/tools/ocsr_workers/molnextr_infer.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+"""MolNexTR OCSR worker, run INSIDE the MolNexTR conda env (py3.8 + torch).
+
+Loads the MolNexTR model once, then serves image->SMILES requests over the line
+protocol in ``_protocol.py``. Launched as a subprocess by
+``chemgraph.tools.ocsr_worker_client``; never imported by ChemGraph itself.
+
+    python molnextr_infer.py --weights /path/molnextr_best.pth [--device auto]
+
+Model API (per the MolNexTR repo, https://github.com/CYF2000127/MolNexTR):
+    from MolNexTR import molnextr
+    model = molnextr(weights_path, device)
+    res = model.predict_final_results(image_path)  # dict with "predicted_smiles"
+
+The exact result key can vary by repo revision; we probe a few likely keys and
+fall back to the module-level ``MolNexTR.get_predictions`` helper if present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _protocol as P  # noqa: E402
+
+# SMILES key candidates seen across MolNexTR revisions / helpers.
+_SMILES_KEYS = ("predicted_smiles", "smiles", "pred_smiles", "SMILES")
+
+
+def _resolve_device(want: str):
+    """Return (torch.device, label). MolNexTR's constructor wants a torch.device.
+
+    Honor the requested device with a safe CPU fallback (Aurora GPUs are Intel,
+    not CUDA).
+    """
+    import torch
+
+    want = (want or "auto").lower()
+    if want == "cpu":
+        return torch.device("cpu"), "cpu"
+    if want in ("cuda", "gpu") and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+    if want in ("xpu", "auto") and getattr(torch, "xpu", None) is not None:
+        try:
+            if torch.xpu.is_available():  # type: ignore[attr-defined]
+                return torch.device("xpu"), "xpu"
+        except Exception:
+            pass
+    if want == "auto" and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+    return torch.device("cpu"), "cpu"
+
+
+def _extract_smiles(res):
+    """Pull a SMILES string out of MolNexTR's prediction result (dict/str/tuple)."""
+    if res is None:
+        return None
+    if isinstance(res, str):
+        return res
+    if isinstance(res, dict):
+        for k in _SMILES_KEYS:
+            if k in res and res[k]:
+                return res[k]
+        return None
+    if isinstance(res, (list, tuple)):
+        for elem in res:
+            smi = _extract_smiles(elem)
+            if smi:
+                return smi
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--weights", required=True)
+    ap.add_argument("--device", default="auto")
+    args = ap.parse_args()
+
+    start = time.monotonic()
+    with P.redirect_c_stdout_to_stderr():
+        import torch  # noqa: F401
+        # The top-level ``MolNexTR.molnextr`` is a SUBMODULE; the model class of
+        # the same name lives inside it. Import the class explicitly.
+        from MolNexTR.molnextr import molnextr as MolNexTRModel
+
+        device, backend = _resolve_device(args.device)
+        # Constructor signature: molnextr(model_path, device=torch.device(...)).
+        model = MolNexTRModel(args.weights, device=device)
+
+    P.emit_ready("molnextr", backend, time.monotonic() - start)
+
+    def infer(image_path: str):
+        res = model.predict_final_results(image_path)
+        return _extract_smiles(res)
+
+    return P.serve("molnextr", infer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chemgraph/tools/ocsr_workers/molscribe_infer.py
+++ b/src/chemgraph/tools/ocsr_workers/molscribe_infer.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""MolScribe OCSR worker, run INSIDE the MolScribe conda env.
+
+Loads the MolScribe model once, then serves image->SMILES requests over the
+line protocol in ``_protocol.py``. Never imported by the bench; launched as a
+subprocess by ``chemgraph.tools.ocsr_worker_client``.
+
+    python molscribe_infer.py --weights /path/swin_base_char_aux_1m.pth [--device auto]
+
+Model API (per the MolScribe repo):
+    from molscribe import MolScribe
+    model = MolScribe(ckpt_path, device=torch.device(dev))
+    out = model.predict_image_file(path)  # -> {"smiles": ..., ...}
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+# _protocol lives next to this file; ensure it's importable regardless of cwd.
+sys.path.insert(0, __import__("os").path.dirname(__import__("os").path.abspath(__file__)))
+import _protocol as P  # noqa: E402
+
+
+def _resolve_device(want: str):
+    """Return a torch.device honoring the requested device with safe fallback."""
+    import torch
+
+    want = (want or "auto").lower()
+    if want == "cpu":
+        return torch.device("cpu"), "cpu"
+    if want in ("cuda", "gpu") and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+    if want in ("xpu", "auto") and getattr(torch, "xpu", None) is not None:
+        try:
+            if torch.xpu.is_available():  # type: ignore[attr-defined]
+                return torch.device("xpu"), "xpu"
+        except Exception:
+            pass
+    if want == "auto" and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+    return torch.device("cpu"), "cpu"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--weights", required=True)
+    ap.add_argument("--device", default="auto")
+    args = ap.parse_args()
+
+    start = time.monotonic()
+    with P.redirect_c_stdout_to_stderr():
+        import torch  # noqa: F401
+        from molscribe import MolScribe
+
+        device, backend = _resolve_device(args.device)
+        model = MolScribe(args.weights, device=device)
+    P.emit_ready("molscribe", backend, time.monotonic() - start)
+
+    def infer(image_path: str):
+        out = model.predict_image_file(image_path)
+        # predict_image_file returns a dict; smiles under "smiles".
+        return (out or {}).get("smiles")
+
+    return P.serve("molscribe", infer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chemgraph/tools/ocsr_workers/ocsrglyph_infer.py
+++ b/src/chemgraph/tools/ocsr_workers/ocsrglyph_infer.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""OCSRGlyph OCSR worker: runs INSIDE the OCSRGlyph conda env (py3.11 + torch).
+
+Loads the OCSRGlyph model once, then serves image->SMILES requests over the
+line protocol in ``_protocol.py``. Never imported by the bench; launched as a
+subprocess by ``chemgraph.tools.ocsr_worker_client``.
+
+    python ocsrglyph_infer.py --weights /path/model.pth [--device auto] [--threads 16]
+
+Model API (per the glyph repo, https://github.com/EdisonScientific/glyph):
+    from glyph.ocsr.predict import OCSRPredictor
+    model = OCSRPredictor(weights_path, device="cpu")
+    smiles = model.predict(image_path)
+
+Two differences from the sibling workers, both verified on this node:
+  * ``device`` is a plain STRING ("cpu"/"cuda"/"xpu"), not a torch.device, so we
+    reuse the usual resolver and hand over ``device.type``.
+  * ``predict`` returns a BARE SMILES STRING, not a dict, so there is no key to
+    dig out (contrast MolScribe's ``{"smiles": ...}``).
+
+``predict`` defaults to ``postprocess=True`` and we deliberately leave it there:
+that default already applies exactly the paper's postprocessing (drop isolated
+``[H]``/``[HH]`` fragments without touching ``[nH]``/``[NH3+]``, then RDKit
+re-canonicalize, falling back to the raw string if it will not parse). Keeping
+the default is what makes our numbers comparable to the published ones; do not
+reimplement it here and do not pass postprocess=False.
+
+Threading: nothing in the bench sets OMP_NUM_THREADS for workers, so the thread
+count is ours to pick. 16 measured fastest on this node (32 was ~25% slower).
+Inference is strictly one image per call: ``predict_batch`` measured 3x SLOWER
+per image, because greedy decoding pads every sequence to the batch's longest.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _protocol as P  # noqa: E402
+
+
+def _resolve_device(want: str):
+    """Return (torch.device, label) honoring the request with a CPU fallback."""
+    import torch
+
+    want = (want or "auto").lower()
+    if want == "cpu":
+        return torch.device("cpu"), "cpu"
+    if want in ("cuda", "gpu") and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+    if want in ("xpu", "auto") and getattr(torch, "xpu", None) is not None:
+        try:
+            if torch.xpu.is_available():  # type: ignore[attr-defined]
+                return torch.device("xpu"), "xpu"
+        except Exception:
+            pass
+    if want == "auto" and torch.cuda.is_available():
+        return torch.device("cuda"), "cuda"
+    return torch.device("cpu"), "cpu"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--weights", required=True)
+    ap.add_argument("--device", default="auto")
+    ap.add_argument("--threads", type=int, default=16,
+                    help="torch intra-op threads (16 measured optimal on Aurora CPU)")
+    args = ap.parse_args()
+
+    start = time.monotonic()
+    with P.redirect_c_stdout_to_stderr():
+        import torch
+        from glyph.ocsr.predict import OCSRPredictor
+
+        if args.threads > 0:
+            torch.set_num_threads(args.threads)
+
+        device, backend = _resolve_device(args.device)
+        # Constructor wants the device as a str, hence ``device.type``.
+        model = OCSRPredictor(args.weights, device=device.type)
+    P.emit_ready("ocsrglyph", backend, time.monotonic() - start)
+
+    def infer(image_path: str):
+        # Returns the SMILES string directly; postprocess=True stays default.
+        # Image prep (RGB convert, 384x384 bilinear, normalize) is internal, and
+        # RGBA vs RGB inputs were verified to predict identically, so our PNGs
+        # need no conversion here.
+        return model.predict(image_path)
+
+    return P.serve("ocsrglyph", infer)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chemgraph/tools/ocsr_workers/requirements-decimer.txt
+++ b/src/chemgraph/tools/ocsr_workers/requirements-decimer.txt
@@ -1,0 +1,14 @@
+# DECIMER specialist OCSR model. Python 3.10, TensorFlow.
+#
+#   conda create -p ~/ocsr-decimer python=3.10 -y
+#   ~/ocsr-decimer/bin/pip install -r requirements-decimer.txt
+#
+# or just run build_decimer.sh, which does the above plus the weight pre-fetch.
+#
+# Weights (~664 MB) are NOT listed here: DECIMER downloads them from Zenodo to
+# ~/.data/DECIMER-V2 on first use. On a host with no outbound network that first
+# call hangs until the startup timeout, so pre-fetch it with the build script.
+#
+# Roughly 2.6 GB installed.
+
+decimer

--- a/src/chemgraph/tools/ocsr_workers/requirements-molnextr.txt
+++ b/src/chemgraph/tools/ocsr_workers/requirements-molnextr.txt
@@ -1,0 +1,45 @@
+# MolNexTR specialist OCSR model. Python 3.8, CPU torch.
+#
+#   conda create -p ~/ocsr-molnextr python=3.8 -y
+#   ~/ocsr-molnextr/bin/pip install torch==1.12.1 torchvision==0.13.1 \
+#       --index-url https://download.pytorch.org/whl/cpu
+#   ~/ocsr-molnextr/bin/pip install -r requirements-molnextr.txt
+#   ~/ocsr-molnextr/bin/pip install -e ~/opt/MolNexTR
+#
+# The source tree comes from https://github.com/CYF2000127/MolNexTR (not on PyPI).
+#
+# The torch line is separate because it needs the CPU wheel index. Aurora's GPUs
+# are Intel, not CUDA, so every worker runs on CPU.
+#
+# Needs the MolNexTR source tree as well (build_molnextr.sh clones it to
+# ~/opt/MolNexTR); the package is not on PyPI. If `pip install -e` fails the
+# worker still runs with PYTHONPATH pointed at the clone.
+#
+# Weights: molnextr_best.pth (~1.1 GB) from HuggingFace CYF200127/MolNexTR.
+#
+# Python 3.8 is not a hard requirement, only what the upstream repo was built
+# against; its torch 2.4/numpy 1.24 combination would run on 3.10 too. Do not
+# "modernize" it without re-running the benchmark: the calibration table
+# describes these exact interpreters.
+#
+# Roughly 6.1 GB installed.
+
+# Inlined from CYF2000127/MolNexTR@main rather than fetched with `-r <URL>`.
+# The URL form defeats the point of recording pins, since it tracks a moving
+# branch. Note the GitHub org is CYF2000127 while the HuggingFace org for the
+# weights is CYF200127: genuinely different names on different hosts, and both
+# build-script lines are correct as written.
+pytorch-lightning
+opencv-python
+pillow
+pyparsing
+six
+albumentations==1.1.0
+SmilesPE
+timm==0.4.12
+pyonmttok==1.37.1
+OpenNMT-py==2.2.0
+matplotlib
+rdkit
+pandas
+huggingface_hub

--- a/src/chemgraph/tools/ocsr_workers/requirements-molscribe.txt
+++ b/src/chemgraph/tools/ocsr_workers/requirements-molscribe.txt
@@ -1,0 +1,22 @@
+# MolScribe specialist OCSR model. Python 3.10, torch 1.13.
+#
+#   conda create -p ~/ocsr-molscribe python=3.10 -y
+#   ~/ocsr-molscribe/bin/pip install -r requirements-molscribe.txt
+#
+# ORDER MATTERS. Install MolScribe first, then re-pin opencv and numpy LAST:
+# opencv>=4.11 drags numpy 2.x back in, and MolScribe's torch 1.13 is compiled
+# against numpy 1.x. Under numpy 2 it does not fail at import; torch.from_numpy
+# raises "Numpy is not available" at inference time, silently, until you predict.
+#
+# Weights: swin_base_char_aux_1m.pth (~1.1 GB) from HuggingFace yujieq/MolScribe,
+# fetched by build_molscribe.sh into ~/ocsr-weights/molscribe/.
+#
+# Roughly 4.4 GB installed.
+
+MolScribe
+huggingface_hub
+
+# these three must come last, in this order
+opencv-python==4.10.0.84
+opencv-python-headless==4.10.0.84
+numpy==1.26.4

--- a/src/chemgraph/tools/ocsr_workers/requirements-ocsrglyph.txt
+++ b/src/chemgraph/tools/ocsr_workers/requirements-ocsrglyph.txt
@@ -1,0 +1,19 @@
+# OCSRGlyph specialist OCSR model. Python 3.11, CPU torch.
+#
+#   conda create -p ~/ocsr-glyph python=3.11 -y
+#   ~/ocsr-glyph/bin/pip install torch==2.9.1 torchvision==0.24.1 \
+#       --index-url https://download.pytorch.org/whl/cpu
+#   ~/ocsr-glyph/bin/pip install -r requirements-ocsrglyph.txt
+#
+# Note the env directory is ~/ocsr-glyph, not ~/ocsr-ocsrglyph.
+#
+# Weights: model.pth (~374 MB) from HuggingFace EdisonScientific/OCSRGlyph,
+# fetched by build_ocsrglyph.sh into ~/ocsr-weights/ocsrglyph/.
+#
+# Roughly 1.8 GB installed. The lightest and fastest of the four (0.30 s per
+# image warm), though the least accurate (76.6% exact).
+
+timm>=1.0
+rdkit>=2024.3.1
+SmilesPE>=0.0.3
+huggingface_hub

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -1,0 +1,570 @@
+"""Hermetic tests for the OCSR core helpers.
+
+No network, no conda envs, no model loads: everything here runs from RDKit and the
+packaged calibration table. Mirrors ``tests/test_docking_tools.py``, which is likewise
+hermetic by default.
+
+Several of these pin behaviour that is silent when broken. Those are marked in the test
+docstring with the consequence, because a reviewer tidying the code later needs to know
+what the assertion is protecting.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+
+import pytest
+
+from chemgraph.tools import ocsr_core as core
+
+
+# ---------------------------------------------------------------------------
+# Image loading and validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def png(tmp_path):
+    """A real 1-molecule PNG, rendered with RDKit so no fixture file is needed."""
+    from rdkit import Chem
+    from rdkit.Chem import Draw
+
+    path = tmp_path / "mol.png"
+    Draw.MolToImage(Chem.MolFromSmiles("CCO"), size=(120, 120)).save(path)
+    return path
+
+
+def test_load_image_bytes_round_trip(png):
+    import base64
+
+    data, mime = core.load_image_bytes(str(png))
+    assert mime == "image/png"
+    assert data.startswith(b"\x89PNG")
+    b64, mime64 = core.load_image_b64(str(png))
+    assert (mime64, base64.b64decode(b64)) == (mime, data)
+    with pytest.raises(FileNotFoundError):
+        core.load_image_bytes(str(png) + ".missing")
+
+
+def test_extract_image_path_only_picks_a_real_image(tmp_path, png):
+    """Pulling a path out of free text must verify it, not trust the extension.
+
+    ``png`` is a tmp_path fixture, so on Windows it carries a drive letter. A pattern
+    that cannot match ``C:`` returns the remainder joined against the current drive,
+    which points at a different filesystem location.
+    """
+    decoy = tmp_path / "notes.png"
+    decoy.write_text("not an image")
+    assert core.extract_image_path(f"read {png} please") == str(png)
+    assert core.extract_image_path(f"read {decoy} please") is None
+    assert core.extract_image_path("no image here") is None
+
+
+def test_mime_is_sniffed_not_taken_from_the_extension(tmp_path):
+    """A text file renamed .png must be refused.
+
+    Silent when broken: the bytes would be base64-ed to a remote endpoint.
+    """
+    fake = tmp_path / "notes.png"
+    fake.write_text("this is not an image")
+    with pytest.raises(ValueError, match="not a recognized image"):
+        core.load_image_bytes(str(fake))
+
+
+def test_oversized_file_is_refused_before_being_read(tmp_path):
+    big = tmp_path / "big.png"
+    big.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 5000)
+    with pytest.raises(ValueError, match="over the"):
+        core.load_image_bytes(str(big), max_bytes=1000)
+
+
+def test_directories_are_refused(tmp_path):
+    """A path that is not a regular file must be refused before it is opened."""
+    with pytest.raises(ValueError, match="not a regular file"):
+        core.load_image_bytes(str(tmp_path))
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo is POSIX-only")
+def test_fifos_are_refused(tmp_path):
+    """FIFOs and device files must not be opened.
+
+    Silent when broken: reading a FIFO blocks forever with no caller-side timeout,
+    and /dev/zero grows the buffer without bound.
+    """
+    fifo = tmp_path / "pipe.png"
+    os.mkfifo(fifo)
+    assert stat.S_ISFIFO(os.lstat(fifo).st_mode)
+    with pytest.raises(ValueError, match="not a regular file"):
+        core.load_image_bytes(str(fifo))
+
+
+# ---------------------------------------------------------------------------
+# SMILES handling
+# ---------------------------------------------------------------------------
+
+
+def test_canonicalize_collapses_kekule_and_aromatic():
+    """DECIMER emits Kekule, the other specialists emit aromatic.
+
+    Silent when broken: vote() would group the same molecule as two answers, and
+    unanimity would drop from 289/422 benchmark items to 12/422. The confidence
+    feature stops working while still returning plausible numbers.
+    """
+    assert core.canonicalize("C1=CC=CC=C1") == core.canonicalize("c1ccccc1")
+    assert core.canonicalize("C(=O)(C(Br)(F)F)O") == core.canonicalize("O=C(O)C(F)(F)Br")
+    for junk in ["not a molecule", "", None]:
+        assert core.canonicalize(junk) is None
+
+
+def test_validate_smiles_core_on_a_good_molecule():
+    r = core.validate_smiles_core("CCO")
+    assert r["valid"] is True
+    assert r["formula"] == "C2H6O"
+    assert r["n_atoms"] == 9  # implicit hydrogens included
+    assert r["n_heavy_atoms"] == 3
+    assert r["n_fragments"] == 1
+    assert r["errors"] == []
+
+
+def test_validate_smiles_core_surfaces_the_rdkit_message():
+    """An invalid SMILES must carry RDKit's own complaint, not a generic failure.
+
+    That message is the whole value of the tool here: a model can act on
+    "Can't kekulize mol" but not on "invalid".
+    """
+    r = core.validate_smiles_core("c1ccccc1(C)(C)")
+    assert r["valid"] is False
+    assert any("kekulize" in e.lower() for e in r["errors"])
+
+
+def test_multi_fragment_is_flagged_but_still_valid():
+    """Two molecules in one image parse cleanly and would corrupt the downstream job.
+
+    Silent when broken: RDKit embeds disconnected fragments overlapping (measured
+    0.20 A closest approach, 0.00 A between centroids for CCO.CCN), so a geometry
+    optimization runs on an interpenetrating pair and reports success.
+    """
+    r = core.validate_smiles_core("CCO.CCN")
+    assert r["valid"] is True
+    assert r["n_fragments"] == 2
+    assert any("disconnected" in e for e in r["errors"])
+
+    salt = core.validate_smiles_core("[Na+].[Cl-]")
+    assert salt["n_fragments"] == 2
+
+
+def test_validate_smiles_core_never_raises():
+    for bad in ["", None, "?????", ">>", 42]:
+        r = core.validate_smiles_core(bad)  # type: ignore[arg-type]
+        assert r["valid"] is False
+        assert r["errors"]
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("CCO", "CCO"),
+        ("```\nCCO\n```", "CCO"),
+        ("```smiles\nc1ccccc1\n```", "c1ccccc1"),
+        ("SMILES: CC(=O)O", "CC(=O)O"),
+        ("The SMILES string is CC(=O)O", "CC(=O)O"),
+        ("N#Cc1no[nH]c1=O", "N#Cc1no[nH]c1=O"),
+    ],
+)
+def test_extract_smiles_finds_the_answer(raw, expected):
+    assert core.extract_smiles(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "refusal",
+    [
+        "I cannot process images.",
+        "I'm unable to view images.",
+        "Sorry, I can't see the image.",
+        "As a text-based model, I cannot analyze pictures.",
+        "No image was provided.",
+    ],
+)
+def test_extract_smiles_rejects_refusals(refusal):
+    """A refusal must not become a prediction.
+
+    Silent when broken: RDKit parses "I cannot process images." as iodine, because
+    I is an element and the parser stops at the space. The tool would report a
+    confident one-atom molecule for an image the model never saw.
+    """
+    assert core.extract_smiles(refusal) is None
+
+
+# ---------------------------------------------------------------------------
+# Consensus
+# ---------------------------------------------------------------------------
+
+
+def _results(*pairs):
+    return [{"model": m, "smiles": s, "ok": True} for m, s in pairs]
+
+
+def test_vote_unanimous_and_the_local_prefix():
+    """Four agreeing models are pattern "4", and "local:x" is the same model as "x"."""
+    v = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"),
+                           ("molscribe", "CCO"), ("ocsrglyph", "CCO")))
+    assert (v["pattern"], v["winner"]) == ("4", "CCO")
+    # Silent when broken: a "local:" name would not match the table's committee, so
+    # check_committee would null the confidence on every ensemble call.
+    v = core.vote(_results(("local:decimer", "CCO"), ("molnextr", "CCO")))
+    assert v["committee"] == ["decimer", "molnextr"]
+
+
+def test_vote_groups_by_canonical_form_not_string():
+    """Same molecule written two ways is one vote, not two."""
+    v = core.vote(_results(("decimer", "C(=O)(C(Br)(F)F)O"),
+                           ("molnextr", "O=C(O)C(F)(F)Br"),
+                           ("molscribe", "O=C(O)C(F)(F)Br"),
+                           ("ocsrglyph", "CC(C)(Br)C(=O)O")))
+    assert v["pattern"] == "3/1"
+    assert v["winner"] == core.canonicalize("O=C(O)C(F)(F)Br")
+
+
+def test_vote_treats_unparseable_output_as_a_dissenting_vote():
+    """A model that ran but produced junk contributes a singleton, not an absence.
+
+    The pattern stays "3/1" rather than collapsing to "3", because a model unable to
+    read the image is evidence about the image, not a smaller committee.
+    """
+    v = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"),
+                           ("molscribe", "CCO"), ("ocsrglyph", "@@@junk")))
+    assert v["pattern"] == "3/1"
+    assert v["committee"] == ["decimer", "molnextr", "molscribe", "ocsrglyph"]
+    assert v["voters"] == ["decimer", "molnextr", "molscribe"]
+    assert "ocsrglyph" in v["abstained"]
+
+
+def test_pattern_always_sums_to_the_committee_size():
+    """The invariant that makes a table's buckets mean one thing.
+
+    Every combination of agreement and abstention over four models must land in one
+    of five buckets, never in a shorter pattern that a smaller committee would give.
+    """
+    cases = [
+        (("CCO", "CCO", "CCO", "CCO"), "4"),
+        (("CCO", "CCO", "CCO", "@@@"), "3/1"),
+        (("CCO", "CCO", "@@@", "???"), "2/1/1"),
+        (("CCO", "CCO", "CCC", "CCC"), "2/2"),
+        (("CCO", "CCC", "@@@", "???"), "1/1/1/1"),
+        (("@@@", "???", "!!!", "###"), "1/1/1/1"),
+    ]
+    for smiles, expected in cases:
+        v = core.vote(_results(*zip(["decimer", "molnextr", "molscribe", "ocsrglyph"],
+                                    smiles)))
+        assert v["pattern"] == expected, smiles
+        assert sum(int(x) for x in v["pattern"].split("/")) == 4
+
+
+def test_vote_breaks_ties_by_model_priority():
+    v = core.vote(
+        _results(("decimer", "CCO"), ("molnextr", "CCN"),
+                 ("molscribe", "CCC"), ("ocsrglyph", "CCF")),
+        priority=["decimer", "molnextr", "molscribe", "ocsrglyph"],
+    )
+    assert v["pattern"] == "1/1/1/1"
+    assert v["winner"] == "CCO"  # decimer wins the four-way tie
+
+
+def test_vote_with_nobody_voting():
+    """Total failure is the all-singletons bucket, not a missing row.
+
+    Dropping the item would remove it from the calibration table and flatter every
+    other bucket. It happened once in 722 benchmark items: a fused polycyclic where
+    all four models emitted unparseable strings, two of them inventing metal atoms.
+    """
+    v = core.vote(_results(("decimer", "@@@"), ("molnextr", "???")))
+    assert v["pattern"] == "1/1"
+    assert v["winner"] is None
+    assert v["voters"] == []
+    assert len(v["abstained"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Calibration and confidence
+# ---------------------------------------------------------------------------
+
+
+def test_packaged_table_is_internally_consistent():
+    """Guards against a hand-edited table: the arithmetic must still close."""
+    t = core.load_calibration()
+    assert sum(c["n"] for c in t["patterns"].values()) == t["n_items"]
+    for name, c in t["patterns"].items():
+        assert sum(int(x) for x in name.split("/")) == len(t["committee"])
+        assert 0 <= c["k"] <= c["n"]
+        assert (c["p"] is None) == (c["n"] < t["min_n_for_point_estimate"])
+        if c["p"] is not None:
+            assert c["p"] == round((c["k"] + 0.5) / (c["n"] + 1), 4)
+        assert c["ci"][0] <= c["ci"][1]
+
+
+def test_check_committee_catches_a_mismatch():
+    t = core.load_calibration()
+    three = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"), ("molscribe", "CCO")))
+    assert "committee_mismatch" in core.check_committee(three, t)
+
+
+# ---------------------------------------------------------------------------
+# Single-model priors
+# ---------------------------------------------------------------------------
+
+
+def test_every_registered_specialist_has_a_prior():
+    """Registering a specialist must give it a confidence, not just a backend.
+
+    The prior reads from SPECIALIST_MODELS, so there is no second table to forget.
+    Values are the measured solo accuracies over the same 722 items.
+    """
+    from chemgraph.tools.ocsr_models import SPECIALIST_MODELS
+
+    n_items = core.load_calibration()["n_items"]
+    measured = core.load_calibration()["model_performance"]
+    assert set(SPECIALIST_MODELS) <= set(measured), (
+        "every registered specialist needs a model_performance entry in the "
+        "calibration table, or backend=<name> reports no confidence"
+    )
+    for model in SPECIALIST_MODELS:
+        c = core.prior_confidence(model)
+        assert c["p"] == measured[model]["accuracy"]
+        assert c["n"] == n_items  # from the table, not a constant in the source
+        assert c["reason"] is None
+        assert not c["label"].startswith("low_n_")
+
+
+def test_single_model_must_not_be_routed_through_vote():
+    """Documents the trap that prior_confidence exists to avoid.
+
+    A one-model vote yields pattern "1", which in the four-model table is the
+    all-different bucket: 8 items, 12.5% correct. Routing DECIMER's 89.9% through
+    it would attach the table's least reliable label to the most accurate model.
+    """
+    t = core.load_calibration()
+    v = core.vote(_results(("decimer", "CCO")))
+    assert v["pattern"] == "1"
+    assert core.confidence("1", t)["reason"] == "unknown_pattern"
+    from chemgraph.tools.ocsr_models import DEFAULT_SPECIALIST
+
+    assert core.prior_confidence(DEFAULT_SPECIALIST)["p"] is not None  # correct path
+
+
+# ---------------------------------------------------------------------------
+# The result contract
+# ---------------------------------------------------------------------------
+
+
+def test_build_result_has_every_contract_key():
+    r = core.build_result()
+    assert len(r) == 18
+    for key in ["ok", "smiles", "valid", "formula", "n_fragments", "confidence",
+                "confidence_label", "confidence_unavailable_reason", "agreement",
+                "basis", "backend_used", "model_used", "cold_start", "latency_s",
+                "error", "warning", "votes", "abstained"]:
+        assert key in r
+
+
+def test_mock_ocsr_satisfies_the_contract():
+    """The hermetic stand-in must produce the shape a real single-model call does.
+
+    Otherwise tests written against it pass while the real path is broken. It used to
+    return a number with basis="prior", which is a shape no backend produces now that
+    a single model reports no per-image confidence.
+    """
+    r = core.mock_ocsr("/nonexistent.png")
+    assert set(r) == set(core.build_result())
+    assert r["ok"] is True
+    assert core.canonicalize(r["smiles"]) is not None
+    assert r["confidence"] is None
+    assert r["basis"] is None
+    assert r["confidence_unavailable_reason"] == (
+        "single_model_has_no_per_image_confidence")
+
+
+# ---------------------------------------------------------------------------
+# Extending the registry without touching Python
+# ---------------------------------------------------------------------------
+
+
+def test_an_abstaining_model_cannot_win_the_tie_break():
+    """Only a model that actually voted may decide the answer.
+
+    The tie-break used to scan every result without re-checking ok, so a model whose
+    output failed to parse still got consulted, and won whenever its unusable string
+    happened to canonicalize into a tied group. The returned SMILES then came from
+    outside `voters`, and the all-different bucket stopped carrying the strongest
+    model's solo accuracy that the calibration table assumes it does.
+    """
+    v = core.vote(
+        [{"model": "decimer", "ok": False, "smiles": "CCN"},
+         {"model": "molnextr", "ok": True, "smiles": "CCO"},
+         {"model": "molscribe", "ok": True, "smiles": "CCN"},
+         {"model": "ocsrglyph", "ok": True, "smiles": "CCF"}],
+        ["decimer", "molnextr", "molscribe", "ocsrglyph"],
+    )
+    assert v["winner"] == "CCO"  # top-priority *voter*, not the abstainer
+    assert "decimer" in v["abstained"]
+    winning_models = v["votes"][v["winner"]]
+    assert set(winning_models) <= set(v["voters"])
+
+
+@pytest.mark.parametrize("table, why", [
+    # A cell whose numbers contradict each other or cannot be read.
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "p": "high"}}},
+     "p is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "p": 2.5}}},
+     "p outside [0, 1]"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 0, "n": 100, "p": 0.99}}},
+     "p contradicts its own k and n"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 5, "n": 2}}}, "k exceeds n"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": "nope"}}},
+     "ci is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": [0.99, 0.1]}}},
+     "ci is reversed"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1,
+                                             "ci": [float("nan"), 1.0]}}},
+     "json.loads accepts NaN, which compares false against everything"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": [-0.5, 1.0]}}},
+     "a probability bound outside [0, 1]"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "label": 7}}},
+     "label is not a string"),
+    # A pattern name that cannot describe this committee.
+    ({"committee": ["a", "b"], "patterns": {"3": {"k": 1, "n": 2}}},
+     "pattern sums to more than the committee"),
+    ({"committee": ["a"], "patterns": {"0/1": {"k": 1, "n": 1}}},
+     "a zero part means a group with no models in it"),
+    ({"committee": ["a"], "patterns": {"2/-1": {"k": 1, "n": 1}}},
+     "int() accepts a minus sign, so this summed to 1 and passed the sum check"),
+    # A committee that can never match a real run.
+    ({"committee": [], "patterns": {"1": {"k": 1, "n": 1}}},
+     "empty committee would disable the mismatch guard entirely"),
+    ({"committee": ["a", "a"], "patterns": {"1/1": {"k": 1, "n": 1}}},
+     "a repeated model mismatches forever"),
+    ({"committee": ["a"], "patterns": {}}, "no patterns"),
+    ({"committee": "a,b", "patterns": {"2": {"k": 1, "n": 2}}},
+     "committee is a string, not a list"),
+    ([], "top level is not an object"),
+    # The model_performance section, which prior_confidence and mock_ocsr read.
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": "not-an-object"}, "section is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"decimer": {"accuracy": "90%"}}},
+     "accuracy is a string"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"decimer": {"accuracy": 0.9, "n": 0}}},
+     "an accuracy backed by zero observations"),
+    ({"patterns": {"1": {"k": 1, "n": 2}}}, "no committee at all"),
+])
+def test_a_table_that_cannot_mean_what_it_says_is_rejected_at_load(
+        tmp_path, monkeypatch, table, why):
+    """A table decides which answers get a confidence, so it fails at load.
+
+    Every case here once loaded cleanly and then either raised a TypeError from deep
+    inside a lookup, naming neither the table nor the field, or returned a confident
+    number that contradicted the table's own k and n.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps(table))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration(str(custom))
+    # Same rejection whichever route the table arrives by.
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(custom))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration()
+
+
+@pytest.mark.parametrize("mutate, why", [
+    (lambda r: r["vision_llms"]["shim"].update({"x": {}}), "shim entry has no wire_name"),
+    (lambda r: r["vision_llms"]["shim"].update({"x": "y"}), "shim entry is a string"),
+    (lambda r: r["vision_llms"]["alcf"].update({"x": "y"}), "alcf entry is a string"),
+    (lambda r: r["specialists"]["decimer"].pop("latency_s"), "no latency_s"),
+    (lambda r: r.update({"defaults": []}), "defaults is a list"),
+    (lambda r: r["specialists"]["decimer"].update({"worker": 7}), "worker is a number"),
+])
+def test_a_registry_that_would_crash_at_import_is_rejected(tmp_path, mutate, why):
+    """The registry is read during module import, so a bad field breaks `import`.
+
+    Each of these used to surface as a KeyError or TypeError from inside a dict
+    comprehension in ocsr_models, taking down `import chemgraph.tools.ocsr_tools` with
+    a traceback that named neither the registry file nor the field at fault.
+    """
+    from importlib import resources
+
+    from chemgraph.tools.ocsr_models import _validate_registry
+
+    packaged = resources.files("chemgraph.tools").joinpath("ocsr_registry.json")
+    registry = json.loads(packaged.read_text())
+    mutate(registry)
+    with pytest.raises(ValueError, match="unusable"):
+        _validate_registry(registry, "test")
+
+
+def test_the_tie_break_follows_the_priority_it_is_given():
+    """Which model wins a tie decides what the all-different bucket measures.
+
+    Ordered so the answer differs from "first in the results list": a test where the
+    priority head is also the list head passes with the rule deleted entirely, which
+    is how this went uncovered. The calibration table records the priority it was
+    fitted under precisely because the number depends on it.
+    """
+    results = _results(("ocsrglyph", "CCC"), ("decimer", "CCO"))
+    assert core.vote(results, ["decimer", "ocsrglyph"])["winner"] == "CCO"
+    assert core.vote(results, ["ocsrglyph", "decimer"])["winner"] == "CCC"
+
+    # And the table's own recorded rule is what the ensemble must use.
+    table = core.load_calibration()
+    assert core.tie_break_order(table) == table["committee"]
+    assert core.tie_break_order({"committee": ["a", "b"]}) == ["a", "b"]
+
+
+def test_canonicalize_is_stereo_blind_by_default():
+    """Most reference labels carry no stereochemistry, so scoring with it marks a
+    model wrong for correctly reading a wedge bond, and splits one molecule into two
+    answers in vote()."""
+    chiral, flat = "C[C@H](N)C(=O)O", "CC(N)C(=O)O"
+    assert core.canonicalize(chiral) == core.canonicalize(flat)
+    assert core.canonicalize(chiral, stereo=True) != core.canonicalize(flat)
+
+
+def test_the_shipped_tie_break_matches_its_own_measured_accuracies():
+    """The packaged table's priority must be the ranking its own numbers imply.
+
+    The order decides who wins an even split, and the all-different bucket measures
+    how often that first model was right, so a priority that disagrees with the
+    accuracies in the same file would be measuring something nobody expects. This
+    order was written by hand before the fitter derived it; the assertion is what
+    keeps the two in step.
+    """
+    table = core.load_calibration()
+    performance = table["model_performance"]
+    by_accuracy = sorted(performance, key=lambda m: -performance[m]["accuracy"])
+    assert core.tie_break_order(table) == by_accuracy
+
+
+@pytest.mark.parametrize("tie_break, why", [
+    ("model priority: b,a", "a typo in the marker falls back to the committee order"),
+    (["b", "a"], "a JSON array is a plausible hand edit and does not parse"),
+    ("model-priority:", "an empty order"),
+    ("model-priority: zzz", "a name that is not in the committee"),
+    ("model-priority: a", "only part of the committee"),
+    ("model-priority: a,b,c", "a name too many"),
+])
+def test_an_unusable_tie_break_is_rejected_at_load(tie_break, why):
+    """Falling back silently would vote one way and quote a number measured another.
+
+    Every parse failure used to return the committee's arbitrary JSON order, so a
+    single mistyped character swapped which model's answer was returned while the
+    confidence stayed the same, with nothing in the result to reveal it.
+    """
+    table = {"committee": ["a", "b"], "tie_break": tie_break,
+             "patterns": {"1/1": {"k": 1, "n": 2}}}
+    with pytest.raises(ValueError, match="tie_break"):
+        core._validate_calibration(table, "test")
+
+    # Absent is fine: an older table falls back to its committee order.
+    core._validate_calibration(
+        {"committee": ["a", "b"], "patterns": {"1/1": {"k": 1, "n": 2}}}, "test")

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -615,3 +615,72 @@ def test_a_marked_up_refusal_is_not_a_molecule():
         "\U0001f6ab **ACCESS DENIED** \U0001f6ab\n\nThe username is not authorized."
     )
     assert core.extract_smiles(denied) is None
+def test_a_registry_naming_a_missing_file_is_reported_as_such(tmp_path, monkeypatch,
+                                                              capsys):
+    """A typo in the registry must say so, not read as "you forgot to install".
+
+    The registry is user-editable, so a wrong filename is an expected mistake. Without
+    this the model resolves as a backend, `--check` tells the user to install it, and
+    the build dies 45 seconds later on "bash: no such file".
+    """
+    import importlib
+    import json as _json
+    from importlib import resources
+
+    packaged = resources.files("chemgraph.tools").joinpath("ocsr_registry.json")
+    reg = _json.loads(packaged.read_text())
+    reg["specialists"]["typo"] = {
+        "latency_s": 1.0,
+        "note": "names files that do not exist",
+        "worker": "typo_infer.py",
+        "install": {"script": "build_typo.sh", "weights": "~/w.pth",
+                    "env": "~/ocsr-typo", "python": "3.11",
+                    "size_gb": 1.0, "weights_gb": 0.1},
+        "install_note": "",
+    }
+    custom = tmp_path / "registry.json"
+    custom.write_text(_json.dumps(reg))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_REGISTRY", str(custom))
+
+    from chemgraph.tools import ocsr_models, ocsr_setup
+    importlib.reload(ocsr_models)
+    importlib.reload(ocsr_setup)
+    try:
+        assert ocsr_setup._missing_registry_files("typo") == [
+            "typo_infer.py", "build_typo.sh",
+        ]
+        # A correctly registered model reports nothing missing.
+        assert ocsr_setup._missing_registry_files(ocsr_models.DEFAULT_SPECIALIST) == []
+
+        assert ocsr_setup.cmd_check() == 1
+        out = capsys.readouterr().out
+        assert "REGISTRY ERROR" in out
+        assert "build_typo.sh" in out
+        # It must NOT send the user off to install something unbuildable.
+        assert "ocsr_setup <model>" not in out
+
+        # And the path helper refuses rather than returning a path to nothing.
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            ocsr_setup._script_path("typo")
+    finally:
+        monkeypatch.delenv("CHEMGRAPH_OCSR_REGISTRY")
+        importlib.reload(ocsr_models)
+        importlib.reload(ocsr_setup)
+
+
+def test_listings_survive_a_table_with_no_measurements(tmp_path, monkeypatch, capsys):
+    """Unmeasured must print as a dash, not crash and not read as zero."""
+    import json as _json
+
+    custom = tmp_path / "cal.json"
+    custom.write_text(_json.dumps({
+        "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(custom))
+
+    from chemgraph.tools import ocsr_setup
+    from chemgraph.tools.ocsr_models import describe_backends
+
+    assert ocsr_setup.cmd_list() == 0
+    assert "--" in capsys.readouterr().out
+    assert "unmeasured" in describe_backends()

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -684,3 +684,66 @@ def test_listings_survive_a_table_with_no_measurements(tmp_path, monkeypatch, ca
     assert ocsr_setup.cmd_list() == 0
     assert "--" in capsys.readouterr().out
     assert "unmeasured" in describe_backends()
+def test_a_new_specialist_needs_no_source_change(tmp_path, monkeypatch):
+    """The promise the registry file exists to keep.
+
+    Adding a model must be a data edit: one entry in ocsr_registry.json plus a worker
+    script. If this test needs a Python change to pass again, something has grown a
+    second hardcoded list of models and the promise is broken.
+    """
+    import json as _json
+    from importlib import resources
+
+    packaged = resources.files("chemgraph.tools").joinpath("ocsr_registry.json")
+    reg = _json.loads(packaged.read_text())
+    reg["specialists"]["newmodel"] = {
+        "latency_s": 1.5,
+        "note": "A hypothetical fifth specialist.",
+        "worker": "newmodel_infer.py",
+        "install": {"script": "build_newmodel.sh", "weights": "~/w/new.pth",
+                    "env": "~/ocsr-new", "python": "3.11",
+                    "size_gb": 2.0, "weights_gb": 0.5},
+        "install_note": "Added via JSON only.",
+    }
+    custom = tmp_path / "registry.json"
+    custom.write_text(_json.dumps(reg))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_REGISTRY", str(custom))
+
+    import importlib
+
+    from chemgraph.tools import ocsr_models, ocsr_setup, ocsr_tools
+    for mod in (ocsr_models, ocsr_setup, ocsr_tools):
+        importlib.reload(mod)
+    try:
+        assert "newmodel" in ocsr_models.SPECIALIST_MODELS
+        assert "newmodel" in ocsr_models.BACKENDS      # usable as backend="newmodel"
+        assert "newmodel" in ocsr_setup.MODELS         # and installable
+        assert "newmodel" in ocsr_tools._specialists()  # and votes in the ensemble
+        # It reaches dispatch rather than being rejected as an unknown backend.
+        r = ocsr_tools.image_to_smiles_core("/nonexistent.png", backend="newmodel")
+        assert "unknown backend" not in (r["error"] or "")
+    finally:
+        monkeypatch.delenv("CHEMGRAPH_OCSR_REGISTRY")
+        for mod in (ocsr_models, ocsr_setup, ocsr_tools):
+            importlib.reload(mod)
+
+
+def test_the_setup_hint_names_a_command_that_actually_runs():
+    """The first thing a new user sees must be copy-pasteable.
+
+    This message is returned into an agent's context when no specialist is installed,
+    so a command that exits 2 costs a retry loop and a confused user. It shipped
+    naming an `install` subcommand that ocsr_setup has never had.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+    from chemgraph.tools import ocsr_models, ocsr_setup
+
+    hint = backends._setup_hint()
+    assert ocsr_models.DEFAULT_SPECIALIST in hint
+
+    # Pull the command out of the backticks and feed it to the CLI's own parser,
+    # not a copy of it, so the two cannot drift apart.
+    command = hint.split("`")[1].split()
+    assert command[:3] == ["python", "-m", "chemgraph.tools.ocsr_setup"]
+    args = ocsr_setup.build_parser().parse_args(command[3:])
+    assert args.model in ocsr_setup.MODELS

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -568,3 +568,50 @@ def test_an_unusable_tie_break_is_rejected_at_load(tie_break, why):
     # Absent is fine: an older table falls back to its committee order.
     core._validate_calibration(
         {"committee": ["a", "b"], "patterns": {"1/1": {"k": 1, "n": 2}}}, "test")
+
+
+@pytest.mark.parametrize("raw, want", [
+    # Markdown emphasis is the dangerous wrapper: "*" is RDKit's wildcard atom, so
+    # "**CCO**" parses as a valid five-atom molecule and was returned as a prediction.
+    ("**CCO**", "CCO"),
+    ("The SMILES is **CC(=O)Oc1ccccc1C(=O)O**", "CC(=O)Oc1ccccc1C(=O)O"),
+    ("*CCO*", "CCO"),
+    ("The answer is `CCO`.", "CCO"),
+    # Parentheses and brackets only cost a match, since "(CCO)" fails to parse.
+    ("(CCO)", "CCO"),
+    ("This is aspirin (CC(=O)Oc1ccccc1C(=O)O).", "CC(=O)Oc1ccccc1C(=O)O"),
+    ("[CCO]", "CCO"),
+    # A JSON reply is the most common structured form, and the "elements" list
+    # beside it is full of strings that parse: "Cl" is a molecule.
+    ('{"elements": ["C", "H", "Cl"], "smiles": "CCCl"}', "CCCl"),
+    ('```json\n{\n  "elements": ["C", "O"],\n  "smiles": "CCO"\n}\n```', "CCO"),
+    # Brackets and parentheses are SMILES syntax and must survive untouched.
+    ("[NH4+]", "[NH4+]"),
+    ("[Na+].[Cl-]", "[Na+].[Cl-]"),
+    ("C(=O)O", "C(=O)O"),
+    ("[C@H](N)C", "[C@H](N)C"),
+    ("*CCO", "*CCO"),
+    ("**[Na+].[Cl-]**", "[Na+].[Cl-]"),
+])
+def test_wrappers_are_peeled_without_damaging_real_smiles(raw, want):
+    """A wrapped SMILES must come back unwrapped, and a real one untouched.
+
+    Silent when broken: emphasis markers are wildcard atoms, so the extracted string
+    stays a valid molecule with extra atoms in it, and every downstream check passes
+    while the answer is wrong.
+    """
+    assert core.extract_smiles(raw) == want
+
+
+def test_a_marked_up_refusal_is_not_a_molecule():
+    """A refusal wrapped in emphasis must not become a wildcard-atom molecule.
+
+    Measured on benchmark replies: an auth-error page yielded the SMILES "**", two
+    wildcard atoms. The LLM backend screens those by keyword before extraction, so
+    this is the guard for every other caller and for wording the screen misses.
+    """
+    denied = (
+        "⚠️ **IMPORTANT AUTHENTICATION NOTICE FROM ARGO** ⚠️\n\n"
+        "\U0001f6ab **ACCESS DENIED** \U0001f6ab\n\nThe username is not authorized."
+    )
+    assert core.extract_smiles(denied) is None

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -1,0 +1,558 @@
+"""Hermetic tests for the OCSR tool and backend layers.
+
+No network, no conda envs, no model loads: the backends are monkeypatched. What is
+under test here is the dispatch and the contract assembly, not the models.
+
+A live test that actually runs a specialist is marked ``llm`` so it only runs under
+``pytest --run-llm`` (see tests/conftest.py).
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+import pytest
+
+from chemgraph.tools import ocsr_backends as backends
+from chemgraph.tools import ocsr_core as core
+from chemgraph.tools import ocsr_models as models
+from chemgraph.tools import ocsr_tools as tools
+
+
+@pytest.fixture
+def png(tmp_path):
+    from rdkit import Chem
+    from rdkit.Chem import Draw
+
+    path = tmp_path / "mol.png"
+    Draw.MolToImage(Chem.MolFromSmiles("CCO"), size=(120, 120)).save(path)
+    return str(path)
+
+
+def _narrow(smiles="CCO", ok=True, model="decimer", **kw):
+    base = {"ok": ok, "smiles": smiles, "raw": "", "model_used": model,
+            "cold_start": False, "latency_s": 0.1, "error": ""}
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Input validation, before any model runs
+# ---------------------------------------------------------------------------
+
+
+def test_core_never_raises(monkeypatch, png):
+    """Even an exploding backend comes back as ok=False."""
+    def boom(*a, **k):
+        raise RuntimeError("worker exploded")
+
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "smiles_from_specialist", boom)
+    r = tools.image_to_smiles_core(png, backend="decimer")
+    assert r["ok"] is False
+    assert "worker exploded" in r["error"]
+
+
+# ---------------------------------------------------------------------------
+# Single-model dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_auto_fails_loudly_when_nothing_is_installed(monkeypatch, png):
+    """It must NOT silently fall through to an LLM.
+
+    Falling through would make the same image give a DECIMER answer on one machine
+    and a Maverick answer on another, with different accuracy, and nothing in the
+    return would make the user look.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: [])
+    r = tools.image_to_smiles_core(png)
+    assert r["ok"] is False
+    assert r["backend_used"] == "none"
+    assert "alcf" in r["error"]  # names the alternative
+
+
+# ---------------------------------------------------------------------------
+# Ensemble
+# ---------------------------------------------------------------------------
+
+
+def _ensemble(monkeypatch, answers: dict):
+    monkeypatch.setattr(backends, "available_specialists", lambda: list(answers))
+    monkeypatch.setattr(
+        backends, "smiles_from_specialist",
+        lambda name, b, **k: _narrow(smiles=answers[name], model=name,
+                                     ok=answers[name] is not None),
+    )
+
+
+@pytest.mark.parametrize("answers, pattern, has_number", [
+    ({"decimer": "CCO", "molnextr": "CCO", "molscribe": "CCO", "ocsrglyph": "CCO"},
+     "4", True),
+    ({"decimer": "CCO", "molnextr": "CCO", "molscribe": "CCO", "ocsrglyph": "CCN"},
+     "3/1", True),
+    ({"decimer": "CCO", "molnextr": "CCO", "molscribe": "CCN", "ocsrglyph": "CCN"},
+     "2/2", False),   # below the sample floor: a label, no decimal
+    ({"decimer": "C1=CC=CC=C1", "molnextr": "c1ccccc1",
+      "molscribe": "c1ccccc1", "ocsrglyph": "c1ccccc1"}, "4", True),
+    ({"decimer": "CCO", "molnextr": "CCO", "molscribe": "CCO", "ocsrglyph": "@@@junk"},
+     "3/1", True),    # an abstention is a dissenting vote, not a smaller committee
+])
+def test_the_ensemble_pattern_and_confidence_track_the_votes(
+        monkeypatch, png, answers, pattern, has_number):
+    """One shape covers unanimity, a majority, a tie, Kekule/aromatic, and abstention.
+
+    The Kekule case is silent when broken: grouping by raw string instead of
+    canonical form drops unanimity from 289/422 benchmark items to 12/422, and the
+    confidence feature stops working while still returning plausible numbers.
+    """
+    _ensemble(monkeypatch, answers)
+    r = tools.image_to_smiles_core(png, backend="ensemble")
+    assert r["ok"] is True
+    assert r["agreement"] == pattern
+    assert (r["confidence"] is not None) is has_number
+    # basis names where the number came from, so it is set only when there is one.
+    assert r["basis"] == ("agreement" if has_number else None)
+    assert sum(int(x) for x in r["agreement"].split("/")) == len(answers)
+
+
+def test_ensemble_on_a_partial_install_refuses_to_guess(monkeypatch, png):
+    """A three-model committee must not be scored with the four-model table."""
+    _ensemble(monkeypatch, {"decimer": "CCO", "molnextr": "CCO", "molscribe": "CCO"})
+    r = tools.image_to_smiles_core(png, backend="ensemble")
+    assert r["ok"] is True                      # we still have an answer
+    assert r["smiles"] == "CCO"
+    assert r["confidence"] is None              # but no number for it
+    assert "committee_mismatch" in r["confidence_unavailable_reason"]
+    assert "committee_mismatch" in r["warning"]
+
+
+# ---------------------------------------------------------------------------
+# LLM backends
+# ---------------------------------------------------------------------------
+
+
+def test_llm_backend_reports_no_confidence(monkeypatch, png):
+    monkeypatch.setattr(backends, "smiles_from_llm",
+                        lambda b, m, backend, model=None, **k:
+                        _narrow(model="meta-llama/Llama-4-Maverick-17B-128E-Instruct"))
+    r = tools.image_to_smiles_core(png, backend="alcf")
+    assert r["ok"] is True
+    assert r["confidence"] is None
+    assert r["basis"] is None
+    assert r["backend_used"] == "alcf"
+
+
+@pytest.mark.parametrize("backend, var", [
+    ("alcf", "ALCF_ACCESS_TOKEN"),
+    ("shim", "ARGO_SHIM_API_KEY"),
+])
+def test_a_missing_credential_names_the_variable(monkeypatch, png, backend, var):
+    """The error has to name the variable, since that is the whole fix."""
+    monkeypatch.delenv(var, raising=False)
+    r = tools.image_to_smiles_core(png, backend=backend)
+    assert r["ok"] is False
+    assert var in r["error"]
+
+
+# ---------------------------------------------------------------------------
+# Model-name resolution
+# ---------------------------------------------------------------------------
+
+
+def test_model_names_are_translated_and_endpoints_are_not_interchangeable():
+    """The shim wants claudeopus48, not claude-opus-4.8. Nobody should memorize that.
+
+    And an ALCF name is not a shim name: sending one the other's spelling fails
+    mid-run with "Invalid model", so it is refused before any call is made.
+    """
+    assert models.resolve_model("shim", "argo:claude-opus-4.8") == "claudeopus48"
+    assert models.resolve_model("shim", "claudeopus48") == "claudeopus48"
+    with pytest.raises(ValueError):
+        models.resolve_model("alcf", "argo:claude-opus-4.8")
+
+
+def test_non_vision_models_are_refused_before_a_call_is_made():
+    """A text-only model handed an image describes a picture it never saw.
+
+    That is worse than an error, so it is refused up front rather than discovered
+    from a confident wrong answer.
+    """
+    with pytest.raises(ValueError, match="not a known"):
+        models.resolve_model("shim", "argo:gpt-4")
+    with pytest.raises(ValueError, match="not a known"):
+        models.resolve_model("alcf", "gpt-4o")
+
+
+# ---------------------------------------------------------------------------
+# The @tool wrappers
+# ---------------------------------------------------------------------------
+
+
+def test_tools_are_registered_with_the_expected_arguments():
+    assert tools.image_to_smiles.name == "image_to_smiles"
+    assert set(tools.image_to_smiles.args) == {"image_path", "backend", "model"}
+    assert set(tools.validate_smiles.args) == {"smiles"}
+
+
+def test_tool_docstring_documents_every_contract_key():
+    """The docstring is the only part of this tool an agent reads, and no test
+    catches a wrong one. This at least pins that the keys are all mentioned."""
+    doc = tools.image_to_smiles.description
+    for key in ["confidence", "confidence_label", "n_fragments", "cold_start",
+                "backend_used", "warning", "votes"]:
+        assert key in doc
+
+
+def test_validate_smiles_tool_runs_through_the_tool_interface():
+    out = tools.validate_smiles.invoke({"smiles": "CCO.CCN"})
+    assert out["valid"] is True
+    assert out["n_fragments"] == 2
+
+
+def test_image_to_smiles_tool_delegates_to_core(monkeypatch, png):
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "smiles_from_specialist",
+                        lambda n, b, **k: _narrow())
+    out = tools.image_to_smiles.invoke({"image_path": png})
+    assert out["ok"] is True
+    assert out["smiles"] == "CCO"
+
+
+# ---------------------------------------------------------------------------
+# Live: needs a real specialist installed. Skipped unless --run-llm.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.llm
+def test_live_default_specialist_reads_a_real_image(png):
+    default = models.DEFAULT_SPECIALIST
+    if default not in backends.available_specialists():
+        pytest.skip(f"{default} is not installed on this host")
+    r = tools.image_to_smiles_core(png, backend=default)
+    assert r["ok"] is True, r["error"]
+    assert core.canonicalize(r["smiles"]) is not None
+    assert r["confidence"] is None  # one model gives no per-image number
+    opted_in = tools.image_to_smiles_core(png, backend=default,
+                                          report_solo_accuracy=True)
+    assert opted_in["confidence"] == core.prior_confidence(default)["p"]
+
+
+# ---------------------------------------------------------------------------
+# Unparseable and prose output from a specialist
+# ---------------------------------------------------------------------------
+
+
+def _worker_returns(monkeypatch, smiles):
+    """Make the worker client hand back a given string, bypassing the real models."""
+    class FakeClient:
+        def predict(self, model, image_bytes, timeout_s=None):
+            return {"ok": bool(smiles), "smiles": smiles, "error": "",
+                    "infer_s": 0.1, "cold_start": False}
+
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "_specialist_client", lambda: FakeClient())
+
+
+@pytest.mark.parametrize("output", [
+    "@@@not a molecule",                 # unparseable
+    "I cannot process images.",          # a refusal RDKit reads as iodine
+    "",                                  # empty
+    None,                                # nothing at all
+])
+def test_specialist_output_that_is_not_a_molecule_is_a_failure(monkeypatch, png, output):
+    """ok=True from a worker means "a string came back", not "it is a molecule".
+
+    Silent when broken: these arrive as confident answers. RDKit parses "I cannot
+    process images." as iodine, because I is an element and the parser stops at the
+    space.
+    """
+    _worker_returns(monkeypatch, output)
+    r = tools.image_to_smiles_core(png, backend="decimer")
+    assert r["ok"] is False
+    assert r["smiles"] is None
+
+
+# ---------------------------------------------------------------------------
+# Untrusted string length
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Path errors an agent produces routinely
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["not_a_directory", "name_too_long"])
+def test_os_errors_return_rather_than_raise(tmp_path, kind, png):
+    """The docstring promises a dict. These are reachable from a path an agent
+    invented, and an exception becomes a hard graph failure instead of something the
+    agent could correct."""
+    if kind == "not_a_directory":
+        f = tmp_path / "plain.txt"
+        f.write_text("x")
+        path = str(f / "inner.png")
+    else:
+        path = str(tmp_path / ("a" * 300 + ".png"))
+
+    r = tools.image_to_smiles_core(path)  # must not raise
+    assert r["ok"] is False
+    assert r["error"]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="chmod 0o000 does not deny reads on Windows")
+def test_an_unreadable_file_returns_rather_than_raises(tmp_path, png):
+    """PermissionError is the OSError an agent hits most often, and it must not
+    escape as an exception."""
+    f = tmp_path / "locked.png"
+    f.write_bytes(pathlib.Path(png).read_bytes())
+    os.chmod(f, 0o000)
+
+    r = tools.image_to_smiles_core(str(f))  # must not raise
+    assert r["ok"] is False
+    assert r["error"]
+
+
+def _custom_table(tmp_path, accuracy=0.111):
+    """A valid table whose accuracies differ from the packaged one."""
+    import json as _json
+    from importlib import resources
+
+    packaged = resources.files("chemgraph.tools").joinpath(
+        "ocsr_calibration_4model.json")
+    table = _json.loads(packaged.read_text())
+    for entry in table["model_performance"].values():
+        entry["accuracy"] = accuracy
+    path = tmp_path / "cal.json"
+    path.write_text(_json.dumps(table))
+    return str(path)
+
+
+def test_calibration_argument_reaches_the_single_model_path(monkeypatch, png, tmp_path):
+    """A refit table must apply to every backend, not only the ensemble.
+
+    The specialist branch called prior_confidence with no table, so it always read
+    the packaged default. A user who refit on their own images got their numbers from
+    backend='ensemble' and someone else's from backend='auto', silently.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "smiles_from_specialist",
+                        lambda n, b, **k: _narrow(model="decimer"))
+    custom = _custom_table(tmp_path)
+    for backend in ("decimer", "auto"):
+        r = tools.image_to_smiles_core(png, backend=backend, calibration=custom,
+                                       report_solo_accuracy=True)
+        assert r["confidence"] == 0.111, backend
+
+
+def test_an_unreadable_table_keeps_the_prediction(monkeypatch, png):
+    """A path typo must not throw away an answer that already cost inference.
+
+    The ensemble loaded the table after running every model, so a bad path discarded
+    a correct prediction and up to 80 s of cold-start work. Both paths now report the
+    failure and keep the SMILES.
+    """
+    _ensemble(monkeypatch, {m: "CCO" for m in
+                            ["decimer", "molnextr", "molscribe", "ocsrglyph"]})
+    r = tools.image_to_smiles_core(png, backend="ensemble", calibration="/nope.json")
+    assert r["ok"] is True
+    assert r["smiles"] == "CCO"
+    assert r["confidence"] is None
+    assert "calibration_unreadable" in r["confidence_unavailable_reason"]
+
+
+def test_auto_uses_an_installed_specialist_when_the_default_is_absent(monkeypatch, png):
+    """Reporting "no local models are installed" while one is installed is false.
+
+    The tool docstring tells an agent to answer that message by switching to a vision
+    LLM, so a compliant agent abandoned a working local model for a less accurate
+    remote one.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["molnextr"])
+    monkeypatch.setattr(backends, "smiles_from_specialist",
+                        lambda n, b, **k: _narrow(model=n))
+    r = tools.image_to_smiles_core(png, backend="auto", report_solo_accuracy=True)
+    assert r["ok"] is True
+    assert r["backend_used"] == "molnextr"
+    assert r["confidence"] == core.prior_confidence("molnextr")["p"]
+
+    monkeypatch.setattr(backends, "available_specialists", lambda: [])
+    r = tools.image_to_smiles_core(png, backend="auto")
+    assert r["ok"] is False
+    assert r["confidence_unavailable_reason"] == "no_specialists_installed"
+
+
+@pytest.mark.parametrize("backend", ["bogus", ["auto"], {}, 7, None, 3.5])
+def test_a_bad_backend_is_reported_and_never_raises(png, backend):
+    """A typo must not be masked by a filesystem error, and must not raise.
+
+    The name is checked before the image is opened, so a bad backend with a bad path
+    says which one is wrong. The check itself used to raise TypeError on an
+    unhashable value, before the catch-all could see it.
+    """
+    r = tools.image_to_smiles_core("/does/not/exist.png", backend=backend)
+    assert r["ok"] is False
+    assert "unknown backend" in r["error"]
+
+
+def test_a_single_model_quotes_no_confidence_unless_asked(monkeypatch, png):
+    """One model cannot say how likely it is to be right about THIS image.
+
+    Its benchmark accuracy is a property of the model on someone else's images, so it
+    is withheld by default and available behind report_solo_accuracy for a caller who
+    knows what it means. Only the ensemble produces a per-image number.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "smiles_from_specialist",
+                        lambda n, b, **k: _narrow(model="decimer"))
+
+    r = tools.image_to_smiles_core(png, backend="decimer")
+    assert r["ok"] is True and r["smiles"] == "CCO"
+    assert r["confidence"] is None
+    assert r["confidence_unavailable_reason"] == "single_model_has_no_per_image_confidence"
+
+    opted_in = tools.image_to_smiles_core(png, backend="decimer",
+                                          report_solo_accuracy=True)
+    assert opted_in["confidence"] == core.prior_confidence("decimer")["p"]
+    assert opted_in["basis"] == "prior"
+
+
+def test_the_ensemble_can_run_a_subset_of_the_installed_models(monkeypatch, png):
+    """The committee is what a table describes, so a caller must be able to pick it.
+
+    Someone with all four installed who fitted a table on two of them could not get a
+    number: the ensemble ran everything and the committee check rejected the table.
+    """
+    _ensemble(monkeypatch, {m: "CCO" for m in
+                            ["decimer", "molnextr", "molscribe", "ocsrglyph"]})
+
+    r = tools.image_to_smiles_core(png, backend="ensemble",
+                                   models_wanted=["decimer", "molnextr"])
+    assert r["model_used"] == "decimer+molnextr"
+    assert r["agreement"] == "2"
+
+    unknown = tools.image_to_smiles_core(png, backend="ensemble",
+                                         models_wanted=["nosuchmodel"])
+    assert unknown["ok"] is False
+    assert "not OCSR specialists" in unknown["error"]
+
+
+def test_a_partial_install_says_which_models_are_missing(monkeypatch, png):
+    """"committee_mismatch: [...] vs [...]" told a user their answer had no
+    confidence without telling them what to do about it."""
+    _ensemble(monkeypatch, {"decimer": "CCO", "molnextr": "CCO"})
+    reason = tools.image_to_smiles_core(
+        png, backend="ensemble")["confidence_unavailable_reason"]
+    assert "molscribe" in reason and "ocsrglyph" in reason
+    assert "ocsr_setup molscribe" in reason      # how to install what is missing
+    assert "ocsr_calibrate --labels" in reason   # or refit for what is present
+
+
+def test_an_unreadable_table_is_reported_on_the_single_model_path(monkeypatch, png):
+    """Falling back to the packaged table would answer with the very numbers the
+    caller was trying to replace."""
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "smiles_from_specialist",
+                        lambda n, b, **k: _narrow(model="decimer"))
+    r = tools.image_to_smiles_core(png, backend="decimer", calibration="/nope.json",
+                                   report_solo_accuracy=True)
+    assert r["ok"] is True and r["smiles"] == "CCO"
+    assert r["confidence"] is None
+    assert "calibration_unreadable" in r["confidence_unavailable_reason"]
+
+
+def test_the_ensemble_votes_by_the_order_the_table_records(monkeypatch, png, tmp_path):
+    """The table's tie_break decides who wins an even split, so the tool must use it.
+
+    Deleting either wiring point, here or in validate(), left the whole suite green:
+    the shipped table's tie_break happens to equal its committee order, so a test
+    built on it cannot tell the two apart. This table records the reverse.
+    """
+    import json as _json
+
+    table = {
+        "committee": ["decimer", "molnextr"],
+        "tie_break": "model-priority: molnextr,decimer",
+        "n_items": 100, "scoring": "stereo_blind", "min_n_for_point_estimate": 20,
+        "patterns": {"1/1": {"k": 77, "n": 100, "p": round(77.5 / 101, 4),
+                             "ci": [0.68, 0.85]}},
+    }
+    path = tmp_path / "cal.json"
+    path.write_text(_json.dumps(table))
+
+    _ensemble(monkeypatch, {"decimer": "CCC", "molnextr": "CCO"})
+    r = tools.image_to_smiles_core(png, backend="ensemble", calibration=str(path))
+    assert r["smiles"] == "CCO"          # molnextr wins, as the table says
+    assert r["confidence"] == round(77.5 / 101, 4)
+    assert r["basis"] == "agreement"
+
+
+# ---------------------------------------------------------------------------
+# Prompt mode
+# ---------------------------------------------------------------------------
+
+
+def _capture_prompt(monkeypatch, reply):
+    """Run smiles_from_llm against a stub endpoint; return (system_prompt, result)."""
+    seen = {}
+
+    class _Msg:
+        content = reply
+
+    class _Choice:
+        message = _Msg()
+
+    class _Resp:
+        choices = [_Choice()]
+
+    class _Completions:
+        def create(self, model, messages, **kw):
+            seen["system"] = messages[0]["content"]
+            return _Resp()
+
+    class _Chat:
+        completions = _Completions()
+
+    class _Client:
+        def __init__(self, **kw):
+            self.chat = _Chat()
+
+    import openai
+    monkeypatch.setattr(openai, "OpenAI", _Client)
+    monkeypatch.setenv("ALCF_ACCESS_TOKEN", "x")
+    return seen
+
+
+def test_legacy_benchmark_mode_sends_the_vendored_prompt(monkeypatch, png):
+    """The vendored prompt is what the shipped calibration table was fitted under, so
+    the default path must keep sending it byte for byte."""
+    from chemgraph.prompt import ocsr_prompt
+
+    seen = _capture_prompt(monkeypatch, "CCO")
+    data, mime = core.load_image_bytes(png)
+    r = backends.smiles_from_llm(data, mime, "alcf")
+    assert seen["system"] == ocsr_prompt.OCSR_SYSTEM_PROMPT
+    assert r["smiles"] == "CCO"
+
+
+def test_structured_mode_asks_for_json_and_reads_the_field(monkeypatch, png):
+    """Structured mode's whole point is that the answer arrives in a named field
+    instead of having to be guessed out of prose."""
+    from chemgraph.prompt import ocsr_prompt
+
+    seen = _capture_prompt(monkeypatch, '{"smiles": "CC(=O)Oc1ccccc1C(=O)O"}')
+    data, mime = core.load_image_bytes(png)
+    r = backends.smiles_from_llm(data, mime, "alcf", prompt_mode="structured")
+    assert seen["system"] == ocsr_prompt.OCSR_STRUCTURED_SYSTEM_PROMPT
+    assert seen["system"] != ocsr_prompt.OCSR_SYSTEM_PROMPT
+    assert r["ok"] is True
+    assert r["smiles"] == "CC(=O)Oc1ccccc1C(=O)O"
+
+
+def test_an_unknown_prompt_mode_is_refused(png):
+    """A typo must not silently fall back to a different prompt from the one the
+    caller asked for, since the confidence numbers depend on which one ran."""
+    r = tools.image_to_smiles_core(png, backend="alcf", prompt_mode="strutured")
+    assert r["ok"] is False
+    assert "prompt_mode" in r["error"]

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -15,6 +15,7 @@ import pathlib
 import pytest
 
 from chemgraph.tools import ocsr_backends as backends
+from chemgraph.tools import ocsr_calibrate as calibrate
 from chemgraph.tools import ocsr_core as core
 from chemgraph.tools import ocsr_models as models
 from chemgraph.tools import ocsr_tools as tools
@@ -556,3 +557,111 @@ def test_an_unknown_prompt_mode_is_refused(png):
     r = tools.image_to_smiles_core(png, backend="alcf", prompt_mode="strutured")
     assert r["ok"] is False
     assert "prompt_mode" in r["error"]
+# -------------------------------------------------------------------------
+# Fitting a calibration table on your own labelled images
+# -------------------------------------------------------------------------
+def _rows(*specs):
+    """(per-model predictions, reference) pairs, the shape fit_calibration takes."""
+    out = []
+    for preds, ref in specs:
+        out.append(([{"model": m, "smiles": s, "ok": s is not None, "error": "",
+                      "infer_s": 0.1} for m, s in preds.items()], ref))
+    return out
+
+
+def test_fit_calibration_counts_what_actually_happened():
+
+    # 25 unanimous-and-right, 5 unanimous-and-wrong: the bucket should say 5/6ish.
+    rows = _rows(*([({"a": "CCO", "b": "CCO"}, "CCO")] * 25
+                   + [({"a": "CCN", "b": "CCN"}, "CCO")] * 5))
+    t = calibrate.fit_calibration(rows, ["a", "b"], min_n=20)
+    cell = t["patterns"]["2"]
+    assert (cell["k"], cell["n"]) == (25, 30)
+    assert 0.80 < cell["p"] < 0.85       # Jeffreys on 25/30
+    assert cell["ci"][0] < cell["p"] < cell["ci"][1]
+    assert t["committee"] == ["a", "b"]
+
+
+def test_a_fitted_table_is_usable_by_confidence():
+    """Round trip: what the fitter writes, the reader must understand."""
+
+    t = calibrate.fit_calibration(_rows(*([({"a": "CCO", "b": "CCO"}, "CCO")] * 40)),
+                            ["a", "b"], min_n=20)
+    c = core.confidence("2", t)
+    assert c["p"] is not None
+    assert c["reason"] is None
+    assert c["label"] in ("unanimous", "strong", "weak", "conflicting")
+# ---------------------------------------------------------------------------
+# The ocsr workflow
+# ---------------------------------------------------------------------------
+
+
+def test_report_renders_the_shipped_table():
+    """The fitter's own report crashed on the table ChemGraph ships.
+
+    It read cell["label"], which fit_calibration writes only above the sample floor
+    and the shipped table does not carry at all. Everything displayed now comes from
+    confidence(), the same call the tool makes, so the report cannot drift from it.
+    """
+    from chemgraph.tools import ocsr_calibrate as calibrate
+
+    text = calibrate.report(core.load_calibration(), 20)
+    assert "unanimous" in text
+    assert "low_n_conflicting" in text  # the 2/2 bucket, below the floor
+
+    # A table with no ci at all is valid; rendering it must not raise either.
+    thin = {"committee": ["a"], "n_items": 5, "scoring": "stereo_blind",
+            "patterns": {"1": {"k": 3, "n": 5}}}
+    core._validate_calibration(thin, "test")
+    assert "no interval" in calibrate.report(thin, 20)
+
+
+def test_the_fitter_withholds_a_number_below_the_sample_floor():
+    """False precision is the thing the floor exists to prevent.
+
+    A bucket of seven with a quoted decimal reads as a measurement; its interval is
+    50 points wide.
+    """
+    rows = _rows(*[({"a": "CCO", "b": "CCO"}, "CCO")] * 7)
+    table = calibrate.fit_calibration(rows, ["a", "b"], min_n=20)
+    assert table["patterns"]["2"]["n"] == 7
+    assert table["patterns"]["2"]["p"] is None
+    assert core.confidence("2", table)["label"].startswith("low_n_")
+
+    plenty = calibrate.fit_calibration(
+        _rows(*[({"a": "CCO", "b": "CCO"}, "CCO")] * 25), ["a", "b"], min_n=20)
+    assert plenty["patterns"]["2"]["p"] is not None
+
+
+def test_the_tie_break_comes_from_the_data_not_the_argument_order():
+    """--models is a set of names; nobody should have to know it is also a ranking.
+
+    The order decides who wins an even split, and the all-different bucket's number
+    measures how often that first model was right. Taking it from the order a caller
+    happened to type would bake an arbitrary choice into their table. It is ranked by
+    the solo accuracy measured on their own images instead, and --tie-break overrides.
+    """
+    data = _rows(*([({"decimer": "CCC", "molnextr": "CCO"}, "CCO")] * 7
+                   + [({"decimer": "CCO", "molnextr": "CCO"}, "CCO")] * 2
+                   + [({"decimer": "CCO", "molnextr": "CCC"}, "CCO")] * 1))
+    # molnextr is right 9/10 here, decimer 3/10, so molnextr must break ties
+    for order in (["decimer", "molnextr"], ["molnextr", "decimer"]):
+        table = calibrate.fit_calibration(data, order)
+        assert core.tie_break_order(table) == ["molnextr", "decimer"], order
+
+    explicit = calibrate.fit_calibration(data, ["decimer", "molnextr"],
+                                         tie_break=["decimer", "molnextr"])
+    assert core.tie_break_order(explicit) == ["decimer", "molnextr"]
+
+
+def test_validate_votes_by_the_table_being_checked():
+    """Comparing observed accuracy against a table means voting the table's way."""
+    table = {
+        "committee": ["a", "b"], "tie_break": "model-priority: b,a",
+        "n_items": 1, "scoring": "stereo_blind",
+        "patterns": {"1/1": {"k": 10, "n": 12, "p": round(10.5 / 13, 4)}},
+    }
+    core._validate_calibration(table, "test")
+    # b is right, a is wrong: voting b-first scores 1/1, voting a-first scores 0/1.
+    rows = _rows(({"a": "CCC", "b": "CCO"}, "CCO"))
+    assert "1/1 = 100%" in calibrate.validate(rows, ["a", "b"], table)


### PR DESCRIPTION
## Summary

The shipped calibration table describes four specific models on RDKit-rendered
diagrams. It was already overridable, but ChemGraph provided no way to generate a
replacement for a different committee or image distribution.

    python -m chemgraph.tools.ocsr_calibrate --labels my.csv --models a,b --out t.json

The fitter uses the same procedure as the shipped table: it runs every selected model
on every labelled image, groups predictions representing the same molecule, and
measures majority correctness for each agreement pattern. It also fits each model's
solo accuracy, so a refit updates the single-model figures in the same pass.

This also provides accuracy estimates for model committees not covered by the shipped
benchmark, using a user-supplied labelled dataset.

`--validate` is a lower-cost check for whether the shipped calibration transfers to a
new image distribution. A full refit needs a few hundred labelled images, while
detecting that the shipped calibration does not transfer may need only a few dozen.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

On this branch:

- `pytest tests/ -k "not tblite"`: 497 passed, 30 skipped, 2 deselected
  (118 OCSR).
- `ruff check .`: passes.

Fitted end to end on RDKit-rendered molecules with the real specialist models: the
fitter emits a table, the tool loads it, and the committee check refuses to apply a
three-model table to a four-model run, so a number from the wrong distribution
never reaches the caller.

## Part of a 5-PR series

Fourth of five. See #183 for the series overview. Sits on top of
`feature/ocsr-tools` and should merge after it.

## Checklist

- [x] Targets `main`; sits on top of `feature/ocsr-tools`, which is under review
- [x] PR is focused on a single logical change
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added tests for the change
- [x] Updated docs / README: the module docstring is the `--help` epilogue