### PR TITLE
Refactor model loading into protocol × endpoint layers (#201, PR 1)

### DIFF
--- a/src/chemgraph/models/alcf_endpoints.py
+++ b/src/chemgraph/models/alcf_endpoints.py
@@ -1,44 +1,34 @@
-import logging
-import os
+"""Deprecated compatibility shim for ALCF model loading.
+
+Construction now lives in ``chemgraph.models.endpoints.alcf`` behind the shared
+OpenAI-compatible protocol builder. Prefer
+``chemgraph.models.loader.load_chat_model``.
+
+The ``_normalize_alcf_model`` helper is re-exported for one release.
+"""
+
+from __future__ import annotations
+
+import warnings
 
 from langchain_openai import ChatOpenAI
 
-from chemgraph.models.supported_models import (
-    ALCF_DEFAULT_BASE_URL,
-    ALCF_METIS_BASE_URL,
-    ALCF_MINERVA_BASE_URL,
-    supported_alcf_metis_models,
-    supported_alcf_minerva_models,
-    supported_alcf_models,
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import alcf as _alcf
+
+# Re-exported for backward compatibility.
+from chemgraph.models.endpoints.alcf import (  # noqa: F401
+    ALCF_MODEL_PREFIX,
+    _normalize_alcf_model,
 )
+from chemgraph.utils.logging_config import setup_logger
 
-logger = logging.getLogger(__name__)
+logger = setup_logger(__name__)
 
-ALCF_MODEL_PREFIX = "alcf:"
-
-
-def _normalize_alcf_model(model_name: str) -> str:
-    """Strip the ``alcf:`` prefix to get the name the endpoint expects.
-
-    ALCF serves each model under its upstream ID.  The prefix only selects the
-    provider inside ChemGraph, so it is removed before the request is sent.
-
-    Parameters
-    ----------
-    model_name : str
-        Requested model identifier, normally ``alcf:``-prefixed.
-
-    Returns
-    -------
-    str
-        Model name to send to the endpoint.
-    """
-    if not model_name.startswith(ALCF_MODEL_PREFIX):
-        return model_name
-
-    stripped = model_name.removeprefix(ALCF_MODEL_PREFIX)
-    logger.info("Stripped alcf: prefix '%s' -> '%s'", model_name, stripped)
-    return stripped
+_DEPRECATION = (
+    "load_alcf_model is deprecated; use "
+    "chemgraph.models.loader.load_chat_model instead."
+)
 
 
 def load_alcf_model(
@@ -46,85 +36,7 @@ def load_alcf_model(
     base_url: str = None,
     api_key: str = None,
 ) -> ChatOpenAI:
-    """Load a model from ALCF inference endpoints.
-
-    ALCF endpoints use Globus OAuth for authentication.  The access token
-    can be supplied directly via *api_key* or through the
-    ``ALCF_ACCESS_TOKEN`` environment variable.
-
-    See https://docs.alcf.anl.gov/services/inference-endpoints/ for setup
-    instructions and https://github.com/argonne-lcf/inference-endpoints
-    for the authentication helper script.
-
-    Parameters
-    ----------
-    model_name : str
-        The name of the model to load.  Must be in ``supported_alcf_models``.
-    base_url : str, optional
-        The base URL of the API endpoint.  Falls back to the base URL of the
-        cluster that serves *model_name* if not provided.
-    api_key : str, optional
-        Globus access token.  If not provided, the function checks the
-        ``ALCF_ACCESS_TOKEN`` environment variable.
-
-    Returns
-    -------
-    ChatOpenAI
-        An instance of LangChain's ChatOpenAI configured for the ALCF
-        endpoint.
-
-    Raises
-    ------
-    ValueError
-        If neither *api_key* nor ``ALCF_ACCESS_TOKEN`` is available, or if
-        the model is not in the supported list.
-    """
-
-    # Resolve access token ---------------------------------------------------
-    if api_key is None:
-        api_key = os.getenv("ALCF_ACCESS_TOKEN")
-
-    if not api_key:
-        raise ValueError(
-            "ALCF access token not found. To authenticate with ALCF:\n"
-            "  1. pip install globus_sdk\n"
-            "  2. wget https://raw.githubusercontent.com/argonne-lcf/inference-endpoints/"
-            "refs/heads/main/inference_auth_token.py\n"
-            "  3. python inference_auth_token.py authenticate\n"
-            "  4. export ALCF_ACCESS_TOKEN=$(python inference_auth_token.py get_access_token)\n"
-            "\n"
-            "See: https://docs.alcf.anl.gov/services/inference-endpoints/#api-access"
-        )
-
-    # Validate model name ----------------------------------------------------
-    if model_name not in supported_alcf_models:
-        raise ValueError(
-            f"Model '{model_name}' is not supported on ALCF. "
-            f"Supported models: {supported_alcf_models}"
-        )
-
-    # Resolve base URL -------------------------------------------------------
-    # Each ALCF cluster is a separate endpoint, so pick the one serving it.
-    if not base_url:
-        if model_name in supported_alcf_minerva_models:
-            base_url = ALCF_MINERVA_BASE_URL
-        elif model_name in supported_alcf_metis_models:
-            base_url = ALCF_METIS_BASE_URL
-        else:
-            base_url = ALCF_DEFAULT_BASE_URL
-
-    # The endpoint knows the model by its upstream ID, not the prefixed one.
-    wire_model = _normalize_alcf_model(model_name)
-
-    try:
-        llm = ChatOpenAI(
-            model=wire_model,
-            base_url=base_url,
-            api_key=api_key,
-        )
-        logger.info(f"Successfully loaded ALCF model: {wire_model} from {base_url}")
-    except Exception as e:
-        logger.error(f"Failed to load ALCF model '{model_name}': {e}")
-        raise
-
-    return llm
+    """Load an ALCF model (deprecated). Delegates to the endpoint."""
+    warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
+    request = ModelRequest(model=model_name, base_url=base_url, api_key=api_key)
+    return _alcf.SPEC.build(request)

--- a/src/chemgraph/models/anthropic.py
+++ b/src/chemgraph/models/anthropic.py
@@ -1,80 +1,34 @@
-"""Load Anthropic models using LangChain."""
+"""Deprecated compatibility shim for Anthropic model loading.
 
-import os
-from getpass import getpass
+Construction now lives in ``chemgraph.models.endpoints.anthropic_direct`` behind
+the Anthropic-native protocol builder. Prefer
+``chemgraph.models.loader.load_chat_model``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
 from langchain_anthropic import ChatAnthropic
-from chemgraph.models.supported_models import supported_anthropic_models
+
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import anthropic_direct as _anthropic_direct
 from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
+
+_DEPRECATION = (
+    "load_anthropic_model is deprecated; use "
+    "chemgraph.models.loader.load_chat_model instead."
+)
 
 
 def load_anthropic_model(
     model_name: str, temperature: float, api_key: str = None, prompt: str = None
 ) -> ChatAnthropic:
-    """
-    Load an Anthropic chat model into LangChain.
-
-    Parameters
-    ----------
-    model_name : str
-        The name of the Anthropic chat model to load. See supported_anthropic_models for list
-        of supported models.
-    temperature : float
-        Controls the randomness of the generated text. A higher temperature results
-        in more random outputs, while a lower temperature results in more deterministic outputs.
-    api_key : str, optional
-        The Anthropic API key. If not provided, the function will attempt to retrieve it
-        from the environment variable `ANTHROPIC_API_KEY`.
-
-    Returns
-    -------
-    ChatAnthropic
-        An instance of LangChain's ChatAnthropic model.
-
-    Raises
-    ------
-    ValueError
-        If the API key is not provided and cannot be retrieved from the environment.
-
-    Notes
-    -----
-    Ensure the model_name provided is one of the supported models. Unsupported models
-    will result in an exception.
-    """
-
-    if api_key is None:
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not api_key:
-            logger.info("Anthropic API key not found in environment variables.")
-            api_key = getpass("Please enter your Anthropic API key: ")
-            os.environ["ANTHROPIC_API_KEY"] = api_key
-
-    if model_name not in supported_anthropic_models:
-        raise ValueError(
-            f"Unsupported model '{model_name}'. Supported models are: {supported_anthropic_models}."
-        )
-
-    try:
-        logger.info(f"Loading Anthropic model: {model_name}")
-        llm = ChatAnthropic(
-            model=model_name,
-            temperature=temperature,
-            api_key=api_key,
-            max_tokens=6000,
-        )
-        # No guarantee that api_key is valid, authentication happens only during invocation
-        logger.info(f"Requested model: {model_name}")
-        logger.info("Anthropic model loaded successfully")
-        return llm
-    except Exception as e:
-        # Can remove this since authentication happens only during invocation
-        if "AuthenticationError" in str(e) or "invalid_api_key" in str(e):
-            logger.warning("Invalid Anthropic API key.")
-            api_key = getpass("Please enter a valid Anthropic API key: ")
-            os.environ["ANTHROPIC_API_KEY"] = api_key
-            # Retry with new API key
-            return load_anthropic_model(model_name, temperature, api_key, prompt)
-        else:
-            logger.error(f"Error loading Anthropic model: {str(e)}")
-            raise
+    """Load an Anthropic chat model (deprecated). Delegates to the endpoint."""
+    warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
+    request = ModelRequest(
+        model=model_name, temperature=temperature, api_key=api_key
+    )
+    return _anthropic_direct.SPEC.build(request)

--- a/src/chemgraph/models/endpoints/__init__.py
+++ b/src/chemgraph/models/endpoints/__init__.py
@@ -1,0 +1,23 @@
+"""Endpoint specifications for the model-loading pipeline.
+
+Each endpoint module declares what makes it different from other endpoints that
+speak the same protocol. The loader selects one ``EndpointSpec`` per request.
+"""
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    is_local_http_endpoint,
+    resolve_api_key,
+)
+
+__all__ = [
+    "CredentialPolicy",
+    "EndpointSpec",
+    "ModelRequest",
+    "PreparedModel",
+    "is_local_http_endpoint",
+    "resolve_api_key",
+]

--- a/src/chemgraph/models/endpoints/alcf.py
+++ b/src/chemgraph/models/endpoints/alcf.py
@@ -1,0 +1,106 @@
+"""ALCF inference endpoints (Sophia default, Minerva, Metis).
+
+Owns cluster URL selection, ``alcf:`` prefix stripping, and the
+``ALCF_ACCESS_TOKEN`` credential. Logic moved verbatim from the previous
+``models/alcf_endpoints.py``.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    resolve_api_key,
+)
+from chemgraph.models.protocols import openai_compatible
+from chemgraph.models.supported_models import (
+    ALCF_DEFAULT_BASE_URL,
+    ALCF_METIS_BASE_URL,
+    ALCF_MINERVA_BASE_URL,
+    supported_alcf_metis_models,
+    supported_alcf_minerva_models,
+    supported_alcf_models,
+)
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "openai_compatible"
+
+ALCF_MODEL_PREFIX = "alcf:"
+
+ALCF_MISSING_KEY_HELP = (
+    "ALCF access token not found. To authenticate with ALCF:\n"
+    "  1. pip install globus_sdk\n"
+    "  2. wget https://raw.githubusercontent.com/argonne-lcf/inference-endpoints/"
+    "refs/heads/main/inference_auth_token.py\n"
+    "  3. python inference_auth_token.py authenticate\n"
+    "  4. export ALCF_ACCESS_TOKEN=$(python inference_auth_token.py get_access_token)\n"
+    "\n"
+    "See: https://docs.alcf.anl.gov/services/inference-endpoints/#api-access"
+)
+
+ALCF_CREDENTIAL = CredentialPolicy(
+    env_var="ALCF_ACCESS_TOKEN",
+    required=True,
+    interactive_prompt=False,
+    missing_key_help=ALCF_MISSING_KEY_HELP,
+)
+
+
+def _normalize_alcf_model(model_name: str) -> str:
+    """Strip the ``alcf:`` prefix to get the name the endpoint expects."""
+    if not model_name.startswith(ALCF_MODEL_PREFIX):
+        return model_name
+    stripped = model_name.removeprefix(ALCF_MODEL_PREFIX)
+    logger.info("Stripped alcf: prefix '%s' -> '%s'", model_name, stripped)
+    return stripped
+
+
+def _resolve_base_url(model_name: str, base_url: str | None) -> str:
+    """Pick the cluster base URL that serves ``model_name`` when not given."""
+    if base_url:
+        return base_url
+    if model_name in supported_alcf_minerva_models:
+        return ALCF_MINERVA_BASE_URL
+    if model_name in supported_alcf_metis_models:
+        return ALCF_METIS_BASE_URL
+    return ALCF_DEFAULT_BASE_URL
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a curated ``alcf:`` model, selecting its cluster endpoint."""
+    requested_model_name = request.model
+
+    # Resolve access token before validating, matching the previous behavior.
+    api_key = resolve_api_key(ALCF_CREDENTIAL, request.api_key)
+
+    if requested_model_name not in supported_alcf_models:
+        raise ValueError(
+            f"Model '{requested_model_name}' is not supported on ALCF. "
+            f"Supported models: {supported_alcf_models}"
+        )
+
+    base_url = _resolve_base_url(requested_model_name, request.base_url)
+    wire_model = _normalize_alcf_model(requested_model_name)
+
+    client_kwargs = dict(model=wire_model, base_url=base_url, api_key=api_key)
+    logger.info("Prepared ALCF model: %s from %s", wire_model, base_url)
+    return PreparedModel(
+        endpoint_name="alcf",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="alcf",
+    protocol=PROTOCOL,
+    matches=lambda model: model in supported_alcf_models,
+    prepare=prepare,
+    protocol_build=openai_compatible.build,
+    credential=ALCF_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/anthropic_direct.py
+++ b/src/chemgraph/models/endpoints/anthropic_direct.py
@@ -1,0 +1,64 @@
+"""Direct Anthropic endpoint (Anthropic-native protocol).
+
+Logic moved verbatim from ``models/anthropic.py``: ``ANTHROPIC_API_KEY`` with
+interactive prompt, curated model validation, ``max_tokens=6000``.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    resolve_api_key,
+)
+from chemgraph.models.protocols import anthropic_native
+from chemgraph.models.supported_models import supported_anthropic_models
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "anthropic_native"
+
+ANTHROPIC_CREDENTIAL = CredentialPolicy(
+    env_var="ANTHROPIC_API_KEY",
+    required=True,
+    interactive_prompt=True,
+)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a curated Anthropic model."""
+    model_name = request.model
+    api_key = resolve_api_key(ANTHROPIC_CREDENTIAL, request.api_key)
+
+    if model_name not in supported_anthropic_models:
+        raise ValueError(
+            f"Unsupported model '{model_name}'. "
+            f"Supported models are: {supported_anthropic_models}."
+        )
+
+    logger.info("Loading Anthropic model: %s", model_name)
+    client_kwargs = dict(
+        model=model_name,
+        temperature=request.temperature,
+        api_key=api_key,
+        max_tokens=6000,
+    )
+    return PreparedModel(
+        endpoint_name="anthropic_direct",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="anthropic_direct",
+    protocol=PROTOCOL,
+    matches=lambda model: model in supported_anthropic_models,
+    prepare=prepare,
+    protocol_build=anthropic_native.build,
+    credential=ANTHROPIC_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/argo.py
+++ b/src/chemgraph/models/endpoints/argo.py
@@ -1,0 +1,224 @@
+"""Argo endpoints (hosted Argo API and shim/proxy/custom OpenAI-compatible).
+
+Owns everything Argo-specific: the wire-name maps, ``CHEMGRAPH_ARGO_MODEL_FORMAT``
+handling, localhost detection, prefix removal, Claude streaming, minimal-parameter
+models, Argo ``user`` payload, and the ``supports_structured_output=False``
+capability. All logic is moved verbatim from the previous ``models/openai.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    is_local_http_endpoint,
+)
+from chemgraph.models.endpoints.openai_direct import (
+    assemble_client_kwargs,
+    validate_reasoning_effort,
+)
+from chemgraph.models.protocols import openai_compatible
+from chemgraph.models.supported_models import (
+    ARGO_DEFAULT_BASE_URL,
+    supported_argo_models,
+)
+from chemgraph.utils.config_utils import normalize_openai_base_url
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "openai_compatible"
+
+ARGO_PREFIX = "argo:"
+
+# Maps user-facing ``argo:`` model names to the internal wire names expected by
+# the Argo API (https://apps.inside.anl.gov/argoapi). When a different endpoint
+# (e.g. ArgoProxy) is used, the ``argo:`` prefix is stripped instead and the
+# remainder is sent as-is.
+ARGO_MODEL_MAP = {
+    # GPT family
+    "argo:gpt-4o": "gpt4o",
+    "argo:gpt-4.1": "gpt41",
+    "argo:gpt-4.1-mini": "gpt41mini",
+    "argo:gpt-4.1-nano": "gpt41nano",
+    "argo:gpt-5": "gpt5",
+    "argo:gpt-5-mini": "gpt5mini",
+    "argo:gpt-5-nano": "gpt5nano",
+    "argo:gpt-5.1": "gpt51",
+    "argo:gpt-5.2": "gpt52",
+    "argo:gpt-5.4": "gpt54",
+    "argo:gpt-5.4-mini": "gpt54mini",
+    "argo:gpt-5.4-nano": "gpt54nano",
+    "argo:gpt-5.5": "gpt55",
+    "argo:gpt-5.6-luna": "gpt56luna",
+    "argo:gpt-5.6-sol": "gpt56sol",
+    "argo:gpt-5.6-terra": "gpt56terra",
+    # Reasoning / o-series
+    "argo:o1": "gpto1",
+    "argo:o3-mini": "gpto3mini",
+    "argo:o3": "gpto3",
+    "argo:o4-mini": "gpto4mini",
+    # Gemini via Argo
+    "argo:gemini-2.5-pro": "gemini25pro",
+    "argo:gemini-2.5-flash": "gemini25flash",
+    "argo:gemini-3.1-flash-lite": "gemini31flashlite",
+    "argo:gemini-3.5-flash": "gemini35flash",
+    # Claude via Argo
+    "argo:claude-opus-4.6": "claudeopus46",
+    "argo:claude-opus-4.5": "claudeopus45",
+    "argo:claude-opus-4.1": "claudeopus41",
+    "argo:claude-haiku-4.5": "claudehaiku45",
+    "argo:claude-sonnet-5": "claudesonnet5",
+    "argo:claude-sonnet-4.6": "claudesonnet46",
+    "argo:claude-sonnet-4.5": "claudesonnet45",
+}
+
+ARGO_LOCAL_OPENAI_MODEL_MAP = {
+    # argo-shim advertises GPT-5.4 with this casing. Lowercase gpt-5.4 is
+    # rejected by the upstream Argo API behind the shim.
+    "argo:gpt-5.4": "GPT-5.4",
+}
+
+# Argo authenticates via the 'user' field, not an API key. A non-empty
+# placeholder is still required because ChatOpenAI demands a value.
+ARGO_CREDENTIAL = CredentialPolicy(env_var="OPENAI_API_KEY", required=False)
+
+
+def _normalize_argo_model(model_name: str, base_url: str | None) -> str:
+    """Normalize an ``argo:``-prefixed model name for the target endpoint.
+
+    * Hosted Argo API endpoints use internal wire names via ``ARGO_MODEL_MAP``.
+    * Argo shim, ArgoProxy, and custom OpenAI-compatible endpoints strip the
+      ``argo:`` prefix and keep the OpenAI-style name.
+    """
+    if not model_name.startswith(ARGO_PREFIX):
+        return model_name
+
+    model_format = os.getenv("CHEMGRAPH_ARGO_MODEL_FORMAT", "").lower()
+    if model_format == "shim":
+        return _normalize_argo_local_openai_model(model_name)
+    if model_format in {"openai", "openai-compatible"}:
+        stripped = model_name.removeprefix(ARGO_PREFIX)
+        logger.info("Stripped argo: prefix '%s' -> '%s'", model_name, stripped)
+        return stripped
+    if model_format in {"wire", "argo"}:
+        return _normalize_argo_wire_model(model_name)
+
+    if is_local_http_endpoint(base_url):
+        stripped = _normalize_argo_local_openai_model(model_name)
+        logger.info(
+            "Using OpenAI-style Argo model for local endpoint '%s': '%s' -> '%s'",
+            base_url,
+            model_name,
+            stripped,
+        )
+        return stripped
+
+    if base_url and "argoapi" in base_url:
+        return _normalize_argo_wire_model(model_name)
+    else:
+        # Non-Argo-API endpoint -- strip prefix only
+        stripped = model_name.removeprefix(ARGO_PREFIX)
+        logger.info("Stripped argo: prefix '%s' -> '%s'", model_name, stripped)
+        return stripped
+
+
+def _normalize_argo_local_openai_model(model_name: str) -> str:
+    """Return the model name expected by local OpenAI-compatible Argo shims."""
+    return ARGO_LOCAL_OPENAI_MODEL_MAP.get(
+        model_name,
+        model_name.removeprefix(ARGO_PREFIX),
+    )
+
+
+def _normalize_argo_wire_model(model_name: str) -> str:
+    """Return the hosted-Argo wire model for an ``argo:`` model name."""
+    normalized = ARGO_MODEL_MAP.get(model_name)
+    if normalized:
+        logger.info("Normalized Argo model '%s' -> '%s'", model_name, normalized)
+        return normalized
+
+    fallback = model_name.removeprefix(ARGO_PREFIX).replace("-", "").replace(".", "")
+    logger.info("Normalized Argo model '%s' -> '%s' (fallback)", model_name, fallback)
+    return fallback
+
+
+def _resolve_argo_api_key(request: ModelRequest) -> str:
+    """Resolve the value passed as the ChatOpenAI api_key for Argo routes.
+
+    Mirrors the previous ``load_openai_model``: explicit key, else
+    ``OPENAI_API_KEY``, else the argo user / ``ARGO_USER`` / ``"chemgraph"``
+    placeholder.
+    """
+    api_key = request.api_key
+    if api_key is None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            api_key = request.argo_user or os.getenv("ARGO_USER", "chemgraph")
+    return api_key
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare an ``argo:`` model for hosted, shim, or custom endpoints."""
+    requested_model_name = request.model
+    base_url = normalize_openai_base_url(request.base_url)
+
+    validate_reasoning_effort(requested_model_name, request.reasoning_effort)
+
+    # Apply default Argo base URL for argo: models when none is specified.
+    if not base_url:
+        base_url = ARGO_DEFAULT_BASE_URL
+        logger.info("Using default Argo base URL: %s", base_url)
+
+    api_key = _resolve_argo_api_key(request)
+
+    if requested_model_name not in supported_argo_models:
+        raise ValueError(
+            f"Unsupported model '{requested_model_name}'. "
+            f"Supported models are: {supported_argo_models}."
+        )
+
+    is_argo_claude_model = requested_model_name.startswith("argo:claude-")
+    is_argo_endpoint = bool(base_url and "argoapi" in base_url)
+    argo_user = (
+        request.argo_user or os.getenv("ARGO_USER", "chemgraph")
+        if is_argo_endpoint
+        else None
+    )
+
+    logger.info("Using custom base URL: %s", base_url)
+    wire_model = _normalize_argo_model(requested_model_name, base_url)
+    if is_argo_endpoint and argo_user:
+        logger.info("Using Argo user from config/ARGO_USER/default: %s", argo_user)
+
+    client_kwargs = assemble_client_kwargs(
+        model=wire_model,
+        requested_model_name=requested_model_name,
+        api_key=api_key,
+        base_url=base_url,
+        temperature=request.temperature,
+        reasoning_effort=request.reasoning_effort,
+        streaming=is_argo_claude_model,
+        argo_user_for_model_kwargs=argo_user if is_argo_endpoint else None,
+    )
+    return PreparedModel(
+        endpoint_name="argo",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        reasoning_effort=request.reasoning_effort,
+        supports_structured_output=False,
+    )
+
+
+SPEC = EndpointSpec(
+    name="argo",
+    protocol=PROTOCOL,
+    matches=lambda model: model.startswith(ARGO_PREFIX),
+    prepare=prepare,
+    protocol_build=openai_compatible.build,
+    credential=ARGO_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/base.py
+++ b/src/chemgraph/models/endpoints/base.py
@@ -1,0 +1,169 @@
+"""Shared, internal types for the endpoint × protocol model-loading pipeline.
+
+The pipeline is::
+
+    caller -> load_chat_model -> endpoint spec -> protocol builder -> client
+
+An *endpoint* declares only what makes it different from other endpoints that
+speak the same protocol: its base URL, credential policy, model-name transform,
+default parameters, and per-model quirks. A *protocol* owns the single
+construction site for one LangChain client class.
+
+Everything in this module is internal. The public model-loading surface remains
+``load_chat_model``, ``LLMSettings``, and ``ChemGraph``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from getpass import getpass
+from typing import TYPE_CHECKING, Any, Callable
+from urllib.parse import urlparse
+
+from chemgraph.utils.logging_config import setup_logger
+
+if TYPE_CHECKING:  # avoid a runtime import cycle with settings.py
+    from langchain_core.language_models.chat_models import BaseChatModel
+
+    from chemgraph.models.settings import LLMSettings
+
+logger = setup_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ModelRequest:
+    """A fully-formed request to load one chat model.
+
+    Built by the loader from either explicit arguments or an ``LLMSettings``
+    object and handed to an endpoint's ``prepare`` callback.
+    """
+
+    model: str
+    temperature: float = 0.0
+    base_url: str | None = None
+    api_key: str | None = None
+    argo_user: str | None = None
+    reasoning_effort: str | None = None
+    settings: "LLMSettings | None" = None
+
+
+@dataclass(frozen=True)
+class CredentialPolicy:
+    """How an endpoint resolves its API key.
+
+    Credentials never cross provider boundaries. The one exception -- the vLLM
+    fallback to ``OPENAI_API_KEY`` -- is expressed explicitly on that endpoint,
+    not encoded here.
+    """
+
+    env_var: str | None = None
+    required: bool = True
+    interactive_prompt: bool = False
+    missing_key_help: str | None = None
+    placeholder: str | None = None
+
+
+@dataclass(frozen=True)
+class PreparedModel:
+    """The result of an endpoint preparing a request.
+
+    Holds everything the protocol builder needs plus caller-visible metadata
+    the loader can surface without re-deriving provider facts.
+    """
+
+    endpoint_name: str
+    protocol: str
+    client_kwargs: dict[str, Any]
+    reasoning_effort: str | None = None
+    supports_structured_output: bool = True
+
+
+@dataclass(frozen=True)
+class EndpointSpec:
+    """Declarative description of one endpoint route.
+
+    ``matches`` decides whether this spec handles a model name; ``prepare``
+    turns a ``ModelRequest`` into a ``PreparedModel``; ``protocol_build`` builds
+    the LangChain client from ``PreparedModel.client_kwargs``.
+    """
+
+    name: str
+    protocol: str
+    matches: Callable[[str], bool]
+    prepare: Callable[[ModelRequest], PreparedModel]
+    protocol_build: Callable[[dict[str, Any]], "BaseChatModel"]
+    credential: CredentialPolicy = field(default_factory=CredentialPolicy)
+
+    def build(self, request: ModelRequest) -> "BaseChatModel":
+        """Prepare the request and construct the client."""
+        prepared = self.prepare(request)
+        return self.protocol_build(prepared.client_kwargs)
+
+
+def is_local_http_endpoint(base_url: str | None) -> bool:
+    """Return True for local HTTP endpoints such as an ``argo-shim``.
+
+    Moved verbatim from ``models/openai.py`` so endpoint modules share one
+    definition.
+    """
+    if not base_url:
+        return False
+    parsed = urlparse(base_url)
+    return parsed.scheme == "http" and parsed.hostname in {
+        "localhost",
+        "127.0.0.1",
+        "::1",
+        "0.0.0.0",
+    }
+
+
+def resolve_api_key(
+    policy: CredentialPolicy,
+    explicit: str | None,
+    *,
+    persist_env: bool = True,
+) -> str | None:
+    """Resolve an API key following an endpoint's credential policy.
+
+    Order: explicit value -> environment variable -> interactive prompt (only
+    when attached to a TTY) -> placeholder. Raises ``ValueError`` when a
+    required key cannot be resolved and no prompt is possible.
+    """
+    if explicit:
+        return explicit
+
+    key = os.getenv(policy.env_var) if policy.env_var else None
+    if key:
+        return key
+
+    if policy.interactive_prompt and sys.stdin.isatty():
+        if policy.env_var:
+            logger.info("%s not found in environment variables.", policy.env_var)
+        key = getpass(_prompt_text(policy))
+        if key and persist_env and policy.env_var:
+            os.environ[policy.env_var] = key
+        return key
+
+    if policy.placeholder is not None:
+        return policy.placeholder
+
+    if policy.required:
+        raise ValueError(policy.missing_key_help or _default_missing_help(policy))
+
+    return None
+
+
+def _prompt_text(policy: CredentialPolicy) -> str:
+    if policy.env_var:
+        return f"Please enter your {policy.env_var} value: "
+    return "Please enter your API key: "
+
+
+def _default_missing_help(policy: CredentialPolicy) -> str:
+    if policy.env_var:
+        return (
+            f"API key not found. Set the {policy.env_var} environment variable."
+        )
+    return "API key not found."

