### PR TITLE
prompt: force executor delegation and preserve reported units

### DIFF
--- a/src/chemgraph/prompt/multi_agent_prompt.py
+++ b/src/chemgraph/prompt/multi_agent_prompt.py
@@ -9,6 +9,9 @@ You are an expert in computational chemistry and the **Planner** responsible for
 
 Your role is to act as a router that decomposes user queries into independent subtasks, dispatches them to executor agents, and decides when the workflow is complete.
 
+### DELEGATION POLICY (critical):
+You do NOT execute tools yourself. For any question involving computed properties, molecular data, or simulation results, you MUST dispatch tasks to executor agents and base your answer on their results — even if you believe you already know the answer. Your internal chemistry knowledge may be outdated or wrong; executor results are the only source of truth. Never answer computational questions directly from memory, and never fabricate or anticipate an executor's result.
+
 ### STATE TRANSITION RULES:
 
 **PHASE 1: Task Decomposition (First invocation)**
@@ -46,6 +49,8 @@ Your role is to act as a router that decomposes user queries into independent su
 
 ### AGGREGATION (when finishing):
 When you set `next_step` to `"FINISH"`, your `thought_process` must contain the **final aggregated answer** to the user's query. Combine the executor results to compute derived quantities (e.g., reaction enthalpy = products - reactants). Base your answer **only** on the executor outputs — do not use external data or standard values.
+
+**Units:** Preserve all values in the exact units and precision reported by the executors. Do NOT perform unit conversions, rounding changes, or renormalization unless (a) the user explicitly asked for a specific unit, or (b) results must be combined and share no common unit — in that case, state the conversion you performed. If executors report the same quantity in different units, present them as reported rather than converting one to match the other.
 
 ### OUTPUT FORMAT:
 You MUST return ONLY a valid JSON object. No text before or after the JSON.
@@ -148,6 +153,11 @@ To help you stay on track:
 - Act as a data aggregator, not a chemical expert.
 - Your only source of truth is the worker agents' outputs.
 - Always cite which values come from which subtasks.
+
+Units:
+- Preserve all values in the exact units and precision reported by the worker agents.
+- Do **not** perform unit conversions, rounding changes, or renormalization unless (a) the user explicitly asked for a specific unit, or (b) values must be combined and share no common unit — in that case, state the conversion you performed.
+- If workers report the same quantity in different units, present them as reported rather than converting one to match the other.
 """
 
 executor_prompt = """
@@ -177,6 +187,7 @@ Instructions:
 5. Once all necessary tools have been called:
    - **Summarize the results accurately**, based only on tool outputs.
    - Do not invent conclusions or values not directly computed by tools.
+   - **Report values exactly as the tools returned them**, preserving the original units and precision. Do not convert units unless the tool's input schema requires a specific unit or the task explicitly asks for a conversion. Always state the unit alongside each value.
 
 Remember: **no simulation or structure may be faked or guessed. All information must come from tool calls.**
 """
@@ -212,6 +223,7 @@ Additional instructions:
 - Carefully check that the values you format are present in the **actual output of prior tools or agents**.
 - Pay close attention to whether the desired result is a **list vs. a scalar**, and choose the correct format accordingly.
 - Populate only the relevant fields; leave the rest as null.
+- **Never convert units or change precision.** Copy each value and its unit exactly as reported by the prior agents, and record the unit in the corresponding unit field. Only emit a different unit if the user explicitly requested it.
 
 You MUST output ONLY a valid JSON object matching the following JSON schema. Do not include any text, markdown fences, or explanation outside the JSON object.
 

--- a/src/chemgraph/prompt/multi_agent_prompt.py
+++ b/src/chemgraph/prompt/multi_agent_prompt.py
@@ -140,24 +140,19 @@ planner_prompt_json = planner_prompt
 
 # Legacy alias — the aggregator role is now handled by the planner on FINISH.
 aggregator_prompt = """
-You are a strict aggregation agent for computational chemistry tasks. Your role is to generate a final answer to the user's query based **only** on the outputs from executor agents.
+You are a strict aggregation agent for computational chemistry tasks. Your role is to generate a final answer to the user's query based **only** on the outputs from other worker agents.
 
 Your instructions:
-- You are given the original user query and the list of outputs from all executor agents.
+- You are given the original user query and the list of outputs from all worker agents.
 - Your job is to **combine and summarize** these outputs to produce a final answer (e.g., reaction enthalpy, Gibbs free energy, entropy).
-- You **must not** use external chemical knowledge, standard values, or any assumptions not found explicitly in the executor outputs.
-- **Do not use standard enthalpies or Gibbs energies of formation from any database. Only use what is present in the executor agents' outputs.**
+- You **must not** use external chemical knowledge, standard values, or any assumptions not found explicitly in the worker outputs.
+- **Do not use standard enthalpies or Gibbs energies of formation from any database. Only use what is present in the worker agents' outputs.**
 - If any required value is missing, state that the result is incomplete. Do not attempt to fill in missing data.
 
 To help you stay on track:
 - Act as a data aggregator, not a chemical expert.
-- Your only source of truth is the executor agents' outputs.
+- Your only source of truth is the worker agents' outputs.
 - Always cite which values come from which subtasks.
-
-Units:
-- Preserve all values in the exact units and precision reported by the executor agents.
-- Do **not** perform unit conversions, rounding changes, or renormalization unless (a) the user explicitly asked for a specific unit, or (b) values must be combined and share no common unit — in that case, state the conversion you performed.
-- If executors report the same quantity in different units, present them as reported rather than converting one to match the other.
 """
 
 executor_prompt = """
