### PR TITLE
Add Aurora on-node LLM inference provider and llama.cpp recipes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,6 +64,15 @@ timeout = 30
 base_url = "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1"
 timeout = 30
 
+# Aurora on-node inference (llama.cpp SYCL llama-server or vLLM-XPU), served as
+# an OpenAI-compatible /v1 endpoint. Use "aurora:<served-model-id>" models. The
+# node IP changes per job and compute nodes have no public IP, so set base_url
+# to a co-located server (127.0.0.1) or an SSH tunnel from a login node. May
+# also be set via the AURORA_BASE_URL environment variable.
+[api.aurora]
+base_url = "http://127.0.0.1:8000/v1"
+timeout = 60
+
 [api.local]
 base_url = "http://localhost:11434"
 timeout = 60

--- a/config/aurora_gpt_oss.toml
+++ b/config/aurora_gpt_oss.toml
@@ -1,0 +1,26 @@
+# ChemGraph config: Aurora gpt-oss-120b endpoint (llama.cpp full-XPU, 2-tile, max context).
+#
+# Usage:
+#   1) Start the endpoint:  scripts/aurora/serve_llamacpp_maxctx.sh gpt-oss-120b
+#   2) Point base_url at it (co-located 127.0.0.1, or an SSH tunnel from a login node),
+#      either by editing [api.aurora].base_url below or exporting AURORA_BASE_URL.
+#   3) Run:  chemgraph run --config config/aurora_gpt_oss.toml -q "..."
+#
+# The model uses the "aurora:" provider, which sends OpenAI-compatible requests to
+# an on-node llama.cpp server. gpt-oss-120b supports tool calling, required by
+# ChemGraph's tool-driven workflows.
+
+[general]
+model = "aurora:gpt-oss-120b"
+workflow = "single_agent"
+output = "last_message"
+recursion_limit = 20
+
+[api.aurora]
+# Override per run with AURORA_BASE_URL, or set your tunnel/node URL here.
+base_url = "http://127.0.0.1:8000/v1"
+timeout = 60
+
+[logging]
+level = "WARNING"
+console = true

--- a/config/aurora_inkling.toml
+++ b/config/aurora_inkling.toml
@@ -1,0 +1,24 @@
+# ChemGraph config: Aurora Inkling inference (two-node recipe).
+# Node 0 runs llama-server (PG10: 10-tile pure GPU, UD-IQ1_S GGUF).
+# Node 1 runs ChemGraph; AURORA_BASE_URL is set by the PBS script from ENDPOINT.txt.
+#
+# Usage:
+#   qsub -q debug-scaling scripts/aurora/two_node_inkling.pbs
+#   # or manually: source scripts/aurora/chemgraph_aurora_env.sh ENDPOINT.txt
+#   chemgraph run --config config/aurora_inkling.toml -q "..."
+
+[general]
+model = "aurora:inkling"
+workflow = "single_agent"
+output = "last_message"
+recursion_limit = 20
+
+[api.aurora]
+# Set by exporting AURORA_BASE_URL (chemgraph_aurora_env.sh reads ENDPOINT.txt).
+# Override manually for a fixed node: base_url = "http://<node_ip>:8000/v1"
+base_url = "http://127.0.0.1:8000/v1"
+timeout = 120
+
+[logging]
+level = "WARNING"
+console = true

--- a/config/aurora_nemotron4.toml
+++ b/config/aurora_nemotron4.toml
@@ -1,0 +1,21 @@
+# ChemGraph config: Aurora Nemotron-4-340B inference (full-XPU, max context, llama.cpp).
+# Node runs llama-server (i1-Q4_K_M, 6-tile full-XPU, -c 32768); AURORA_BASE_URL points at it.
+#
+# Usage:
+#   scripts/aurora/serve_llamacpp_maxctx.sh nemotron-4-340b     # start the server
+#   source scripts/aurora/chemgraph_aurora_env.sh ENDPOINT.txt  # or set AURORA_BASE_URL manually
+#   chemgraph run --config config/aurora_nemotron4.toml -q "..."
+
+[general]
+model = "aurora:nemotron-4-340b"
+workflow = "single_agent"
+output = "last_message"
+recursion_limit = 20
+
+[api.aurora]
+base_url = "http://127.0.0.1:8000/v1"
+timeout = 120
+
+[logging]
+level = "WARNING"
+console = true

--- a/config/aurora_nemotron_ultra.toml
+++ b/config/aurora_nemotron_ultra.toml
@@ -1,0 +1,25 @@
+# ChemGraph config: Aurora Nemotron-3-Ultra inference (two-node recipe).
+# Node 0 runs llama-server (Nemotron-3-Ultra UD-IQ2_M, single-tile MoE->CPU or 3x DP).
+# Node 1 runs ChemGraph; AURORA_BASE_URL is set by the PBS script from ENDPOINT.txt.
+#
+# Usage (two-node):
+#   qsub -q debug-scaling scripts/aurora/two_node_nemotron_ultra.pbs
+#   qsub -q debug-scaling -v MODE=dp,... scripts/aurora/two_node_nemotron_ultra.pbs
+#   # or manually: source scripts/aurora/chemgraph_aurora_env.sh ENDPOINT.txt
+#   chemgraph run --config config/aurora_nemotron_ultra.toml -q "..."
+
+[general]
+model = "aurora:nemotron-3-ultra"
+workflow = "single_agent"
+output = "last_message"
+recursion_limit = 20
+
+[api.aurora]
+# Set by exporting AURORA_BASE_URL (chemgraph_aurora_env.sh reads ENDPOINT.txt).
+# Override manually: base_url = "http://<node_ip>:8000/v1"
+base_url = "http://127.0.0.1:8000/v1"
+timeout = 120
+
+[logging]
+level = "WARNING"
+console = true

