### PR TITLE
Add OpenRouter as a first-class provider

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,6 +48,10 @@ argo_user = ""
 base_url = "https://api.groq.com/openai/v1"
 timeout = 30
 
+[api.openrouter]
+base_url = "https://openrouter.ai/api/v1"
+timeout = 60
+
 [api.anthropic]
 base_url = "https://api.anthropic.com"
 timeout = 30

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ x-chemgraph-common: &chemgraph-common
     ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
     GEMINI_API_KEY: ${GEMINI_API_KEY:-}
     GROQ_API_KEY: ${GROQ_API_KEY:-}
+    OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
     CHEMGRAPH_LOG_DIR: /app/cg_logs
     PYTHONPATH: /app/src
     ARGO_USER: ${ARGO_USER:-}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -50,6 +50,12 @@ spec:
               name: chemgraph-secrets
               key: groq-api-key
               optional: true
+        - name: OPENROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: chemgraph-secrets
+              key: openrouter-api-key
+              optional: true
         - name: ARGO_USER
           valueFrom:
             secretKeyRef:

--- a/k8s/mcp-deployment.yaml
+++ b/k8s/mcp-deployment.yaml
@@ -50,6 +50,12 @@ spec:
               name: chemgraph-secrets
               key: groq-api-key
               optional: true
+        - name: OPENROUTER_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: chemgraph-secrets
+              key: openrouter-api-key
+              optional: true
         - name: ARGO_USER
           valueFrom:
             secretKeyRef:

--- a/k8s/secrets.yaml.template
+++ b/k8s/secrets.yaml.template
@@ -9,5 +9,6 @@ stringData:
   anthropic-api-key: "YOUR_ANTHROPIC_API_KEY"
   gemini-api-key: "YOUR_GEMINI_API_KEY"
   groq-api-key: "YOUR_GROQ_API_KEY"
+  openrouter-api-key: "YOUR_OPENROUTER_API_KEY"
   argo-user: "YOUR_ARGO_USER"
   alcf-access-token: "YOUR_ALCF_ACCESS_TOKEN"

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -24,6 +24,7 @@ from chemgraph.models.local_model import load_ollama_model
 from chemgraph.models.anthropic import load_anthropic_model
 from chemgraph.models.gemini import load_gemini_model
 from chemgraph.models.groq import load_groq_model