@@ -187,7 +182,6 @@ Instructions:
 5. Once all necessary tools have been called:
    - **Summarize the results accurately**, based only on tool outputs.
    - Do not invent conclusions or values not directly computed by tools.
-   - **Report values exactly as the tools returned them**, preserving the original units and precision. Do not convert units unless the tool's input schema requires a specific unit or the task explicitly asks for a conversion. Always state the unit alongside each value.
 
 Remember: **no simulation or structure may be faked or guessed. All information must come from tool calls.**
 """
@@ -223,7 +217,6 @@ Additional instructions:
 - Carefully check that the values you format are present in the **actual output of prior tools or agents**.
 - Pay close attention to whether the desired result is a **list vs. a scalar**, and choose the correct format accordingly.
 - Populate only the relevant fields; leave the rest as null.
-- Preserve the reported unit exactly, and use the reported numeric value without converting or intentionally rounding it. Because scalar JSON fields are numeric, insignificant trailing zeros may not be retained. Do not infer extra precision. Only emit a different unit if the user explicitly requested it.
 
 You MUST output ONLY a valid JSON object matching the following JSON schema. Do not include any text, markdown fences, or explanation outside the JSON object.
 

--- a/src/chemgraph/prompt/multi_agent_prompt.py
+++ b/src/chemgraph/prompt/multi_agent_prompt.py
@@ -223,7 +223,7 @@ Additional instructions:
 - Carefully check that the values you format are present in the **actual output of prior tools or agents**.
 - Pay close attention to whether the desired result is a **list vs. a scalar**, and choose the correct format accordingly.
 - Populate only the relevant fields; leave the rest as null.
-- **Never convert units or change precision.** Copy each value and its unit exactly as reported by the prior agents, and record the unit in the corresponding unit field. Only emit a different unit if the user explicitly requested it.
+- Preserve the reported unit exactly, and use the reported numeric value without converting or intentionally rounding it. Because scalar JSON fields are numeric, insignificant trailing zeros may not be retained. Do not infer extra precision. Only emit a different unit if the user explicitly requested it.
 
 You MUST output ONLY a valid JSON object matching the following JSON schema. Do not include any text, markdown fences, or explanation outside the JSON object.
 

--- a/src/chemgraph/prompt/multi_agent_prompt.py
+++ b/src/chemgraph/prompt/multi_agent_prompt.py
@@ -140,24 +140,24 @@ planner_prompt_json = planner_prompt
 
 # Legacy alias — the aggregator role is now handled by the planner on FINISH.
 aggregator_prompt = """
-You are a strict aggregation agent for computational chemistry tasks. Your role is to generate a final answer to the user's query based **only** on the outputs from other worker agents.
+You are a strict aggregation agent for computational chemistry tasks. Your role is to generate a final answer to the user's query based **only** on the outputs from executor agents.
 
 Your instructions:
-- You are given the original user query and the list of outputs from all worker agents.
+- You are given the original user query and the list of outputs from all executor agents.
 - Your job is to **combine and summarize** these outputs to produce a final answer (e.g., reaction enthalpy, Gibbs free energy, entropy).
-- You **must not** use external chemical knowledge, standard values, or any assumptions not found explicitly in the worker outputs.
-- **Do not use standard enthalpies or Gibbs energies of formation from any database. Only use what is present in the worker agents' outputs.**
+- You **must not** use external chemical knowledge, standard values, or any assumptions not found explicitly in the executor outputs.
+- **Do not use standard enthalpies or Gibbs energies of formation from any database. Only use what is present in the executor agents' outputs.**
 - If any required value is missing, state that the result is incomplete. Do not attempt to fill in missing data.
 
 To help you stay on track:
 - Act as a data aggregator, not a chemical expert.
-- Your only source of truth is the worker agents' outputs.
+- Your only source of truth is the executor agents' outputs.
 - Always cite which values come from which subtasks.
 
 Units:
-- Preserve all values in the exact units and precision reported by the worker agents.
+- Preserve all values in the exact units and precision reported by the executor agents.
 - Do **not** perform unit conversions, rounding changes, or renormalization unless (a) the user explicitly asked for a specific unit, or (b) values must be combined and share no common unit — in that case, state the conversion you performed.
-- If workers report the same quantity in different units, present them as reported rather than converting one to match the other.
+- If executors report the same quantity in different units, present them as reported rather than converting one to match the other.
 """
 
 executor_prompt = """


### PR DESCRIPTION
Two related failure modes in the multi-agent prompts:

1. The planner would sometimes answer computational chemistry questions from its own knowledge instead of dispatching to executor agents, since it is confident about common molecules. Add an explicit DELEGATION POLICY stating that executor results are the only source of truth, including the "even if you believe you know the answer" case that drives the shortcut.

2. Agents would silently convert units (eV <-> kJ/mol, etc.) while summarizing or aggregating, making values hard to trace back to the tool output that produced them. Add a units rule at every stage that touches a value: - executor: report tool output in original units/precision - planner AGGREGATION (FINISH): no conversion when composing the final answer - aggregator (legacy alias): same rule - formatter: copy value and unit verbatim into the response schema

The conversion rule allows two escapes: an explicit user request, or combining values with no common unit, in which case the conversion must be stated.

The units rule and delegation policy are placed outside the blocks that get_planner_prompt(human_supervised=False) strips, so both survive in the unsupervised prompt.

<!--
Thanks for contributing! Keep PRs small and focused — one logical change.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

<!-- What does this PR do, and why? -->

## Related issues

<!-- e.g. Closes #123 -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

<!-- Commands you ran, new tests added, manual verification -->

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [ ] `ruff check .` passes
- [ ] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [ ] Added/updated tests for the change
- [ ] Updated docs / README for any user-facing change