--- a/src/chemgraph/models/endpoints/google_direct.py
+++ b/src/chemgraph/models/endpoints/google_direct.py
@@ -1,0 +1,64 @@
+"""Direct Gemini endpoint (Google-native protocol).
+
+Logic moved verbatim from ``models/gemini.py``: ``GEMINI_API_KEY`` with
+interactive prompt, curated model validation, ``max_output_tokens=6000``.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    resolve_api_key,
+)
+from chemgraph.models.protocols import google_native
+from chemgraph.models.supported_models import supported_gemini_models
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "google_native"
+
+GOOGLE_CREDENTIAL = CredentialPolicy(
+    env_var="GEMINI_API_KEY",
+    required=True,
+    interactive_prompt=True,
+)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a curated Gemini model."""
+    model_name = request.model
+    api_key = resolve_api_key(GOOGLE_CREDENTIAL, request.api_key)
+
+    if model_name not in supported_gemini_models:
+        raise ValueError(
+            f"Unsupported model '{model_name}'. "
+            f"Supported models are: {supported_gemini_models}."
+        )
+
+    logger.info("Loading Gemini model: %s", model_name)
+    client_kwargs = dict(
+        model=model_name,
+        temperature=request.temperature,
+        api_key=api_key,
+        max_output_tokens=6000,
+    )
+    return PreparedModel(
+        endpoint_name="google_direct",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="google_direct",
+    protocol=PROTOCOL,
+    matches=lambda model: model in supported_gemini_models,
+    prepare=prepare,
+    protocol_build=google_native.build,
+    credential=GOOGLE_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/openai_direct.py
+++ b/src/chemgraph/models/endpoints/openai_direct.py
@@ -1,0 +1,158 @@
+"""Direct OpenAI endpoint and the shared OpenAI-compatible kwargs assembly.
+
+``assemble_client_kwargs`` is the single place that reproduces the two
+parameter shapes the previous ``load_openai_model`` produced -- the
+``base_url``-present shape (used by Argo, ALCF, vLLM, custom endpoints) and the
+plain OpenAI shape. Every OpenAI-compatible endpoint funnels its kwargs through
+it so the protocol builder stays a one-liner.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    resolve_api_key,
+)
+from chemgraph.models.protocols import openai_compatible
+from chemgraph.models.supported_models import (
+    MODELS_WITH_REASONING_EFFORT,
+    MODELS_WITHOUT_TEMPERATURE,
+    SUPPORTED_REASONING_EFFORTS,
+    supported_openai_models,
+)
+from chemgraph.utils.config_utils import normalize_openai_base_url
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "openai_compatible"
+
+OPENAI_CREDENTIAL = CredentialPolicy(
+    env_var="OPENAI_API_KEY",
+    required=True,
+    interactive_prompt=True,
+    missing_key_help="OPENAI_API_KEY not set. Please provide an OpenAI API key.",
+)
+
+
+def validate_reasoning_effort(requested_model_name: str, reasoning_effort: str | None) -> None:
+    """Validate reasoning-effort support for a model. Moved from ``openai.py``."""
+    if reasoning_effort is None:
+        return
+    if requested_model_name not in MODELS_WITH_REASONING_EFFORT:
+        raise ValueError(
+            f"Model '{requested_model_name}' does not have verified "
+            "reasoning-effort support."
+        )
+    if reasoning_effort not in SUPPORTED_REASONING_EFFORTS:
+        supported = ", ".join(sorted(SUPPORTED_REASONING_EFFORTS))
+        raise ValueError(
+            f"Unsupported reasoning effort '{reasoning_effort}'. "
+            f"Choose one of: {supported}."
+        )
+
+
+def assemble_client_kwargs(
+    *,
+    model: str,
+    requested_model_name: str,
+    api_key: str | None,
+    base_url: str | None,
+    temperature: float,
+    reasoning_effort: str | None = None,
+    streaming: bool = False,
+    argo_user_for_model_kwargs: str | None = None,
+) -> dict[str, Any]:
+    """Build ``ChatOpenAI`` kwargs, mirroring the previous ``load_openai_model``.
+
+    A non-null ``base_url`` selects the custom-endpoint shape (``max_tokens``
+    4000 plus sampling params); a null ``base_url`` selects the plain OpenAI
+    shape (``max_tokens`` 6000). Models in ``MODELS_WITHOUT_TEMPERATURE`` omit
+    all optional sampling parameters.
+    """
+    minimal = requested_model_name in MODELS_WITHOUT_TEMPERATURE
+    if base_url is not None:
+        kwargs: dict[str, Any] = dict(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            max_tokens=4000,
+        )
+        if minimal:
+            logger.info(
+                "Using minimal request parameters for model '%s'",
+                requested_model_name,
+            )
+        else:
+            kwargs.update(
+                temperature=temperature,
+                top_p=1.0,
+                frequency_penalty=0.0,
+                presence_penalty=0.0,
+            )
+        if reasoning_effort is not None:
+            kwargs["reasoning_effort"] = reasoning_effort
+        if streaming:
+            kwargs["streaming"] = True
+        if argo_user_for_model_kwargs:
+            kwargs["model_kwargs"] = {"user": argo_user_for_model_kwargs}
+    else:
+        kwargs = dict(model=model, api_key=api_key, max_tokens=6000)
+        if minimal:
+            logger.info(
+                "Using minimal request parameters for model '%s'",
+                requested_model_name,
+            )
+        else:
+            kwargs["temperature"] = temperature
+        if reasoning_effort is not None:
+            kwargs["reasoning_effort"] = reasoning_effort
+    return kwargs
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a direct (unprefixed, curated) OpenAI model."""
+    requested_model_name = request.model
+    base_url = normalize_openai_base_url(request.base_url)
+
+    validate_reasoning_effort(requested_model_name, request.reasoning_effort)
+
+    if requested_model_name not in supported_openai_models:
+        raise ValueError(
+            f"Unsupported model '{requested_model_name}'. "
+            f"Supported models are: {supported_openai_models}."
+        )
+
+    api_key = resolve_api_key(OPENAI_CREDENTIAL, request.api_key)
+
+    logger.info("Loading OpenAI model: %s", requested_model_name)
+    client_kwargs = assemble_client_kwargs(
+        model=requested_model_name,
+        requested_model_name=requested_model_name,
+        api_key=api_key,
+        base_url=base_url,
+        temperature=request.temperature,
+        reasoning_effort=request.reasoning_effort,
+    )
+    return PreparedModel(
+        endpoint_name="openai_direct",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        reasoning_effort=request.reasoning_effort,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="openai_direct",
+    protocol=PROTOCOL,
+    matches=lambda model: model in supported_openai_models,
+    prepare=prepare,
+    protocol_build=openai_compatible.build,
+    credential=OPENAI_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/openrouter.py
+++ b/src/chemgraph/models/endpoints/openrouter.py
@@ -1,0 +1,89 @@
+"""OpenRouter endpoint (OpenAI-compatible).
+
+Owns ``openrouter:`` prefix stripping, the ``OPENROUTER_API_KEY`` credential
+(never ``OPENAI_API_KEY``), the higher default token budget, and the restricted
+optional-parameter set. Logic moved verbatim from ``models/openrouter.py``.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+    resolve_api_key,
+)
+from chemgraph.models.protocols import openai_compatible
+from chemgraph.models.supported_models import (
+    MODELS_WITHOUT_TEMPERATURE,
+    OPENROUTER_DEFAULT_BASE_URL,
+)
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "openai_compatible"
+
+OPENROUTER_PREFIX = "openrouter:"
+
+# Higher than the OpenAI/Groq defaults on purpose: most models served through
+# OpenRouter emit reasoning tokens by default, and those count against the
+# *completion* budget. Too small a cap lets chain-of-thought exhaust it before
+# the tool call is emitted, producing an empty turn the graph reads as a dead end.
+OPENROUTER_DEFAULT_MAX_TOKENS = 8000
+
+OPENROUTER_MISSING_KEY_HELP = (
+    "OpenRouter API key not found. Set the OPENROUTER_API_KEY "
+    "environment variable:\n"
+    "  export OPENROUTER_API_KEY='your_key_here'\n"
+    "  Get a key at: https://openrouter.ai/keys"
+)
+
+# Falls back to OPENROUTER_API_KEY. Never to OPENAI_API_KEY.
+OPENROUTER_CREDENTIAL = CredentialPolicy(
+    env_var="OPENROUTER_API_KEY",
+    required=True,
+    interactive_prompt=True,
+    missing_key_help=OPENROUTER_MISSING_KEY_HELP,
+)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare an ``openrouter:`` model. The slug is sent verbatim."""
+    # Keep the prefixed name -- it is what the quirk sets are keyed on.
+    requested_model_name = request.model
+    model_name = requested_model_name.removeprefix(OPENROUTER_PREFIX)
+
+    api_key = resolve_api_key(OPENROUTER_CREDENTIAL, request.api_key)
+
+    logger.info("Loading OpenRouter model: %s", model_name)
+    client_kwargs = dict(
+        model=model_name,
+        api_key=api_key,
+        base_url=request.base_url or OPENROUTER_DEFAULT_BASE_URL,
+        max_tokens=OPENROUTER_DEFAULT_MAX_TOKENS,
+    )
+    # top_p / frequency_penalty / presence_penalty are deliberately not sent:
+    # they are no-ops at temperature 0, and OpenRouter fans requests out to a
+    # rotating pool of upstream providers whose real parameter support is
+    # narrower than the advertised union.
+    if requested_model_name not in MODELS_WITHOUT_TEMPERATURE:
+        client_kwargs["temperature"] = request.temperature
+
+    return PreparedModel(
+        endpoint_name="openrouter",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="openrouter",
+    protocol=PROTOCOL,
+    matches=lambda model: model.startswith(OPENROUTER_PREFIX),
+    prepare=prepare,
+    protocol_build=openai_compatible.build,
+    credential=OPENROUTER_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/vllm.py
+++ b/src/chemgraph/models/endpoints/vllm.py
@@ -1,0 +1,101 @@
+"""vLLM / custom OpenAI-compatible fallback endpoint.
+
+Consolidates the two ad-hoc fallbacks that previously lived in
+``agent/llm_agent.py`` and ``agent/turn.py`` (the latter via
+``_custom_openai_compatible_kwargs``). Selected only for an otherwise unknown
+model when a base URL is available.
+
+PR 1 preserves the current env-first precedence (``VLLM_BASE_URL`` /
+``OPENAI_API_KEY`` win over explicit arguments). The richer ``[api.vllm]``
+precedence and deprecation warnings are introduced in PR 3.
+"""
+
+from __future__ import annotations
+
+import os
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+)
+from chemgraph.models.protocols import openai_compatible
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "openai_compatible"
+
+DUMMY_KEY = "dummy_vllm_key"
+
+# The endpoint may not use a key; a placeholder is accepted. The deprecated
+# OPENAI_API_KEY fallback is applied explicitly below (the one sanctioned
+# cross-provider credential exception).
+VLLM_CREDENTIAL = CredentialPolicy(
+    env_var="VLLM_API_KEY",
+    required=False,
+    placeholder=DUMMY_KEY,
+)
+
+
+def resolve_base_url(request: ModelRequest) -> str | None:
+    """Resolve the custom endpoint URL (env-first, matching current behavior)."""
+    return os.getenv("VLLM_BASE_URL", request.base_url or "") or None
+
+
+def resolve_api_key(request: ModelRequest) -> str:
+    """Resolve the key: OPENAI_API_KEY (deprecated) -> explicit -> dummy."""
+    return os.getenv("OPENAI_API_KEY", request.api_key or DUMMY_KEY)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a custom OpenAI-compatible endpoint for an unknown model."""
+    base_url = resolve_base_url(request)
+    if not base_url:
+        raise ValueError(
+            f"Unsupported model or missing base URL for: {request.model}"
+        )
+    api_key = resolve_api_key(request)
+
+    logger.info(
+        "Attempting to load model '%s' from custom endpoint: %s",
+        request.model,
+        base_url,
+    )
+    client_kwargs = dict(
+        model=request.model,
+        temperature=request.temperature,
+        base_url=base_url,
+        api_key=api_key,
+        max_tokens=4000,
+        top_p=1.0,
+        frequency_penalty=0.0,
+        presence_penalty=0.0,
+    )
+    user = request.argo_user or os.getenv("ARGO_USER")
+    if base_url and "argoapi" in base_url and user:
+        client_kwargs["model_kwargs"] = {"user": user}
+
+    return PreparedModel(
+        endpoint_name="vllm",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+def can_handle(request: ModelRequest) -> bool:
+    """Return True when a custom endpoint URL is available for the fallback."""
+    return resolve_base_url(request) is not None
+
+
+SPEC = EndpointSpec(
+    name="vllm",
+    protocol=PROTOCOL,
+    # Matching is resolved by the loader as a last resort, not by model name.
+    matches=lambda model: False,
+    prepare=prepare,
+    protocol_build=openai_compatible.build,
+    credential=VLLM_CREDENTIAL,
+)

--- a/src/chemgraph/models/gemini.py
+++ b/src/chemgraph/models/gemini.py
@@ -1,12 +1,26 @@
-"""Load Gemini models using LangChain."""
+"""Deprecated compatibility shim for Gemini model loading.
 
-import os
-from getpass import getpass
+Construction now lives in ``chemgraph.models.endpoints.google_direct`` behind
+the Google-native protocol builder. Prefer
+``chemgraph.models.loader.load_chat_model``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
 from langchain_google_genai import ChatGoogleGenerativeAI
-from chemgraph.models.supported_models import supported_gemini_models
+
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import google_direct as _google_direct
 from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
+
+_DEPRECATION = (
+    "load_gemini_model is deprecated; use "
+    "chemgraph.models.loader.load_chat_model instead."
+)
 
 
 def load_gemini_model(
@@ -16,81 +30,9 @@ def load_gemini_model(
     prompt: str = None,
     base_url: str = None,
 ) -> ChatGoogleGenerativeAI:
-    """Load an Gemini chat model into LangChain.
-
-    This function loads an Gemini model and configures it for use with LangChain.
-    It handles API key management, including prompting for the key if not provided
-    or if the provided key is invalid.
-
-    Parameters
-    ----------
-    model_name : str
-        The name of the Gemini chat model to load. See supported_gemini_models for list
-        of supported models.
-    temperature : float
-        Controls the randomness of the generated text. Higher values (e.g., 0.8)
-        make the output more random, while lower values (e.g., 0.2) make it more
-        deterministic.
-    api_key : str, optional
-        The Google API key. If not provided, the function will attempt to retrieve it
-        from the environment variable `GEMINI_API_KEY`.
-    prompt : str, optional
-        Custom prompt to use when requesting the API key from the user.
-
-    Returns
-    -------
-    ChatGoogleGenerativeAI
-        An instance of LangChain's ChatGoogleGenerativeAI model.
-
-    Raises
-    ------
-    ValueError
-        If the model name is not in the list of supported models.
-    Exception
-        If there is an error loading the model or if the API key is invalid.
-
-    Notes
-    -----
-    The function will:
-    1. Check for the API key in the environment variables
-    2. Prompt for the key if not found
-    3. Validate the model name against supported models
-    4. Attempt to load the model
-    5. Handle any authentication errors by prompting for a new key
-    """
-
-    if api_key is None:
-        api_key = os.getenv("GEMINI_API_KEY")
-        if not api_key:
-            logger.info("Google API key not found in environment variables.")
-            api_key = getpass("Please enter your Google API key: ")
-            os.environ["GEMINI_API_KEY"] = api_key
-
-    if model_name not in supported_gemini_models:
-        raise ValueError(
-            f"Unsupported model '{model_name}'. Supported models are: {supported_gemini_models}."
-        )
-
-    try:
-        logger.info(f"Loading Gemini model: {model_name}")
-        llm = ChatGoogleGenerativeAI(
-            model=model_name,
-            temperature=temperature,
-            api_key=api_key,
-            max_output_tokens=6000,
-        )
-        # No guarantee that api_key is valid, authentication happens only during invocation
-        logger.info(f"Requested model: {model_name}")
-        logger.info("Gemini model loaded successfully")
-        return llm
-    except Exception as e:
-        # Can remove this since authentication happens only during invocation
-        if "AuthenticationError" in str(e) or "invalid_api_key" in str(e):
-            logger.warning("Invalid Google API key.")
-            api_key = getpass("Please enter a valid Google API key: ")
-            os.environ["GEMINI_API_KEY"] = api_key
-            # Retry with new API key
-            return load_gemini_model(model_name, temperature, api_key, prompt)
-        else:
-            logger.error(f"Error loading Google model: {str(e)}")
-            raise
+    """Load a Gemini chat model (deprecated). Delegates to the endpoint."""
+    warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
+    request = ModelRequest(
+        model=model_name, temperature=temperature, api_key=api_key, base_url=base_url
+    )
+    return _google_direct.SPEC.build(request)

--- a/src/chemgraph/models/openai.py
+++ b/src/chemgraph/models/openai.py
@@ -1,160 +1,38 @@
-"""Load OpenAI models using LangChain."""
+"""Deprecated compatibility shim for OpenAI / Argo model loading.
 
-import os
-from getpass import getpass
-from urllib.parse import urlparse
+The construction logic now lives in ``chemgraph.models.endpoints.openai_direct``
+and ``chemgraph.models.endpoints.argo`` behind the shared protocol builder.
+Prefer ``chemgraph.models.loader.load_chat_model``.
+
+This module keeps the previous public surface -- ``load_openai_model`` and the
+``_normalize_argo_model`` helper -- for one release.
+"""
+
+from __future__ import annotations
+
+import warnings
 
 from langchain_openai import ChatOpenAI
 
-from chemgraph.models.supported_models import (
-    ARGO_DEFAULT_BASE_URL,
-    MODELS_WITHOUT_TEMPERATURE,
-    MODELS_WITH_REASONING_EFFORT,
-    SUPPORTED_REASONING_EFFORTS,
-    supported_openai_models,
-    supported_argo_models,
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import argo as _argo
+from chemgraph.models.endpoints import openai_direct as _openai_direct
+
+# Re-exported for backward compatibility (tests and external callers import it).
+from chemgraph.models.endpoints.argo import (  # noqa: F401
+    ARGO_LOCAL_OPENAI_MODEL_MAP,
+    ARGO_MODEL_MAP,
+    _normalize_argo_model,
 )
-from chemgraph.utils.config_utils import normalize_openai_base_url
+from chemgraph.models.endpoints.base import is_local_http_endpoint as _is_local_http_endpoint  # noqa: F401
 from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
 
-# Maps user-facing ``argo:`` model names to the internal wire names
-# expected by the Argo API (https://apps.inside.anl.gov/argoapi).
-# When a different endpoint (e.g. ArgoProxy) is used, the ``argo:``
-# prefix is stripped instead and the remainder is sent as-is.
-ARGO_MODEL_MAP = {
-    # GPT family
-    "argo:gpt-4o": "gpt4o",
-    "argo:gpt-4.1": "gpt41",
-    "argo:gpt-4.1-mini": "gpt41mini",
-    "argo:gpt-4.1-nano": "gpt41nano",
-    "argo:gpt-5": "gpt5",
-    "argo:gpt-5-mini": "gpt5mini",
-    "argo:gpt-5-nano": "gpt5nano",
-    "argo:gpt-5.1": "gpt51",
-    "argo:gpt-5.2": "gpt52",
-    "argo:gpt-5.4": "gpt54",
-    "argo:gpt-5.4-mini": "gpt54mini",
-    "argo:gpt-5.4-nano": "gpt54nano",
-    "argo:gpt-5.5": "gpt55",
-    "argo:gpt-5.6-luna": "gpt56luna",
-    "argo:gpt-5.6-sol": "gpt56sol",
-    "argo:gpt-5.6-terra": "gpt56terra",
-
-    # Reasoning / o-series
-    "argo:o1": "gpto1",
-    "argo:o3-mini": "gpto3mini",
-    "argo:o3": "gpto3",
-    "argo:o4-mini": "gpto4mini",
-    # Gemini via Argo
-    "argo:gemini-2.5-pro": "gemini25pro",
-    "argo:gemini-2.5-flash": "gemini25flash",
-    "argo:gemini-3.1-flash-lite": "gemini31flashlite",
-    "argo:gemini-3.5-flash": "gemini35flash",
-    # Claude via Argo
-    "argo:claude-opus-4.6": "claudeopus46",
-    "argo:claude-opus-4.5": "claudeopus45",
-    "argo:claude-opus-4.1": "claudeopus41",
-    "argo:claude-haiku-4.5": "claudehaiku45",
-    "argo:claude-sonnet-5": "claudesonnet5",
-    "argo:claude-sonnet-4.6": "claudesonnet46",
-    "argo:claude-sonnet-4.5": "claudesonnet45",
-}
-
-
-ARGO_LOCAL_OPENAI_MODEL_MAP = {
-    # argo-shim advertises GPT-5.4 with this casing. Lowercase gpt-5.4 is
-    # rejected by the upstream Argo API behind the shim.
-    "argo:gpt-5.4": "GPT-5.4",
-}
-
-
-def _normalize_argo_model(model_name: str, base_url: str) -> str:
-    """Normalize an ``argo:``-prefixed model name for the target endpoint.
-
-    * Hosted Argo API endpoints use internal wire names via
-      ``ARGO_MODEL_MAP``.
-    * Argo shim, ArgoProxy, and custom OpenAI-compatible endpoints strip the
-      ``argo:`` prefix and keep the OpenAI-style name.
-
-    Parameters
-    ----------
-    model_name : str
-        Requested model identifier.
-    base_url : str
-        Endpoint base URL used to choose normalization behavior.
-
-    Returns
-    -------
-    str
-        Endpoint-specific model name.
-    """
-    if not model_name.startswith("argo:"):
-        return model_name
-
-    model_format = os.getenv("CHEMGRAPH_ARGO_MODEL_FORMAT", "").lower()
-    if model_format == "shim":
-        return _normalize_argo_local_openai_model(model_name)
-    if model_format in {"openai", "openai-compatible"}:
-        stripped = model_name.removeprefix("argo:")
-        logger.info("Stripped argo: prefix '%s' -> '%s'", model_name, stripped)
-        return stripped
-    if model_format in {"wire", "argo"}:
-        return _normalize_argo_wire_model(model_name)
-
-    if _is_local_http_endpoint(base_url):
-        stripped = _normalize_argo_local_openai_model(model_name)
-        logger.info(
-            "Using OpenAI-style Argo model for local endpoint '%s': '%s' -> '%s'",
-            base_url,
-            model_name,
-            stripped,
-        )
-        return stripped
-
-    if base_url and "argoapi" in base_url:
-        return _normalize_argo_wire_model(model_name)
-    else:
-        # Non-Argo-API endpoint -- strip prefix only
-        stripped = model_name.removeprefix("argo:")
-        logger.info("Stripped argo: prefix '%s' -> '%s'", model_name, stripped)
-        return stripped
-
-
-def _normalize_argo_local_openai_model(model_name: str) -> str:
-    """Return the model name expected by local OpenAI-compatible Argo shims."""
-    return ARGO_LOCAL_OPENAI_MODEL_MAP.get(
-        model_name,
-        model_name.removeprefix("argo:"),
-    )
-
-
-def _normalize_argo_wire_model(model_name: str) -> str:
-    """Return the hosted-Argo wire model for an ``argo:`` model name."""
-    normalized = ARGO_MODEL_MAP.get(model_name)
-    if normalized:
-        logger.info("Normalized Argo model '%s' -> '%s'", model_name, normalized)
-        return normalized
-
-    fallback = model_name.removeprefix("argo:").replace("-", "").replace(".", "")
-    logger.info(
-        "Normalized Argo model '%s' -> '%s' (fallback)", model_name, fallback
-    )
-    return fallback
-
-
-def _is_local_http_endpoint(base_url: str | None) -> bool:
-    """Return True for local HTTP endpoints such as ``argo-shim``."""
-    if not base_url:
-        return False
-    parsed = urlparse(base_url)
-    return parsed.scheme == "http" and parsed.hostname in {
-        "localhost",
-        "127.0.0.1",
-        "::1",
-        "0.0.0.0",
-    }
+_DEPRECATION = (
+    "load_openai_model is deprecated; use "
+    "chemgraph.models.loader.load_chat_model instead."
+)
 
 
 def load_openai_model(
@@ -166,176 +44,20 @@ def load_openai_model(
     argo_user: str = None,
     reasoning_effort: str = None,
 ) -> ChatOpenAI:
-    """Load an OpenAI chat model into LangChain.
+    """Load an OpenAI or Argo chat model (deprecated).
 
-    This function loads an OpenAI model and configures it for use with LangChain.
-    It handles API key management, including prompting for the key if not provided
-    or if the provided key is invalid.
-
-    Parameters
-    ----------
-    model_name : str
-        The name of the OpenAI chat model to load. See supported_openai_models for list
-        of supported models.
-    temperature : float
-        Controls the randomness of the generated text. Higher values (e.g., 0.8)
-        make the output more random, while lower values (e.g., 0.2) make it more
-        deterministic.
-    api_key : str, optional
-        The OpenAI API key. If not provided, the function will attempt to retrieve it
-        from the environment variable `OPENAI_API_KEY`.
-    prompt : str, optional
-        Custom prompt to use when requesting the API key from the user.
-    reasoning_effort : str, optional
-        Reasoning effort for manually verified models that support it.
-
-    Returns
-    -------
-    ChatOpenAI
-        An instance of LangChain's ChatOpenAI model.
-
-    Raises
-    ------
-    ValueError
-        If the model name is not in the list of supported models.
-    Exception
-        If there is an error loading the model or if the API key is invalid.
-
-    Notes
-    -----
-    The function will:
-    1. Check for the API key in the environment variables
-    2. Prompt for the key if not found
-    3. Validate the model name against supported models
-    4. Attempt to load the model
-    5. Handle any authentication errors by prompting for a new key
+    Delegates to the ``openai_direct`` or ``argo`` endpoint depending on the
+    model name. The signature is preserved for backward compatibility.
     """
+    warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
 
-    requested_model_name = model_name
-    base_url = normalize_openai_base_url(base_url)
-
-    if reasoning_effort is not None:
-        if requested_model_name not in MODELS_WITH_REASONING_EFFORT:
-            raise ValueError(
-                f"Model '{requested_model_name}' does not have verified "
-                "reasoning-effort support."
-            )
-        if reasoning_effort not in SUPPORTED_REASONING_EFFORTS:
-            supported = ", ".join(sorted(SUPPORTED_REASONING_EFFORTS))
-            raise ValueError(
-                f"Unsupported reasoning effort '{reasoning_effort}'. "
-                f"Choose one of: {supported}."
-            )
-
-    # Apply default Argo base URL for argo: models when none is specified.
-    if model_name.startswith("argo:") and not base_url:
-        base_url = ARGO_DEFAULT_BASE_URL
-        logger.info("Using default Argo base URL: %s", base_url)
-
-    if api_key is None:
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            if model_name.startswith("argo:"):
-                # Argo API authenticates via the 'user' field, not an API key.
-                # Use argo_user as a placeholder since ChatOpenAI requires a value.
-                api_key = argo_user or os.getenv("ARGO_USER", "chemgraph")
-            else:
-                logger.warning("OPENAI_API_KEY not found in environment variables.")
-                print("OPENAI_API_KEY not set. Please enter your OpenAI API key.")
-                api_key = getpass("OpenAI API key: ")
-                os.environ["OPENAI_API_KEY"] = api_key
-
-    if (
-        model_name not in supported_openai_models
-        and model_name not in supported_argo_models
-    ):
-        raise ValueError(
-            f"Unsupported model '{model_name}'. "
-            f"Supported models are: {supported_openai_models}."
-        )
-
-    is_argo_claude_model = model_name.startswith("argo:claude-")
-    is_argo_endpoint = bool(base_url and "argoapi" in base_url)
-    argo_user = (
-        argo_user or os.getenv("ARGO_USER", "chemgraph")
-        if is_argo_endpoint
-        else None
+    request = ModelRequest(
+        model=model_name,
+        temperature=temperature,
+        base_url=base_url,
+        api_key=api_key,
+        argo_user=argo_user,
+        reasoning_effort=reasoning_effort,
     )
-
-    try:
-        if base_url is not None:
-            logger.info(f"Using custom base URL: {base_url}")
-            model_name = _normalize_argo_model(model_name, base_url)
-            llm_kwargs = dict(
-                model=model_name,
-                api_key=api_key,
-                base_url=base_url,
-                max_tokens=4000,
-            )
-            if requested_model_name in MODELS_WITHOUT_TEMPERATURE:
-                logger.info(
-                    "Using minimal request parameters for model '%s'",
-                    requested_model_name,
-                )
-            else:
-                llm_kwargs.update(
-                    temperature=temperature,
-                    top_p=1.0,
-                    frequency_penalty=0.0,
-                    presence_penalty=0.0,
-                )
-            if reasoning_effort is not None:
-                llm_kwargs["reasoning_effort"] = reasoning_effort
-            # Anthropic requires streaming for requests that may exceed its
-            # non-streaming duration limit. LangChain still aggregates the
-            # chunks into one response for callers using ``invoke``.
-            if is_argo_claude_model:
-                llm_kwargs["streaming"] = True
-            # Argo gateways may require an explicit "user" field in payload.
-            if is_argo_endpoint and argo_user:
-                llm_kwargs["model_kwargs"] = {"user": argo_user}
-                logger.info(
-                    "Using Argo user from config/ARGO_USER/default: %s", argo_user
-                )
-            llm = ChatOpenAI(**llm_kwargs)
-        else:
-            logger.info(f"Loading OpenAI model: {model_name}")
-            openai_kwargs = dict(
-                model=model_name,
-                api_key=api_key,
-                max_tokens=6000,
-            )
-            if requested_model_name in MODELS_WITHOUT_TEMPERATURE:
-                logger.info(
-                    "Using minimal request parameters for model '%s'",
-                    requested_model_name,
-                )
-            else:
-                openai_kwargs["temperature"] = temperature
-            if reasoning_effort is not None:
-                openai_kwargs["reasoning_effort"] = reasoning_effort
-            llm = ChatOpenAI(**openai_kwargs)
-        # Authentication happens only during invocation.
-        logger.info(f"Requested model: {model_name}")
-        logger.info("OpenAI model loaded successfully")
-        return llm
-    except Exception as e:
-        # Can remove this since authentication happens only during invocation
-        if "AuthenticationError" in str(e) or "invalid_api_key" in str(e):
-            logger.warning("Invalid OpenAI API key.")
-            print("The provided OpenAI API key is invalid. Please enter a valid key.")
-            api_key = getpass("OpenAI API key: ")
-            os.environ["OPENAI_API_KEY"] = api_key
-            # Retry with new API key
-            return load_openai_model(
-                requested_model_name,
-                temperature,
-                api_key,
-                prompt,
-                base_url,
-                argo_user,
-                reasoning_effort,
-            )
-        else:
-            logger.error(f"Error loading OpenAI model: {str(e)}")
-            raise
+    endpoint = _argo.SPEC if model_name.startswith("argo:") else _openai_direct.SPEC
+    return endpoint.build(request)

--- a/src/chemgraph/models/openrouter.py
+++ b/src/chemgraph/models/openrouter.py
@@ -1,24 +1,33 @@
-"""Load OpenRouter models using LangChain's OpenAI-compatible client."""
+"""Deprecated compatibility shim for OpenRouter model loading.
 
-import os
-import sys
-from getpass import getpass
+Construction now lives in ``chemgraph.models.endpoints.openrouter`` behind the
+shared OpenAI-compatible protocol builder. Prefer
+``chemgraph.models.loader.load_chat_model``.
+
+``OPENROUTER_DEFAULT_MAX_TOKENS`` is re-exported for one release.
+"""
+
+from __future__ import annotations
+
+import warnings
 
 from langchain_openai import ChatOpenAI
 
-from chemgraph.models.supported_models import (
-    MODELS_WITHOUT_TEMPERATURE,
-    OPENROUTER_DEFAULT_BASE_URL,
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import openrouter as _openrouter
+
+# Re-exported for backward compatibility.
+from chemgraph.models.endpoints.openrouter import (  # noqa: F401
+    OPENROUTER_DEFAULT_MAX_TOKENS,
 )
 from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
 
-# Higher than the OpenAI/Groq defaults on purpose: most models served through
-# OpenRouter emit reasoning tokens by default, and those count against the
-# *completion* budget. Too small a cap lets chain-of-thought exhaust it before
-# the tool call is emitted, producing an empty turn the graph reads as a dead end.
-OPENROUTER_DEFAULT_MAX_TOKENS = 8000
+_DEPRECATION = (
+    "load_openrouter_model is deprecated; use "
+    "chemgraph.models.loader.load_chat_model instead."
+)
 
 
 def load_openrouter_model(
@@ -28,72 +37,12 @@ def load_openrouter_model(
     base_url: str = None,
     max_tokens: int = OPENROUTER_DEFAULT_MAX_TOKENS,
 ) -> ChatOpenAI:
-    """Load an OpenRouter chat model into LangChain.
-
-    OpenRouter exposes an OpenAI-compatible API, so this returns a
-    ``ChatOpenAI`` pointed at the OpenRouter endpoint. Any slug from
-    https://openrouter.ai/models works; ``supported_openrouter_models`` is a
-    discovery list, not a gate.
-
-    Parameters
-    ----------
-    model_name : str
-        Model identifier with the ``openrouter:`` prefix. The prefix is
-        stripped and the remainder sent verbatim (e.g. ``moonshotai/kimi-k3``).
-    temperature : float
-        Sampling temperature. Omitted for ``MODELS_WITHOUT_TEMPERATURE`` entries.
-    api_key : str, optional
-        Falls back to ``OPENROUTER_API_KEY``. Never to ``OPENAI_API_KEY``.
-    base_url : str, optional
-        Endpoint override. Defaults to ``OPENROUTER_DEFAULT_BASE_URL``.
-    max_tokens : int
-        Completion-token budget. See ``OPENROUTER_DEFAULT_MAX_TOKENS``.
-
-    Returns
-    -------
-    ChatOpenAI
-        A LangChain chat model bound to the OpenRouter endpoint.
-
-    Raises
-    ------
-    ValueError
-        If no API key is available and there is no terminal to prompt on.
-    """
-    # Keep the prefixed name -- it is what the quirk sets are keyed on.
-    requested_model_name = model_name
-    model_name = model_name.removeprefix("openrouter:")
-
-    if api_key is None:
-        api_key = os.getenv("OPENROUTER_API_KEY")
-    if not api_key:
-        # Only prompt when there is a terminal. Under the eval harness
-        # (nohup/cron) getpass() would not fail -- it would block on stdin
-        # forever, with no traceback and no exit code.
-        if sys.stdin.isatty():
-            logger.info("OpenRouter API key not found in environment variables.")
-            api_key = getpass("Please enter your OpenRouter API key: ")
-            os.environ["OPENROUTER_API_KEY"] = api_key
-        else:
-            raise ValueError(
-                "OpenRouter API key not found. Set the OPENROUTER_API_KEY "
-                "environment variable:\n"
-                "  export OPENROUTER_API_KEY='your_key_here'\n"
-                "  Get a key at: https://openrouter.ai/keys"
-            )
-
-    logger.info("Loading OpenRouter model: %s", model_name)
-    llm_kwargs = dict(
+    """Load an OpenRouter chat model (deprecated). Delegates to the endpoint."""
+    warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
+    request = ModelRequest(
         model=model_name,
+        temperature=temperature,
         api_key=api_key,
-        base_url=base_url or OPENROUTER_DEFAULT_BASE_URL,
-        max_tokens=max_tokens,
+        base_url=base_url,
     )
-    # top_p / frequency_penalty / presence_penalty are deliberately not sent:
-    # they are no-ops at temperature 0, and OpenRouter fans requests out to a
-    # rotating pool of upstream providers whose real parameter support is
-    # narrower than the advertised union.
-    if requested_model_name not in MODELS_WITHOUT_TEMPERATURE:
-        llm_kwargs["temperature"] = temperature
-
-    # Authentication happens only during invocation.
-    return ChatOpenAI(**llm_kwargs)
+    return _openrouter.SPEC.build(request)

--- a/src/chemgraph/models/protocols/__init__.py
+++ b/src/chemgraph/models/protocols/__init__.py
@@ -1,0 +1,6 @@
+"""Protocol builders: the sole construction sites for LangChain chat clients.
+
+Each protocol module owns exactly one client class. Endpoints prepare fully
+formed keyword arguments and hand them here; these builders add no
+endpoint-specific logic.
+"""

--- a/src/chemgraph/models/protocols/anthropic_native.py
+++ b/src/chemgraph/models/protocols/anthropic_native.py
@@ -1,0 +1,12 @@
+"""The only production construction site for ``ChatAnthropic``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_anthropic import ChatAnthropic
+
+
+def build(client_kwargs: dict[str, Any]) -> ChatAnthropic:
+    """Construct a ``ChatAnthropic`` from prepared keyword arguments."""
+    return ChatAnthropic(**client_kwargs)

--- a/src/chemgraph/models/protocols/google_native.py
+++ b/src/chemgraph/models/protocols/google_native.py
@@ -1,0 +1,12 @@
+"""The only production construction site for ``ChatGoogleGenerativeAI``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+
+def build(client_kwargs: dict[str, Any]) -> ChatGoogleGenerativeAI:
+    """Construct a ``ChatGoogleGenerativeAI`` from prepared keyword arguments."""
+    return ChatGoogleGenerativeAI(**client_kwargs)

--- a/src/chemgraph/models/protocols/openai_compatible.py
+++ b/src/chemgraph/models/protocols/openai_compatible.py
@@ -1,0 +1,17 @@
+"""The only production construction site for ``ChatOpenAI``.
+
+Every OpenAI-compatible endpoint (OpenAI direct, both Argo variants, all three
+ALCF clusters, OpenRouter, and vLLM/custom endpoints) reaches this builder. It
+receives fully prepared kwargs and applies no endpoint-specific conditions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+
+
+def build(client_kwargs: dict[str, Any]) -> ChatOpenAI:
+    """Construct a ``ChatOpenAI`` from prepared keyword arguments."""
+    return ChatOpenAI(**client_kwargs)

--- a/tests/test_endpoints_route_matrix.py
+++ b/tests/test_endpoints_route_matrix.py
@@ -1,0 +1,240 @@
+"""Route-matrix parity tests for the endpoint × protocol layer (PR 1).
+
+Each case exercises an endpoint's ``prepare`` directly and asserts the resolved
+endpoint name, protocol, base URL, wire model name, credential source, and
+final client kwargs. These lock in behavior parity with the pre-refactor
+provider loaders before the loader and agent are migrated in PR 2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import alcf as alcf_ep
+from chemgraph.models.endpoints import anthropic_direct as anthropic_ep
+from chemgraph.models.endpoints import argo as argo_ep
+from chemgraph.models.endpoints import google_direct as google_ep
+from chemgraph.models.endpoints import openai_direct as openai_ep
+from chemgraph.models.endpoints import openrouter as openrouter_ep
+from chemgraph.models.endpoints import vllm as vllm_ep
+from chemgraph.models.supported_models import (
+    ALCF_DEFAULT_BASE_URL,
+    ALCF_METIS_BASE_URL,
+    ALCF_MINERVA_BASE_URL,
+    ARGO_DEFAULT_BASE_URL,
+    OPENROUTER_DEFAULT_BASE_URL,
+)
+
+ARGO_HOSTED_URL = "https://apps.inside.anl.gov/argoapi/v1"
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    """Isolate credential/URL resolution from the developer's environment."""
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "ALCF_ACCESS_TOKEN",
+        "OPENROUTER_API_KEY",
+        "VLLM_API_KEY",
+        "VLLM_BASE_URL",
+        "ARGO_USER",
+        "CHEMGRAPH_ARGO_MODEL_FORMAT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# --- Direct OpenAI ---------------------------------------------------------
+
+
+def test_openai_direct_route():
+    prepared = openai_ep.prepare(
+        ModelRequest(model="gpt-4o", temperature=0.0, api_key="sk-explicit")
+    )
+    assert prepared.endpoint_name == "openai_direct"
+    assert prepared.protocol == "openai_compatible"
+    assert prepared.supports_structured_output is True
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "gpt-4o"
+    assert kwargs["api_key"] == "sk-explicit"
+    assert "base_url" not in kwargs  # plain OpenAI shape
+    assert kwargs["max_tokens"] == 6000
+    assert kwargs["temperature"] == 0.0
+
+
+def test_openai_direct_rejects_unknown_model():
+    with pytest.raises(ValueError, match="Unsupported model"):
+        openai_ep.prepare(ModelRequest(model="not-a-real-model", api_key="k"))
+
+
+# --- Argo hosted (wire names) ----------------------------------------------
+
+
+def test_argo_hosted_route_uses_wire_name_and_user_payload():
+    prepared = argo_ep.prepare(
+        ModelRequest(model="argo:gpt-4o", base_url=ARGO_HOSTED_URL, argo_user="alice")
+    )
+    assert prepared.endpoint_name == "argo"
+    assert prepared.protocol == "openai_compatible"
+    assert prepared.supports_structured_output is False
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "gpt4o"  # wire name
+    assert kwargs["base_url"] == ARGO_HOSTED_URL
+    assert kwargs["model_kwargs"] == {"user": "alice"}
+    assert kwargs["max_tokens"] == 4000
+
+
+def test_argo_defaults_base_url_when_absent():
+    prepared = argo_ep.prepare(ModelRequest(model="argo:gpt-4o"))
+    assert prepared.client_kwargs["base_url"] == ARGO_DEFAULT_BASE_URL
+
+
+def test_argo_claude_model_streams():
+    prepared = argo_ep.prepare(
+        ModelRequest(model="argo:claude-sonnet-4.6", base_url=ARGO_HOSTED_URL)
+    )
+    assert prepared.client_kwargs["streaming"] is True
+
+
+def test_argo_minimal_parameter_model_omits_sampling():
+    prepared = argo_ep.prepare(
+        ModelRequest(model="argo:gpt-5", base_url=ARGO_HOSTED_URL)
+    )
+    kwargs = prepared.client_kwargs
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+
+
+# --- Argo compatible (shim/proxy, prefix stripped) -------------------------
+
+
+def test_argo_compatible_route_strips_prefix_for_local_shim():
+    prepared = argo_ep.prepare(
+        ModelRequest(model="argo:gpt-4.1-mini", base_url="http://localhost:8080/v1")
+    )
+    # A non-argoapi custom endpoint keeps the OpenAI-style name (prefix
+    # stripped) and does not attach a hosted-Argo user payload.
+    assert prepared.client_kwargs["model"] == "gpt-4.1-mini"
+    assert "model_kwargs" not in prepared.client_kwargs
+
+
+# --- ALCF three clusters ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model, expected_url, expected_wire",
+    [
+        (
+            "alcf:meta-llama/Llama-3.3-70B-Instruct",
+            ALCF_DEFAULT_BASE_URL,
+            "meta-llama/Llama-3.3-70B-Instruct",
+        ),
+        ("alcf:nemotron-3-ultra", ALCF_MINERVA_BASE_URL, "nemotron-3-ultra"),
+        (
+            "alcf:Mistral-Large-3-675B-Instruct-2512",
+            ALCF_METIS_BASE_URL,
+            "Mistral-Large-3-675B-Instruct-2512",
+        ),
+    ],
+)
+def test_alcf_cluster_routing(model, expected_url, expected_wire):
+    prepared = alcf_ep.prepare(ModelRequest(model=model, api_key="tok"))
+    assert prepared.endpoint_name == "alcf"
+    assert prepared.client_kwargs["base_url"] == expected_url
+    assert prepared.client_kwargs["model"] == expected_wire
+    assert prepared.client_kwargs["api_key"] == "tok"
+
+
+def test_alcf_requires_token():
+    with pytest.raises(ValueError, match="ALCF access token not found"):
+        alcf_ep.prepare(ModelRequest(model="alcf:nemotron-3-ultra"))
+
+
+# --- OpenRouter -------------------------------------------------------------
+
+
+def test_openrouter_curated_route():
+    prepared = openrouter_ep.prepare(
+        ModelRequest(model="openrouter:moonshotai/kimi-k3", api_key="or-key")
+    )
+    assert prepared.endpoint_name == "openrouter"
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "moonshotai/kimi-k3"  # prefix stripped, slug verbatim
+    assert kwargs["base_url"] == OPENROUTER_DEFAULT_BASE_URL
+    assert kwargs["max_tokens"] == 8000
+    assert "top_p" not in kwargs  # restricted optional params
+
+
+def test_openrouter_uncurated_slug_still_resolves():
+    prepared = openrouter_ep.prepare(
+        ModelRequest(model="openrouter:some/unknown-model", api_key="or-key")
+    )
+    assert prepared.client_kwargs["model"] == "some/unknown-model"
+
+
+def test_openrouter_never_uses_openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+    with pytest.raises(ValueError, match="OpenRouter API key not found"):
+        openrouter_ep.prepare(ModelRequest(model="openrouter:moonshotai/kimi-k3"))
+
+
+# --- Anthropic / Gemini direct ---------------------------------------------
+
+
+def test_anthropic_direct_route():
+    prepared = anthropic_ep.prepare(
+        ModelRequest(model="claude-3-5-sonnet-20241022", api_key="ak")
+    )
+    assert prepared.endpoint_name == "anthropic_direct"
+    assert prepared.protocol == "anthropic_native"
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "claude-3-5-sonnet-20241022"
+    assert kwargs["api_key"] == "ak"
+    assert kwargs["max_tokens"] == 6000
+
+
+def test_google_direct_route():
+    prepared = google_ep.prepare(
+        ModelRequest(model="gemini-2.5-pro", api_key="gk")
+    )
+    assert prepared.endpoint_name == "google_direct"
+    assert prepared.protocol == "google_native"
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "gemini-2.5-pro"
+    assert kwargs["max_output_tokens"] == 6000
+
+
+# --- vLLM / custom fallback -------------------------------------------------
+
+
+def test_vllm_route_with_configured_base_url():
+    prepared = vllm_ep.prepare(
+        ModelRequest(model="my-local-model", base_url="http://localhost:8000/v1")
+    )
+    assert prepared.endpoint_name == "vllm"
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "my-local-model"
+    assert kwargs["base_url"] == "http://localhost:8000/v1"
+    assert kwargs["api_key"] == "dummy_vllm_key"  # placeholder when no key set
+
+
+def test_vllm_without_endpoint_raises():
+    with pytest.raises(ValueError, match="missing base URL"):
+        vllm_ep.prepare(ModelRequest(model="my-local-model"))
+
+
+def test_vllm_can_handle_reflects_configured_url(monkeypatch):
+    assert vllm_ep.can_handle(ModelRequest(model="x")) is False
+    monkeypatch.setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+    assert vllm_ep.can_handle(ModelRequest(model="x")) is True
+
+
+# --- Credential precedence --------------------------------------------------
+
+
+def test_explicit_key_overrides_environment(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    prepared = openai_ep.prepare(ModelRequest(model="gpt-4o", api_key="sk-explicit"))
+    assert prepared.client_kwargs["api_key"] == "sk-explicit"

--- a/tests/test_protocol_construction_guard.py
+++ b/tests/test_protocol_construction_guard.py
@@ -1,0 +1,40 @@
+"""Guard: chat clients are constructed only in the protocol builders.
+
+After PR 1, no module under ``chemgraph/models`` may construct ``ChatOpenAI``,
+``ChatAnthropic``, or ``ChatGoogleGenerativeAI`` except the corresponding
+``protocols/*`` builder. (Agent-layer call sites in ``chemgraph/agent`` are
+migrated in PR 2 and are intentionally out of scope for this guard.)
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+MODELS_DIR = pathlib.Path(__file__).resolve().parents[1] / "src" / "chemgraph" / "models"
+
+# Each client class may be constructed only in its designated builder file.
+ALLOWED = {
+    "ChatOpenAI(": "protocols/openai_compatible.py",
+    "ChatAnthropic(": "protocols/anthropic_native.py",
+    "ChatGoogleGenerativeAI(": "protocols/google_native.py",
+}
+
+
+def _offenders(needle: str, allowed_rel: str) -> list[str]:
+    allowed = (MODELS_DIR / allowed_rel).resolve()
+    hits: list[str] = []
+    for path in MODELS_DIR.rglob("*.py"):
+        if path.resolve() == allowed:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if needle in line:
+                hits.append(f"{path.relative_to(MODELS_DIR)}:{lineno}: {line.strip()}")
+    return hits
+
+
+def test_no_direct_client_construction_in_models():
+    problems: list[str] = []
+    for needle, allowed_rel in ALLOWED.items():
+        problems.extend(_offenders(needle, allowed_rel))
+    assert not problems, "Unexpected direct client construction:\n" + "\n".join(problems)


### PR DESCRIPTION
## Summary

First of three PRs for #201. Introduces a **protocol × endpoint** architecture for model loading so every caller can eventually follow one pipeline:

```
caller → load_chat_model → endpoint spec → protocol builder → client
```

This PR builds the new layer and proves behavior parity. The central loader and agent callers are migrated in PR 2; config/auth cleanup lands in PR 3.

## What changed

**New `models/protocols/`** — the only construction sites for LangChain clients:
- `openai_compatible.py` (sole `ChatOpenAI`), `anthropic_native.py` (sole `ChatAnthropic`), `google_native.py` (sole `ChatGoogleGenerativeAI`).

**New `models/endpoints/`**:
- `base.py` — internal types `ModelRequest`, `CredentialPolicy`, `EndpointSpec`, `PreparedModel` + shared `resolve_api_key` / `is_local_http_endpoint`.
- One spec per endpoint: `openai_direct`, `argo` (hosted + shim), `alcf` (sophia/minerva/metis), `openrouter`, `vllm`, `anthropic_direct`, `google_direct`. Logic **moved verbatim** from the previous provider loaders.

**Root modules → deprecated shims** (`openai.py`, `anthropic.py`, `gemini.py`, `alcf_endpoints.py`, `openrouter.py`): identical signatures, delegate to the endpoints, emit `DeprecationWarning`, and keep re-exporting their helpers for one release.

## Scope / non-goals for this PR
- **No caller behavior changes.** `loader.py`, `ChemGraph.__init__`, and `run_turn` are untouched here; the two remaining `ChatOpenAI(` sites in `agent/` are migrated in PR 2.
- Academy is out of scope (it inherits the loader via `LLMSettings`).

## Testing
- `ruff check` clean on all new/changed files.
- New `tests/test_endpoints_route_matrix.py` (21 cases across every endpoint) and `tests/test_protocol_construction_guard.py` (no direct construction under `models/` outside `protocols/`).
- Parity: existing `test_openai_model_normalization.py`, `test_alcf_base_url.py`, `test_openrouter_provider.py` all still pass through the shims. 128 model/agent tests green.
- Real-LLM smoke (optional): `pytest tests/test_run_agent.py --run-llm` with a live key exercises shims → endpoints → protocol builders.