### PR TITLE
Add main-agent file reads and subagent tool events

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,6 +68,14 @@ available interactively:
 chemgraph run --interactive --workflow main_agent
 ```
 
+While a delegated subagent is working, the CLI prints each subagent tool call
+and its arguments as it starts. Supervisor-only delegation and file-read calls
+and tool results are not printed.
+
+The supervisor's `read_file` tool reads only files stored in the durable graph
+state by a subagent. It does not grant access to the host filesystem or to
+files written under `CHEMGRAPH_LOG_DIR`.
+
 The development workspace Deep Agent can execute broad filesystem and shell
 actions. Enable it only in a disposable, trusted workspace after reviewing the
 CLI warning.

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -60,6 +60,13 @@ session-oriented async methods. This API is
 intended for durable, interactive supervisor workflows; consult the class
 docstrings in the installed version for constructor and persistence options.
 
+`MainAgentSession` accepts an optional `on_event` callback with the signature
+`(event_name, payload)`. Tagged `tool_call_started` payloads include
+`subagent_name`, allowing callers to distinguish delegated tool activity from
+supervisor tools. The supervisor can use `read_file` for checkpoint-backed
+files returned by subagents, but this does not expose host files or session
+artifacts.
+
 For CLI use, the equivalent is:
 
 ```bash

--- a/src/chemgraph/agent/events.py
+++ b/src/chemgraph/agent/events.py
@@ -8,6 +8,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 logger = logging.getLogger(__name__)
 
 EventCallback = Callable[[str, dict], None]
+SUBAGENT_METADATA_KEY = "chemgraph_subagent"
 
 
 def _serialized_name(serialized: Any) -> str | None:
@@ -121,12 +122,16 @@ class _BaseDashboardEventCallback(BaseCallbackHandler):
         self._emit("llm_call_failed", {"error": repr(error)})
 
     def on_tool_start(self, serialized, input_str, **kwargs) -> None:
+        payload = {
+            "tool_name": _serialized_name(serialized),
+            "arguments": _serialize_state(input_str),
+        }
+        metadata = kwargs.get("metadata")
+        if isinstance(metadata, dict) and metadata.get(SUBAGENT_METADATA_KEY):
+            payload["subagent_name"] = str(metadata[SUBAGENT_METADATA_KEY])
         self._emit(
             "tool_call_started",
-            {
-                "tool_name": _serialized_name(serialized),
-                "arguments": _serialize_state(input_str),
-            },
+            payload,
         )
 
     def on_tool_end(self, output, **kwargs) -> None:

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -12,6 +12,7 @@ from langchain_core.messages import HumanMessage
 from langgraph.errors import GraphInterrupt
 from langgraph.types import Command
 
+from chemgraph.agent.events import EventCallback, _AstreamEventCallback
 from chemgraph.agent.turn import serialize_state
 from chemgraph.graphs.main_agent import latest_assistant_text
 from chemgraph.memory.schemas import MainAgentGraphConfig, MainAgentSessionMetadata
@@ -95,6 +96,7 @@ class MainAgentSession:
         recursion_limit: int = 50,
         session_store: SessionStore | None = None,
         session_metadata: MainAgentSessionMetadata | None = None,
+        on_event: EventCallback | None = None,
     ):
         if recursion_limit <= 0:
             raise ValueError("recursion_limit must be positive.")
@@ -104,6 +106,10 @@ class MainAgentSession:
             "configurable": {"thread_id": self._thread_id},
             "recursion_limit": recursion_limit,
         }
+        if on_event is not None:
+            self.config["callbacks"] = [
+                _AstreamEventCallback(on_event, self._thread_id)
+            ]
         self._failed = False
         self._pending: tuple[PendingInterrupt, ...] = ()
         self.session_store = session_store

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -604,6 +604,23 @@ def create_main_agent_session(
         recursion_limit=agent.recursion_limit,
         session_store=agent.session_store,
         session_metadata=metadata,
+        on_event=_render_main_agent_event,
+    )
+
+
+def _render_main_agent_event(event: str, payload: dict[str, Any]) -> None:
+    """Render one tagged subagent tool call during interactive execution."""
+    if event != "tool_call_started":
+        return
+    subagent_name = payload.get("subagent_name")
+    if not subagent_name:
+        return
+    tool_name = payload.get("tool_name") or "unknown"
+    arguments = payload.get("arguments", "")
+    console.print(
+        f"[dim]Subagent[/dim] [bold cyan]{escape(str(subagent_name))}[/bold cyan] "
+        f"[dim]→[/dim] [bold]{escape(str(tool_name))}[/bold]"
+        f"({escape(str(arguments))})"
     )
 
 

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -17,6 +17,7 @@ from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.errors import GraphInterrupt
 
