### PR TITLE
fix: improve ASE result metadata

### DIFF
--- a/src/chemgraph/mcp/mace_mcp_parsl.py
+++ b/src/chemgraph/mcp/mace_mcp_parsl.py
@@ -16,7 +16,7 @@ from chemgraph.schemas.mace_parsl_schema import (
     mace_input_schema,
     mace_input_schema_ensemble,
 )
-from chemgraph.tools.parsl_tools import run_mace_core
+from chemgraph.tools.parsl_tools import _result_potential_energy, run_mace_core
 from parsl import python_app
 
 warnings.warn(
@@ -97,14 +97,6 @@ def run_mace_single(params: mace_input_schema):
         MACE calculation result.
     """
     return run_mace_core(params)
-
-
-def _result_potential_energy(result: dict) -> float | None:
-    """Return canonical energy with a fallback for legacy tool results."""
-    potential_energy = result.get("potential_energy")
-    if potential_energy is not None:
-        return potential_energy
-    return result.get("single_point_energy")
 
 
 @mcp.tool(

--- a/src/chemgraph/mcp/mace_mcp_parsl.py
+++ b/src/chemgraph/mcp/mace_mcp_parsl.py
@@ -99,6 +99,14 @@ def run_mace_single(params: mace_input_schema):
     return run_mace_core(params)
 
 
+def _result_potential_energy(result: dict) -> float | None:
+    """Return canonical energy with a fallback for legacy tool results."""
+    potential_energy = result.get("potential_energy")
+    if potential_energy is not None:
+        return potential_energy
+    return result.get("single_point_energy")
+
+
 @mcp.tool(
     name="run_mace_ensemble",
     description="Run an ensemble of MACE calculations",
@@ -167,12 +175,15 @@ def run_mace_ensemble(params: mace_input_schema_ensemble):
             status = (
                 res.get("status", "unknown") if isinstance(res, dict) else "success"
             )
-            energy = res.get("single_point_energy") if isinstance(res, dict) else None
+            energy = None
+            if isinstance(res, dict):
+                energy = _result_potential_energy(res)
             results.append(
                 {
                     "structure": struct_name,
                     "output_result_file": out_file,
                     "status": status,
+                    "potential_energy": energy,
                     "single_point_energy": energy,
                     "raw_result": res,  # keep full result if needed by the LLM
                 }

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -381,8 +381,19 @@ class ASEOutputSchema(BaseModel):
     simulation_input: ASEInputSchema = Field(
         description="Simulation input for Atomic Simulation Environment."
     )
-    single_point_energy: float = Field(
-        default=None, description="Single-point energy/Potential energy"
+    potential_energy: Optional[float] = Field(
+        default=None,
+        description=(
+            "Potential energy in eV evaluated at the reported structure. For "
+            "optimization-based drivers, this is the final-structure energy."
+        ),
+    )
+    single_point_energy: Optional[float] = Field(
+        default=None,
+        description=(
+            "Deprecated compatibility alias for potential_energy. New consumers "
+            "should use potential_energy."
+        ),
     )
     energy_unit: str = Field(default="eV", description="The unit of the energy reported.")
     dipole_value: List[Optional[float]] = Field(

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -14,6 +14,11 @@ import torch
 
 _logger = logging.getLogger(__name__)
 
+_DEFAULT_MODEL_NAMES = {
+    "mace_mp": "medium-mpa-0",
+    "mace_off": "medium",
+}
+
 # Process-wide lock for MACE operations.
 # MACE model deserialization (torch.load) triggers torch.fx.symbolic_trace
 # inside Contraction.__init__, which temporarily patches
@@ -132,7 +137,9 @@ class MaceCalc(BaseModel):
     )
     model: Optional[Union[str, Path]] = Field(
         default=None,
-        description="Path to the model. If None, it will use the default model for the selected calculator type. "
+        description="Path to the model. If None, MACE selects its default model. "
+        "ChemGraph records 'medium-mpa-0' for mace_mp and 'medium' for mace_off "
+        "in successful simulation output. "
         "Options: 'small', 'medium', 'large', 'small-0b', 'medium-0b', 'small-0b2', 'medium-0b2','large-0b2', 'medium-0b3', 'medium-mpa-0', 'medium-omat-0', 'mace-matpes-pbe-0', 'mace-matpes-r2scan-0'",
     )
     device: str = Field(
@@ -159,6 +166,17 @@ class MaceCalc(BaseModel):
         default=21.167088422553647,  # Equivalent to 40.0 * units.Bohr,
         description="Cutoff radius in Bohr for D3 dispersion corrections (only for 'mace_mp').",
     )
+
+    def get_model_name_for_output(self) -> Optional[Union[str, Path]]:
+        """Return the model identifier to record in simulation output.
+
+        MACE still receives ``None`` when the caller omits a model. This
+        method only supplies ChemGraph's maintained name for that upstream
+        default so persisted simulation metadata is not ambiguous.
+        """
+        if self.model is not None:
+            return self.model
+        return _DEFAULT_MODEL_NAMES.get(self.calculator_type)
 
     def get_calculator(self):
         """Get the appropriate MACECalculator instance based on the selected calculator type.

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -393,6 +393,28 @@ def create_xyz_string(atomic_numbers, positions) -> Optional[str]:
         return None
 
 
+def _energy_result_metadata(
+    driver: str,
+    potential_energy: float,
+    results_file: str,
+    *,
+    converged: Optional[bool] = None,
+    optimization_steps: Optional[int] = None,
+) -> dict:
+    """Build consistent energy metadata for a successful tool result."""
+    result = {
+        "driver": driver,
+        "potential_energy": potential_energy,
+        "energy_unit": "eV",
+        "results_file": os.path.abspath(results_file),
+    }
+    if converged is not None:
+        result["converged"] = converged
+    if optimization_steps is not None:
+        result["optimization_steps"] = optimization_steps
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Unified ASE simulation core
 # ---------------------------------------------------------------------------
@@ -511,8 +533,8 @@ def run_ase_core(params: ASEInputSchema) -> dict:
     # ------------------------------------------------------------------
     if driver in ("energy", "dipole"):
         logger.info("Running single-point %s calculation", driver)
-        energy = atoms.get_potential_energy()
-        logger.info("Single-point energy: %s eV", energy)
+        potential_energy = float(atoms.get_potential_energy())
+        logger.info("Single-point energy: %s eV", potential_energy)
         final_structure = atoms_to_atomsdata(atoms)
 
         dipole: List[Optional[float]] = [None, None, None]
@@ -532,7 +554,8 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             simulation_input=params,
             success=True,
             dipole_value=dipole,
-            single_point_energy=energy,
+            potential_energy=potential_energy,
+            single_point_energy=potential_energy,
             wall_time=wall_time,
         )
         with open(output_results_file, "w", encoding="utf-8") as wf:
@@ -542,14 +565,26 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         if driver == "energy":
             return {
                 "status": "success",
-                "message": f"Simulation completed. Results saved to {os.path.abspath(output_results_file)}",
-                "single_point_energy": energy,
+                "message": (
+                    "Single-point energy calculation completed. "
+                    f"Results saved to {os.path.abspath(output_results_file)}"
+                ),
+                **_energy_result_metadata(
+                    driver, potential_energy, output_results_file
+                ),
+                "single_point_energy": potential_energy,
                 "unit": "eV",
             }
         else:  # dipole
             return {
                 "status": "success",
-                "message": f"Simulation completed. Results saved to {os.path.abspath(output_results_file)}",
+                "message": (
+                    "Dipole calculation completed. "
+                    f"Results saved to {os.path.abspath(output_results_file)}"
+                ),
+                **_energy_result_metadata(
+                    driver, potential_energy, output_results_file
+                ),
                 "dipole_moment": dipole,
                 "dipole_unit": "e * Angstrom",
             }
@@ -570,15 +605,17 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             raise ValueError(f"Unsupported optimizer: {optimizer}")
 
         logger.info("Running optimization with %s (fmax=%s, steps=%s)", optimizer, fmax, steps)
+        optimization_steps = 0
         if len(atoms) > 1:
             dyn = optimizer_class(atoms)
             converged = dyn.run(fmax=fmax, steps=steps)
+            optimization_steps = dyn.nsteps
         else:
             converged = True
         logger.info("Optimization converged=%s", converged)
 
