### PR TITLE
Add tool and worker agent registries

### DIFF
--- a/docs/registries.md
+++ b/docs/registries.md
@@ -4,10 +4,10 @@ ChemGraph provides explicit registries for discovering in-process tools and
 worker graphs without eagerly importing every implementation. These registries
 are intended to support orchestration and, later, controlled benchmarking.
 
-The first registry release deliberately excludes MCP tools, skills, selector
-middleware, and benchmark code. The `main_agent` graph is also excluded from
-both registries: it remains the orchestration graph that consumes registered
-workers.
+The first registry release deliberately excludes MCP tools, generated IRI API
+tool collections, skills, selector middleware, and benchmark code. The
+`main_agent` graph is also excluded from both registries: it remains the
+orchestration graph that consumes registered workers.
 
 ## Tool registry
 
@@ -66,9 +66,9 @@ worker = registry.build("single_agent", llm=model)
 ```
 
 The registered workers are `single_agent`, `multi_agent`, `python_relp`,
-`graspa`, `mock_agent`, `graspa_mcp`, `rag_agent`, `single_agent_xanes`, and
-`molecular_docking`. Existing `python_repl` and `graspa_agent` spellings are
-supported as aliases.
+`graspa`, `mock_agent`, `graspa_mcp`, `rag_agent`, `single_agent_xanes`,
+`molecular_docking`, and `single_agent_iri`. Existing `python_repl`,
+`graspa_agent`, and `iri` spellings are supported as aliases.
 
 Standalone workers keep their existing default in-memory checkpointer. When a
 worker is handed to an orchestration graph, use `as_subagent()` or

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -84,8 +84,9 @@ workers = registry.as_subagents(
 main_graph = construct_main_agent_graph(model, subagents=workers)
 ```
 
-`as_subagents()` validates the whole requested set before constructing any
-worker. Per-worker constructor arguments are supplied through `options`:
+`as_subagents()` validates names, availability, constructor loading, and
+constructor options for the whole requested set before invoking any constructor.
+Per-worker constructor arguments are supplied through `options`:
 
 ```python
 workers = registry.as_subagents(
@@ -101,5 +102,11 @@ workers = registry.as_subagents(
 ```
 
 Both registries support explicit custom registration with `ToolSpec` or
-`AgentSpec`. Duplicate names and aliases are rejected unless a caller
-intentionally replaces a tool specification.
+`AgentSpec`. Passing `replace=True` allows an existing canonical specification
+to be replaced. An agent replacement may retain, remove, or add aliases owned
+by that same canonical agent, but it cannot claim a canonical name or alias
+owned by another entry.
+
+Batch prevalidation catches registry, availability, import, and constructor
+option errors. It does not roll back workers if a constructor itself raises at
+runtime after an earlier worker was constructed.

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -1,0 +1,105 @@
+# Tool and agent registries
+
+ChemGraph provides explicit registries for discovering in-process tools and
+worker graphs without eagerly importing every implementation. These registries
+are intended to support orchestration and, later, controlled benchmarking.
+
+The first registry release deliberately excludes MCP tools, skills, selector
+middleware, and benchmark code. The `main_agent` graph is also excluded from
+both registries: it remains the orchestration graph that consumes registered
+workers.
+
+## Tool registry
+
+`ToolRegistry` contains the LangChain `BaseTool` objects implemented in
+`chemgraph.tools`. The manifest stores import paths and metadata, so creating a
+registry does not import optional tool modules.
+
+```python
+from chemgraph.registry import ToolRegistry
+
+registry = ToolRegistry()
+
+# Inspect metadata without loading tool implementations.
+print(registry.names())
+ase_specs = registry.specs(tags={"ase"})
+
+# Resolve only the tools needed by a graph or model.
+tools = registry.resolve(["molecule_name_to_smiles", "run_ase"])
+```
+
+Tools can be selected by one or more tags. A tool must contain every requested
+tag to match:
+
+```python
+analysis_tools = registry.resolve(tags={"ase", "analysis"})
+```
+
+Some tools need optional Python packages, environment variables, or external
+executables. Use `availability()` to inspect those requirements, or set
+`require_available=True` to fail before loading the tool:
+
+```python
+status = registry.availability("run_docking")
+if status.available:
+    docking = registry.get("run_docking", require_available=True)
+else:
+    print(status.issues)
+```
+
+Passing `require_available=False` does not make an unavailable dependency work;
+it only defers validation to the tool implementation.
+
+## Agent registry
+
+`AgentRegistry` contains ChemGraph worker graph constructors. It provides the
+same canonical workflow names used by the command-line interface, except for
+`main_agent`:
+
+```python
+from chemgraph.registry import AgentRegistry
+
+registry = AgentRegistry()
+print(registry.names())
+
+worker = registry.build("single_agent", llm=model)
+```
+
+The registered workers are `single_agent`, `multi_agent`, `python_relp`,
+`graspa`, `mock_agent`, `graspa_mcp`, `rag_agent`, `single_agent_xanes`, and
+`molecular_docking`. Existing `python_repl` and `graspa_agent` spellings are
+supported as aliases.
+
+Standalone workers keep their existing default in-memory checkpointer. When a
+worker is handed to an orchestration graph, use `as_subagent()` or
+`as_subagents()`. These adapters compile the worker with `checkpointer=None` so
+it inherits checkpointing from the parent graph:
+
+```python
+workers = registry.as_subagents(
+    ["single_agent", "python_relp"],
+    llm=model,
+)
+
+main_graph = construct_main_agent_graph(model, subagents=workers)
+```
+
+`as_subagents()` validates the whole requested set before constructing any
+worker. Per-worker constructor arguments are supplied through `options`:
+
+```python
+workers = registry.as_subagents(
+    ["single_agent", "graspa_mcp"],
+    llm=model,
+    options={
+        "graspa_mcp": {
+            "executor_tools": executor_tools,
+            "analysis_tools": analysis_tools,
+        }
+    },
+)
+```
+
+Both registries support explicit custom registration with `ToolSpec` or
+`AgentSpec`. Duplicate names and aliases are rejected unless a caller
+intentionally replaces a tool specification.