--- a/docs/aurora_recipes.md
+++ b/docs/aurora_recipes.md
@@ -1,0 +1,188 @@
+# Aurora LLM Inference Recipes for ChemGraph
+
+Full-XPU, maximum-context llama.cpp inference on ALCF Aurora for four models, served to ChemGraph via
+the [`aurora:`](running_local_models.md#aurora-on-node-inference-aurora-models) provider. Every recipe
+keeps **all model weights on the GPU** (no MoE→CPU offload) and runs at each model's **native maximum
+context length**. GPU tiles are partitioned so the LLM and the scientific workload never share tiles,
+and both CPU sockets stay free for the science process.
+
+| Model | `aurora:` id | Quant / GGUF | LLM tiles | Free for science | Max context |
+|-------|--------------|--------------|-----------|-----------------|-------------|
+| gpt-oss-120b | `aurora:gpt-oss-120b` | MXFP4 (~60 GB) | 2 (1 GPU) | 10 tiles + both CPUs | 131 072 |
+| Nemotron-3-Ultra-550B | `aurora:nemotron-3-ultra` | UD-IQ2_M (~181 GB) | 6 (3 GPUs) | 6 tiles + both CPUs | 262 144 |
+| Inkling | `aurora:inkling` | UD-IQ1_S (~270 GB) | 8 (4 GPUs) | 4 tiles + both CPUs | 131 072 |
+| Nemotron-4-340B | `aurora:nemotron-4-340b` | i1-Q4_K_M (~196 GB) | 6 (3 GPUs) | 6 tiles + both CPUs | 4 096 |
+
+Each Aurora node has 6 GPUs × 2 tiles = **12 tiles** of ~64 GB HBM. The KV cache is small relative to
+weights (few KV heads), so max context fits the listed tile counts with headroom — no extra tiles are
+needed to go from a short context to the maximum.
+
+---
+
+## Prerequisites
+
+### 1. Build llama.cpp with the SYCL backend
+
+**There is no facility-wide llama.cpp module on Aurora — you must build it once.** A self-contained PBS
+script is provided; it uses only Aurora modules (oneapi, cmake, ninja) and system git (no conda), and
+merges the Inkling PR so a single build serves all four models.
+
+```bash
+qsub -q debug -v LLAMA_ROOT=$HOME/llamacpp-sycl scripts/aurora/build_llamacpp_sycl.pbs
+# result: $HOME/llamacpp-sycl/build/bin/llama-server  (+ llama-cli, llama-bench)
+```
+
+The serve scripts default to `BIN=$HOME/llamacpp-sycl/build/bin`; override `BIN` if you build elsewhere.
+Key CMake flags (already set in the script): `-DGGML_SYCL=ON -DGGML_SYCL_F16=ON
+-DGGML_SYCL_DEVICE_ARCH=pvc -DCMAKE_CXX_COMPILER=icpx -DLLAMA_BUILD_SERVER=ON`.
+
+Architecture notes: `gpt-oss`, `nemotron_h` (Nemotron-3-Ultra), and `nemotron` (Nemotron-4-340B) are on
+recent llama.cpp `master`; the `inkling` architecture needs PR #25731, which the build script merges
+(`BUILD_INKLING=1`, default).
+
+### 2. Download the GGUF weights
+
+Point each recipe's `GGUF` at the model's first shard. The `alcf-aurora-llm` campaign contains the
+download scripts; place the GGUFs where the serve script's `GGUF` variable points (or override it).
+
+---
+
+## Common launch pattern
+
+All models use the same unified serve script, which selects tiles, GGUF, max context, and alias from
+the model key:
+
+```bash
+# on the LLM node:
+BIN=$HOME/llamacpp-sycl/build/bin \
+  scripts/aurora/serve_llamacpp_maxctx.sh <model-key> [port]
+#   model-key ∈ { gpt-oss-120b | nemotron-3-ultra | inkling | nemotron-4-340b }
+```
+
+It runs `llama-server` with: `-ngl 99` (all layers on GPU), `--split-mode layer` (row split crashes on
+`nemotron_h`), **no `-ncmoe`**, `-fa on`, `--jinja` (tool calls), `-c <model max>`,
+`--parallel 4 --cont-batching`, `--host 0.0.0.0`. `ZE_AFFINITY_MASK` pins the model's tile group;
+`GGML_SYCL_ENABLE_VMM=0` is required on PVC.
+
+Then point ChemGraph at it (co-located, or from another node via the intra-cluster IP / SSH tunnel):
+
+```bash
+export AURORA_BASE_URL="http://<llm_node_ip>:8000/v1"
+chemgraph run --model aurora:<model-key> -q "..."
+# or:  chemgraph run --config config/aurora_<model>.toml -q "..."
+```
+
+For the scientific workload, set **its own** `ZE_AFFINITY_MASK` to the complementary (free) tiles so
+the two processes never share a tile.
+
+---
+
+## Recipe 1 — gpt-oss-120b (2 tiles, same node)
+
+LLM on tiles 0–1 (1 GPU); science on tiles 2–11 + both CPU sockets.
+
+```bash
+scripts/aurora/serve_llamacpp_maxctx.sh gpt-oss-120b 8000
+# ZE_AFFINITY_MASK=0,1  -c 131072  --split-mode layer  (weights ~60 GB + KV ~19 GB @ max)
+# Science: export ZE_AFFINITY_MASK=2,3,4,5,6,7,8,9,10,11
+chemgraph run --model aurora:gpt-oss-120b -q "Build water from SMILES O and optimize with EMT."
+```
+gpt-oss uses `openai_harmony`, which fetches its tiktoken vocab; the serve script sets the ALCF proxy
+(+ `no_proxy=127.0.0.1`) and caches it under `TIKTOKEN_RS_CACHE_DIR`.
+Reference: decode ~34 tok/s (2-tile), TTFT ~50 ms; ~8% decode penalty at 131 072 vs short context.
+
+## Recipe 2 — Nemotron-3-Ultra-550B (6 tiles, same node)
+
+LLM on tiles 0–5 (3 GPUs); science on tiles 6–11 + both CPU sockets.
+
+```bash
+scripts/aurora/serve_llamacpp_maxctx.sh nemotron-3-ultra 8000
+# ZE_AFFINITY_MASK=0,1,2,3,4,5  -c 262144  --split-mode layer  (weights ~181 GB + KV ~3 GB @ max)
+# Science: export ZE_AFFINITY_MASK=6,7,8,9,10,11
+chemgraph run --model aurora:nemotron-3-ultra -q "..."
+```
+MoE experts are on GPU (no CPU offload), so the LLM uses little CPU/DDR during decode. Layer split is
+pipeline-serial → decode ~5.8 tok/s (vs ~7 tok/s for the older MoE→CPU 1-tile path — same order of
+magnitude, and it keeps both CPU sockets free). Min tiles for max context = 4; 6 is used for headroom.
+
+KV note: Nemotron-3-Ultra is a **hybrid** model — only its 12 attention layers carry context-scaling
+KV (the 48 Mamba2 layers hold a small constant state; the 48 MoE layers none), and `kv_heads=2`. So
+even at 262 144 the KV cache is only ~3 GB — it is weights-bound, not KV-bound. (Full-XPU layer-split
+was validated at 8 tiles / short context; at max context KV adds ~3 GB, so 6 tiles remain ample.)
+
+## Recipe 3 — Inkling (8 tiles, or full node with ChemGraph on a second node)
+
+LLM on tiles 0–7 (4 GPUs); science on tiles 8–11 + both CPUs. For maximum isolation, run Inkling on
+one node and ChemGraph on a second node (two-node PBS below).
+
+```bash
+scripts/aurora/serve_llamacpp_maxctx.sh inkling 8000
+# ZE_AFFINITY_MASK=0,1,...,7  -c 131072  --split-mode layer  (weights ~270 GB + KV ~33 GB @ max)
+# Science: export ZE_AFFINITY_MASK=8,9,10,11
+chemgraph run --model aurora:inkling -q "..."
+```
+Reference: decode ~6.7 tok/s. Min tiles for max context = 6; 8 is used for headroom / better split.
+
+## Recipe 4 — Nemotron-4-340B (6 tiles, same node)
+
+LLM on tiles 0–5 (3 GPUs); science on tiles 6–11 + both CPUs. Dense model (no MoE).
+
+```bash
+scripts/aurora/serve_llamacpp_maxctx.sh nemotron-4-340b 8000
+# ZE_AFFINITY_MASK=0,1,2,3,4,5  -c 4096  --split-mode layer  (weights ~196 GB + KV ~1.6 GB @ max)
+# Science: export ZE_AFFINITY_MASK=6,7,8,9,10,11
+chemgraph run --model aurora:nemotron-4-340b -q "..."
+```
+Reference: decode ~2.3 tok/s, TTFT ~2.4 s (dense 340B does full-model FLOPs/token). Max context for
+the Q4_K_M quant is 4 096 (GGUF n_ctx_train=4096; llama.cpp clamps to it). Min tiles = 4; 6 used for headroom.
+
+---
+
+## Two-node deployment (LLM on one node, ChemGraph on another)
+
+For full compute isolation, run the LLM server on one node and the ChemGraph scientific workload on a
+separate node. The nodes communicate via node 0's intra-cluster IP (written to `ENDPOINT.txt`).
+
+```bash
+qsub -q debug-scaling scripts/aurora/two_node_inkling.pbs           # Inkling + ChemGraph
+qsub -q debug-scaling scripts/aurora/two_node_nemotron_ultra.pbs    # Nemotron-3-Ultra + ChemGraph
+```
+
+Both scripts run `select=2`: node 0 serves the model full-XPU (via SSH), node 1 runs `chemgraph run`
+against `AURORA_BASE_URL=http://<node0_ip>:8000/v1`.
+
+---
+
+## Context length note
+
+ChemGraph prepends the full conversation history on every LLM call, so context grows per agent step; a
+short `-c 4096` truncates a simple multi-step workflow (`finish_reason: length`). These recipes use each
+model's **native maximum context**, which fits the listed tile counts (KV cache is small vs weights),
+so ChemGraph runs of any realistic length are safe. If you need to trade context for a bit more decode
+speed, lower `-c` via the `CTX` env var (e.g. `CTX=8192`).
+
+## Known caveats
+
+- **Nemotron-4-340B is limited to 4096 context (model architecture).** Nemotron-4-340B-Instruct was
+  pretrained with `max_position_embeddings = 4096` and **no RoPE scaling** (confirmed in both the
+  upstream HF config and the GGUF header, `nemotron.context_length = 4096`). llama.cpp clamps any larger
+  `-c` down to 4096 (`n_ctx_seq > n_ctx_train` warning). This is a hard architectural limit, not a
+  quantization or checkpoint artifact — there is no official long-context variant, and forcing longer
+  context via RoPE extension degrades quality (and can break tool-calling, which ChemGraph relies on).
+  4096 is sufficient for typical single-agent tasks (the co-located EMT test passed), but is marginal
+  for long multi-tool chains. **For long-context ChemGraph workflows, use gpt-oss-120b (131072),
+  Inkling (131072), or Nemotron-3-Ultra (262144) instead.**
+
+## File locations
+
+| File | Purpose |
+|------|---------|
+| `scripts/aurora/build_llamacpp_sycl.pbs` | Build llama.cpp SYCL for Aurora (all 4 models) |
+| `scripts/aurora/serve_llamacpp_maxctx.sh` | Unified full-XPU max-context serve (pick model by key) |
+| `scripts/aurora/two_node_inkling.pbs` | Two-node: Inkling LLM + ChemGraph |
+| `scripts/aurora/two_node_nemotron_ultra.pbs` | Two-node: Nemotron-3-Ultra LLM + ChemGraph |
+| `scripts/aurora/chemgraph_aurora_env.sh` | Export `AURORA_BASE_URL` from `ENDPOINT.txt` |
+| `config/aurora_gpt_oss.toml` | ChemGraph config: `aurora:gpt-oss-120b` |
+| `config/aurora_nemotron_ultra.toml` | ChemGraph config: `aurora:nemotron-3-ultra` |
+| `config/aurora_inkling.toml` | ChemGraph config: `aurora:inkling` |
+| `config/aurora_nemotron4.toml` | ChemGraph config: `aurora:nemotron-4-340b` |

--- a/docs/running_local_models.md
+++ b/docs/running_local_models.md
@@ -45,6 +45,34 @@ route through a compatible ChemGraph provider/model ID, and implement reliable
 tool calling. Review the script's hardware/model assumptions and test a
 non-destructive query first. Ollama remains the documented first local route.
 
+## Aurora on-node inference (`aurora:` models)
+
+ChemGraph has a first-class provider for on-node LLM servers on ALCF Aurora
+(llama.cpp SYCL `llama-server` or vLLM-XPU) that expose an OpenAI-compatible
+`/v1` endpoint. Use an `aurora:<served-model-id>` model, where the id matches
+the server's advertised name (`llama-server --alias` / vLLM
+`--served-model-name`). Any served id works; `chemgraph models` lists a few for
+discovery.
+
+```bash
+# On the Aurora node serving the model (OpenAI-compatible /v1 on :8000):
+export AURORA_BASE_URL="http://127.0.0.1:8000/v1"   # co-located, or an SSH tunnel
+chemgraph run --model aurora:gpt-oss-120b \
+  -q "Build water from SMILES O, optimize it with EMT, and report the energy."
+```
+
+Or configure it in `config.toml`:
+
+```toml
+[api.aurora]
+base_url = "http://127.0.0.1:8000/v1"
+```
+
+The endpoint address changes per job and compute nodes have no public IP, so run
+ChemGraph on the same node (`127.0.0.1`) or tunnel from a login node. The chosen
+model must support tool calling. Authentication is usually disabled, so the API
+key defaults to `"dummy"`.
+
 ## Privacy boundary
 
 Local inference alone does not make a workflow offline. PubChem lookup, remote

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
       - Docker: docker_support.md
       - Kubernetes: kubernetes.md
       - Local models: running_local_models.md