-        single_point_energy = float(atoms.get_potential_energy())
-        logger.info("Post-optimization energy: %s eV", single_point_energy)
+        potential_energy = float(atoms.get_potential_energy())
+        logger.info("Post-optimization energy: %s eV", potential_energy)
         final_structure = AtomsData(
             numbers=atoms.numbers,
             positions=atoms.positions,
@@ -713,9 +750,9 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     logger.info("Computing thermochemistry (T=%s K, P=%s Pa)", temperature, pressure)
                     if len(atoms) == 1:
                         thermo_data = {
-                            "enthalpy": single_point_energy,
+                            "enthalpy": potential_energy,
                             "entropy": 0.0,
-                            "gibbs_free_energy": single_point_energy,
+                            "gibbs_free_energy": potential_energy,
                             "unit": "eV",
                         }
                     else:
@@ -735,7 +772,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
 
                         thermo = IdealGasThermo(
                             vib_energies=all_energies,
-                            potentialenergy=single_point_energy,
+                            potentialenergy=potential_energy,
                             atoms=atoms,
                             geometry=geometry,
                             symmetrynumber=symmetrynumber,
@@ -772,7 +809,8 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             thermochemistry=thermo_data,
             success=True,
             ir_data=ir_data,
-            single_point_energy=single_point_energy,
+            potential_energy=potential_energy,
+            single_point_energy=potential_energy,
             wall_time=wall_time,
         )
         with open(output_results_file, "w", encoding="utf-8") as wf:
@@ -780,16 +818,32 @@ def run_ase_core(params: ASEInputSchema) -> dict:
 
         # ---- minimal return payload ----
         abs_output = os.path.abspath(output_results_file)
+        energy_metadata = _energy_result_metadata(
+            driver,
+            potential_energy,
+            output_results_file,
+            converged=converged,
+            optimization_steps=optimization_steps,
+        )
         if driver == "opt":
+            if converged:
+                message = f"Geometry optimization converged. Results saved to {abs_output}"
+            else:
+                message = (
+                    "Geometry optimization completed without convergence after "
+                    f"{optimization_steps} steps. Results saved to {abs_output}"
+                )
             return {
                 "status": "success",
-                "message": f"Simulation completed. Results saved to {abs_output}",
-                "single_point_energy": single_point_energy,
+                "message": message,
+                **energy_metadata,
+                "single_point_energy": potential_energy,
                 "unit": "eV",
             }
         elif driver == "vib":
             return {
                 "status": "success",
+                **energy_metadata,
                 "result": {"vibrational_frequencies": vib_data},
                 "message": (
                     "Vibrational analysis completed; frequencies returned. "
@@ -799,6 +853,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         elif driver == "thermo":
             return {
                 "status": "success",
+                **energy_metadata,
                 "result": {"thermochemistry": thermo_data},
                 "message": (
                     "Thermochemistry computed and returned. "
@@ -808,6 +863,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         elif driver == "ir":
             return {
                 "status": "success",
+                **energy_metadata,
                 "result": {"vibrational_frequencies": vib_data},
                 "message": (
                     "Infrared computed and returned. "

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from chemgraph.schemas.atomsdata import AtomsData
 from chemgraph.schemas.ase_input import ASEInputSchema, ASEOutputSchema
+from chemgraph.schemas.calculators.mace_calc import MaceCalc
 
 logger = logging.getLogger(__name__)
 
@@ -308,6 +309,21 @@ def load_calculator(calculator: dict) -> tuple[object, dict, object]:
     return ase_calculator, extra_info, calc
 
 
+def _simulation_input_for_output(
+    params: ASEInputSchema, calc_model: object
+) -> ASEInputSchema:
+    """Return simulation input enriched with output-only calculator metadata."""
+    if not isinstance(calc_model, MaceCalc) or calc_model.model is not None:
+        return params
+
+    model_name = calc_model.get_model_name_for_output()
+    if model_name is None:
+        return params
+
+    output_calculator = calc_model.model_copy(update={"model": model_name})
+    return params.model_copy(update={"calculator": output_calculator})
+
+
 # ---------------------------------------------------------------------------
 # Misc helpers (kept for backward compat / UI)
 # ---------------------------------------------------------------------------
@@ -513,6 +529,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             ),
         }
     logger.info("Calculator loaded successfully: %s", type(calc).__name__)
+    simulation_input = _simulation_input_for_output(params, calc_model)
 
     try:
         atoms = read(input_structure_file)
@@ -551,7 +568,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             input_structure_file=input_structure_file,
             converged=True,
             final_structure=final_structure,
-            simulation_input=params,
+            simulation_input=simulation_input,
             success=True,
             dipole_value=dipole,
             potential_energy=potential_energy,
@@ -804,7 +821,7 @@ def run_ase_core(params: ASEInputSchema) -> dict:
             input_structure_file=input_structure_file,
             converged=converged,
             final_structure=final_structure,
-            simulation_input=params,
+            simulation_input=simulation_input,
             vibrational_frequencies=vib_data,
             thermochemistry=thermo_data,
             success=True,

--- a/src/chemgraph/tools/parsl_tools.py
+++ b/src/chemgraph/tools/parsl_tools.py
@@ -26,6 +26,15 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
+
+def _result_potential_energy(result: dict) -> float | None:
+    """Return canonical energy with a fallback for legacy tool results."""
+    potential_energy = result.get("potential_energy")
+    if potential_energy is not None:
+        return potential_energy
+    return result.get("single_point_energy")
+
+
 # ---------------------------------------------------------------------------
 # Core execution — delegates to the unified implementation
 # ---------------------------------------------------------------------------

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -477,8 +477,16 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         )
 
     # Energy
-    if ase_output.single_point_energy is not None:
+    energy_ev = ase_output.potential_energy
+    if energy_ev is None:
         energy_ev = ase_output.single_point_energy
+    driver = ase_output.simulation_input.driver
+    energy_label = (
+        "Single Point Energy"
+        if driver in {"energy", "dipole"}
+        else "Final Potential Energy"
+    )
+    if energy_ev is not None:
         calc_results.append(f"""
         <li class='regular-item'>
             <div class="unit-toggle">
@@ -488,13 +496,13 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                 <button onclick="toggleEnergyUnit('kcalmol')" data-unit="kcalmol">kcal/mol</button>
             </div>
             <div>
-                <strong>Single Point Energy</strong> (<span class="energy-unit">eV</span>): 
+                <strong>{energy_label}</strong> (<span class="energy-unit">eV</span>):
                 <span class="energy-value" data-ev="{energy_ev:.6f}"></span>
             </div>
         </li>""")
     else:
         calc_results.append(
-            f"<li class='regular-item'><strong>Single Point Energy</strong> ({ase_output.energy_unit}): N/A</li>"
+            f"<li class='regular-item'><strong>{energy_label}</strong> ({ase_output.energy_unit}): N/A</li>"
         )
 
     # Vibrational Frequencies

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -78,6 +78,21 @@ def test_mace_calculator_schema_rejects_invalid_variant(calculator_type):
         MaceCalc(calculator_type=calculator_type)
 
 
+@pytest.mark.parametrize(
+    ("calculator_type", "model", "expected"),
+    [
+        ("mace_mp", None, "medium-mpa-0"),
+        ("mace_off", None, "medium"),
+        ("mace_anicc", None, None),
+        ("mace_mp", "small-0b2", "small-0b2"),
+    ],
+)
+def test_mace_model_name_for_output(calculator_type, model, expected):
+    calc = MaceCalc(calculator_type=calculator_type, model=model)
+
+    assert calc.get_model_name_for_output() == expected
+
+
 @pytest.mark.skipif(
     importlib.util.find_spec("mace") is None, reason="MACE not installed"
 )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,6 +1,7 @@
 """Test suite for MCP servers."""
 
 from concurrent.futures import Future
+import importlib.util
 import inspect
 import json
 from pathlib import Path
@@ -315,6 +316,52 @@ def test_mace_ensemble_energy_prefers_canonical_key():
         )
         == -1.0
     )
+
+
+@pytest.mark.parametrize(
+    ("calculator_type", "expected_model"),
+    [("mace_mp", "medium-mpa-0"), ("mace_off", "medium")],
+)
+@pytest.mark.skipif(
+    importlib.util.find_spec("mace") is None, reason="MACE not installed"
+)
+def test_run_ase_core_records_default_mace_model(
+    monkeypatch, tmp_path, calculator_type, expected_model
+):
+    """Persist the MACE default name without changing calculator input."""
+    from ase import Atoms
+    from ase.calculators.emt import EMT
+    from ase.io import write as ase_write
+
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.schemas.calculators.mace_calc import MaceCalc
+    from chemgraph.tools import ase_core
+
+    input_path = tmp_path / "cu.xyz"
+    output_path = tmp_path / "output.json"
+    ase_write(input_path, Atoms("Cu", positions=[[0.0, 0.0, 0.0]]))
+
+    received_models = []
+
+    def fake_get_calculator(self):
+        received_models.append(self.model)
+        return EMT()
+
+    monkeypatch.setattr(MaceCalc, "get_calculator", fake_get_calculator)
+    params = ASEInputSchema.model_construct(
+        input_structure_file=str(input_path),
+        output_results_file=str(output_path),
+        driver="opt",
+        calculator=MaceCalc(calculator_type=calculator_type),
+    )
+
+    result = ase_core.run_ase_core(params)
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert result["status"] == "success", result
+    assert received_models == [None]
+    assert params.calculator.model is None
+    assert output["simulation_input"]["calculator"]["model"] == expected_model
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -300,8 +300,7 @@ def test_run_ase_core_reports_optimization_completion(
 
 
 def test_mace_ensemble_energy_prefers_canonical_key():
-    pytest.importorskip("parsl")
-    from chemgraph.mcp.mace_mcp_parsl import _result_potential_energy
+    from chemgraph.tools.parsl_tools import _result_potential_energy
 
     assert (
         _result_potential_energy(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -224,8 +224,97 @@ def test_run_ase_core_creates_output_parent_directory(monkeypatch, tmp_path):
     result = ase_core.run_ase_core(params)
 
     assert result["status"] == "success", result
+    assert result["driver"] == "energy"
+    assert result["potential_energy"] == pytest.approx(-1.234)
+    assert result["single_point_energy"] == pytest.approx(-1.234)
+    assert result["energy_unit"] == "eV"
+    assert result["results_file"] == str(output_path.resolve())
     assert output_path.exists()
     assert output_path.parent.is_dir()
+
+
+@pytest.mark.parametrize(
+    ("converged", "expected_steps", "expected_message"),
+    [
+        (True, 2, "Geometry optimization converged."),
+        (
+            False,
+            7,
+            "Geometry optimization completed without convergence after 7 steps.",
+        ),
+    ],
+)
+def test_run_ase_core_reports_optimization_completion(
+    monkeypatch, tmp_path, converged, expected_steps, expected_message
+):
+    from ase import Atoms
+    import ase.optimize
+    from ase.io import write as ase_write
+
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.tools import ase_core
+
+    input_path = tmp_path / "h2.xyz"
+    output_path = tmp_path / "optimization.json"
+    ase_write(input_path, Atoms(numbers=[1, 1], positions=[[0, 0, 0], [0, 0, 0.74]]))
+
+    class _FakeCalc:
+        def get_potential_energy(self, _atoms=None, force_consistent=False):
+            return -1.234
+
+    class _FakeOptimizer:
+        def __init__(self, _atoms):
+            self.nsteps = 0
+
+        def run(self, *, fmax, steps):
+            self.nsteps = expected_steps
+            return converged
+
+    monkeypatch.setattr(
+        ase_core, "load_calculator", lambda _calculator: (_FakeCalc(), {}, None)
+    )
+    monkeypatch.setattr(ase.optimize, "BFGS", _FakeOptimizer)
+    params = ASEInputSchema(
+        input_structure_file=str(input_path),
+        output_results_file=str(output_path),
+        driver="opt",
+        steps=7,
+        calculator={"calculator_type": "emt"},
+    )
+
+    result = ase_core.run_ase_core(params)
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert result["status"] == "success"
+    assert result["driver"] == "opt"
+    assert result["converged"] is converged
+    assert result["optimization_steps"] == expected_steps
+    assert result["potential_energy"] == pytest.approx(-1.234)
+    assert result["single_point_energy"] == pytest.approx(-1.234)
+    assert result["energy_unit"] == "eV"
+    assert result["results_file"] == str(output_path.resolve())
+    assert expected_message in result["message"]
+    assert output["potential_energy"] == pytest.approx(-1.234)
+    assert output["single_point_energy"] == pytest.approx(-1.234)
+
+
+def test_mace_ensemble_energy_prefers_canonical_key():
+    pytest.importorskip("parsl")
+    from chemgraph.mcp.mace_mcp_parsl import _result_potential_energy
+
+    assert (
+        _result_potential_energy(
+            {"potential_energy": -2.0, "single_point_energy": -1.0}
+        )
+        == -2.0
+    )
+    assert _result_potential_energy({"single_point_energy": -1.0}) == -1.0
+    assert (
+        _result_potential_energy(
+            {"potential_energy": None, "single_point_energy": -1.0}
+        )
+        == -1.0
+    )
 
 
 @pytest.mark.asyncio
@@ -283,10 +372,16 @@ async def test_run_ase_energy_simple(base_ase_input_dict):
         res = await client.call_tool("run_ase", {"params": input_data})
         result_dict = json.loads(res.content[0].text)
         assert result_dict["status"] == "success"
+        assert result_dict["driver"] == "energy"
+        assert result_dict["potential_energy"] == result_dict["single_point_energy"]
+        assert result_dict["energy_unit"] == "eV"
+        assert result_dict["results_file"] == str(
+            Path(input_data["output_results_file"]).resolve()
+        )
         assert "single_point_energy" in result_dict
 
         assert isinstance(res.content[0], TextContent)
-        assert "Simulation completed" in res.content[0].text
+        assert "Single-point energy calculation completed" in res.content[0].text
 
 
 @pytest.mark.asyncio

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -37,6 +37,7 @@ sample_ase_output = {
         "temperature": 298.0,
         "pressure": 101325.0,
     },
+    "potential_energy": -13.786080327355158,
     "single_point_energy": -13.786080327355158,
     "energy_unit": "eV",
     "dipole_value": [None, None, None],
@@ -132,6 +133,37 @@ def test_generate_html_distinguishes_filtered_and_legacy_modes(tmp_path):
     legacy_content = legacy_html.read_text(encoding="utf-8")
     assert legacy_content.count("<td>Translation/Rotation</td>") == 6
     assert "This legacy result includes the first 6" in legacy_content
+
+
+@pytest.mark.parametrize(
+    ("driver", "legacy_energy", "expected_label"),
+    [
+        ("energy", False, "Single Point Energy"),
+        ("thermo", False, "Final Potential Energy"),
+        ("thermo", True, "Final Potential Energy"),
+    ],
+)
+def test_generate_html_labels_energy_by_driver(
+    tmp_path, driver, legacy_energy, expected_label
+):
+    output = json.loads(json.dumps(sample_ase_output))
+    output["simulation_input"]["driver"] = driver
+    if legacy_energy:
+        output.pop("potential_energy")
+
+    results_json = tmp_path / f"{driver}.json"
+    report_html = tmp_path / f"{driver}.html"
+    results_json.write_text(json.dumps(output), encoding="utf-8")
+
+    generate_html.invoke(
+        {
+            "results_json_path": str(results_json),
+            "output_path": str(report_html),
+        }
+    )
+
+    content = report_html.read_text(encoding="utf-8")
+    assert expected_label in content
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

- Record the maintained default MACE model name in successful ASE output when callers omit `model`, while continuing to pass `None` to MACE itself.
- Add `potential_energy` as the canonical ASE energy field and retain `single_point_energy` as a deprecated compatibility alias.
- Report the driver, energy unit, results path, convergence state, and optimization step count consistently.
- Use driver-aware completion messages and report labels, with legacy-energy fallback in the Parsl ensemble aggregator.

Fixes #190.

## Compatibility

- Existing consumers can continue reading `single_point_energy`.
- Explicit MACE model selections are unchanged.
- The output-only default model mapping records `medium-mpa-0` for `mace_mp` and `medium` for `mace_off`.

## Testing

- `ruff check .`
- Focused `.cg_fix_ase` CI regression tests: 5 passed
- Full `.cg_fix_ase` suite with `pytest tests/ -k "not tblite"`: 449 passed, 29 skipped, 2 deselected

## Checklist

- [x] Added regression coverage for default MACE model persistence
- [x] Added regression coverage for energy metadata and optimization completion
- [x] Preserved backward compatibility for existing result consumers
- [x] Kept behavior changes in separate topic-focused commits