--- a/examples/registries/run_registries.py
+++ b/examples/registries/run_registries.py
@@ -1,0 +1,135 @@
+"""Explore ChemGraph's tool and worker-agent registries.
+
+The default run needs no model or provider credentials. It lists registered
+entries, checks optional runtime requirements, resolves a small tool set, and
+invokes the calculator directly.
+
+Pass ``--model`` (with that provider configured) to also construct
+``single_agent`` as a standalone graph and as a ``CompiledSubAgent``.
+Constructing the graphs does not call the model.
+
+Examples
+--------
+python examples/registries/run_registries.py
+python examples/registries/run_registries.py --model gpt-4o-mini
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from chemgraph.registry import AgentRegistry, ToolRegistry
+
+
+DEMO_TOOL_NAMES = (
+    "molecule_name_to_smiles",
+    "smiles_to_coordinate_file",
+    "calculator",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line options."""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--model",
+        help=(
+            "Optional ChemGraph model name used to construct example worker "
+            "graphs, such as gpt-4o-mini."
+        ),
+    )
+    return parser.parse_args()
+
+
+def show_tool_registry(registry: ToolRegistry) -> list:
+    """Inspect tools and return a small, dependency-safe tool set."""
+    print("Registered tools:")
+    for spec in registry.specs():
+        status = registry.availability(spec.name)
+        availability = "available" if status.available else "unavailable"
+        print(f"  {spec.name:26} {availability:11} tags={sorted(spec.tags)}")
+        for issue in status.issues:
+            print(f"    - {issue}")
+
+    tools = registry.resolve(DEMO_TOOL_NAMES, require_available=True)
+    print("\nResolved demo tools:", ", ".join(tool.name for tool in tools))
+
+    calculator = registry.get("calculator", require_available=True)
+    result = calculator.invoke({"expression": "2 * pi + 5"})
+    print("Calculator result for '2 * pi + 5':", result)
+    return tools
+
+
+def show_agent_registry(registry: AgentRegistry) -> None:
+    """Inspect worker graphs without importing or constructing them."""
+    print("\nRegistered worker agents:")
+    for spec in registry.specs():
+        status = registry.availability(spec.name)
+        availability = "available" if status.available else "unavailable"
+        aliases = f" aliases={list(spec.aliases)}" if spec.aliases else ""
+        print(f"  {spec.name:26} {availability:11}{aliases}")
+        for issue in status.issues:
+            print(f"    - {issue}")
+
+    print("\nAlias resolution:")
+    print("  python_repl ->", registry.resolve_name("python_repl"))
+    print("  graspa_agent ->", registry.resolve_name("graspa_agent"))
+    print("  main_agent is intentionally not registered")
+
+
+def construct_worker_examples(
+    registry: AgentRegistry,
+    *,
+    model_name: str,
+    tools: list,
+) -> None:
+    """Construct a worker in standalone and parent-checkpointed forms."""
+    from chemgraph.models.loader import load_chat_model
+
+    llm = load_chat_model(model_name)
+
+    standalone = registry.build(
+        "single_agent",
+        llm=llm,
+        tools=tools,
+    )
+    print("\nStandalone single_agent:")
+    print("  graph type:", type(standalone).__name__)
+    print("  checkpointer:", type(standalone.checkpointer).__name__)
+
+    subagent = registry.as_subagent(
+        "single_agent",
+        llm=llm,
+        tools=tools,
+    )
+    print("\nCompiledSubAgent (not bound to main_agent):")
+    print("  name:", subagent["name"])
+    print("  description:", subagent["description"])
+    print("  inherits parent checkpointer:", subagent["runnable"].checkpointer is None)
+
+
+def main() -> int:
+    """Run the registry demonstration."""
+    args = parse_args()
+    tools = show_tool_registry(ToolRegistry())
+
+    agent_registry = AgentRegistry()
+    show_agent_registry(agent_registry)
+
+    if args.model:
+        construct_worker_examples(
+            agent_registry,
+            model_name=args.model,
+            tools=tools,
+        )
+    else:
+        print("\nPass --model to construct standalone and subagent worker graphs.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/registries/run_registries.py
+++ b/examples/registries/run_registries.py
@@ -77,6 +77,7 @@ def show_agent_registry(registry: AgentRegistry) -> None:
     print("\nAlias resolution:")
     print("  python_repl ->", registry.resolve_name("python_repl"))
     print("  graspa_agent ->", registry.resolve_name("graspa_agent"))
+    print("  iri ->", registry.resolve_name("iri"))
     print("  main_agent is intentionally not registered")
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
   - Using ChemGraph:
       - Command-line interface: cli.md
       - Workflows: workflows.md
+      - Tool and agent registries: registries.md
       - Calculators: calculators.md
       - Python API: python_api.md
       - Streamlit interface: streamlit_web_interface.md

--- a/src/chemgraph/graphs/graspa_agent.py
+++ b/src/chemgraph/graphs/graspa_agent.py
@@ -16,6 +16,8 @@ from chemgraph.state.state import State
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def route_tools(state: State):
     """Route to the 'tools' node if the last message has tool calls; otherwise, route to 'done'.
@@ -104,6 +106,7 @@ def construct_graspa_graph(
     structured_output: bool = False,
     formatter_prompt: str = formatter_prompt,
     tools: list = None,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct a geometry optimization graph.
 
@@ -126,7 +129,8 @@ def construct_graspa_graph(
     """
     try:
         logger.info("Constructing gRASPA graph")
-        checkpointer = MemorySaver()
+        if checkpointer is _DEFAULT_CHECKPOINTER:
+            checkpointer = MemorySaver()
         if tools is None:
             tools = [run_graspa]
         tool_node = ToolNode(tools=tools)

--- a/src/chemgraph/graphs/graspa_mcp.py
+++ b/src/chemgraph/graphs/graspa_mcp.py
@@ -21,6 +21,8 @@ from chemgraph.prompt.graspa_prompt import (
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def planner_agent(
     state: PlannerState,
@@ -296,6 +298,7 @@ def construct_graspa_mcp_graph(
     analyst_prompt: str = analyst_prompt,
     executor_tools: list = None,
     analysis_tools: list = None,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct the gRASPA MCP map-reduce graph.
 
@@ -319,7 +322,8 @@ def construct_graspa_mcp_graph(
     CompiledStateGraph
         Compiled gRASPA MCP graph.
     """
-    checkpointer = MemorySaver()
+    if checkpointer is _DEFAULT_CHECKPOINTER:
+        checkpointer = MemorySaver()
 
     # Create the Executor subgraph
     executor_subgraph = construct_executor_subgraph(

--- a/src/chemgraph/graphs/mock_agent.py
+++ b/src/chemgraph/graphs/mock_agent.py
@@ -19,6 +19,8 @@ from chemgraph.state.state import State
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def ChemGraphAgent(state: State, llm: ChatOpenAI, system_prompt: str, tools=None):
     """LLM node that processes messages and decides next actions.
@@ -61,6 +63,7 @@ def construct_mock_agent_graph(
     llm: ChatOpenAI,
     system_prompt: str = single_agent_prompt,
     tools: list = None,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct a geometry optimization graph.
 
@@ -78,7 +81,8 @@ def construct_mock_agent_graph(
         The constructed single agent graph
     """
     logger.info("Constructing mock agent graph")
-    checkpointer = MemorySaver()
+    if checkpointer is _DEFAULT_CHECKPOINTER:
+        checkpointer = MemorySaver()
     if tools is None:
         tools = [
             file_to_atomsdata,

--- a/src/chemgraph/graphs/molecular_docking.py
+++ b/src/chemgraph/graphs/molecular_docking.py
@@ -24,6 +24,8 @@ from chemgraph.tools.docking_tools import run_docking
 # ligand-receptor binding are included; general gas-phase/DFT tools are omitted.
 DEFAULT_DOCKING_TOOLS = [run_docking, molecule_name_to_smiles]
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def construct_molecular_docking_graph(
     llm: ChatOpenAI,
@@ -36,6 +38,7 @@ def construct_molecular_docking_graph(
     max_retries: int = 1,
     human_supervised: bool = False,
     terminal_tool_names: Collection[str] = (),
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct the molecular docking graph.
 
@@ -59,6 +62,9 @@ def construct_molecular_docking_graph(
     """
     if tools is None:
         tools = list(DEFAULT_DOCKING_TOOLS)
+    graph_kwargs = {}
+    if checkpointer is not _DEFAULT_CHECKPOINTER:
+        graph_kwargs["checkpointer"] = checkpointer
     return construct_single_agent_graph(
         llm,
         system_prompt=system_prompt,
@@ -70,4 +76,5 @@ def construct_molecular_docking_graph(
         max_retries=max_retries,
         human_supervised=human_supervised,
         terminal_tool_names=terminal_tool_names,
+        **graph_kwargs,
     )

--- a/src/chemgraph/graphs/multi_agent.py
+++ b/src/chemgraph/graphs/multi_agent.py
@@ -40,6 +40,8 @@ from chemgraph.prompt.multi_agent_prompt import (
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 # ---------------------------------------------------------------------------
 # Serialization helpers
@@ -792,6 +794,7 @@ def construct_multi_agent_graph(
     max_retries: int = 1,
     max_task_retries: int = 2,
     human_supervised: bool = False,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct the planner-executor graph using the Send() pattern.
 
@@ -844,7 +847,8 @@ def construct_multi_agent_graph(
             calculator,
         ]
 
-    checkpointer = MemorySaver()
+    if checkpointer is _DEFAULT_CHECKPOINTER:
+        checkpointer = MemorySaver()
 
     # Build the executor subgraph
     executor_subgraph = construct_executor_subgraph(

--- a/src/chemgraph/graphs/python_relp_agent.py
+++ b/src/chemgraph/graphs/python_relp_agent.py
@@ -14,6 +14,8 @@ from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 class State(TypedDict):
     """Type definition for the state dictionary used in the graph.
@@ -171,7 +173,11 @@ def CompChemAgent(state: State, llm: ChatOpenAI, system_prompt=single_agent_prom
     return {"messages": [llm_with_tools.invoke(messages)]}
 
 
-def construct_relp_graph(llm: ChatOpenAI, system_prompt=single_agent_prompt):
+def construct_relp_graph(
+    llm: ChatOpenAI,
+    system_prompt=single_agent_prompt,
+    checkpointer=_DEFAULT_CHECKPOINTER,
+):
     """Construct a graph for REPL-based Python execution workflow.
 
     This function creates a state graph that implements a workflow for executing
@@ -197,7 +203,8 @@ def construct_relp_graph(llm: ChatOpenAI, system_prompt=single_agent_prompt):
     """
     try:
         logger.info("Constructing geometry optimization graph")
-        checkpointer = MemorySaver()
+        if checkpointer is _DEFAULT_CHECKPOINTER:
+            checkpointer = MemorySaver()
         tools = [
             repl_tool,
             calculator,

--- a/src/chemgraph/graphs/rag_agent.py
+++ b/src/chemgraph/graphs/rag_agent.py
@@ -46,6 +46,8 @@ from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 # ---------------------------------------------------------------------------
 # Helpers (reuse the repeated-tool-call detection from single_agent)
@@ -190,6 +192,7 @@ def construct_rag_agent_graph(
     llm,
     system_prompt: str = rag_agent_prompt,
     tools: list = None,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct a RAG agent graph with document retrieval and chemistry tools.
 
@@ -210,7 +213,8 @@ def construct_rag_agent_graph(
     """
     try:
         logger.info("Constructing RAG agent graph")
-        checkpointer = MemorySaver()
+        if checkpointer is _DEFAULT_CHECKPOINTER:
+            checkpointer = MemorySaver()
 
         if tools is None:
             tools = _default_tools()

--- a/src/chemgraph/graphs/single_agent_iri.py
+++ b/src/chemgraph/graphs/single_agent_iri.py
@@ -28,6 +28,8 @@ from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def route_tools(state: State):
     if isinstance(state, list):
@@ -79,6 +81,7 @@ def construct_iri_graph(
     structured_output: bool = False,
     formatter_prompt: str = formatter_prompt,
     tools: list | None = None,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct the single-agent IRI graph.
 
@@ -91,9 +94,14 @@ def construct_iri_graph(
     system_prompt : str, optional
         System prompt. If omitted, auto-selected based on ``tools``:
         category -> ``alcf_iri_prompt``, flat/other -> ``alcf_iri_flat_prompt``.
+    checkpointer : optional
+        LangGraph checkpointer used to compile the graph. When omitted, a new
+        ``MemorySaver`` preserves standalone behavior. Pass ``None`` when
+        embedding this graph so it inherits the parent checkpointer.
     """
     logger.info("Constructing single_agent_iri graph")
-    checkpointer = MemorySaver()
+    if checkpointer is _DEFAULT_CHECKPOINTER:
+        checkpointer = MemorySaver()
     if tools is None:
         tools = ALCF_IRI_FLAT_TOOLS
     if system_prompt is None:

--- a/src/chemgraph/graphs/single_agent_xanes.py
+++ b/src/chemgraph/graphs/single_agent_xanes.py
@@ -23,6 +23,8 @@ from chemgraph.state.state import State
 
 logger = setup_logger(__name__)
 
+_DEFAULT_CHECKPOINTER = object()
+
 
 def _tool_call_signature(tool_calls) -> tuple:
     """Create a comparable signature for a list of tool calls.
@@ -169,6 +171,7 @@ def construct_single_agent_xanes_graph(
     structured_output: bool = False,
     formatter_prompt: str = xanes_formatter_prompt,
     tools: list = None,
+    checkpointer=_DEFAULT_CHECKPOINTER,
 ):
     """Construct a single-agent graph for XANES/FDMNES workflows.
 
@@ -207,7 +210,8 @@ def construct_single_agent_xanes_graph(
                 "The run_xanes tool will not work without the FDMNES executable."
             )
 
-        checkpointer = MemorySaver()
+        if checkpointer is _DEFAULT_CHECKPOINTER:
+            checkpointer = MemorySaver()
         if tools is None:
             tools = [
                 molecule_name_to_smiles,

--- a/src/chemgraph/registry/__init__.py
+++ b/src/chemgraph/registry/__init__.py
@@ -1,0 +1,25 @@
+"""Public registry APIs for ChemGraph tools."""
+
+from chemgraph.registry.tools import (
+    DuplicateRegistryEntryError,
+    RegistryAvailability,
+    RegistryError,
+    RegistryLoadError,
+    RegistryUnavailableError,
+    RuntimeRequirement,
+    ToolRegistry,
+    ToolSpec,
+    UnknownRegistryEntryError,
+)
+
+__all__ = [
+    "DuplicateRegistryEntryError",
+    "RegistryAvailability",
+    "RegistryError",
+    "RegistryLoadError",
+    "RegistryUnavailableError",
+    "RuntimeRequirement",
+    "ToolRegistry",
+    "ToolSpec",
+    "UnknownRegistryEntryError",
+]

--- a/src/chemgraph/registry/__init__.py
+++ b/src/chemgraph/registry/__init__.py
@@ -1,4 +1,6 @@
-"""Public registry APIs for ChemGraph tools."""
+"""Public registry APIs for ChemGraph tools and worker agents."""
+
+from chemgraph.registry.agents import AgentRegistry, AgentSpec
 
 from chemgraph.registry.tools import (
     DuplicateRegistryEntryError,
@@ -13,6 +15,8 @@ from chemgraph.registry.tools import (
 )
 
 __all__ = [
+    "AgentRegistry",
+    "AgentSpec",
     "DuplicateRegistryEntryError",
     "RegistryAvailability",
     "RegistryError",

--- a/src/chemgraph/registry/agents.py
+++ b/src/chemgraph/registry/agents.py
@@ -173,24 +173,29 @@ class AgentRegistry:
             self.register(spec)
 
     def register(self, spec: AgentSpec, *, replace: bool = False) -> None:
-        """Register one worker specification."""
+        """Register or replace one worker specification."""
         if not isinstance(spec, AgentSpec):
             raise TypeError("AgentRegistry entries must be AgentSpec objects.")
         if not spec.name:
             raise ValueError("Registry names must not be empty.")
 
+        previous = self._specs.get(spec.name)
         claimed = (spec.name, *spec.aliases)
-        duplicates = [
-            name
-            for name in claimed
-            if name in self._specs or name in self._aliases
-        ]
-        if duplicates and not (replace and duplicates == [spec.name]):
-            raise DuplicateRegistryEntryError(
-                f"Agent name or alias already registered: {duplicates!r}."
+        collisions = []
+        for name in claimed:
+            owner = name if name in self._specs else self._aliases.get(name)
+            if owner is None:
+                continue
+            replacing_same_agent = (
+                replace and previous is not None and owner == spec.name
             )
-        if replace and spec.name in self._specs:
-            previous = self._specs[spec.name]
+            if not replacing_same_agent:
+                collisions.append(name)
+        if collisions:
+            raise DuplicateRegistryEntryError(
+                f"Agent name or alias already registered: {collisions!r}."
+            )
+        if previous is not None:
             for alias in previous.aliases:
                 self._aliases.pop(alias, None)
 
@@ -266,6 +271,20 @@ class AgentRegistry:
         self._constructors[spec.name] = constructor
         return constructor
 
+    def _prepare_constructor(
+        self,
+        spec: AgentSpec,
+        llm: Any,
+        constructor_kwargs: Mapping[str, Any],
+    ) -> Callable[..., Any]:
+        """Load a constructor and validate its arguments without invoking it."""
+        constructor = self._get_constructor(spec)
+        try:
+            inspect.signature(constructor).bind(llm, **constructor_kwargs)
+        except TypeError as exc:
+            raise TypeError(f"Invalid options for agent {spec.name!r}: {exc}") from exc
+        return constructor
+
     def build(
         self,
         name: str,
@@ -283,11 +302,7 @@ class AgentRegistry:
         if require_available and not status.available:
             raise RegistryUnavailableError(spec.name, status.issues)
 
-        constructor = self._get_constructor(spec)
-        try:
-            inspect.signature(constructor).bind(llm, **constructor_kwargs)
-        except TypeError as exc:
-            raise TypeError(f"Invalid options for agent {spec.name!r}: {exc}") from exc
+        constructor = self._prepare_constructor(spec, llm, constructor_kwargs)
         return constructor(llm, **constructor_kwargs)
 
     def as_subagent(
@@ -325,7 +340,7 @@ class AgentRegistry:
         options: Mapping[str, Mapping[str, Any]] | None = None,
         require_available: bool = True,
     ) -> list[CompiledSubAgent]:
-        """Validate and build an explicit worker list atomically."""
+        """Prevalidate and build an explicit worker list."""
         requested = tuple(names)
         canonical = tuple(self.resolve_name(name) for name in requested)
         if len(canonical) != len(set(canonical)):
@@ -338,6 +353,10 @@ class AgentRegistry:
         for requested_name, canonical_name in zip(requested, canonical, strict=True):
             spec = self.get_spec(canonical_name)
             kwargs = dict(by_name.get(requested_name, by_name.get(canonical_name, {})))
+            if kwargs.get("checkpointer") is not None:
+                raise ValueError(
+                    "Registry subagents must inherit the parent checkpointer."
+                )
             kwargs["checkpointer"] = None
             status = self.availability(
                 canonical_name,
@@ -349,14 +368,18 @@ class AgentRegistry:
         if unavailable:
             raise RegistryUnavailableError("worker agents", unavailable)
 
+        constructors = [
+            self._prepare_constructor(spec, llm, kwargs) for spec, kwargs in prepared
+        ]
         return [
-            self.as_subagent(
-                spec.name,
-                llm=llm,
-                require_available=False,
-                **kwargs,
+            {
+                "name": spec.name,
+                "description": spec.description,
+                "runnable": constructor(llm, **kwargs),
+            }
+            for (spec, kwargs), constructor in zip(
+                prepared, constructors, strict=True
             )
-            for spec, kwargs in prepared
         ]
 
 

--- a/src/chemgraph/registry/agents.py
+++ b/src/chemgraph/registry/agents.py
@@ -159,6 +159,13 @@ BUILTIN_AGENT_SPECS: tuple[AgentSpec, ...] = (
         ),
         tags=frozenset({"docking", "drug-discovery"}),
     ),
+    AgentSpec(
+        "single_agent_iri",
+        "ALCF IRI Facility API worker for facility status and HPC operations.",
+        "chemgraph.graphs.single_agent_iri:construct_iri_graph",
+        aliases=("iri",),
+        tags=frozenset({"alcf", "iri", "hpc"}),
+    ),
 )
 
 

--- a/src/chemgraph/registry/agents.py
+++ b/src/chemgraph/registry/agents.py
@@ -1,0 +1,363 @@
+"""Registry for ChemGraph worker graph constructors."""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from deepagents.middleware.subagents import CompiledSubAgent
+
+from chemgraph.registry.tools import (
+    DuplicateRegistryEntryError,
+    RegistryAvailability,
+    RegistryLoadError,
+    RegistryUnavailableError,
+    RuntimeRequirement,
+    UnknownRegistryEntryError,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AgentSpec:
+    """Lazy metadata for one worker graph."""
+
+    name: str
+    description: str
+    import_path: str
+    aliases: tuple[str, ...] = ()
+    default_tool_names: tuple[str, ...] = ()
+    requirements: tuple[RuntimeRequirement, ...] = ()
+    required_arguments: tuple[str, ...] = ()
+    tags: frozenset[str] = field(default_factory=frozenset)
+    test_only: bool = False
+
+
+_GRASPA_EXECUTABLE = (
+    "/lus/flare/projects/IQC/thang/soft/gRASPA/graspa-sycl/bin/sycl.out"
+)
+_CORE_TOOLS = (
+    "smiles_to_coordinate_file",
+    "molecule_name_to_smiles",
+    "run_ase",
+    "extract_output_json",
+    "calculator",
+)
+
+
+BUILTIN_AGENT_SPECS: tuple[AgentSpec, ...] = (
+    AgentSpec(
+        "single_agent",
+        "General ChemGraph worker for molecular construction and ASE simulations.",
+        "chemgraph.graphs.single_agent:construct_single_agent_graph",
+        default_tool_names=_CORE_TOOLS,
+        tags=frozenset({"general", "chemistry"}),
+    ),
+    AgentSpec(
+        "multi_agent",
+        "Planner-executor ChemGraph worker for decomposable chemistry tasks.",
+        "chemgraph.graphs.multi_agent:construct_multi_agent_graph",
+        default_tool_names=_CORE_TOOLS,
+        tags=frozenset({"planning", "chemistry"}),
+    ),
+    AgentSpec(
+        "python_relp",
+        "Python REPL worker for calculations and programmatic analysis.",
+        "chemgraph.graphs.python_relp_agent:construct_relp_graph",
+        aliases=("python_repl",),
+        default_tool_names=("python_repl", "calculator"),
+        tags=frozenset({"python", "analysis"}),
+    ),
+    AgentSpec(
+        "graspa",
+        "Specialist worker for gRASPA adsorption calculations.",
+        "chemgraph.graphs.graspa_agent:construct_graspa_graph",
+        aliases=("graspa_agent",),
+        default_tool_names=("run_graspa",),
+        requirements=(
+            RuntimeRequirement(
+                "path", _GRASPA_EXECUTABLE, "configure the gRASPA-SYCL runtime"
+            ),
+        ),
+        tags=frozenset({"graspa", "adsorption"}),
+    ),
+    AgentSpec(
+        "mock_agent",
+        "Non-executing workflow used to test tool-call generation.",
+        "chemgraph.graphs.mock_agent:construct_mock_agent_graph",
+        default_tool_names=(
+            "file_to_atomsdata",
+            "smiles_to_atomsdata",
+            "run_ase",
+            "molecule_name_to_smiles",
+            "save_atomsdata_to_file",
+            "calculator",
+        ),
+        tags=frozenset({"testing"}),
+        test_only=True,
+    ),
+    AgentSpec(
+        "graspa_mcp",
+        "Planner-executor worker for externally supplied gRASPA MCP tools.",
+        "chemgraph.graphs.graspa_mcp:construct_graspa_mcp_graph",
+        required_arguments=("executor_tools", "analysis_tools"),
+        tags=frozenset({"graspa", "mcp", "planning"}),
+    ),
+    AgentSpec(
+        "rag_agent",
+        "RAG worker for document-grounded chemistry questions.",
+        "chemgraph.graphs.rag_agent:construct_rag_agent_graph",
+        default_tool_names=(
+            "load_document",
+            "query_knowledge_base",
+            "file_to_atomsdata",
+            "smiles_to_coordinate_file",
+            "run_ase",
+            "molecule_name_to_smiles",
+            "save_atomsdata_to_file",
+            "calculator",
+        ),
+        requirements=(
+            RuntimeRequirement("module", "faiss", "install chemgraph[rag]"),
+            RuntimeRequirement(
+                "module", "langchain_text_splitters", "install chemgraph[rag]"
+            ),
+        ),
+        tags=frozenset({"rag", "chemistry"}),
+    ),
+    AgentSpec(
+        "single_agent_xanes",
+        "Specialist worker for FDMNES XANES simulations and analysis.",
+        "chemgraph.graphs.single_agent_xanes:construct_single_agent_xanes_graph",
+        default_tool_names=(
+            "molecule_name_to_smiles",
+            "smiles_to_coordinate_file",
+            "run_ase",
+            "run_xanes",
+            "fetch_xanes_data",
+            "plot_xanes_data",
+        ),
+        requirements=(
+            RuntimeRequirement(
+                "environment", "FDMNES_EXE", "set it to the FDMNES executable"
+            ),
+        ),
+        tags=frozenset({"xanes", "spectroscopy"}),
+    ),
+    AgentSpec(
+        "molecular_docking",
+        "Specialist worker for AutoDock Vina molecular docking.",
+        "chemgraph.graphs.molecular_docking:construct_molecular_docking_graph",
+        default_tool_names=("run_docking", "molecule_name_to_smiles"),
+        requirements=(
+            RuntimeRequirement(
+                "module", "vina", "install AutoDock Vina from conda-forge"
+            ),
+            RuntimeRequirement("module", "meeko", "install chemgraph[docking]"),
+        ),
+        tags=frozenset({"docking", "drug-discovery"}),
+    ),
+)
+
+
+class AgentRegistry:
+    """Discover, construct, and adapt ChemGraph worker graphs."""
+
+    def __init__(self, specs: Iterable[AgentSpec] | None = None):
+        self._specs: dict[str, AgentSpec] = {}
+        self._aliases: dict[str, str] = {}
+        self._constructors: dict[str, Callable[..., Any]] = {}
+        for spec in BUILTIN_AGENT_SPECS if specs is None else specs:
+            self.register(spec)
+
+    def register(self, spec: AgentSpec, *, replace: bool = False) -> None:
+        """Register one worker specification."""
+        if not isinstance(spec, AgentSpec):
+            raise TypeError("AgentRegistry entries must be AgentSpec objects.")
+        if not spec.name:
+            raise ValueError("Registry names must not be empty.")
+
+        claimed = (spec.name, *spec.aliases)
+        duplicates = [
+            name
+            for name in claimed
+            if name in self._specs or name in self._aliases
+        ]
+        if duplicates and not (replace and duplicates == [spec.name]):
+            raise DuplicateRegistryEntryError(
+                f"Agent name or alias already registered: {duplicates!r}."
+            )
+        if replace and spec.name in self._specs:
+            previous = self._specs[spec.name]
+            for alias in previous.aliases:
+                self._aliases.pop(alias, None)
+
+        self._specs[spec.name] = spec
+        self._constructors.pop(spec.name, None)
+        for alias in spec.aliases:
+            self._aliases[alias] = spec.name
+
+    def resolve_name(self, name: str) -> str:
+        """Resolve a canonical name or registered alias."""
+        canonical = self._aliases.get(name, name)
+        if canonical not in self._specs:
+            raise UnknownRegistryEntryError(f"Unknown worker agent: {name!r}.")
+        return canonical
+
+    def names(self, *, tags: Iterable[str] = ()) -> tuple[str, ...]:
+        """Return canonical worker names in registration order."""
+        requested = frozenset(tags)
+        return tuple(
+            name
+            for name, spec in self._specs.items()
+            if not requested or requested.issubset(spec.tags)
+        )
+
+    def specs(self, *, tags: Iterable[str] = ()) -> tuple[AgentSpec, ...]:
+        """Return worker specifications, optionally filtered by tags."""
+        return tuple(self._specs[name] for name in self.names(tags=tags))
+
+    def get_spec(self, name: str) -> AgentSpec:
+        """Return metadata for one worker without importing its graph module."""
+        return self._specs[self.resolve_name(name)]
+
+    def availability(
+        self,
+        name: str,
+        *,
+        constructor_kwargs: Mapping[str, Any] | None = None,
+    ) -> RegistryAvailability:
+        """Check runtime and required-constructor inputs for a worker."""
+        spec = self.get_spec(name)
+        kwargs = constructor_kwargs or {}
+        issues = [
+            issue
+            for requirement in spec.requirements
+            if (issue := requirement.issue())
+        ]
+        issues.extend(
+            f"missing non-empty constructor argument {argument!r}"
+            for argument in spec.required_arguments
+            if not kwargs.get(argument)
+        )
+        return RegistryAvailability(name=spec.name, issues=tuple(issues))
+
+    def _get_constructor(self, spec: AgentSpec) -> Callable[..., Any]:
+        if spec.name in self._constructors:
+            return self._constructors[spec.name]
+        module_name, separator, attribute = spec.import_path.partition(":")
+        if not separator or not module_name or not attribute:
+            raise RegistryLoadError(
+                f"Agent {spec.name!r} has invalid import path {spec.import_path!r}."
+            )
+        try:
+            module = importlib.import_module(module_name)
+            constructor = getattr(module, attribute)
+        except (ImportError, AttributeError) as exc:
+            raise RegistryLoadError(
+                f"Could not load agent {spec.name!r} from {spec.import_path!r}: {exc}"
+            ) from exc
+        if not callable(constructor):
+            raise RegistryLoadError(
+                f"Agent constructor {spec.import_path!r} is not callable."
+            )
+        self._constructors[spec.name] = constructor
+        return constructor
+
+    def build(
+        self,
+        name: str,
+        *,
+        llm: Any,
+        require_available: bool = True,
+        **constructor_kwargs: Any,
+    ) -> Any:
+        """Build one registered worker through its existing constructor."""
+        spec = self.get_spec(name)
+        status = self.availability(
+            spec.name,
+            constructor_kwargs=constructor_kwargs,
+        )
+        if require_available and not status.available:
+            raise RegistryUnavailableError(spec.name, status.issues)
+
+        constructor = self._get_constructor(spec)
+        try:
+            inspect.signature(constructor).bind(llm, **constructor_kwargs)
+        except TypeError as exc:
+            raise TypeError(f"Invalid options for agent {spec.name!r}: {exc}") from exc
+        return constructor(llm, **constructor_kwargs)
+
+    def as_subagent(
+        self,
+        name: str,
+        *,
+        llm: Any,
+        require_available: bool = True,
+        **constructor_kwargs: Any,
+    ) -> CompiledSubAgent:
+        """Build one worker as a parent-checkpointed CompiledSubAgent."""
+        if constructor_kwargs.get("checkpointer") is not None and (
+            "checkpointer" in constructor_kwargs
+        ):
+            raise ValueError("Registry subagents must inherit the parent checkpointer.")
+        constructor_kwargs["checkpointer"] = None
+        spec = self.get_spec(name)
+        runnable = self.build(
+            spec.name,
+            llm=llm,
+            require_available=require_available,
+            **constructor_kwargs,
+        )
+        return {
+            "name": spec.name,
+            "description": spec.description,
+            "runnable": runnable,
+        }
+
+    def as_subagents(
+        self,
+        names: Iterable[str],
+        *,
+        llm: Any,
+        options: Mapping[str, Mapping[str, Any]] | None = None,
+        require_available: bool = True,
+    ) -> list[CompiledSubAgent]:
+        """Validate and build an explicit worker list atomically."""
+        requested = tuple(names)
+        canonical = tuple(self.resolve_name(name) for name in requested)
+        if len(canonical) != len(set(canonical)):
+            raise DuplicateRegistryEntryError(
+                "A worker was requested more than once through a name or alias."
+            )
+        by_name = options or {}
+        prepared: list[tuple[AgentSpec, dict[str, Any]]] = []
+        unavailable: list[str] = []
+        for requested_name, canonical_name in zip(requested, canonical, strict=True):
+            spec = self.get_spec(canonical_name)
+            kwargs = dict(by_name.get(requested_name, by_name.get(canonical_name, {})))
+            kwargs["checkpointer"] = None
+            status = self.availability(
+                canonical_name,
+                constructor_kwargs=kwargs,
+            )
+            if require_available and not status.available:
+                unavailable.extend(f"{canonical_name}: {issue}" for issue in status.issues)
+            prepared.append((spec, kwargs))
+        if unavailable:
+            raise RegistryUnavailableError("worker agents", unavailable)
+
+        return [
+            self.as_subagent(
+                spec.name,
+                llm=llm,
+                require_available=False,
+                **kwargs,
+            )
+            for spec, kwargs in prepared
+        ]
+
+
+__all__ = ["AgentRegistry", "AgentSpec", "BUILTIN_AGENT_SPECS"]

--- a/src/chemgraph/registry/tools.py
+++ b/src/chemgraph/registry/tools.py
@@ -1,0 +1,398 @@
+"""Registry for ChemGraph's in-process LangChain tools."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+import shutil
+from typing import Literal
+
+from langchain_core.tools import BaseTool
+
+
+class RegistryError(Exception):
+    """Base class for registry errors."""
+
+
+class UnknownRegistryEntryError(RegistryError, KeyError):
+    """Raised when a registry name is unknown."""
+
+
+class DuplicateRegistryEntryError(RegistryError, ValueError):
+    """Raised when a name or alias is registered more than once."""
+
+
+class RegistryLoadError(RegistryError, RuntimeError):
+    """Raised when a lazy registry entry cannot be loaded."""
+
+
+class RegistryUnavailableError(RegistryError, RuntimeError):
+    """Raised when an entry's runtime requirements are unavailable."""
+
+    def __init__(self, name: str, issues: Iterable[str]):
+        self.name = name
+        self.issues = tuple(issues)
+        details = "; ".join(self.issues)
+        super().__init__(f"Registry entry {name!r} is unavailable: {details}")
+
+
+RequirementKind = Literal["module", "environment", "executable", "path"]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeRequirement:
+    """One import, environment, or executable needed at runtime."""
+
+    kind: RequirementKind
+    value: str
+    hint: str = ""
+
+    def issue(self) -> str | None:
+        """Return an actionable issue when this requirement is not met."""
+        available = False
+        if self.kind == "module":
+            try:
+                available = importlib.util.find_spec(self.value) is not None
+            except (ImportError, ModuleNotFoundError, ValueError):
+                available = False
+        elif self.kind == "environment":
+            available = bool(os.environ.get(self.value))
+        elif self.kind == "executable":
+            available = shutil.which(self.value) is not None
+        elif self.kind == "path":
+            path = Path(self.value)
+            available = path.is_file() and os.access(path, os.X_OK)
+
+        if available:
+            return None
+        label = {
+            "module": "Python module",
+            "environment": "environment variable",
+            "executable": "executable",
+            "path": "executable path",
+        }[self.kind]
+        message = f"missing {label} {self.value!r}"
+        return f"{message} ({self.hint})" if self.hint else message
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryAvailability:
+    """Availability result for a registry entry."""
+
+    name: str
+    issues: tuple[str, ...] = ()
+
+    @property
+    def available(self) -> bool:
+        """Whether all checked requirements are available."""
+        return not self.issues
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpec:
+    """Lazy metadata for one ChemGraph tool."""
+
+    name: str
+    description: str
+    import_path: str | None
+    tags: frozenset[str] = field(default_factory=frozenset)
+    requirements: tuple[RuntimeRequirement, ...] = ()
+    interactive: bool = False
+    executes_code: bool = False
+
+
+_GRASPA_EXECUTABLE = (
+    "/lus/flare/projects/IQC/thang/soft/gRASPA/graspa-sycl/bin/sycl.out"
+)
+
+
+BUILTIN_TOOL_SPECS: tuple[ToolSpec, ...] = (
+    ToolSpec(
+        "extract_output_json",
+        "Load a JSON result produced by an ASE calculation.",
+        "chemgraph.tools.ase_tools:extract_output_json",
+        frozenset({"ase", "files"}),
+    ),
+    ToolSpec(
+        "file_to_atomsdata",
+        "Read a structure file into ChemGraph's AtomsData schema.",
+        "chemgraph.tools.ase_tools:file_to_atomsdata",
+        frozenset({"ase", "files"}),
+    ),
+    ToolSpec(
+        "save_atomsdata_to_file",
+        "Write ChemGraph AtomsData to a structure file.",
+        "chemgraph.tools.ase_tools:save_atomsdata_to_file",
+        frozenset({"ase", "files"}),
+    ),
+    ToolSpec(
+        "get_symmetry_number",
+        "Determine a molecule's rotational symmetry number.",
+        "chemgraph.tools.ase_tools:get_symmetry_number",
+        frozenset({"ase", "analysis"}),
+    ),
+    ToolSpec(
+        "is_linear_molecule",
+        "Determine whether a molecule is linear.",
+        "chemgraph.tools.ase_tools:is_linear_molecule",
+        frozenset({"ase", "analysis"}),
+    ),
+    ToolSpec(
+        "run_ase",
+        "Run an ASE energy, optimization, vibration, or thermochemistry task.",
+        "chemgraph.tools.ase_tools:run_ase",
+        frozenset({"ase", "simulation"}),
+    ),
+    ToolSpec(
+        "molecule_name_to_smiles",
+        "Resolve a molecule name to a SMILES string.",
+        "chemgraph.tools.cheminformatics_tools:molecule_name_to_smiles",
+        frozenset({"cheminformatics", "structure"}),
+    ),
+    ToolSpec(
+        "smiles_to_atomsdata",
+        "Generate AtomsData coordinates from a SMILES string.",
+        "chemgraph.tools.cheminformatics_tools:smiles_to_atomsdata",
+        frozenset({"cheminformatics", "structure"}),
+    ),
+    ToolSpec(
+        "smiles_to_coordinate_file",
+        "Generate a coordinate file from a SMILES string.",
+        "chemgraph.tools.cheminformatics_tools:smiles_to_coordinate_file",
+        frozenset({"cheminformatics", "structure", "files"}),
+    ),
+    ToolSpec(
+        "calculator",
+        "Evaluate a mathematical expression safely.",
+        "chemgraph.tools.generic_tools:calculator",
+        frozenset({"generic"}),
+    ),
+    ToolSpec(
+        "ask_human",
+        "Pause graph execution to request human input.",
+        "chemgraph.tools.generic_tools:ask_human",
+        frozenset({"generic", "interactive"}),
+        interactive=True,
+    ),
+    ToolSpec(
+        "python_repl",
+        "Execute Python code in a persistent in-process REPL.",
+        "chemgraph.tools.generic_tools:repl_tool",
+        frozenset({"generic", "python"}),
+        executes_code=True,
+    ),
+    ToolSpec(
+        "run_docking",
+        "Dock a small molecule with AutoDock Vina.",
+        "chemgraph.tools.docking_tools:run_docking",
+        frozenset({"docking", "simulation"}),
+        (
+            RuntimeRequirement(
+                "module", "vina", "install AutoDock Vina from conda-forge"
+            ),
+            RuntimeRequirement("module", "meeko", "install chemgraph[docking]"),
+        ),
+    ),
+    ToolSpec(
+        "run_graspa",
+        "Run a gRASPA adsorption calculation.",
+        "chemgraph.tools.graspa_tools:run_graspa",
+        frozenset({"graspa", "simulation"}),
+        (
+            RuntimeRequirement(
+                "path", _GRASPA_EXECUTABLE, "configure the gRASPA-SYCL runtime"
+            ),
+        ),
+    ),
+    ToolSpec(
+        "load_document",
+        "Load a document into the in-process RAG vector store.",
+        "chemgraph.tools.rag_tools:load_document",
+        frozenset({"rag", "files"}),
+        (
+            RuntimeRequirement("module", "faiss", "install chemgraph[rag]"),
+            RuntimeRequirement(
+                "module", "langchain_text_splitters", "install chemgraph[rag]"
+            ),
+        ),
+    ),
+    ToolSpec(
+        "query_knowledge_base",
+        "Query documents loaded into the in-process RAG vector store.",
+        "chemgraph.tools.rag_tools:query_knowledge_base",
+        frozenset({"rag", "analysis"}),
+        (RuntimeRequirement("module", "faiss", "install chemgraph[rag]"),),
+    ),
+    ToolSpec(
+        "generate_html",
+        "Generate an HTML report for an ASE result.",
+        "chemgraph.tools.report_tools:generate_html",
+        frozenset({"report", "files"}),
+    ),
+    ToolSpec(
+        "run_xanes",
+        "Run an FDMNES XANES calculation.",
+        "chemgraph.tools.xanes_tools:run_xanes",
+        frozenset({"xanes", "simulation"}),
+        (
+            RuntimeRequirement(
+                "environment", "FDMNES_EXE", "set it to the FDMNES executable"
+            ),
+        ),
+    ),
+    ToolSpec(
+        "fetch_xanes_data",
+        "Fetch structures for XANES calculations from Materials Project.",
+        "chemgraph.tools.xanes_tools:fetch_xanes_data",
+        frozenset({"xanes", "data"}),
+        (RuntimeRequirement("module", "mp_api", "install chemgraph[xanes]"),),
+    ),
+    ToolSpec(
+        "plot_xanes_data",
+        "Plot XANES spectra from FDMNES results.",
+        "chemgraph.tools.xanes_tools:plot_xanes_data",
+        frozenset({"xanes", "analysis"}),
+    ),
+)
+
+
+class ToolRegistry:
+    """Discover and lazily resolve ChemGraph's in-process LLM tools."""
+
+    def __init__(self, specs: Iterable[ToolSpec] | None = None):
+        self._specs: dict[str, ToolSpec] = {}
+        self._tools: dict[str, BaseTool] = {}
+        for spec in BUILTIN_TOOL_SPECS if specs is None else specs:
+            self.register(spec)
+
+    def register(
+        self,
+        entry: ToolSpec | BaseTool,
+        *,
+        tags: Iterable[str] = (),
+        replace: bool = False,
+    ) -> None:
+        """Register a lazy specification or an already-created tool."""
+        if isinstance(entry, BaseTool):
+            spec = ToolSpec(
+                name=entry.name,
+                description=entry.description,
+                import_path=None,
+                tags=frozenset(tags),
+            )
+            tool = entry
+        elif isinstance(entry, ToolSpec):
+            spec = entry
+            tool = None
+        else:
+            raise TypeError("ToolRegistry entries must be ToolSpec or BaseTool objects.")
+
+        if not spec.name:
+            raise ValueError("Registry names must not be empty.")
+        if spec.name in self._specs and not replace:
+            raise DuplicateRegistryEntryError(
+                f"Tool {spec.name!r} is already registered."
+            )
+        self._specs[spec.name] = spec
+        self._tools.pop(spec.name, None)
+        if tool is not None:
+            self._tools[spec.name] = tool
+
+    def names(self, *, tags: Iterable[str] = ()) -> tuple[str, ...]:
+        """Return canonical names in deterministic registration order."""
+        requested = frozenset(tags)
+        return tuple(
+            name
+            for name, spec in self._specs.items()
+            if not requested or requested.issubset(spec.tags)
+        )
+
+    def specs(self, *, tags: Iterable[str] = ()) -> tuple[ToolSpec, ...]:
+        """Return specifications, optionally filtered by tags."""
+        return tuple(self._specs[name] for name in self.names(tags=tags))
+
+    def get_spec(self, name: str) -> ToolSpec:
+        """Return metadata for one tool without importing it."""
+        try:
+            return self._specs[name]
+        except KeyError as exc:
+            raise UnknownRegistryEntryError(f"Unknown tool: {name!r}.") from exc
+
+    def availability(self, name: str) -> RegistryAvailability:
+        """Check declared runtime requirements without loading the tool."""
+        spec = self.get_spec(name)
+        issues = tuple(
+            issue for requirement in spec.requirements if (issue := requirement.issue())
+        )
+        return RegistryAvailability(name=name, issues=issues)
+
+    def get(self, name: str, *, require_available: bool = False) -> BaseTool:
+        """Resolve and cache one tool."""
+        spec = self.get_spec(name)
+        if require_available and not (status := self.availability(name)).available:
+            raise RegistryUnavailableError(name, status.issues)
+        if name in self._tools:
+            return self._tools[name]
+        if spec.import_path is None:
+            raise RegistryLoadError(f"Tool {name!r} has no import path or instance.")
+
+        module_name, separator, attribute = spec.import_path.partition(":")
+        if not separator or not module_name or not attribute:
+            raise RegistryLoadError(
+                f"Tool {name!r} has invalid import path {spec.import_path!r}."
+            )
+        try:
+            module = importlib.import_module(module_name)
+            tool = getattr(module, attribute)
+        except (ImportError, AttributeError) as exc:
+            raise RegistryLoadError(
+                f"Could not load tool {name!r} from {spec.import_path!r}: {exc}"
+            ) from exc
+        if not isinstance(tool, BaseTool):
+            raise RegistryLoadError(
+                f"{spec.import_path!r} resolved to {type(tool).__name__}, not BaseTool."
+            )
+        if tool.name != name:
+            raise RegistryLoadError(
+                f"Tool {spec.import_path!r} is named {tool.name!r}, expected {name!r}."
+            )
+        self._tools[name] = tool
+        return tool
+
+    def resolve(
+        self,
+        names: Iterable[str] | None = None,
+        *,
+        tags: Iterable[str] = (),
+        require_available: bool = False,
+    ) -> list[BaseTool]:
+        """Resolve tools in requested or registry order."""
+        selected = tuple(names) if names is not None else self.names(tags=tags)
+        requested_tags = frozenset(tags)
+        if requested_tags:
+            selected = tuple(
+                name
+                for name in selected
+                if requested_tags.issubset(self.get_spec(name).tags)
+            )
+        return [
+            self.get(name, require_available=require_available) for name in selected
+        ]
+
+
+__all__ = [
+    "BUILTIN_TOOL_SPECS",
+    "DuplicateRegistryEntryError",
+    "RegistryAvailability",
+    "RegistryError",
+    "RegistryLoadError",
+    "RegistryUnavailableError",
+    "RuntimeRequirement",
+    "ToolRegistry",
+    "ToolSpec",
+    "UnknownRegistryEntryError",
+]

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -22,6 +22,7 @@ EXPECTED_WORKERS = (
     "rag_agent",
     "single_agent_xanes",
     "molecular_docking",
+    "single_agent_iri",
 )
 
 
@@ -54,6 +55,7 @@ def test_existing_workflow_aliases_resolve_to_canonical_workers():
 
     assert registry.resolve_name("python_repl") == "python_relp"
     assert registry.resolve_name("graspa_agent") == "graspa"
+    assert registry.resolve_name("iri") == "single_agent_iri"
     assert registry.get_spec("python_repl").name == "python_relp"
 
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -25,6 +25,14 @@ EXPECTED_WORKERS = (
 )
 
 
+def _factory_v1(_llm):
+    return "factory-v1"
+
+
+def _factory_v2(_llm):
+    return "factory-v2"
+
+
 def _graspa_mcp_options():
     return {
         "executor_tools": [calculator],
@@ -65,6 +73,91 @@ def test_registration_rejects_duplicate_names_and_aliases():
                 aliases=("worker",),
             )
         )
+
+
+def test_replacement_retains_changes_aliases_and_invalidates_constructor():
+    registry = AgentRegistry(specs=())
+    registry.register(
+        AgentSpec(
+            "worker",
+            "Worker v1",
+            "tests.test_agent_registry:_factory_v1",
+            aliases=("keep", "remove"),
+        )
+    )
+    assert registry.build("worker", llm=object()) == "factory-v1"
+
+    replacement = AgentSpec(
+        "worker",
+        "Worker v2",
+        "tests.test_agent_registry:_factory_v2",
+        aliases=("keep", "new"),
+    )
+    registry.register(replacement, replace=True)
+
+    assert registry.get_spec("worker") is replacement
+    assert registry.resolve_name("keep") == "worker"
+    assert registry.resolve_name("new") == "worker"
+    with pytest.raises(UnknownRegistryEntryError, match="Unknown worker agent"):
+        registry.resolve_name("remove")
+    assert registry.build("worker", llm=object()) == "factory-v2"
+
+
+@pytest.mark.parametrize("foreign_identifier", ["other", "other_alias"])
+def test_replacement_rejects_identifiers_owned_by_another_agent(
+    foreign_identifier,
+):
+    original = AgentSpec(
+        "worker",
+        "Worker",
+        "tests.test_agent_registry:_factory_v1",
+        aliases=("worker_alias",),
+    )
+    other = AgentSpec(
+        "other",
+        "Other",
+        "tests.test_agent_registry:_factory_v1",
+        aliases=("other_alias",),
+    )
+    registry = AgentRegistry(specs=(original, other))
+
+    with pytest.raises(DuplicateRegistryEntryError, match="already registered"):
+        registry.register(
+            AgentSpec(
+                "worker",
+                "Replacement",
+                "tests.test_agent_registry:_factory_v2",
+                aliases=("worker_alias", foreign_identifier),
+            ),
+            replace=True,
+        )
+
+    assert registry.specs() == (original, other)
+    assert registry.resolve_name("worker_alias") == "worker"
+    assert registry.resolve_name("other_alias") == "other"
+
+
+def test_replacement_rejects_a_canonical_name_owned_as_an_alias():
+    original = AgentSpec(
+        "first",
+        "First",
+        "tests.test_agent_registry:_factory_v1",
+        aliases=("second",),
+    )
+    registry = AgentRegistry(specs=(original,))
+
+    with pytest.raises(DuplicateRegistryEntryError, match="already registered"):
+        registry.register(
+            AgentSpec(
+                "second",
+                "Second",
+                "tests.test_agent_registry:_factory_v2",
+            ),
+            replace=True,
+        )
+
+    assert registry.specs() == (original,)
+    assert registry.resolve_name("second") == "first"
 
 
 def test_graspa_mcp_requires_both_external_tool_groups():
@@ -129,6 +222,46 @@ def test_batch_validation_occurs_before_any_worker_is_built(monkeypatch):
             ["single_agent", "graspa_mcp"],
             llm=object(),
             options={"graspa_mcp": {"executor_tools": [calculator]}},
+        )
+    assert calls == []
+
+
+def test_batch_options_are_bound_before_any_worker_is_built(monkeypatch):
+    registry = AgentRegistry(
+        specs=(
+            AgentSpec("first", "First", "unused:first"),
+            AgentSpec("second", "Second", "unused:second"),
+        )
+    )
+    calls = []
+
+    def constructor(_llm, checkpointer=None):
+        calls.append(checkpointer)
+        return object()
+
+    monkeypatch.setattr(registry, "_get_constructor", lambda _spec: constructor)
+
+    with pytest.raises(TypeError, match="Invalid options for agent 'second'"):
+        registry.as_subagents(
+            ["first", "second"],
+            llm=object(),
+            options={"second": {"unexpected": True}},
+            require_available=False,
+        )
+    assert calls == []
+
+
+def test_batch_rejects_an_independent_checkpointer_before_loading(monkeypatch):
+    registry = AgentRegistry()
+    calls = []
+    monkeypatch.setattr(registry, "_get_constructor", lambda spec: calls.append(spec))
+
+    with pytest.raises(ValueError, match="inherit the parent checkpointer"):
+        registry.as_subagents(
+            ["single_agent", "python_relp"],
+            llm=object(),
+            options={"python_relp": {"checkpointer": MemorySaver()}},
+            require_available=False,
         )
     assert calls == []
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,0 +1,142 @@
+import pytest
+from langgraph.checkpoint.memory import MemorySaver
+
+from chemgraph.cli.commands import ALL_WORKFLOW_TYPES
+from chemgraph.registry import (
+    AgentRegistry,
+    AgentSpec,
+    DuplicateRegistryEntryError,
+    RegistryUnavailableError,
+    UnknownRegistryEntryError,
+)
+from chemgraph.tools.generic_tools import calculator
+
+
+EXPECTED_WORKERS = (
+    "single_agent",
+    "multi_agent",
+    "python_relp",
+    "graspa",
+    "mock_agent",
+    "graspa_mcp",
+    "rag_agent",
+    "single_agent_xanes",
+    "molecular_docking",
+)
+
+
+def _graspa_mcp_options():
+    return {
+        "executor_tools": [calculator],
+        "analysis_tools": [calculator],
+    }
+
+
+def test_builtin_registry_contains_worker_graphs_not_main_agent():
+    registry = AgentRegistry()
+
+    assert registry.names() == EXPECTED_WORKERS
+    assert set(registry.names()) == set(ALL_WORKFLOW_TYPES) - {"main_agent"}
+    with pytest.raises(UnknownRegistryEntryError, match="Unknown worker agent"):
+        registry.get_spec("main_agent")
+
+
+def test_existing_workflow_aliases_resolve_to_canonical_workers():
+    registry = AgentRegistry()
+
+    assert registry.resolve_name("python_repl") == "python_relp"
+    assert registry.resolve_name("graspa_agent") == "graspa"
+    assert registry.get_spec("python_repl").name == "python_relp"
+
+
+def test_registration_rejects_duplicate_names_and_aliases():
+    registry = AgentRegistry(specs=())
+    spec = AgentSpec("worker", "Worker", "tests.test_agent_registry:_factory")
+    registry.register(spec)
+
+    with pytest.raises(DuplicateRegistryEntryError, match="already registered"):
+        registry.register(spec)
+    with pytest.raises(DuplicateRegistryEntryError, match="already registered"):
+        registry.register(
+            AgentSpec(
+                "another",
+                "Another worker",
+                "tests.test_agent_registry:_factory",
+                aliases=("worker",),
+            )
+        )
+
+
+def test_graspa_mcp_requires_both_external_tool_groups():
+    registry = AgentRegistry()
+
+    status = registry.availability("graspa_mcp")
+    assert status.available is False
+    assert status.issues == (
+        "missing non-empty constructor argument 'executor_tools'",
+        "missing non-empty constructor argument 'analysis_tools'",
+    )
+
+    with pytest.raises(RegistryUnavailableError, match="executor_tools"):
+        registry.build("graspa_mcp", llm=object())
+
+
+def test_all_workers_build_standalone_with_default_memory_checkpointer():
+    registry = AgentRegistry()
+
+    for name in registry.names():
+        kwargs = _graspa_mcp_options() if name == "graspa_mcp" else {}
+        graph = registry.build(
+            name,
+            llm=object(),
+            require_available=False,
+            **kwargs,
+        )
+        assert isinstance(graph.checkpointer, MemorySaver), name
+
+
+def test_all_workers_adapt_to_parent_checkpointed_subagents():
+    registry = AgentRegistry()
+    workers = registry.as_subagents(
+        registry.names(),
+        llm=object(),
+        options={"graspa_mcp": _graspa_mcp_options()},
+        require_available=False,
+    )
+
+    assert tuple(worker["name"] for worker in workers) == EXPECTED_WORKERS
+    assert all(worker["description"] for worker in workers)
+    assert all(worker["runnable"].checkpointer is None for worker in workers)
+
+
+def test_subagent_rejects_an_independent_checkpointer():
+    with pytest.raises(ValueError, match="inherit the parent checkpointer"):
+        AgentRegistry().as_subagent(
+            "single_agent",
+            llm=object(),
+            require_available=False,
+            checkpointer=MemorySaver(),
+        )
+
+
+def test_batch_validation_occurs_before_any_worker_is_built(monkeypatch):
+    registry = AgentRegistry()
+    calls = []
+    monkeypatch.setattr(registry, "_get_constructor", lambda _spec: calls.append)
+
+    with pytest.raises(RegistryUnavailableError, match="analysis_tools"):
+        registry.as_subagents(
+            ["single_agent", "graspa_mcp"],
+            llm=object(),
+            options={"graspa_mcp": {"executor_tools": [calculator]}},
+        )
+    assert calls == []
+
+
+def test_alias_and_canonical_name_cannot_be_requested_together():
+    with pytest.raises(DuplicateRegistryEntryError, match="more than once"):
+        AgentRegistry().as_subagents(
+            ["python_relp", "python_repl"],
+            llm=object(),
+            require_available=False,
+        )

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,0 +1,143 @@
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.tools import BaseTool, tool
+
+from chemgraph.registry import (
+    DuplicateRegistryEntryError,
+    RegistryUnavailableError,
+    RuntimeRequirement,
+    ToolRegistry,
+    ToolSpec,
+    UnknownRegistryEntryError,
+)
+
+
+EXPECTED_TOOLS = (
+    "extract_output_json",
+    "file_to_atomsdata",
+    "save_atomsdata_to_file",
+    "get_symmetry_number",
+    "is_linear_molecule",
+    "run_ase",
+    "molecule_name_to_smiles",
+    "smiles_to_atomsdata",
+    "smiles_to_coordinate_file",
+    "calculator",
+    "ask_human",
+    "python_repl",
+    "run_docking",
+    "run_graspa",
+    "load_document",
+    "query_knowledge_base",
+    "generate_html",
+    "run_xanes",
+    "fetch_xanes_data",
+    "plot_xanes_data",
+)
+
+
+@tool
+def custom_tool(value: str) -> str:
+    """Return a value unchanged."""
+    return value
+
+
+def test_builtin_registry_contains_only_llm_tools():
+    registry = ToolRegistry()
+
+    assert registry.names() == EXPECTED_TOOLS
+    assert "main_agent" not in registry.names()
+    assert all("mcp" not in spec.tags for spec in registry.specs())
+
+
+def test_every_builtin_resolves_to_matching_base_tool():
+    registry = ToolRegistry()
+
+    resolved = registry.resolve()
+
+    assert len(resolved) == len(EXPECTED_TOOLS)
+    assert all(isinstance(item, BaseTool) for item in resolved)
+    assert tuple(item.name for item in resolved) == EXPECTED_TOOLS
+
+
+def test_registry_filters_by_all_requested_tags():
+    registry = ToolRegistry()
+
+    assert registry.names(tags={"ase", "analysis"}) == (
+        "get_symmetry_number",
+        "is_linear_molecule",
+    )
+    assert [tool.name for tool in registry.resolve(tags={"docking"})] == [
+        "run_docking"
+    ]
+
+
+def test_lazy_spec_is_not_imported_until_get(monkeypatch):
+    calls = []
+
+    def fake_import(name):
+        calls.append(name)
+        return SimpleNamespace(candidate=custom_tool)
+
+    monkeypatch.setattr("chemgraph.registry.tools.importlib.import_module", fake_import)
+    registry = ToolRegistry(
+        specs=(
+            ToolSpec(
+                name="custom_tool",
+                description="Custom tool",
+                import_path="example.lazy:candidate",
+            ),
+        )
+    )
+
+    assert registry.names() == ("custom_tool",)
+    assert calls == []
+    assert registry.get("custom_tool") is custom_tool
+    assert calls == ["example.lazy"]
+    assert registry.get("custom_tool") is custom_tool
+    assert calls == ["example.lazy"]
+
+
+def test_register_eager_tool_and_reject_duplicate():
+    registry = ToolRegistry(specs=())
+    registry.register(custom_tool, tags={"custom"})
+
+    assert registry.get("custom_tool") is custom_tool
+    assert registry.names(tags={"custom"}) == ("custom_tool",)
+    with pytest.raises(DuplicateRegistryEntryError, match="already registered"):
+        registry.register(custom_tool)
+
+
+def test_unknown_tool_is_clear():
+    with pytest.raises(UnknownRegistryEntryError, match="Unknown tool"):
+        ToolRegistry().get("main_agent")
+
+
+def test_require_available_aggregates_runtime_issue(monkeypatch):
+    monkeypatch.delenv("CHEMGRAPH_TEST_EXECUTABLE", raising=False)
+    registry = ToolRegistry(
+        specs=(
+            ToolSpec(
+                name="custom_tool",
+                description="Custom tool",
+                import_path="example.lazy:candidate",
+                requirements=(
+                    RuntimeRequirement(
+                        "environment",
+                        "CHEMGRAPH_TEST_EXECUTABLE",
+                        "set it for this test tool",
+                    ),
+                ),
+            ),
+        )
+    )
+
+    status = registry.availability("custom_tool")
+    assert status.available is False
+    assert status.issues == (
+        "missing environment variable 'CHEMGRAPH_TEST_EXECUTABLE' "
+        "(set it for this test tool)",
+    )
+    with pytest.raises(RegistryUnavailableError, match="CHEMGRAPH_TEST_EXECUTABLE"):
+        registry.get("custom_tool", require_available=True)


### PR DESCRIPTION
## Summary

- Add a lazy `ToolRegistry` for ChemGraph’s 20 individually exported in-process LangChain tools, with metadata, tag filtering, custom registration, and runtime availability checks.
- Add an `AgentRegistry` for the ten worker workflows, including aliases, standalone construction, and `CompiledSubAgent` adaptation with inherited checkpointing.
- Add registry documentation and a credential-free example that demonstrates discovery, availability checks, tool resolution, and optional worker construction.
- Keep MCP tools, generated IRI API tool collections, skills, benchmarks, selector middleware, and `main_agent` registration out of scope; `main_agent` remains the orchestration graph.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check .`
- `pytest tests/ -k "not tblite"`: 471 passed, 29 skipped, 2 deselected
- `mkdocs build --strict`
- `PYTHONPATH=src python examples/registries/run_registries.py`

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change