### PR TITLE
fix: preserve MACE calculator variants during ASE input validation

### DIFF
--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -176,9 +176,11 @@ def _coerce_calculator_payload(data: Any) -> Any:
                 f"Available calculators are: {available_calc_names}"
             )
 
+        calculator_class = available_calcs[calc_key]
         init_args = calc.copy()
-        init_args.pop("calculator_type", None)
-        data["calculator"] = available_calcs[calc_key](**init_args)
+        if calculator_class is not MaceCalc:
+            init_args.pop("calculator_type", None)
+        data["calculator"] = calculator_class(**init_args)
         return data
 
     elif hasattr(calc, "__class__"):

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -8,7 +8,7 @@ import tempfile
 import threading
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 from pydantic import BaseModel, Field
 import torch
 
@@ -126,9 +126,9 @@ class MaceCalc(BaseModel):
         by default 21.167088422553647 (40.0 * units.Bohr)
     """
 
-    calculator_type: str = Field(
+    calculator_type: Literal["mace_mp", "mace_off", "mace_anicc"] = Field(
         default="mace_mp",
-        description="Type of calculator. Options: 'mace_mp' (default) or 'mace_off'.",
+        description="Type of calculator. Options: 'mace_mp' (default), 'mace_off', or 'mace_anicc'.",
     )
     model: Optional[Union[str, Path]] = Field(
         default=None,

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -1,6 +1,7 @@
 import importlib.util
 import pytest
 import numpy as np
+from pydantic import ValidationError
 from chemgraph.schemas.calculators.emt_calc import EMTCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
 from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
@@ -39,6 +40,69 @@ def test_default_calculator_is_in_detected_available_calculators():
     assert available
     assert "Calculator availability detected during ChemGraph initialization" in context
     assert default in context
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("mace") is None, reason="MACE not installed"
+)
+@pytest.mark.parametrize("calculator_type", ["mace_mp", "mace_off", "mace_anicc"])
+@pytest.mark.parametrize(
+    ("schema_name", "structure_input"),
+    [
+        ("ASEInputSchema", {"input_structure_file": "methane.xyz"}),
+        (
+            "ase_input_schema_ensemble",
+            {"input_structure_directory": "structures"},
+        ),
+    ],
+)
+def test_mace_variant_preserved_by_ase_schema(
+    calculator_type, schema_name, structure_input
+):
+    from chemgraph.schemas import ase_input
+
+    schema = getattr(ase_input, schema_name)
+    params = schema(
+        **structure_input,
+        calculator={"calculator_type": calculator_type, "device": "cpu"},
+    )
+
+    assert isinstance(params.calculator, MaceCalc)
+    assert params.calculator.calculator_type == calculator_type
+    assert params.model_dump()["calculator"]["calculator_type"] == calculator_type
+
+
+@pytest.mark.parametrize("calculator_type", ["mace_invalid", "Mace", "MaceCalc"])
+def test_mace_calculator_schema_rejects_invalid_variant(calculator_type):
+    with pytest.raises(ValidationError):
+        MaceCalc(calculator_type=calculator_type)
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("mace") is None, reason="MACE not installed"
+)
+@pytest.mark.parametrize("calculator_type", ["mace_invalid", "Mace", "MaceCalc"])
+@pytest.mark.parametrize(
+    ("schema_name", "structure_input"),
+    [
+        ("ASEInputSchema", {"input_structure_file": "methane.xyz"}),
+        (
+            "ase_input_schema_ensemble",
+            {"input_structure_directory": "structures"},
+        ),
+    ],
+)
+def test_ase_schema_rejects_invalid_mace_variant(
+    calculator_type, schema_name, structure_input
+):
+    from chemgraph.schemas import ase_input
+
+    schema = getattr(ase_input, schema_name)
+    with pytest.raises(ValidationError):
+        schema(
+            **structure_input,
+            calculator={"calculator_type": calculator_type, "device": "cpu"},
+        )
 
 
 def test_emt_calculator():


### PR DESCRIPTION
## Summary

- Preserve `mace_mp`, `mace_off`, and `mace_anicc` when ASE input dictionaries are converted into `MaceCalc` schemas.
- Reject unsupported MACE variants during Pydantic validation while retaining the existing xTB-to-TBLite alias behavior.
- Add schema-only regression coverage for single and ensemble ASE inputs without loading models or accessing the network.

## Related issues

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check` on all tracked Python files: passed.
- Focused calculator-schema tests: 3 passed and 12 skipped because MACE is not installed in the active interpreter; a dependency-discovery shim verified all valid and invalid single/ensemble cases plus the xTB alias without calculator/model loading.
- Environment-compatible core suite: 394 passed, 39 skipped, 16 deselected.
- The literal `ruff check .` is obstructed locally by the pre-existing untracked `.cg_uma_env/` virtual environment. The literal core command additionally has eight MACE setup errors because `mace-torch` is absent and one MCP subprocess failure because the checkout is not editable-installed in the active interpreter.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [ ] `ruff check .` passes (all tracked Python files pass; only the untracked local virtual environment fails)
- [ ] `pytest tests/ -k "not tblite"` passes (394 passed; local MACE/editable-install environment gaps remain)
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change (reviewed; no documentation change needed)