+from chemgraph.models.openrouter import load_openrouter_model
 from chemgraph.models.codex import load_codex_model
 from chemgraph.models.supported_models import (
     MODELS_WITH_REASONING_EFFORT,
@@ -296,6 +297,13 @@ class ChemGraph:
 
             if model_name.startswith("codex:"):
                 llm = load_codex_model(model_name)
+            elif model_name.startswith("openrouter:"):
+                llm = load_openrouter_model(
+                    model_name=model_name,
+                    api_key=api_key,
+                    base_url=base_url,
+                    temperature=temperature,
+                )
             elif (
                 model_name in supported_openai_models
                 or model_name in supported_argo_models

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -108,6 +108,19 @@ def check_api_keys(model_name: str) -> tuple[bool, str]:
     if model_name.startswith("codex:"):
         return True, ""
 
+    # OpenRouter models. Checked before the OpenAI branch below, whose
+    # ``"o1"/"o3"/"o4" in model_lower`` test is a substring match that would
+    # otherwise claim slugs like ``openrouter:openai/o3``, and before the
+    # local-model branch, which would claim ``openrouter:meta-llama/...``.
+    if model_name.startswith("openrouter:"):
+        if not os.getenv("OPENROUTER_API_KEY"):
+            return (
+                False,
+                "OpenRouter API key not found. Set the OPENROUTER_API_KEY "
+                "environment variable. Get a key at https://openrouter.ai/keys",
+            )
+        return True, ""
+
     # OpenAI models (including GPT family, o-series, and Argo OpenAI)
     if (
         model_name in supported_openai_models

--- a/src/chemgraph/cli/formatting.py
+++ b/src/chemgraph/cli/formatting.py
@@ -56,6 +56,10 @@ def list_models() -> None:
 
     # Categorize models by provider
     model_info = {
+        # Prefix-routed providers first: the lookup below breaks on the first
+        # substring match, so "openrouter:openai/gpt-oss-120b" would otherwise
+        # be claimed by the "openai" / "gpt" / "llama" keys.
+        "openrouter:": {"provider": "OpenRouter", "type": "Cloud"},
         "openai": {"provider": "OpenAI", "type": "Cloud"},
         "gpt": {"provider": "OpenAI", "type": "Cloud"},
         "claude": {"provider": "Anthropic", "type": "Cloud"},
@@ -127,6 +131,11 @@ def check_api_keys_status() -> None:
             "examples": "groq:llama-3.3-70b-versatile",
         },
         {
+            "provider": "OpenRouter",
+            "env_var": "OPENROUTER_API_KEY",
+            "examples": "openrouter:moonshotai/kimi-k3",
+        },
+        {
             "provider": "ALCF",
             "env_var": "ALCF_ACCESS_TOKEN",
             "examples": "Llama-3.1-405B, Qwen3-32B",
@@ -162,6 +171,7 @@ def check_api_keys_status() -> None:
     console.print("  [cyan]OpenAI:[/cyan] https://platform.openai.com/api-keys")
     console.print("  [cyan]Anthropic:[/cyan] https://console.anthropic.com/")
     console.print("  [cyan]Google:[/cyan] https://aistudio.google.com/apikey")
+    console.print("  [cyan]OpenRouter:[/cyan] https://openrouter.ai/keys")
 
 
 # ---------------------------------------------------------------------------

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -15,6 +15,7 @@ from chemgraph.models.gemini import load_gemini_model
 from chemgraph.models.groq import load_groq_model
 from chemgraph.models.local_model import load_ollama_model
 from chemgraph.models.openai import load_openai_model
+from chemgraph.models.openrouter import load_openrouter_model
 from chemgraph.models.settings import LLMSettings
 from chemgraph.models.supported_models import (
     supported_alcf_models,
@@ -76,6 +77,13 @@ def load_chat_model(
 
     if model_name.startswith("codex:"):
         return load_codex_model(model_name)
+    elif model_name.startswith("openrouter:"):
+        return load_openrouter_model(
+            model_name=model_name,
+            api_key=api_key,
+            base_url=base_url,
+            temperature=temperature,
+        )
     elif model_name in supported_openai_models or model_name in supported_argo_models:
         kwargs = {
             "model_name": model_name,
@@ -109,5 +117,5 @@ def load_chat_model(
         raise ValueError(
             f"Model '{model_name}' not found in any supported model list. "
             "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
-            "codex:<model>, argo:<model>, ALCF, or Ollama."
+            "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama."
         )

--- a/src/chemgraph/models/openrouter.py
+++ b/src/chemgraph/models/openrouter.py
@@ -1,0 +1,99 @@
+"""Load OpenRouter models using LangChain's OpenAI-compatible client."""
+
+import os
+import sys
+from getpass import getpass
+
+from langchain_openai import ChatOpenAI
+
+from chemgraph.models.supported_models import (
+    MODELS_WITHOUT_TEMPERATURE,
+    OPENROUTER_DEFAULT_BASE_URL,
+)
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+# Higher than the OpenAI/Groq defaults on purpose: most models served through
+# OpenRouter emit reasoning tokens by default, and those count against the
+# *completion* budget. Too small a cap lets chain-of-thought exhaust it before
+# the tool call is emitted, producing an empty turn the graph reads as a dead end.
+OPENROUTER_DEFAULT_MAX_TOKENS = 8000
+
+
+def load_openrouter_model(
+    model_name: str,
+    temperature: float = 0.0,
+    api_key: str = None,
+    base_url: str = None,
+    max_tokens: int = OPENROUTER_DEFAULT_MAX_TOKENS,
+) -> ChatOpenAI:
+    """Load an OpenRouter chat model into LangChain.
+
+    OpenRouter exposes an OpenAI-compatible API, so this returns a
+    ``ChatOpenAI`` pointed at the OpenRouter endpoint. Any slug from
+    https://openrouter.ai/models works; ``supported_openrouter_models`` is a
+    discovery list, not a gate.
+
+    Parameters
+    ----------
+    model_name : str
+        Model identifier with the ``openrouter:`` prefix. The prefix is
+        stripped and the remainder sent verbatim (e.g. ``moonshotai/kimi-k3``).
+    temperature : float
+        Sampling temperature. Omitted for ``MODELS_WITHOUT_TEMPERATURE`` entries.
+    api_key : str, optional
+        Falls back to ``OPENROUTER_API_KEY``. Never to ``OPENAI_API_KEY``.
+    base_url : str, optional
+        Endpoint override. Defaults to ``OPENROUTER_DEFAULT_BASE_URL``.
+    max_tokens : int
+        Completion-token budget. See ``OPENROUTER_DEFAULT_MAX_TOKENS``.
+
+    Returns
+    -------
+    ChatOpenAI
+        A LangChain chat model bound to the OpenRouter endpoint.
+
+    Raises
+    ------
+    ValueError
+        If no API key is available and there is no terminal to prompt on.
+    """
+    # Keep the prefixed name -- it is what the quirk sets are keyed on.
+    requested_model_name = model_name
+    model_name = model_name.removeprefix("openrouter:")
+
+    if api_key is None:
+        api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        # Only prompt when there is a terminal. Under the eval harness
+        # (nohup/cron) getpass() would not fail -- it would block on stdin
+        # forever, with no traceback and no exit code.
+        if sys.stdin.isatty():
+            logger.info("OpenRouter API key not found in environment variables.")
+            api_key = getpass("Please enter your OpenRouter API key: ")
+            os.environ["OPENROUTER_API_KEY"] = api_key
+        else:
+            raise ValueError(
+                "OpenRouter API key not found. Set the OPENROUTER_API_KEY "
+                "environment variable:\n"
+                "  export OPENROUTER_API_KEY='your_key_here'\n"
+                "  Get a key at: https://openrouter.ai/keys"
+            )
+
+    logger.info("Loading OpenRouter model: %s", model_name)
+    llm_kwargs = dict(
+        model=model_name,
+        api_key=api_key,
+        base_url=base_url or OPENROUTER_DEFAULT_BASE_URL,
+        max_tokens=max_tokens,
+    )
+    # top_p / frequency_penalty / presence_penalty are deliberately not sent:
+    # they are no-ops at temperature 0, and OpenRouter fans requests out to a
+    # rotating pool of upstream providers whose real parameter support is
+    # narrower than the advertised union.
+    if requested_model_name not in MODELS_WITHOUT_TEMPERATURE:
+        llm_kwargs["temperature"] = temperature
+
+    # Authentication happens only during invocation.
+    return ChatOpenAI(**llm_kwargs)

--- a/src/chemgraph/models/settings.py
+++ b/src/chemgraph/models/settings.py
@@ -117,6 +117,8 @@ def _extract_endpoint_from_cli_toml(raw: Mapping[str, Any]) -> dict[str, Any]:
     if isinstance(model, str):
         if model.startswith("argo:"):
             base_url = (api.get("argo") or {}).get("base_url")
+        elif model.startswith("openrouter:"):
+            base_url = (api.get("openrouter") or {}).get("base_url")
         else:
             for section_name in ("openai", "anthropic", "gemini", "alcf", "ollama"):
                 section = api.get(section_name) or {}
@@ -138,6 +140,8 @@ def _provider_section_for(model: Any) -> str:
             return "argo"
         if model.startswith("groq:"):
             return "groq"
+        if model.startswith("openrouter:"):
+            return "openrouter"
     return "openai"
 
 

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -130,9 +130,6 @@ OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 # This list is curated for *discovery* only (--list-models, UI dropdown); it is
 # NOT a gate. Dispatch is by prefix, so any slug from
 # https://openrouter.ai/models also works.
-# Every entry supports tool calling, which each ChemGraph workflow needs.
-# Slugs are the undated ones, which OpenRouter keeps stable; dated snapshots
-# such as deepseek-v4-pro-0813 also work but are not carried here.
 supported_openrouter_models = [
     # DeepSeek
     "openrouter:deepseek/deepseek-v4-pro",

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -121,6 +121,21 @@ supported_gemini_models = [
 # See https://console.groq.com/docs/models for current models.
 supported_groq_models: list[str] = []
 
+# Default OpenRouter API base URL (OpenAI-compatible).
+OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
+# OpenRouter models -- use the "openrouter:" prefix (e.g.
+# "openrouter:moonshotai/kimi-k3"). The prefix is stripped before the request
+# and the remainder is sent as the OpenRouter slug verbatim.
+# This list is curated for *discovery* (--list-models, UI dropdown, per-model
+# quirk sets such as MODELS_WITHOUT_TEMPERATURE); it is NOT a gate. Dispatch is
+# by prefix, so any slug from https://openrouter.ai/models also works.
+supported_openrouter_models = [
+    "openrouter:moonshotai/kimi-k3",
+    "openrouter:deepseek/deepseek-v4-pro",
+    "openrouter:deepseek/deepseek-v4-flash",
+]
+
 # Default Argo API base URL (used when no --base-url is provided).
 ARGO_DEFAULT_BASE_URL = "https://apps.inside.anl.gov/argoapi/v1"
 
@@ -202,4 +217,5 @@ all_supported_models = (
     + supported_argo_models
     + supported_gemini_models
     + supported_groq_models
+    + supported_openrouter_models
 )

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -127,13 +127,30 @@ OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
 # OpenRouter models -- use the "openrouter:" prefix (e.g.
 # "openrouter:moonshotai/kimi-k3"). The prefix is stripped before the request
 # and the remainder is sent as the OpenRouter slug verbatim.
-# This list is curated for *discovery* (--list-models, UI dropdown, per-model
-# quirk sets such as MODELS_WITHOUT_TEMPERATURE); it is NOT a gate. Dispatch is
-# by prefix, so any slug from https://openrouter.ai/models also works.
+# This list is curated for *discovery* only (--list-models, UI dropdown); it is
+# NOT a gate. Dispatch is by prefix, so any slug from
+# https://openrouter.ai/models also works.
+# Every entry supports tool calling, which each ChemGraph workflow needs.
+# Slugs are the undated ones, which OpenRouter keeps stable; dated snapshots
+# such as deepseek-v4-pro-0813 also work but are not carried here.
 supported_openrouter_models = [
-    "openrouter:moonshotai/kimi-k3",
+    # DeepSeek
     "openrouter:deepseek/deepseek-v4-pro",
     "openrouter:deepseek/deepseek-v4-flash",
+    # Kimi
+    "openrouter:moonshotai/kimi-k3",
+    "openrouter:moonshotai/kimi-k2.6",
+    # Qwen
+    "openrouter:qwen/qwen3.8-max",
+    "openrouter:qwen/qwen3.8-2.4t-a95b",
+    "openrouter:qwen/qwen3.8-27b",
+    "openrouter:qwen/qwen3.7-flash",
+    # GLM
+    "openrouter:z-ai/glm-5.2",
+    "openrouter:z-ai/glm-5.1",
+    # MiniMax
+    "openrouter:minimax/minimax-m3",
+    "openrouter:minimax/minimax-m2.7",
 ]
 
 # Default Argo API base URL (used when no --base-url is provided).
@@ -171,6 +188,7 @@ supported_argo_models = [
     "argo:gemini-3.1-flash-lite",
     "argo:gemini-3.5-flash",
     # Claude via Argo
+    "argo:claude-opus-5",
     "argo:claude-opus-4.8",
     "argo:claude-opus-4.7",
     "argo:claude-opus-4.6",

--- a/src/chemgraph/utils/config_utils.py
+++ b/src/chemgraph/utils/config_utils.py
@@ -10,6 +10,7 @@ from chemgraph.models.supported_models import (
     ALCF_METIS_BASE_URL,
     ALCF_MINERVA_BASE_URL,
     ARGO_DEFAULT_BASE_URL,
+    OPENROUTER_DEFAULT_BASE_URL,
     all_supported_models,
     supported_alcf_metis_models,
     supported_alcf_minerva_models,
@@ -113,6 +114,12 @@ def get_base_url_for_model_from_nested_config(
         return normalize_openai_base_url(
             api.get("openai", {}).get("base_url") or ARGO_DEFAULT_BASE_URL
         )
+    # Prefix-routed, and matched before any list lookup: the fallthrough at the
+    # end of this function returns [api.openai].base_url, so an uncurated
+    # openrouter: slug would otherwise be sent to whatever OpenAI-compatible
+    # endpoint is configured there (the Argo gateway, by default).
+    if model_name.startswith("openrouter:"):
+        return api.get("openrouter", {}).get("base_url") or OPENROUTER_DEFAULT_BASE_URL
     if model_name in supported_openai_models:
         return normalize_openai_base_url(api.get("openai", {}).get("base_url"))
     # Minerva and Metis have their own endpoints, and [api.alcf] base_url
@@ -153,6 +160,9 @@ def get_base_url_for_model_from_flat_config(
         return normalize_openai_base_url(
             config.get("api_openai_base_url") or ARGO_DEFAULT_BASE_URL
         )
+    # See the note in get_base_url_for_model_from_nested_config.
+    if model_name.startswith("openrouter:"):
+        return config.get("api_openrouter_base_url") or OPENROUTER_DEFAULT_BASE_URL
     if model_name in supported_openai_models:
         return normalize_openai_base_url(config.get("api_openai_base_url"))
     # See the note in get_base_url_for_model_from_nested_config.

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -122,6 +122,10 @@ def get_default_config() -> Dict[str, Any]:
                 "base_url": "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
                 "timeout": 30,
             },
+            "openrouter": {
+                "base_url": "https://openrouter.ai/api/v1",
+                "timeout": 60,
+            },
             "local": {"base_url": "http://localhost:11434", "timeout": 60},
         },
         "chemistry": {

--- a/tests/test_openrouter_provider.py
+++ b/tests/test_openrouter_provider.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from chemgraph.cli.commands import check_api_keys
+from chemgraph.models.loader import load_chat_model
+from chemgraph.models.openrouter import (
+    OPENROUTER_DEFAULT_MAX_TOKENS,
+    load_openrouter_model,
+)
+from chemgraph.models.supported_models import (
+    OPENROUTER_DEFAULT_BASE_URL,
+    all_supported_models,
+    supported_openrouter_models,
+)
+from chemgraph.utils.config_utils import (
+    get_base_url_for_model_from_flat_config,
+    get_base_url_for_model_from_nested_config,
+)
+
+CURATED_MODEL = "openrouter:moonshotai/kimi-k3"
+UNCURATED_MODEL = "openrouter:some/unknown-model"
+# The value shipped in the repo's config.toml -- an OpenRouter model must never
+# resolve to it.
+ARGO_BASE_URL = "https://apps.inside.anl.gov/argoapi/api/v1/resource/chat/"
+
+
+def test_curated_models_carry_the_openrouter_prefix():
+    assert supported_openrouter_models
+    for model in supported_openrouter_models:
+        assert model.startswith("openrouter:")
+
+
+def test_curated_models_are_in_all_supported_models():
+    assert set(supported_openrouter_models) <= set(all_supported_models)
+
+
+def test_flat_config_does_not_route_openrouter_to_argo():
+    config = {"api_openai_base_url": ARGO_BASE_URL}
+
+    assert (
+        get_base_url_for_model_from_flat_config(CURATED_MODEL, config)
+        == OPENROUTER_DEFAULT_BASE_URL
+    )
+
+
+def test_nested_config_does_not_route_openrouter_to_argo():
+    config = {"api": {"openai": {"base_url": ARGO_BASE_URL}}}
+
+    assert (
+        get_base_url_for_model_from_nested_config(CURATED_MODEL, config)
+        == OPENROUTER_DEFAULT_BASE_URL
+    )
+
+
+def test_configured_openrouter_base_url_is_honoured():
+    custom = "https://example.invalid/api/v1"
+
+    assert (
+        get_base_url_for_model_from_nested_config(
+            CURATED_MODEL,
+            {
+                "api": {
+                    "openai": {"base_url": ARGO_BASE_URL},
+                    "openrouter": {"base_url": custom},
+                }
+            },
+        )
+        == custom
+    )
+    assert (
+        get_base_url_for_model_from_flat_config(
+            CURATED_MODEL,
+            {"api_openai_base_url": ARGO_BASE_URL, "api_openrouter_base_url": custom},
+        )
+        == custom
+    )
+
+
+def test_uncurated_openrouter_slug_still_resolves():
+    """Dispatch is by prefix, not list membership.
+
+    If either resolver used ``in supported_openrouter_models`` instead, an
+    uncurated slug would fall through to the ``[api.openai]`` catch-all.
+    """
+    assert (
+        get_base_url_for_model_from_nested_config(
+            UNCURATED_MODEL, {"api": {"openai": {"base_url": ARGO_BASE_URL}}}
+        )
+        == OPENROUTER_DEFAULT_BASE_URL
+    )
+    assert (
+        get_base_url_for_model_from_flat_config(
+            UNCURATED_MODEL, {"api_openai_base_url": ARGO_BASE_URL}
+        )
+        == OPENROUTER_DEFAULT_BASE_URL
+    )
+
+
+def test_load_openrouter_model_strips_the_prefix():
+    llm = load_openrouter_model(CURATED_MODEL, api_key="dummy")
+
+    assert llm.model_name == "moonshotai/kimi-k3"
+    assert llm.openai_api_base == OPENROUTER_DEFAULT_BASE_URL
+    assert llm.max_tokens == OPENROUTER_DEFAULT_MAX_TOKENS
+
+
+def test_explicit_base_url_overrides_the_default():
+    custom = "http://127.0.0.1:8000/v1"
+    llm = load_openrouter_model(CURATED_MODEL, base_url=custom, api_key="dummy")
+
+    assert llm.openai_api_base == custom
+
+
+def test_api_key_comes_from_the_environment(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-from-env")
+
+    llm = load_openrouter_model(CURATED_MODEL)
+
+    assert llm.openai_api_key.get_secret_value() == "sk-or-from-env"
+
+
+def test_openai_api_key_is_never_used_as_a_fallback(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-should-not-leak")
+    monkeypatch.setattr(sys, "stdin", io.StringIO())
+
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+        load_openrouter_model(CURATED_MODEL)
+
+
+def test_missing_key_raises_instead_of_prompting_when_not_a_tty(monkeypatch):
+    """A getpass() prompt with no terminal blocks forever instead of failing.
+
+    The eval harness runs unattended, where a hang has no traceback and no
+    exit code -- strictly worse than a crash.
+    """
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    # StringIO().isatty() is False.
+    monkeypatch.setattr(sys, "stdin", io.StringIO())
+
+    with pytest.raises(ValueError, match="openrouter.ai/keys"):
+        load_openrouter_model(CURATED_MODEL)
+
+
+def test_loader_dispatches_openrouter_and_forwards_base_url():
+    """Also pins that ``base_url`` is not dropped the way the groq branch drops it."""
+    default = load_chat_model(model_name=CURATED_MODEL, api_key="dummy")
+    assert default.openai_api_base == OPENROUTER_DEFAULT_BASE_URL
+
+    custom = "https://example.invalid/api/v1"
+    forwarded = load_chat_model(
+        model_name=CURATED_MODEL, api_key="dummy", base_url=custom
+    )
+    assert forwarded.openai_api_base == custom
+
+
+def test_check_api_keys_reports_openrouter(monkeypatch):
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    ok, message = check_api_keys(CURATED_MODEL)
+    assert not ok
+    assert "OPENROUTER_API_KEY" in message
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+    assert check_api_keys(CURATED_MODEL) == (True, "")
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["openrouter:openai/o3", "openrouter:meta-llama/llama-4-maverick"],
+)
+def test_check_api_keys_is_not_fooled_by_substring_matches(monkeypatch, model):
+    """``"o3" in model_lower`` and ``"llama" in model_lower`` are substring tests.
+
+    Without the OpenRouter branch running first, these slugs would be routed to
+    the OpenAI key check and the no-key-needed local branch respectively.
+    """
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-present")
+
+    ok, message = check_api_keys(model)
+
+    assert not ok
+    assert "OPENROUTER_API_KEY" in message


### PR DESCRIPTION
## Summary

Adds [OpenRouter](https://openrouter.ai) as a provider, selected with an
`openrouter:` prefix in the same style as the existing `groq:` and `codex:`
routes. OpenRouter is OpenAI-compatible, so the loader returns a `ChatOpenAI`
bound to `https://openrouter.ai/api/v1` and keyed on `OPENROUTER_API_KEY`. The
prefix is stripped before the request goes out, so the slug reaches OpenRouter
verbatim.

`[api.openrouter]` ships in `config.toml`, so OpenRouter coexists with Argo and
ALCF in one config file, and `OPENROUTER_API_KEY` is forwarded through
docker-compose and the k8s manifests alongside the other provider keys.

Dispatch is by prefix, not list membership: `supported_openrouter_models` is a
discovery list for `--list-models` and for the per-model quirk sets, not a gate.
Any slug from openrouter.ai/models works without a release, which matters
because that catalog changes far faster than ChemGraph does. This matches how
`groq:` and `codex:` already behave.

Fix #168 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

`tests/test_openrouter_provider.py` (new, 187 lines) covers prefix dispatch,
base-URL resolution through both config resolvers, the API-key check, the
non-TTY failure path, and the constructed client parameters. No network access.

Gates:

```bash
ruff check .                     # All checks passed
pytest tests/ -k "not tblite"    # 453 passed, 28 skipped, 2 deselected
```

Also verified end to end against the live API — `openrouter:deepseek/deepseek-v4-flash`
answered a real query through the CLI, confirming the prefix is stripped
correctly and the request reaches openrouter.ai.

The k8s and docker-compose changes were syntax-checked but not deployed.


## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [ ] Updated docs / README for any user-facing change

---

Written with AI assistance (Claude Code); reviewed before submitting.