+from chemgraph.agent.events import SUBAGENT_METADATA_KEY
 from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.memory.subagent_recorder import SubagentRunRecorder
 
@@ -109,10 +110,17 @@ def _adapt_subagent(
 ) -> CompiledSubAgent:
     runnable = spec["runnable"]
 
+    def child_config(config: RunnableConfig) -> RunnableConfig:
+        adapted_config = dict(config)
+        metadata = dict(adapted_config.get("metadata") or {})
+        metadata[SUBAGENT_METADATA_KEY] = spec["name"]
+        adapted_config["metadata"] = metadata
+        return adapted_config
+
     def invoke(state: Any, config: RunnableConfig) -> Any:
         run_id = recorder.start(spec["name"], state, config) if recorder else None
         try:
-            result = runnable.invoke(state, config=config)
+            result = runnable.invoke(state, config=child_config(config))
         except GraphInterrupt:
             if recorder and run_id:
                 recorder.interrupted(run_id)
@@ -129,7 +137,7 @@ def _adapt_subagent(
     async def ainvoke(state: Any, config: RunnableConfig) -> Any:
         run_id = recorder.start(spec["name"], state, config) if recorder else None
         try:
-            result = await runnable.ainvoke(state, config=config)
+            result = await runnable.ainvoke(state, config=child_config(config))
         except GraphInterrupt:
             if recorder and run_id:
                 recorder.interrupted(run_id)

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -8,7 +8,7 @@ from typing import Any
 from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendProtocol
-from deepagents.middleware import SubAgentMiddleware
+from deepagents.middleware import FilesystemMiddleware, SubAgentMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent
 from langchain.agents import create_agent
 from langchain_core.messages import AIMessage, ToolMessage, convert_to_messages
@@ -42,6 +42,8 @@ Rules:
    appropriate only for independent read-only work.
 7. If deepagent is available, do not generate the code or file edits yourself;
    delegate those tasks to deepagent.
+8. Use `read_file` to inspect checkpoint-backed files returned by subagents
+   when their contents are needed. This tool cannot access host files.
 """
 
 
@@ -188,8 +190,12 @@ def _validate_main_tools(main_tools: Sequence[BaseTool]) -> None:
     names = [getattr(item, "name", "") for item in main_tools]
     if any(not name for name in names):
         raise ValueError("Every supervisor tool must have a non-empty name.")
-    if "task" in names:
-        raise ValueError("Supervisor tool name 'task' is reserved for subagents.")
+    reserved = {"read_file", "task"}
+    if conflicts := sorted(reserved.intersection(names)):
+        formatted = ", ".join(repr(name) for name in conflicts)
+        raise ValueError(
+            f"Supervisor tool name(s) {formatted} are reserved for middleware."
+        )
     if len(names) != len(set(names)):
         raise ValueError("Supervisor tool names must be unique.")
 
@@ -280,15 +286,20 @@ def construct_main_agent_graph(
     validated_subagents = _validate_subagents(registered_subagents, subagent_recorder)
     supervisor_tools = list(main_tools or [])
     _validate_main_tools(supervisor_tools)
-    middleware = SubAgentMiddleware(
-        backend=StateBackend(),
+    state_backend = StateBackend()
+    filesystem_middleware = FilesystemMiddleware(
+        backend=state_backend,
+        tools=["read_file"],
+    )
+    subagent_middleware = SubAgentMiddleware(
+        backend=state_backend,
         subagents=validated_subagents,
     )
     return create_agent(
         model=llm,
         tools=supervisor_tools,
         system_prompt=system_prompt,
-        middleware=[middleware],
+        middleware=[filesystem_middleware, subagent_middleware],
         checkpointer=checkpointer if checkpointer is not None else InMemorySaver(),
         name="main_agent",
     )

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from langchain_core.messages import AIMessage
+from chemgraph.agent.events import SUBAGENT_METADATA_KEY
 from chemgraph.agent.llm_agent import ChemGraph
 from chemgraph.agent.turn import _TurnEventCallback
 
@@ -198,6 +199,35 @@ def test_turn_event_callback_skips_llm_decision_without_tool_calls():
     )
 
     assert [event for event, _payload in events] == ["llm_call_finished"]
+
+
+def test_tool_event_includes_optional_subagent_name():
+    events = []
+    callback = _TurnEventCallback(
+        lambda event, payload: events.append((event, payload)),
+        "thread-1",
+    )
+
+    callback.on_tool_start(
+        {"name": "run_ase"},
+        "{'calculator': 'EMT'}",
+        metadata={SUBAGENT_METADATA_KEY: "chemgraph"},
+    )
+    callback.on_tool_start(
+        {"name": "read_file"},
+        "{'file_path': '/result.txt'}",
+    )
+
+    assert events[0] == (
+        "tool_call_started",
+        {
+            "thread_id": "thread-1",
+            "tool_name": "run_ase",
+            "arguments": "{'calculator': 'EMT'}",
+            "subagent_name": "chemgraph",
+        },
+    )
+    assert "subagent_name" not in events[1][1]
 
 
 def test_turn_event_callback_ignores_llm_decision_extraction_errors():

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -293,6 +293,59 @@ async def test_file_state_addition_restores_legacy_checkpoint():
 
 
 @pytest.mark.asyncio
+async def test_subagent_tool_events_include_direct_subagent_name():
+    @tool
+    def inspect_value(value: str) -> str:
+        """Inspect a test value."""
+        return f"inspected {value}"
+
+    worker_model = _ScriptedChatModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "inspect_value",
+                        "args": {"value": "sample"},
+                        "id": "inspect-1",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            AIMessage(content="Worker finished."),
+        ]
+    )
+    worker = create_agent(worker_model, tools=[inspect_value], name="worker")
+    supervisor_model = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_task_call("task-1")]),
+            AIMessage(content="Supervisor finished."),
+        ]
+    )
+    events = []
+    graph = construct_main_agent_graph(
+        supervisor_model,
+        subagents=[_subagent(worker)],
+    )
+    session = MainAgentSession(
+        graph,
+        thread_id="subagent-events",
+        on_event=lambda event, payload: events.append((event, payload)),
+    )
+
+    await session.run("Inspect a value")
+
+    started = [payload for event, payload in events if event == "tool_call_started"]
+    task_event = next(payload for payload in started if payload["tool_name"] == "task")
+    worker_event = next(
+        payload for payload in started if payload["tool_name"] == "inspect_value"
+    )
+    assert "subagent_name" not in task_event
+    assert worker_event["subagent_name"] == "worker"
+    assert "sample" in worker_event["arguments"]
+
+
+@pytest.mark.asyncio
 async def test_nested_subagent_interrupt_resumes_then_completes_turn():
     llm = _ScriptedChatModel(
         responses=[

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -1,9 +1,11 @@
 """Tests for the middleware-based main-agent supervisor."""
 
-from typing import Annotated, Any, TypedDict
+from typing import Annotated, Any, NotRequired, TypedDict
 
 import pytest
-from deepagents.backends import LocalShellBackend
+from deepagents.backends import LocalShellBackend, StateBackend
+from deepagents.middleware import SubAgentMiddleware
+from langchain.agents import create_agent
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
@@ -23,6 +25,10 @@ from chemgraph.graphs.single_agent import construct_single_agent_graph
 
 class _MessageState(TypedDict):
     messages: Annotated[list, add_messages]
+
+
+class _FileState(_MessageState):
+    files: NotRequired[dict[str, Any]]
 
 
 class _ScriptedChatModel(BaseChatModel):
@@ -152,6 +158,28 @@ def _terminal_tool_subgraph():
     return builder.compile(checkpointer=None)
 
 
+def _file_writing_subgraph():
+    def write_node(_state):
+        timestamp = "2026-08-18T00:00:00+00:00"
+        return {
+            "messages": [AIMessage(content="Saved /results.txt")],
+            "files": {
+                "/results.txt": {
+                    "content": "energy=-1.0",
+                    "encoding": "utf-8",
+                    "created_at": timestamp,
+                    "modified_at": timestamp,
+                }
+            },
+        }
+
+    builder = StateGraph(_FileState)
+    builder.add_node("write", write_node)
+    builder.add_edge(START, "write")
+    builder.add_edge("write", END)
+    return builder.compile(checkpointer=None)
+
+
 def _subagent(runnable, *, name: str = "worker", description: str = "Test worker"):
     return {"name": name, "description": description, "runnable": runnable}
 
@@ -186,7 +214,82 @@ async def test_main_agent_delegates_and_keeps_normal_turns_on_one_thread():
         "Calculate something",
         "Explain that result",
     ]
-    assert {tool.name for tool in llm.bound_tools} == {"task"}
+    assert {tool.name for tool in llm.bound_tools} == {"read_file", "task"}
+
+
+@pytest.mark.asyncio
+async def test_main_agent_reads_subagent_files_across_turns():
+    read_call = {
+        "name": "read_file",
+        "args": {"file_path": "/results.txt"},
+        "id": "read-1",
+        "type": "tool_call",
+    }
+    llm = _ScriptedChatModel(
+        responses=[
+            AIMessage(content="", tool_calls=[_task_call("task-1")]),
+            AIMessage(content="", tool_calls=[read_call]),
+            AIMessage(content="The energy is -1.0."),
+            AIMessage(
+                content="",
+                tool_calls=[{**read_call, "id": "read-2"}],
+            ),
+            AIMessage(content="The saved energy is still -1.0."),
+        ]
+    )
+    graph = construct_main_agent_graph(
+        llm,
+        subagents=[_subagent(_file_writing_subgraph())],
+    )
+    session = MainAgentSession(graph, thread_id="checkpoint-files")
+
+    first = await session.run("Calculate and save the energy")
+    second = await session.run("Read the saved energy again")
+
+    assert first.assistant_response == "The energy is -1.0."
+    assert second.assistant_response == "The saved energy is still -1.0."
+    snapshot = graph.get_state(session.config).values
+    assert snapshot["files"]["/results.txt"]["content"] == "energy=-1.0"
+    read_results = [
+        message.content
+        for message in snapshot["messages"]
+        if isinstance(message, ToolMessage) and message.name == "read_file"
+    ]
+    assert len(read_results) == 2
+    assert all("energy=-1.0" in result for result in read_results)
+
+
+@pytest.mark.asyncio
+async def test_file_state_addition_restores_legacy_checkpoint():
+    saver = InMemorySaver()
+    config = {"configurable": {"thread_id": "legacy-checkpoint"}}
+    subagent = _subagent(_answering_subgraph("done"))
+    legacy_graph = create_agent(
+        model=_ScriptedChatModel(responses=[AIMessage(content="Legacy response")]),
+        tools=[],
+        middleware=[
+            SubAgentMiddleware(backend=StateBackend(), subagents=[subagent])
+        ],
+        checkpointer=saver,
+        name="main_agent",
+    )
+    await legacy_graph.ainvoke(
+        {"messages": [HumanMessage(content="Legacy question")]},
+        config=config,
+    )
+    upgraded_graph = construct_main_agent_graph(
+        _ScriptedChatModel(responses=[]),
+        subagents=[subagent],
+        checkpointer=saver,
+    )
+
+    snapshot = await upgraded_graph.aget_state(config)
+
+    assert [message.content for message in snapshot.values["messages"]] == [
+        "Legacy question",
+        "Legacy response",
+    ]
+    assert snapshot.values["files"] == {}
 
 
 @pytest.mark.asyncio
@@ -594,31 +697,46 @@ def test_subagent_validation(specs, error, match):
         )
 
 
-def test_main_tools_are_extensible_and_task_is_reserved():
+def test_main_tools_are_extensible_and_middleware_names_are_reserved():
     @tool
-    def read_file(path: str) -> str:
-        """Return test file contents."""
-        return path
+    def lookup_value(value: str) -> str:
+        """Return a test value."""
+        return value
 
     llm = _ScriptedChatModel(responses=[AIMessage(content="done")])
     graph = construct_main_agent_graph(
         llm,
         subagents=[_subagent(_answering_subgraph("done"))],
-        main_tools=[read_file],
+        main_tools=[lookup_value],
     )
     assert graph is not None
+    graph.invoke(
+        {"messages": [HumanMessage(content="Use no tools")]},
+        config={"configurable": {"thread_id": "custom-main-tool"}},
+    )
+    assert {tool.name for tool in llm.bound_tools} == {
+        "lookup_value",
+        "read_file",
+        "task",
+    }
+
+    @tool("read_file")
+    def duplicate_read_file(path: str) -> str:
+        """Conflict with the filesystem middleware tool."""
+        return path
 
     @tool("task")
     def duplicate_task(description: str) -> str:
         """Conflict with the middleware task tool."""
         return description
 
-    with pytest.raises(ValueError, match="reserved"):
-        construct_main_agent_graph(
-            llm,
-            subagents=[_subagent(_answering_subgraph("done"))],
-            main_tools=[duplicate_task],
-        )
+    for duplicate in (duplicate_read_file, duplicate_task):
+        with pytest.raises(ValueError, match="reserved"):
+            construct_main_agent_graph(
+                llm,
+                subagents=[_subagent(_answering_subgraph("done"))],
+                main_tools=[duplicate],
+            )
 
 
 def test_single_agent_preserves_default_and_allows_inherited_checkpointer():

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -72,6 +72,67 @@ def test_main_agent_is_a_cli_workflow():
     assert "main_agent" in cli_main._WORKFLOW_CHOICES
 
 
+def test_interactive_event_renders_only_tagged_subagent_tool_calls():
+    with console.capture() as capture:
+        commands._render_main_agent_event(
+            "tool_call_started",
+            {
+                "subagent_name": "chemgraph",
+                "tool_name": "run_ase",
+                "arguments": "{'calculator': 'EMT'}",
+            },
+        )
+        commands._render_main_agent_event(
+            "tool_call_started",
+            {"tool_name": "task", "arguments": "{'description': 'work'}"},
+        )
+        commands._render_main_agent_event(
+            "tool_call_finished",
+            {
+                "subagent_name": "chemgraph",
+                "tool_name": "run_ase",
+                "result": "large result",
+            },
+        )
+
+    output = capture.get()
+    assert "chemgraph" in output
+    assert "run_ase" in output
+    assert "EMT" in output
+    assert "task" not in output
+    assert "large result" not in output
+
+
+def test_create_main_agent_session_installs_interactive_event_renderer(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        def __init__(self, workflow, **kwargs):
+            captured["workflow"] = workflow
+            captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "chemgraph.agent.main_session.MainAgentSession",
+        FakeSession,
+    )
+    metadata = MainAgentSessionMetadata(
+        graph_config=MainAgentGraphConfig(model_name="test-model")
+    )
+    agent = SimpleNamespace(
+        workflow=object(),
+        main_agent_metadata=metadata,
+        session_id="thread-1",
+        recursion_limit=25,
+        session_store=None,
+    )
+
+    commands.create_main_agent_session(agent)
+
+    assert captured["workflow"] is agent.workflow
+    assert captured["thread_id"] == "thread-1"
+    assert captured["on_event"] is commands._render_main_agent_event
+
+
 def test_main_agent_query_runs_each_turn_on_same_session():
     session = _FakeMainSession([_turn_result(), _turn_result()])
 


### PR DESCRIPTION
## Summary

- Add a checkpoint-backed `read_file` tool to the main-agent supervisor by sharing one `StateBackend` with subagent middleware. This does not expose host files or `CHEMGRAPH_LOG_DIR` artifacts.
- Tag delegated tool activity with the direct subagent name and render subagent tool starts during interactive CLI turns without printing supervisor calls or tool results.
- Preserve legacy main-agent checkpoints and document the Python and CLI behavior.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `/opt/anaconda3/bin/ruff check src/chemgraph/agent/events.py src/chemgraph/agent/main_session.py src/chemgraph/cli/commands.py src/chemgraph/graphs/main_agent.py tests/test_llm_agent.py tests/test_main_agent.py tests/test_main_agent_cli.py`
- `./.cg_fix_ase/bin/pytest -q tests/test_llm_agent.py tests/test_main_agent.py tests/test_main_agent_cli.py tests/test_graphs.py` — 94 passed
- `pytest tests/ -k "not tblite"` — 417 passed, 29 skipped, 2 deselected
- `git diff --check main...HEAD`

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change
- [ ] `ruff check .` passes (the checkout contains unrelated untracked environments; all changed Python files pass Ruff)
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change