+      - Aurora inference recipes: aurora_recipes.md
       - HPC and Academy: hpc_and_academy.md
   - Evaluation: evaluation.md
   - Experimental:

--- a/scripts/aurora/build_llamacpp_sycl.pbs
+++ b/scripts/aurora/build_llamacpp_sycl.pbs
@@ -1,0 +1,99 @@
+#!/bin/bash -l
+#PBS -l select=1
+#PBS -l place=scatter
+#PBS -l walltime=00:59:00
+#PBS -q debug
+#PBS -A MatSciAI
+#PBS -l filesystems=flare
+#PBS -N llamacpp-sycl-build
+#PBS -j oe
+
+# Build llama.cpp with the Intel SYCL backend for Aurora (Intel Data Center GPU Max / PVC).
+# Produces llama-server (+ llama-cli, llama-bench) that runs all four Aurora recipe models:
+# gpt-oss-120b, Nemotron-3-Ultra (nemotron_h), Nemotron-4-340B (nemotron), and Inkling.
+#
+# There is NO facility-wide llama.cpp module on Aurora, so each user must build it once. This script
+# is self-contained: it uses only Aurora modules (oneapi compiler, cmake, ninja) and system git —
+# no personal conda/env required.
+#
+# Usage:
+#   qsub -q debug -v LLAMA_ROOT=$HOME/llamacpp-sycl scripts/aurora/build_llamacpp_sycl.pbs
+#   # then point recipes at:  BIN=$LLAMA_ROOT/build/bin
+#
+# Inkling note: the `inkling` architecture is not on llama.cpp main yet; it requires PR #25731.
+# Set BUILD_INKLING=1 (default) to merge that PR so all four models work. The other three models
+# work from a recent main tip on their own.
+
+set -euo pipefail
+
+# ---- config (override with qsub -v) ----
+LLAMA_ROOT=${LLAMA_ROOT:-$HOME/llamacpp-sycl}     # where to clone + build
+LLAMA_REF=${LLAMA_REF:-master}                    # base ref (branch/tag/commit) with gpt-oss/nemotron
+BUILD_INKLING=${BUILD_INKLING:-1}                 # 1 = also merge PR #25731 for Inkling support
+SRC=$LLAMA_ROOT/llama.cpp
+BUILD=$LLAMA_ROOT/build
+LOGS=$LLAMA_ROOT/logs
+export http_proxy=${http_proxy:-http://proxy.alcf.anl.gov:3128}
+export https_proxy=${https_proxy:-http://proxy.alcf.anl.gov:3128}
+export ftp_proxy=${ftp_proxy:-http://proxy.alcf.anl.gov:3128}
+
+mkdir -p "$LOGS" "$BUILD"
+
+# ---- toolchain from Aurora modules (no conda needed) ----
+module load oneapi/release/2025.3.1     # provides icx / icpx + SYCL runtime
+module load cmake ninja 2>/dev/null || module load cmake/3.31.11 ninja/1.13.0
+
+echo "host=$(hostname) date=$(date -Is)"
+echo "icpx=$(icpx --version 2>&1 | head -1)"
+echo "cmake=$(cmake --version | head -1)  ninja=$(ninja --version 2>/dev/null)"
+
+# ---- fetch source ----
+if [ ! -d "$SRC/.git" ]; then
+  echo "Cloning llama.cpp into $SRC ..."
+  git clone https://github.com/ggml-org/llama.cpp.git "$SRC"
+fi
+cd "$SRC"
+git fetch --all --tags
+git checkout -f "$LLAMA_REF"
+git pull --ff-only 2>/dev/null || true
+echo "base git=$(git rev-parse HEAD) $(git log -1 --oneline)"
+
+# ---- optional: merge Inkling PR #25731 ----
+if [ "$BUILD_INKLING" = "1" ]; then
+  if ! grep -RIl -i 'inkling' src include ggml >/dev/null 2>&1; then
+    echo "Merging PR #25731 for Inkling architecture ..."
+    git fetch origin pull/25731/head:pr-25731
+    # rebase the PR onto the chosen base so the other 3 models stay current
+    git checkout -f pr-25731
+  fi
+  grep -RIl -i 'inkling' src include ggml 2>/dev/null | head -3 \
+    || { echo "ERROR: inkling arch not present after merge"; exit 3; }
+fi
+
+# ---- sanity: all four architectures present ----
+echo "=== architecture presence check ==="
+for a in "gpt-oss" "nemotron_h" "nemotron" "inkling"; do
+  if grep -RIl -i "$a" src include ggml >/dev/null 2>&1; then echo "  OK   $a"; else echo "  MISS $a"; fi
+done
+
+# ---- configure + build (SYCL for PVC) ----
+rm -rf "$BUILD"
+cmake -S "$SRC" -B "$BUILD" -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_SYCL=ON \
+  -DGGML_SYCL_F16=ON \
+  -DGGML_SYCL_DEVICE_ARCH=pvc \
+  -DCMAKE_C_COMPILER=icx \
+  -DCMAKE_CXX_COMPILER=icpx \
+  -DLLAMA_BUILD_TESTS=OFF \
+  -DLLAMA_BUILD_EXAMPLES=ON \
+  -DLLAMA_BUILD_SERVER=ON
+
+cmake --build "$BUILD" -j "$(nproc)"
+
+echo "=== binaries ==="
+ls -lh "$BUILD/bin/llama-server" "$BUILD/bin/llama-cli" "$BUILD/bin/llama-bench" 2>/dev/null
+echo
+echo "Build complete. Point the ChemGraph Aurora recipes at this build:"
+echo "  export BIN=$BUILD/bin"
+echo "BUILD_OK=1 date=$(date -Is)"

--- a/scripts/aurora/chemgraph_aurora_env.sh
+++ b/scripts/aurora/chemgraph_aurora_env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Point ChemGraph at a running Aurora llama.cpp LLM endpoint.
+#
+# Reads the ENDPOINT.txt written by the two-node serve PBS and exports the
+# variables the `aurora:` provider uses. Source it (do not execute):
+#
+#   source scripts/aurora/chemgraph_aurora_env.sh [/path/to/ENDPOINT.txt]
+#   chemgraph run --model aurora:gpt-oss-120b -q "What is the SMILES for water?"
+#
+# If ChemGraph runs on a different node than the server, first open a tunnel from
+# a login node (compute nodes have no public IP), e.g.
+#   ssh -N -L 8000:<node_ip>:8000 <you>@aurora.alcf.anl.gov
+# and set AURORA_BASE_URL=http://127.0.0.1:8000/v1 instead.
+
+_ep="${1:-ENDPOINT.txt}"
+if [ ! -f "$_ep" ]; then
+  echo "ENDPOINT file not found: $_ep" >&2
+  echo "Start the server first: scripts/aurora/serve_llamacpp_maxctx.sh <model-key>" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+_url=$(grep '^url=' "$_ep" | cut -d= -f2-)
+_model=$(grep '^chemgraph_model=' "$_ep" | cut -d= -f2-)
+export AURORA_BASE_URL="$_url"
+export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"   # llama-server does not enforce auth by default
+
+echo "AURORA_BASE_URL=$AURORA_BASE_URL"
+echo "Use: chemgraph run --model ${_model:-aurora:gpt-oss-120b} -q \"...\""

--- a/scripts/aurora/serve_llamacpp_maxctx.sh
+++ b/scripts/aurora/serve_llamacpp_maxctx.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Serve one of the four Aurora models with llama.cpp SYCL, FULL-XPU (all weights on GPU, no MoE
+# offload), at each model's MAXIMUM context length. Source-able / callable; picks tiles, GGUF, and
+# context automatically from MODEL. Exposes an OpenAI-compatible /v1 endpoint for ChemGraph's
+# `aurora:` provider.
+#
+# Usage:
+#   scripts/aurora/serve_llamacpp_maxctx.sh gpt-oss-120b        [PORT]
+#   scripts/aurora/serve_llamacpp_maxctx.sh nemotron-3-ultra    [PORT]
+#   scripts/aurora/serve_llamacpp_maxctx.sh inkling             [PORT]
+#   scripts/aurora/serve_llamacpp_maxctx.sh nemotron-4-340b     [PORT]
+#
+# All models: full-XPU (-ngl 99, no -ncmoe), layer split across the model's tile group, -fa on,
+# --jinja (tool calls). Context is each model's native maximum; KV cache is small vs weights so it
+# fits the listed tile counts. Tiles not used by the LLM (and both CPU sockets) are free for the
+# scientific workload — set that process's own ZE_AFFINITY_MASK to the complementary tiles.
+
+set -o pipefail
+
+MODEL_KEY=${1:?"usage: serve_llamacpp_maxctx.sh <gpt-oss-120b|nemotron-3-ultra|inkling|nemotron-4-340b> [port]"}
+PORT=${2:-8000}
+
+ALCF=/lus/flare/projects/MatSciAI/xiaoliyan/workdir/alcf-aurora-llm
+BIN=${BIN:-$HOME/llamacpp-sycl/build/bin}   # your llama.cpp SYCL build (see build_llamacpp_sycl.pbs)
+NThreads=${NThreads:-64}
+NPAR=${NPAR:-4}
+
+# Per-model: GGUF (first shard), tile mask (full-XPU), native max context, served alias.
+case "$MODEL_KEY" in
+  gpt-oss-120b)
+    GGUF=$ALCF/gpt-oss-120b/models/ggml-org-gpt-oss-120b-GGUF/gpt-oss-120b-MXFP4.gguf
+    TILES=${TILES:-0,1}                     # 2 tiles (1 GPU); free: 2-11
+    CTX=${CTX:-131072}
+    SERVED=gpt-oss-120b
+    # gpt-oss needs the openai_harmony vocab (fetched via proxy on first run, then cached)
+    export http_proxy=${http_proxy:-http://proxy.alcf.anl.gov:3128}
+    export https_proxy=${https_proxy:-http://proxy.alcf.anl.gov:3128}
+    export no_proxy=${no_proxy:-127.0.0.1,localhost} NO_PROXY=${NO_PROXY:-127.0.0.1,localhost}
+    export TIKTOKEN_RS_CACHE_DIR=${TIKTOKEN_RS_CACHE_DIR:-$HOME/.cache/tiktoken-rs}
+    mkdir -p "$TIKTOKEN_RS_CACHE_DIR"
+    ;;
+  nemotron-3-ultra)
+    GGUF=$ALCF/nemotron/models/gguf/UD-IQ2_M/NVIDIA-Nemotron-3-Ultra-550B-A55B-UD-IQ2_M-00001-of-00005.gguf
+    TILES=${TILES:-0,1,2,3,4,5}             # 6 tiles (3 GPUs); free: 6-11.  (min 4 for max ctx)
+    CTX=${CTX:-262144}
+    SERVED=nemotron-3-ultra
+    ;;
+  inkling)
+    GGUF=$ALCF/inkling/models/unsloth-Inkling-GGUF/UD-IQ1_S/inkling-UD-IQ1_S-00001-of-00007.gguf
+    TILES=${TILES:-0,1,2,3,4,5,6,7}         # 8 tiles (4 GPUs); free: 8-11.  (min 6 for max ctx)
+    CTX=${CTX:-131072}
+    SERVED=inkling
+    ;;
+  nemotron-4-340b)
+    GGUF=$ALCF/nemotron/models/gguf-n4/Nemotron-4-340B-Instruct-hf.i1-Q4_K_M.gguf
+    TILES=${TILES:-0,1,2,3,4,5}             # 6 tiles (3 GPUs); free: 6-11.  (min 4 for max ctx)
+    CTX=${CTX:-4096}   # i1-Q4_K_M GGUF n_ctx_train=4096
+    SERVED=nemotron-4-340b
+    ;;
+  *) echo "unknown MODEL_KEY '$MODEL_KEY'"; exit 2 ;;
+esac
+
+echo "START $(date -Is) host=$(hostname) MODEL=$MODEL_KEY TILES=$TILES CTX=$CTX PORT=$PORT"
+[ -e "$GGUF" ] || { echo "ERROR: GGUF not found ($GGUF)"; exit 2; }
+
+module load oneapi/release/2025.3.1
+# Full-XPU: do NOT set ONEAPI_DEVICE_SELECTOR/ZE_AFFINITY conflicts; ZE_AFFINITY_MASK selects the
+# model's tiles, layer split spreads weights across them. GGML_SYCL_ENABLE_VMM=0 required on PVC.
+export ZE_FLAT_DEVICE_HIERARCHY=FLAT
+export ZE_AFFINITY_MASK=$TILES
+export ONEAPI_DEVICE_SELECTOR=level_zero:gpu ZES_ENABLE_SYSMAN=1
+export GGML_SYCL_ENABLE_VMM=0
+JT=${PBS_JOBID:-$$}
+export TRITON_CACHE_DIR=/tmp/tc_${JT} SYCL_CACHE_DIR=/tmp/sc_${JT}
+mkdir -p "$TRITON_CACHE_DIR" "$SYCL_CACHE_DIR"
+
+# -sm layer (row split crashes on nemotron_h_moe); -ngl 99 all layers on GPU; NO -ncmoe.
+exec numactl --interleave=all \
+  "$BIN/llama-server" \
+    -m "$GGUF" \
+    -c "$CTX" -ngl 99 --split-mode layer \
+    -fa on -t "$NThreads" --no-mmap \
+    --jinja --parallel "$NPAR" --cont-batching \
+    --alias "$SERVED" \
+    --host 0.0.0.0 --port "$PORT"

--- a/scripts/aurora/two_node_inkling.pbs
+++ b/scripts/aurora/two_node_inkling.pbs
@@ -1,0 +1,127 @@
+#!/bin/bash -l
+#PBS -l select=2
+#PBS -l place=scatter
+#PBS -l walltime=01:00:00
+#PBS -q debug-scaling
+#PBS -A MatSciAI
+#PBS -l filesystems=flare
+#PBS -N ink-chemgraph
+#PBS -j oe
+#PBS -o /lus/flare/projects/MatSciAI/xiaoliyan/workdir/alcf-aurora-llm/inkling/logs/chemgraph_two_node.out
+
+# Two-node ChemGraph + Inkling inference recipe:
+#   Node 0: llama-server (Inkling UD-IQ1_S, C_PG8 — 8-tile pure GPU, max ctx, --jinja for tool calls)
+#   Node 1: ChemGraph scientific workload (aurora:inkling via AURORA_BASE_URL)
+#
+# The two nodes communicate via the intra-cluster IP of node 0 written to ENDPOINT.txt.
+# No SSH tunnel needed — both nodes are on the same job allocation.
+#
+# Usage:
+#   qsub -q debug-scaling scripts/aurora/two_node_inkling.pbs
+#   qsub -q debug-scaling -v QUERY="Optimize water with EMT and report energy",CTX=4096 ...
+#
+# Performance reference (Inkling UD-IQ1_S, PG10, single stream):
+#   gen ~6.73 tok/s, prefill ~8.7 tok/s, TTFT ~2.3 s
+
+set -o pipefail
+
+# ── paths ────────────────────────────────────────────────────────────────────
+INKLING=/lus/flare/projects/MatSciAI/xiaoliyan/workdir/alcf-aurora-llm/inkling
+BIN=${BIN:-$HOME/llamacpp-sycl/build/bin}   # your llama.cpp SYCL build (see build_llamacpp_sycl.pbs)
+GGUF=${GGUF:-$INKLING/models/unsloth-Inkling-GGUF/UD-IQ1_S/inkling-UD-IQ1_S-00001-of-00007.gguf}
+CG_REPO=${CG_REPO:-/lus/flare/projects/MatSciAI/xiaoliyan/workdir/ChemGraph}
+CG_VENV=${CG_VENV:-/lus/flare/projects/MatSciAI/xiaoliyan/software/venvs/chemgraph}
+CENV=${CENV:-/lus/flare/projects/MatSciAI/xiaoliyan/software/conda/envs/aurora-llm}
+LOGDIR=${LOGDIR:-$INKLING/logs}; mkdir -p "$LOGDIR"
+
+# ── tunable parameters ────────────────────────────────────────────────────────
+PORT=${PORT:-8000}; SERVED=${SERVED:-inkling}
+CTX=${CTX:-131072}; NPAR=${NPAR:-4}; NThreads=${NThreads:-32}   # 131072 = Inkling native max context
+QUERY=${QUERY:-"Build water from SMILES O, optimize it with EMT, and report the final energy."}
+
+# ── node layout ───────────────────────────────────────────────────────────────
+NODE0=$(head -1 "$PBS_NODEFILE")      # LLM server node
+NODE1=$(sed -n '2p' "$PBS_NODEFILE")  # ChemGraph / science node
+NODE0_IP=$(ssh "$NODE0" hostname -i 2>/dev/null | awk '{print $1}')
+echo "START $(date -Is) job=$PBS_JOBID"
+echo "NODE0=$NODE0 (ip=$NODE0_IP) -> llama-server"
+echo "NODE1=$NODE1 -> ChemGraph"
+echo "GGUF=$GGUF PORT=$PORT CTX=$CTX"
+[ -e "$GGUF" ] || { echo "ERROR: GGUF not found ($GGUF)"; exit 2; }
+
+# ── launch all-XPU llama-server on node 0 (8-tile pure GPU, max context) ──────
+# All-XPU: ZE_AFFINITY_MASK=0..7 (8 tiles), NO -ncmoe, layer split, fa on, --jinja.
+# Validated at -c 131072 (max ctx, 8k fill PASS = campaign arm C_PG8). node 0 is dedicated
+# to the LLM; node 1 runs ChemGraph, so using 10 tiles here is fine.
+ssh "$NODE0" bash -s <<SSHEOF &
+set -o pipefail
+module load oneapi/release/2025.3.1
+export ZE_FLAT_DEVICE_HIERARCHY=FLAT
+export ZE_AFFINITY_MASK=0,1,2,3,4,5,6,7
+export GGML_SYCL_ENABLE_VMM=0
+export ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+JT=${PBS_JOBID:-$$}
+export TRITON_CACHE_DIR=/tmp/tc_\${JT} SYCL_CACHE_DIR=/tmp/sc_\${JT}
+mkdir -p "\$TRITON_CACHE_DIR" "\$SYCL_CACHE_DIR"
+echo "all-XPU llama-server: 8-tile layer split -c $CTX on \$(hostname)"
+"$BIN/llama-server" \
+  -m "$GGUF" \
+  -c $CTX -ngl 99 -sm layer \
+  -ts 0.125,0.125,0.125,0.125,0.125,0.125,0.125,0.125 \
+  -fa on --reasoning off --jinja \
+  --no-mmap -t $NThreads \
+  --parallel $NPAR --cont-batching \
+  --alias $SERVED \
+  --host 0.0.0.0 --port $PORT > "$LOGDIR/inkling_server.out" 2>&1
+echo "llama-server exited \$?"
+SSHEOF
+SRV_PID=$!
+
+# ── wait for server to become ready ──────────────────────────────────────────
+READY=0
+for _ in $(seq 1 180); do
+  curl -sf "http://$NODE0_IP:$PORT/health" >/dev/null 2>&1 && { READY=1; echo "server ready $(date -Is)"; break; }
+  sleep 10
+done
+if [ "$READY" != 1 ]; then
+  echo "SERVER NOT READY — tail:"; tail -40 "$LOGDIR/inkling_server.out"
+  kill $SRV_PID 2>/dev/null; exit 4
+fi
+
+# ── publish endpoint ──────────────────────────────────────────────────────────
+cat > "$CG_REPO/ENDPOINT.txt" <<EOF
+node=$NODE0
+ip=$NODE0_IP
+url=http://$NODE0_IP:$PORT/v1
+model=aurora:$SERVED
+job=$PBS_JOBID
+started=$(date -Is)
+EOF
+echo "ENDPOINT: http://$NODE0_IP:$PORT/v1  model=aurora:$SERVED"
+
+# ── run ChemGraph on node 1 ───────────────────────────────────────────────────
+# AURORA_BASE_URL points at node 0's server; node 1 reaches it via intra-cluster IP.
+echo "=== ChemGraph run on $NODE1 ==="
+ssh "$NODE1" bash -s <<CGEOF
+set -o pipefail
+export AURORA_BASE_URL="http://$NODE0_IP:$PORT/v1"
+export OPENAI_API_KEY=dummy
+export http_proxy=http://proxy.alcf.anl.gov:3128 https_proxy=http://proxy.alcf.anl.gov:3128
+export no_proxy="$NODE0_IP,127.0.0.1,localhost" NO_PROXY="$NODE0_IP,127.0.0.1,localhost"
+export LD_LIBRARY_PATH="$CENV/lib:\$LD_LIBRARY_PATH"
+export CHEMGRAPH_LOG_DIR="$LOGDIR/cg_logs"
+mkdir -p "\$CHEMGRAPH_LOG_DIR"
+cd "$CG_REPO"
+"$CG_VENV/bin/chemgraph" run \
+  --model aurora:$SERVED \
+  --workflow single_agent \
+  --output last_message \
+  -v \
+  -q "$QUERY" 2>&1 | tee "$LOGDIR/chemgraph_run.out"
+echo "CHEMGRAPH_RC=\${PIPESTATUS[0]}"
+CGEOF
+
+echo "=== shutting down server ==="
+kill $SRV_PID 2>/dev/null
+wait $SRV_PID 2>/dev/null
+echo "DONE $(date -Is)"

--- a/scripts/aurora/two_node_nemotron_ultra.pbs
+++ b/scripts/aurora/two_node_nemotron_ultra.pbs
@@ -1,0 +1,126 @@
+#!/bin/bash -l
+#PBS -l select=2
+#PBS -l place=scatter
+#PBS -l walltime=01:00:00
+#PBS -q debug-scaling
+#PBS -A MatSciAI
+#PBS -l filesystems=flare
+#PBS -N n3u-chemgraph
+#PBS -j oe
+#PBS -o /lus/flare/projects/MatSciAI/xiaoliyan/workdir/alcf-aurora-llm/nemotron/logs/chemgraph_two_node.out
+
+# Two-node ChemGraph + Nemotron-3-Ultra inference recipe (single serve, all-XPU, max context):
+#   Node 0: llama-server (Nemotron-3-Ultra UD-IQ2_M, all-XPU 6-tile layer split, experts on GPU,
+#           -c 262144 = native max context). No MoE->CPU offload.
+#   Node 1: ChemGraph scientific workload (aurora:nemotron-3-ultra via AURORA_BASE_URL)
+#
+# Leaves tiles 6-11 + both CPU sockets free for the science process (set its own ZE_AFFINITY_MASK).
+#
+# Usage:
+#   qsub -q debug-scaling scripts/aurora/two_node_nemotron_ultra.pbs
+#   qsub -q debug-scaling -v QUERY="Optimize water with EMT and report energy" ...
+
+set -o pipefail
+
+# ── paths ────────────────────────────────────────────────────────────────────
+NEMO=/lus/flare/projects/MatSciAI/xiaoliyan/workdir/alcf-aurora-llm/nemotron
+BIN=${BIN:-$HOME/llamacpp-sycl/build/bin}   # your llama.cpp SYCL build (see build_llamacpp_sycl.pbs)
+GGUF=${GGUF:-$(ls "$NEMO/models/gguf/UD-IQ2_M"/*-00001-of-*.gguf 2>/dev/null | head -1)}
+CG_REPO=${CG_REPO:-/lus/flare/projects/MatSciAI/xiaoliyan/workdir/ChemGraph}
+CG_VENV=${CG_VENV:-/lus/flare/projects/MatSciAI/xiaoliyan/software/venvs/chemgraph}
+CENV=${CENV:-/lus/flare/projects/MatSciAI/xiaoliyan/software/conda/envs/aurora-llm}
+LOGDIR=${LOGDIR:-$NEMO/logs}; mkdir -p "$LOGDIR"
+
+# ── tunable parameters ────────────────────────────────────────────────────────
+PORT=${PORT:-8000}; SERVED=${SERVED:-nemotron-3-ultra}
+NTILES=${NTILES:-6}                       # 6 tiles (3 GPUs); free: 6-11
+CTX=${CTX:-262144}                        # native max context
+NPAR=${NPAR:-4}; NThreads=${NThreads:-64}
+QUERY=${QUERY:-"Build water from SMILES O, optimize it with EMT, and report the final energy."}
+
+# ── node layout ───────────────────────────────────────────────────────────────
+NODE0=$(head -1 "$PBS_NODEFILE")
+NODE1=$(sed -n '2p' "$PBS_NODEFILE")
+NODE0_IP=$(ssh "$NODE0" hostname -i 2>/dev/null | awk '{print $1}')
+echo "START $(date -Is) job=$PBS_JOBID"
+echo "NODE0=$NODE0 (ip=$NODE0_IP) -> llama-server (all-XPU ${NTILES}-tile, -c $CTX)"
+echo "NODE1=$NODE1 -> ChemGraph"
+echo "GGUF=$GGUF PORT=$PORT CTX=$CTX"
+[ -e "$GGUF" ] || { echo "ERROR: GGUF not found ($GGUF)"; exit 2; }
+
+# ── launch single all-XPU server on node 0 ───────────────────────────────────
+# All weights on GPU (experts included, NO -ncmoe); layer split across NTILES tiles.
+# -sm row crashes on nemotron_h_moe, so -sm layer is required. KV @262144 is only ~3 GB
+# (hybrid: 12 attention layers, kv_heads=2), so 6 tiles hold weights+KV comfortably.
+MASK=$(seq -s, 0 $((NTILES-1)))
+ssh "$NODE0" bash -s <<SSHEOF &
+set -o pipefail
+module load oneapi/release/2025.3.1
+export ZE_FLAT_DEVICE_HIERARCHY=FLAT ZE_AFFINITY_MASK=$MASK
+export ONEAPI_DEVICE_SELECTOR=level_zero:gpu ZES_ENABLE_SYSMAN=1
+export GGML_SYCL_ENABLE_VMM=0
+JT=${PBS_JOBID:-$$}
+export TRITON_CACHE_DIR=/tmp/tc_\${JT} SYCL_CACHE_DIR=/tmp/sc_\${JT}
+mkdir -p "\$TRITON_CACHE_DIR" "\$SYCL_CACHE_DIR"
+echo "all-XPU single-serve: ${NTILES}-tile layer split (mask=$MASK) -c $CTX on \$(hostname)"
+numactl --interleave=all \
+  "$BIN/llama-server" \
+    -m "$GGUF" \
+    -c $CTX -ngl 99 --split-mode layer \
+    -fa on -t $NThreads --numa numactl --no-mmap \
+    --jinja --parallel $NPAR --cont-batching \
+    --alias $SERVED \
+    --host 0.0.0.0 --port $PORT > "$LOGDIR/n3u_server.out" 2>&1
+SSHEOF
+SRV_PID=$!
+ENDPOINT_URL="http://$NODE0_IP:$PORT/v1"
+
+# ── wait for endpoint ─────────────────────────────────────────────────────────
+READY=0
+for _ in $(seq 1 180); do
+  curl -sf "http://$NODE0_IP:$PORT/health" >/dev/null 2>&1 && { READY=1; echo "server ready $(date -Is)"; break; }
+  sleep 10
+done
+if [ "$READY" != 1 ]; then
+  echo "SERVER NOT READY — tail:"; tail -40 "$LOGDIR/n3u_server.out" 2>/dev/null
+  kill $SRV_PID 2>/dev/null; exit 4
+fi
+
+# ── publish endpoint ──────────────────────────────────────────────────────────
+cat > "$CG_REPO/ENDPOINT.txt" <<EOF
+node=$NODE0
+ip=$NODE0_IP
+url=$ENDPOINT_URL
+model=aurora:$SERVED
+tiles=$MASK
+ctx=$CTX
+job=$PBS_JOBID
+started=$(date -Is)
+EOF
+echo "ENDPOINT: $ENDPOINT_URL  model=aurora:$SERVED  tiles=$MASK  ctx=$CTX"
+
+# ── ChemGraph on node 1 ───────────────────────────────────────────────────────
+echo "=== ChemGraph run on $NODE1 ==="
+ssh "$NODE1" bash -s <<CGEOF
+set -o pipefail
+export AURORA_BASE_URL="$ENDPOINT_URL"
+export OPENAI_API_KEY=dummy
+export http_proxy=http://proxy.alcf.anl.gov:3128 https_proxy=http://proxy.alcf.anl.gov:3128
+export no_proxy="$NODE0_IP,127.0.0.1,localhost" NO_PROXY="$NODE0_IP,127.0.0.1,localhost"
+export LD_LIBRARY_PATH="$CENV/lib:\$LD_LIBRARY_PATH"
+export CHEMGRAPH_LOG_DIR="$LOGDIR/cg_logs"
+mkdir -p "\$CHEMGRAPH_LOG_DIR"
+cd "$CG_REPO"
+"$CG_VENV/bin/chemgraph" run \
+  --model aurora:$SERVED \
+  --workflow single_agent \
+  --output last_message \
+  -v \
+  -q "$QUERY" 2>&1 | tee "$LOGDIR/chemgraph_run.out"
+echo "CHEMGRAPH_RC=\${PIPESTATUS[0]}"
+CGEOF
+
+echo "=== shutting down ==="
+kill $SRV_PID 2>/dev/null
+wait $SRV_PID 2>/dev/null
+echo "DONE $(date -Is)"

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -20,6 +20,10 @@ from chemgraph.memory.schemas import (
 from chemgraph.memory.subagent_recorder import SubagentRunRecorder
 from chemgraph.models.openai import load_openai_model
 from chemgraph.models.alcf_endpoints import load_alcf_model
+from chemgraph.models.aurora_endpoints import (
+    AURORA_MODEL_PREFIX,
+    load_aurora_model,
+)
 from chemgraph.models.local_model import load_ollama_model
 from chemgraph.models.anthropic import load_anthropic_model
 from chemgraph.models.gemini import load_gemini_model
@@ -298,6 +302,13 @@ class ChemGraph:
 
             if model_name.startswith("codex:"):
                 llm = load_codex_model(model_name)
+            elif model_name.startswith(AURORA_MODEL_PREFIX):
+                llm = load_aurora_model(
+                    model_name=model_name,
+                    base_url=base_url,
+                    api_key=api_key,
+                    temperature=temperature,
+                )
             elif model_name.startswith("openrouter:"):
                 llm = load_openrouter_model(
                     model_name=model_name,

--- a/src/chemgraph/models/aurora_endpoints.py
+++ b/src/chemgraph/models/aurora_endpoints.py
@@ -1,0 +1,103 @@
+import logging
+import os
+
+from langchain_openai import ChatOpenAI
+
+from chemgraph.models.supported_models import AURORA_DEFAULT_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+AURORA_MODEL_PREFIX = "aurora:"
+
+
+def _normalize_aurora_model(model_name: str) -> str:
+    """Strip the ``aurora:`` prefix to get the name the endpoint expects.
+
+    Aurora on-node servers advertise each model under its own id
+    (llama-server ``--alias`` / vLLM ``--served-model-name``). The prefix only
+    selects the provider inside ChemGraph, so it is removed before the request
+    is sent.
+
+    Parameters
+    ----------
+    model_name : str
+        Requested model identifier, normally ``aurora:``-prefixed.
+
+    Returns
+    -------
+    str
+        Model name to send to the endpoint.
+    """
+    if not model_name.startswith(AURORA_MODEL_PREFIX):
+        return model_name
+
+    stripped = model_name.removeprefix(AURORA_MODEL_PREFIX)
+    logger.info("Stripped aurora: prefix '%s' -> '%s'", model_name, stripped)
+    return stripped
+
+
+def load_aurora_model(
+    model_name: str,
+    base_url: str = None,
+    api_key: str = None,
+    temperature: float = 0.0,
+) -> ChatOpenAI:
+    """Load a model from an Aurora on-node inference server.
+
+    Aurora LLM servers (llama.cpp SYCL ``llama-server`` or vLLM-XPU) expose an
+    OpenAI-compatible ``/v1`` endpoint. Because a compute node has no public IP
+    and its address changes per job, the base URL is usually supplied via
+    *base_url*, the ``AURORA_BASE_URL`` environment variable, or
+    ``[api.aurora].base_url`` in the config; it falls back to
+    ``AURORA_DEFAULT_BASE_URL`` (a co-located ``127.0.0.1`` server).
+
+    These servers typically do not enforce authentication, so *api_key* defaults
+    to ``"dummy"`` (``langchain_openai`` requires a non-empty value).
+
+    The selected model MUST support OpenAI tool calling; ChemGraph's workflows
+    are tool-driven.
+
+    Parameters
+    ----------
+    model_name : str
+        Model identifier, normally ``aurora:``-prefixed. The remainder must
+        match the server's advertised model id.
+    base_url : str, optional
+        Endpoint base URL. Falls back to ``AURORA_BASE_URL`` then
+        ``AURORA_DEFAULT_BASE_URL``.
+    api_key : str, optional
+        API key. Falls back to ``AURORA_API_KEY`` / ``OPENAI_API_KEY`` then
+        ``"dummy"``.
+    temperature : float, optional
+        Sampling temperature, by default 0.0.
+
+    Returns
+    -------
+    ChatOpenAI
+        A LangChain ``ChatOpenAI`` configured for the Aurora endpoint.
+    """
+    if not base_url:
+        base_url = os.getenv("AURORA_BASE_URL") or AURORA_DEFAULT_BASE_URL
+
+    if not api_key:
+        api_key = (
+            os.getenv("AURORA_API_KEY") or os.getenv("OPENAI_API_KEY") or "dummy"
+        )
+
+    wire_model = _normalize_aurora_model(model_name)
+
+    try:
+        llm = ChatOpenAI(
+            model=wire_model,
+            base_url=base_url,
+            api_key=api_key,
+            temperature=temperature,
+        )
+        logger.info(
+            "Successfully loaded Aurora model: %s from %s", wire_model, base_url
+        )
+    except Exception as e:
+        logger.error("Failed to load Aurora model '%s': %s", model_name, e)
+        raise
+
+    return llm

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -10,6 +10,10 @@ from typing import Optional
 
 from chemgraph.models.alcf_endpoints import load_alcf_model
 from chemgraph.models.anthropic import load_anthropic_model
+from chemgraph.models.aurora_endpoints import (
+    AURORA_MODEL_PREFIX,
+    load_aurora_model,
+)
 from chemgraph.models.codex import load_codex_model
 from chemgraph.models.gemini import load_gemini_model
 from chemgraph.models.groq import load_groq_model
@@ -77,6 +81,13 @@ def load_chat_model(
 
     if model_name.startswith("codex:"):
         return load_codex_model(model_name)
+    elif model_name.startswith(AURORA_MODEL_PREFIX):
+        return load_aurora_model(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            temperature=temperature,
+        )
     elif model_name.startswith("openrouter:"):
         return load_openrouter_model(
             model_name=model_name,

--- a/src/chemgraph/models/settings.py
+++ b/src/chemgraph/models/settings.py
@@ -119,6 +119,8 @@ def _extract_endpoint_from_cli_toml(raw: Mapping[str, Any]) -> dict[str, Any]:
             base_url = (api.get("argo") or {}).get("base_url")
         elif model.startswith("openrouter:"):
             base_url = (api.get("openrouter") or {}).get("base_url")
+        elif model.startswith("aurora:"):
+            base_url = (api.get("aurora") or {}).get("base_url")
         else:
             for section_name in ("openai", "anthropic", "gemini", "alcf", "ollama"):
                 section = api.get(section_name) or {}
@@ -142,6 +144,8 @@ def _provider_section_for(model: Any) -> str:
             return "groq"
         if model.startswith("openrouter:"):
             return "openrouter"
+        if model.startswith("aurora:"):
+            return "aurora"
     return "openai"
 
 

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -150,6 +150,27 @@ supported_openrouter_models = [
     "openrouter:minimax/minimax-m2.7",
 ]
 
+# Default Aurora inference base URL. Aurora on-node LLM servers (llama.cpp SYCL
+# `llama-server` or vLLM-XPU) expose an OpenAI-compatible ``/v1`` endpoint. The
+# node IP changes per job and compute nodes have no public IP, so callers
+# normally override this with --base-url / [api.aurora].base_url / AURORA_BASE_URL
+# (e.g. co-located on the same node, or via an SSH tunnel from a login node).
+AURORA_DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
+
+# Aurora models -- all use the "aurora:" prefix (e.g.
+# "aurora:gpt-oss-120b"). The prefix only routes the request inside ChemGraph
+# and is stripped before the name is sent to the endpoint, where it must match
+# the server's advertised model id (llama-server ``--alias`` / vLLM
+# ``--served-model-name``). This list is for *discovery* only (--list-models,
+# UI dropdown); dispatch is by prefix, so any served model id also works.
+# The chosen model MUST support OpenAI tool calling for ChemGraph workflows.
+supported_aurora_models = [
+    "aurora:gpt-oss-120b",
+    "aurora:inkling",
+    "aurora:nemotron-3-ultra",
+    "aurora:nemotron-4-340b",
+]
+
 # Default Argo API base URL (used when no --base-url is provided).
 ARGO_DEFAULT_BASE_URL = "https://apps.inside.anl.gov/argoapi/v1"
 
@@ -233,4 +254,5 @@ all_supported_models = (
     + supported_gemini_models
     + supported_groq_models
     + supported_openrouter_models
+    + supported_aurora_models
 )

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -100,6 +100,39 @@ def _calculator_key(name: str) -> str:
     return _CALCULATOR_ALIASES.get(normalized, normalized[:4])
 
 
+def _accepted_calculator_types(calc_class: Type[BaseModel]) -> list[str]:
+    """Return the accepted ``calculator_type`` values for a calculator class.
+
+    The agent must supply the ``calculator_type`` *field value* (e.g. ``"emt"``),
+    not the class name (``"EMTCalc"``). This reads the value(s) allowed by the
+    class's ``calculator_type`` field -- the members of a ``Literal`` when the
+    field is constrained, otherwise its default -- so error messages can name
+    what a caller should actually pass.
+    """
+    import typing
+
+    field = getattr(calc_class, "model_fields", {}).get("calculator_type")
+    if field is None:
+        return []
+    annotation = getattr(field, "annotation", None)
+    if typing.get_origin(annotation) is typing.Literal:
+        return [str(v) for v in typing.get_args(annotation)]
+    default = getattr(field, "default", None)
+    return [str(default)] if isinstance(default, str) and default else []
+
+
+def _accepted_calculator_type_hint(
+    calculator_classes: List[Type[BaseModel]],
+) -> str:
+    """Build a human/agent-friendly list of accepted ``calculator_type`` values."""
+    values: list[str] = []
+    for calc_class in calculator_classes:
+        for value in _accepted_calculator_types(calc_class):
+            if value not in values:
+                values.append(value)
+    return ", ".join(repr(v) for v in values)
+
+
 # Define all possible calculator classes
 _all_calculator_classes: List[Optional[Type[BaseModel]]] = [
     FAIRChemCalc,
@@ -171,9 +204,11 @@ def _coerce_calculator_payload(data: Any) -> Any:
 
         calc_key = _calculator_key(calc_name)
         if calc_key not in available_calcs:
+            accepted = _accepted_calculator_type_hint(available_calculator_classes)
             raise ValueError(
-                f"Calculator {calc_name} is not an allowed or available calculator. "
-                f"Available calculators are: {available_calc_names}"
+                f"Calculator {calc_name!r} is not an allowed or available "
+                "calculator. Set 'calculator_type' to one of these accepted "
+                f"values: {accepted} (available calculators: {available_calc_names})."
             )
 
         calculator_class = available_calcs[calc_key]
@@ -187,9 +222,11 @@ def _coerce_calculator_payload(data: Any) -> Any:
         calc_type_name = calc.__class__.__name__
         calc_key = _calculator_key(calc_type_name.removesuffix("Calc"))
         if calc_key not in available_calcs:
+            accepted = _accepted_calculator_type_hint(available_calculator_classes)
             raise ValueError(
-                f"Calculator {calc_type_name} is not an allowed or available calculator. "
-                f"Available calculators are: {available_calc_names}"
+                f"Calculator {calc_type_name} is not an allowed or available "
+                "calculator. Set 'calculator_type' to one of these accepted "
+                f"values: {accepted} (available calculators: {available_calc_names})."
             )
     return data
 

--- a/src/chemgraph/utils/config_utils.py
+++ b/src/chemgraph/utils/config_utils.py
@@ -10,6 +10,7 @@ from chemgraph.models.supported_models import (
     ALCF_METIS_BASE_URL,
     ALCF_MINERVA_BASE_URL,
     ARGO_DEFAULT_BASE_URL,
+    AURORA_DEFAULT_BASE_URL,
     OPENROUTER_DEFAULT_BASE_URL,
     all_supported_models,
     supported_alcf_metis_models,
@@ -120,6 +121,11 @@ def get_base_url_for_model_from_nested_config(
     # endpoint is configured there (the Argo gateway, by default).
     if model_name.startswith("openrouter:"):
         return api.get("openrouter", {}).get("base_url") or OPENROUTER_DEFAULT_BASE_URL
+    # Prefix-routed Aurora on-node endpoints (llama-server / vLLM-XPU). The base
+    # URL is site/job-specific, so honor [api.aurora].base_url before the
+    # generic openai fallthrough; otherwise default to a co-located server.
+    if model_name.startswith("aurora:"):
+        return api.get("aurora", {}).get("base_url") or AURORA_DEFAULT_BASE_URL
     if model_name in supported_openai_models:
         return normalize_openai_base_url(api.get("openai", {}).get("base_url"))
     # Minerva and Metis have their own endpoints, and [api.alcf] base_url
@@ -163,6 +169,9 @@ def get_base_url_for_model_from_flat_config(
     # See the note in get_base_url_for_model_from_nested_config.
     if model_name.startswith("openrouter:"):
         return config.get("api_openrouter_base_url") or OPENROUTER_DEFAULT_BASE_URL
+    # See the note in get_base_url_for_model_from_nested_config.
+    if model_name.startswith("aurora:"):
+        return config.get("api_aurora_base_url") or AURORA_DEFAULT_BASE_URL
     if model_name in supported_openai_models:
         return normalize_openai_base_url(config.get("api_openai_base_url"))
     # See the note in get_base_url_for_model_from_nested_config.

--- a/tests/test_aurora_endpoints.py
+++ b/tests/test_aurora_endpoints.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from chemgraph.models.aurora_endpoints import (
+    _normalize_aurora_model,
+    load_aurora_model,
+)
+from chemgraph.models.loader import load_chat_model
+from chemgraph.models.supported_models import (
+    AURORA_DEFAULT_BASE_URL,
+    all_supported_models,
+    supported_aurora_models,
+)
+from chemgraph.utils.config_utils import (
+    get_base_url_for_model_from_flat_config,
+    get_base_url_for_model_from_nested_config,
+)
+
+AURORA_MODEL = "aurora:gpt-oss-120b"
+CUSTOM_URL = "http://x4000c0s0b0n0:8000/v1"
+
+
+def test_every_aurora_model_carries_the_prefix():
+    assert all(m.startswith("aurora:") for m in supported_aurora_models)
+
+
+def test_supported_aurora_models_has_no_duplicates():
+    assert len(supported_aurora_models) == len(set(supported_aurora_models))
+
+
+def test_aurora_models_are_in_all_supported_models():
+    assert set(supported_aurora_models) <= set(all_supported_models)
+
+
+def test_normalize_strips_the_prefix():
+    assert _normalize_aurora_model(AURORA_MODEL) == "gpt-oss-120b"
+    assert _normalize_aurora_model("aurora:nemotron-4-340b") == "nemotron-4-340b"
+
+
+def test_normalize_leaves_unprefixed_names_alone():
+    assert _normalize_aurora_model("gpt-oss-120b") == "gpt-oss-120b"
+
+
+def test_base_url_falls_back_to_the_aurora_default():
+    assert (
+        get_base_url_for_model_from_nested_config(AURORA_MODEL, {})
+        == AURORA_DEFAULT_BASE_URL
+    )
+    assert (
+        get_base_url_for_model_from_flat_config(AURORA_MODEL, {})
+        == AURORA_DEFAULT_BASE_URL
+    )
+
+
+def test_base_url_honours_configured_aurora_url():
+    assert (
+        get_base_url_for_model_from_nested_config(
+            AURORA_MODEL, {"api": {"aurora": {"base_url": CUSTOM_URL}}}
+        )
+        == CUSTOM_URL
+    )
+    assert (
+        get_base_url_for_model_from_flat_config(
+            AURORA_MODEL, {"api_aurora_base_url": CUSTOM_URL}
+        )
+        == CUSTOM_URL
+    )
+
+
+def test_uncurated_served_id_still_routes_by_prefix():
+    # Dispatch is by prefix, not list membership: an id not in the discovery
+    # list still resolves to the aurora endpoint.
+    assert (
+        get_base_url_for_model_from_flat_config("aurora:some-served-id", {})
+        == AURORA_DEFAULT_BASE_URL
+    )
+
+
+def test_load_aurora_model_strips_prefix_and_uses_base_url():
+    llm = load_aurora_model(AURORA_MODEL, base_url=CUSTOM_URL, api_key="dummy")
+    assert llm.openai_api_base == CUSTOM_URL
+    assert llm.model_name == "gpt-oss-120b"
+
+
+def test_load_aurora_model_defaults_base_url_and_dummy_key(monkeypatch):
+    monkeypatch.delenv("AURORA_BASE_URL", raising=False)
+    monkeypatch.delenv("AURORA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm = load_aurora_model(AURORA_MODEL)
+    assert llm.openai_api_base == AURORA_DEFAULT_BASE_URL
+    assert llm.model_name == "gpt-oss-120b"
+
+
+def test_env_base_url_is_used_when_no_explicit_url(monkeypatch):
+    monkeypatch.setenv("AURORA_BASE_URL", CUSTOM_URL)
+    llm = load_aurora_model("aurora:nemotron-3-ultra", api_key="dummy")
+    assert llm.openai_api_base == CUSTOM_URL
+    assert llm.model_name == "nemotron-3-ultra"
+
+
+def test_loader_dispatches_aurora_prefix_to_chatopenai():
+    llm = load_chat_model(AURORA_MODEL, base_url=CUSTOM_URL, api_key="dummy")
+    assert type(llm).__name__ == "ChatOpenAI"
+    assert llm.openai_api_base == CUSTOM_URL
+    assert llm.model_name == "gpt-oss-120b"
+
+
+def test_lm_settings_extract_aurora_base_url_from_cli_toml(tmp_path):
+    from chemgraph.models.settings import load_lm_settings
+
+    cfg = tmp_path / "aurora.toml"
+    cfg.write_text(
+        "\n".join(
+            [
+                "[general]",
+                f'model = "{AURORA_MODEL}"',
+                "[api.aurora]",
+                f'base_url = "{CUSTOM_URL}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    settings = load_lm_settings(cfg)
+    assert settings.model == AURORA_MODEL
+    assert settings.base_url == CUSTOM_URL

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -42,6 +42,24 @@ def test_default_calculator_is_in_detected_available_calculators():
     assert default in context
 
 
+def test_invalid_calculator_type_error_lists_accepted_values():
+    # Regression: the error used to list class names (e.g. "EMTCalc"), which
+    # misled agents into passing the class name as calculator_type. It should
+    # instead name the accepted calculator_type field values (e.g. "emt").
+    from chemgraph.schemas.ase_input import ASEInputSchema
+
+    with pytest.raises(ValidationError) as excinfo:
+        ASEInputSchema(
+            input_structure_file="water.xyz",
+            driver="opt",
+            calculator={"calculator_type": "EMTCalc"},
+        )
+
+    message = str(excinfo.value)
+    assert "accepted values" in message
+    assert "'emt'" in message
+
+
 @pytest.mark.skipif(
     importlib.util.find_spec("mace") is None, reason="MACE not installed"
 )


### PR DESCRIPTION
<!--
Thanks for contributing! Keep PRs small and focused — one logical change.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

Additions for running ChemGraph on ALCF Aurora with a locally-served LLM (four models), plus a bug fix
that benefits all providers:

**1. Fix: invalid `calculator_type` error now lists accepted field values** (`schemas/ase_input.py`)

The previous error listed calculator *class names* (`['MaceCalc', 'EMTCalc']`), but the schema requires
a *field value* (`'emt'`, `'mace_mp'`, …). A tool-calling LLM that passed `"EMTCalc"` would read the
error, see `EMTCalc` in the list, and retry with the same wrong value — looping until the recursion
limit. The message now reads:

```
Calculator 'EMTCalc' is not an allowed or available calculator.
Set 'calculator_type' to one of these accepted values: 'emt', 'mace_mp', 'mace_off', 'mace_anicc'
(available calculators: ['MaceCalc', 'EMTCalc']).
```

**2. New provider: `aurora:` for Aurora on-node inference** (`models/aurora_endpoints.py` + wiring)

Adds a first-class `aurora:` prefix provider for OpenAI-compatible LLM servers running on ALCF Aurora
compute nodes (llama.cpp SYCL `llama-server`). Analogous to the existing `alcf:` provider. Base URL is
resolved from `--base-url` / `AURORA_BASE_URL` env / `[api.aurora].base_url` in config /
`http://127.0.0.1:8000/v1` default. API key defaults to `"dummy"` (on-node servers don't enforce auth).
Any served model id works; the curated list (`aurora:gpt-oss-120b`, `aurora:inkling`,
`aurora:nemotron-3-ultra`, `aurora:nemotron-4-340b`) is for discovery only.

**3. New recipes: full-XPU llama.cpp inference alongside scientific workloads** (`scripts/aurora/`,
`docs/aurora_recipes.md`)

A recipe document (`docs/aurora_recipes.md`) covers all four models. Every recipe is **full-XPU**
(all weights on GPU, **no MoE→CPU offload**), runs at each model's **native maximum context**, and
partitions GPU tiles so the LLM and the scientific workload never share tiles (both CPU sockets stay
free for science). Tile isolation is via `ZE_AFFINITY_MASK` set independently per process; all use
`--jinja` for tool calls, `--parallel 1` (single serve).

| Model | `aurora:` id | LLM tiles | Free for science | Max context |
|-------|--------------|-----------|-----------------|-------------|
| gpt-oss-120b (MXFP4) | `aurora:gpt-oss-120b` | 2 (1 GPU) | 10 tiles + both CPUs | 131 072 |
| Nemotron-3-Ultra (UD-IQ2_M) | `aurora:nemotron-3-ultra` | 6 (3 GPUs) | 6 tiles + both CPUs | 262 144 |
| Inkling (UD-IQ1_S) | `aurora:inkling` | 8 (4 GPUs) | 4 tiles + both CPUs | 131 072 |
| Nemotron-4-340B (i1-Q4_K_M) | `aurora:nemotron-4-340b` | 6 (3 GPUs) | 6 tiles + both CPUs | **4 096** ⚠ |

⚠ Nemotron-4-340B-Instruct was pretrained with `max_position_embeddings = 4096` and no RoPE scaling
(confirmed in the upstream HF config and GGUF header). This is a hard architectural limit — no
long-context variant exists and RoPE extension degrades tool-calling quality. Use gpt-oss-120b,
Inkling, or Nemotron-3-Ultra for long-context ChemGraph workflows.

The KV cache is small vs weights (few KV heads), so max context fits the listed tile counts with
headroom. For Nemotron-3-Ultra (hybrid Mamba2 + MoE), only the 12 attention layers carry
context-scaling KV (kv_heads=2), so KV at max context is only ~3 GB.

Scripts / config:
- `scripts/aurora/build_llamacpp_sycl.pbs`: **build llama.cpp with the SYCL backend** — there is no
  facility-wide llama.cpp module on Aurora, so users build it once. Self-contained (Aurora oneapi/
  cmake/ninja modules + system git, no conda); merges Inkling PR #25731 so one build serves all four
  models. Portable output at `$HOME/llamacpp-sycl/build/bin` (the serve scripts' default `BIN`).
- `scripts/aurora/serve_llamacpp_maxctx.sh`: unified full-XPU max-context serve; selects tiles, GGUF,
  context, and alias from the model key (`gpt-oss-120b|nemotron-3-ultra|inkling|nemotron-4-340b`).
- `scripts/aurora/two_node_inkling.pbs`, `scripts/aurora/two_node_nemotron_ultra.pbs`: two-node PBS
  (`select=2`); LLM on node 0 (SSH launch), ChemGraph on node 1, via intra-cluster IP.
- `scripts/aurora/chemgraph_aurora_env.sh`: sets `AURORA_BASE_URL` from `ENDPOINT.txt`.
- Configs: `config/aurora_gpt_oss.toml`, `config/aurora_inkling.toml`,
  `config/aurora_nemotron_ultra.toml`, `config/aurora_nemotron4.toml`.
- All four ids registered in `supported_aurora_models`.

## Related issues

None.

## Type of change

- [x] Bug fix — invalid `calculator_type` error message misleading tool-calling agents
- [x] New feature — `aurora:` LLM provider + full-XPU llama.cpp serving recipes (4 models)
- [x] Docs — `docs/aurora_recipes.md` (recipes + llama.cpp build + known caveats),
      `docs/running_local_models.md` (Aurora section), mkdocs nav

## How was this tested?

**Calculator fix** — regression test added
(`tests/test_calculators.py::test_invalid_calculator_type_error_lists_accepted_values`). Also verified
live: with the fix, a tool-calling agent that passed `"EMTCalc"` self-corrected to `"emt"` on the next
call and completed the EMT optimization successfully.

**`aurora:` provider** — 13 hermetic tests in `tests/test_aurora_endpoints.py` covering prefix
stripping, base URL resolution (flat + nested config, env var override, default fallback),
`load_aurora_model` construction, `load_chat_model` dispatch, and `LLMSettings` TOML extraction. No
network required.

**End-to-end on Aurora — all four models validated** (ALCF `capacity` queue, 4-node parallel job):
each model ran co-located on one node (LLM full-XPU on its tile group + ChemGraph scientific workload
on the same node using the free tiles + idle CPU socket). All four completed an EMT geometry
optimization via the `aurora:` provider — `smiles_to_coordinate_file` → `run_ase` → converged,
energy reported — with `overall_rc=0`.

| Model | Context served | ChemGraph result |
|-------|---------------|-----------------|
| gpt-oss-120b | 131 072 | ✅ converged, 1.879 eV |
| Nemotron-3-Ultra | 262 144 | ✅ converged |
| Inkling | 131 072 | ✅ converged |
| Nemotron-4-340B | 4 096 (model max) | ✅ converged |

Two issues found and fixed during testing: (a) ChemGraph's 30s init probe timed out on the first
request at max context → added a pre-warm request before ChemGraph connects; (b) Inkling OOM at
131 072 with `--parallel 4` → switched to `--parallel 1` (single serve, matching the recipe intent).

**CI gate on `feature/aurora-llm-inference`:**
```
ruff check .                      # all checks passed
pytest tests/ -k "not tblite"    # 477 passed, 29 skipped
```

**Two-node PBS scripts** — bash syntax validated (`bash -n`). Two-node design is derived from the
validated single-node recipes and the established two-node SSH pattern used across the
alcf-aurora-llm campaign.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change
