### PR TITLE
Single loader + agent migration (#201, PR 2)

### DIFF
--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -18,24 +18,10 @@ from chemgraph.memory.schemas import (
     SessionMessage,
 )
 from chemgraph.memory.subagent_recorder import SubagentRunRecorder
-from chemgraph.models.openai import load_openai_model
-from chemgraph.models.alcf_endpoints import load_alcf_model
-from chemgraph.models.local_model import load_ollama_model
-from chemgraph.models.anthropic import load_anthropic_model
-from chemgraph.models.gemini import load_gemini_model
-from chemgraph.models.groq import load_groq_model
-from chemgraph.models.openrouter import load_openrouter_model
-from chemgraph.models.codex import load_codex_model
+from chemgraph.models.loader import load_chat_model_prepared
 from chemgraph.models.supported_models import (
     MODELS_WITH_REASONING_EFFORT,
     SUPPORTED_REASONING_EFFORTS,
-    supported_openai_models,
-    supported_ollama_models,
-    supported_anthropic_models,
-    supported_alcf_models,
-    supported_argo_models,
-    supported_gemini_models,
-
 )
 
 from chemgraph.schemas.ase_input import (
@@ -289,93 +275,18 @@ class ChemGraph:
         self._session_title: Optional[str] = None
 
         try:
-            # Use hardcoded optimal values for tool calling
-            temperature = 0.0  # Deterministic responses
-            max_tokens = 4000  # Sufficient for most tasks
-            top_p = 1.0  # No nucleus sampling filtering
-            frequency_penalty = 0.0  # No repetition penalty
-            presence_penalty = 0.0  # No presence penalty
-
-            if model_name.startswith("codex:"):
-                llm = load_codex_model(model_name)
-            elif model_name.startswith("openrouter:"):
-                llm = load_openrouter_model(
-                    model_name=model_name,
-                    api_key=api_key,
-                    base_url=base_url,
-                    temperature=temperature,
-                )
-            elif (
-                model_name in supported_openai_models
-                or model_name in supported_argo_models
-            ):
-                openai_load_kwargs = {
-                    "model_name": model_name,
-                    "temperature": temperature,
-                    "base_url": base_url,
-                }
-                if argo_user is not None:
-                    openai_load_kwargs["argo_user"] = argo_user
-                if reasoning_effort is not None:
-                    openai_load_kwargs["reasoning_effort"] = reasoning_effort
-                llm = load_openai_model(
-                    **openai_load_kwargs,
-                )
-            elif model_name in supported_ollama_models:
-                llm = load_ollama_model(model_name=model_name, temperature=temperature)
-            elif model_name in supported_alcf_models:
-                llm = load_alcf_model(
-                    model_name=model_name, base_url=base_url, api_key=api_key
-                )
-            elif model_name in supported_anthropic_models:
-                llm = load_anthropic_model(
-                    model_name=model_name, api_key=api_key, temperature=temperature
-                )
-            elif model_name in supported_gemini_models:
-                llm = load_gemini_model(
-                    model_name=model_name, api_key=api_key, temperature=temperature
-                )
-            elif model_name.startswith("groq:"):
-                llm = load_groq_model(
-                    model_name=model_name, api_key=api_key, temperature=temperature
-                )
-
-            else:  # Assume it might be a vLLM or other custom OpenAI-compatible endpoint
-                # Use environment variables for vLLM base_url and a dummy api_key if not provided
-                # These would be set by docker-compose for the jupyter_lab service
-                vllm_base_url = os.getenv("VLLM_BASE_URL", base_url)
-                # ChatOpenAI requires an api_key, even if the endpoint doesn't use it.
-                vllm_api_key = os.getenv(
-                    "OPENAI_API_KEY", api_key if api_key else "dummy_vllm_key"
-                )
-
-                if vllm_base_url:
-                    logger.info(
-                        f"Attempting to load model '{model_name}' from custom endpoint: {vllm_base_url}"
-                    )
-                    from langchain_openai import ChatOpenAI
-
-                    llm = ChatOpenAI(
-                        model=model_name,
-                        temperature=temperature,
-                        base_url=vllm_base_url,
-                        api_key=vllm_api_key,
-                        max_tokens=max_tokens,
-                        top_p=top_p,
-                        frequency_penalty=frequency_penalty,
-                        presence_penalty=presence_penalty,
-                    )
-                    logger.info(
-                        f"Successfully initialized ChatOpenAI for model '{model_name}' at {vllm_base_url}"
-                    )
-                else:
-                    logger.error(
-                        f"Model '{model_name}' is not in any supported list and no VLLM_BASE_URL/base_url provided."
-                    )
-                    raise ValueError(
-                        f"Unsupported model or missing base URL for: {model_name}"
-                    )
-
+            # Deterministic temperature for tool calling; all other endpoint
+            # defaults (max_tokens, sampling params, custom-endpoint fallback)
+            # are owned by the endpoint specs behind load_chat_model.
+            temperature = 0.0
+            llm, prepared_model = load_chat_model_prepared(
+                model_name=model_name,
+                temperature=temperature,
+                base_url=base_url,
+                api_key=api_key,
+                argo_user=argo_user,
+                reasoning_effort=reasoning_effort,
+            )
         except Exception as e:
             logger.error(f"Exception thrown when loading {model_name}: {str(e)}")
             raise e
@@ -452,7 +363,10 @@ class ChemGraph:
             self.planner_prompt = append_calculator_context(self.planner_prompt)
             self.executor_prompt = append_calculator_context(self.executor_prompt)
 
-        if model_name in supported_argo_models:
+        # Structured-output capability is a resolved endpoint fact (e.g. Argo
+        # endpoints do not support it); read it back from the loader rather than
+        # re-deriving provider membership here.
+        if not prepared_model.supports_structured_output:
             self.support_structured_output = False
         else:
             self.support_structured_output = support_structured_output

--- a/src/chemgraph/agent/turn.py
+++ b/src/chemgraph/agent/turn.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import logging
-import os
 import time
 import uuid
 from typing import Any, Collection
@@ -142,34 +141,6 @@ def serialize_state(state, *, max_depth: int = 50, _seen: set[int] | None = None
     return str(state)
 
 
-def _custom_openai_compatible_kwargs(
-    *,
-    model_name: str,
-    temperature: float,
-    base_url: str,
-    api_key: str,
-    max_tokens: int,
-    top_p: float,
-    frequency_penalty: float,
-    presence_penalty: float,
-    argo_user: str | None,
-) -> dict:
-    kwargs = {
-        "model": model_name,
-        "temperature": temperature,
-        "base_url": base_url,
-        "api_key": api_key,
-        "max_tokens": max_tokens,
-        "top_p": top_p,
-        "frequency_penalty": frequency_penalty,
-        "presence_penalty": presence_penalty,
-    }
-    user = argo_user or os.getenv("ARGO_USER")
-    if base_url and "argoapi" in base_url and user:
-        kwargs["model_kwargs"] = {"user": user}
-    return kwargs
-
-
 @dataclasses.dataclass(frozen=True)
 class TurnResult:
     """Result of one bounded ChemGraph single-agent turn."""
@@ -272,36 +243,17 @@ def _load_turn_llm(
     argo_user: str | None,
 ) -> Any:
     temperature = 0.0
-    try:
-        return load_chat_model(
-            settings=LLMSettings(
-                model=model_name,
-                base_url=base_url,
-                api_key=api_key,
-                argo_user=argo_user,
-                temperature=temperature,
-            ),
-        )
-    except ValueError:
-        pass
-
-    endpoint = os.getenv("VLLM_BASE_URL", base_url or "")
-    key = os.getenv("OPENAI_API_KEY", api_key or "dummy_vllm_key")
-    if not endpoint:
-        raise ValueError(f"Unsupported model or missing base URL for: {model_name}")
-    from langchain_openai import ChatOpenAI
-
-    return ChatOpenAI(
-        **_custom_openai_compatible_kwargs(
-            model_name=model_name,
-            temperature=temperature,
-            base_url=endpoint,
-            api_key=key,
-            max_tokens=4000,
-            top_p=1.0,
-            frequency_penalty=0.0,
-            presence_penalty=0.0,
+    # load_chat_model owns endpoint resolution, including the vLLM/custom
+    # OpenAI-compatible fallback (via the ``vllm`` endpoint). Missing
+    # credentials and invalid recognized-provider settings propagate as their
+    # actual errors rather than being swallowed and retried as a custom endpoint.
+    return load_chat_model(
+        settings=LLMSettings(
+            model=model_name,
+            base_url=base_url,
+            api_key=api_key,
             argo_user=argo_user,
+            temperature=temperature,
         ),
     )
 

--- a/src/chemgraph/models/endpoints/alcf.py
+++ b/src/chemgraph/models/endpoints/alcf.py
@@ -74,14 +74,13 @@ def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a curated ``alcf:`` model, selecting its cluster endpoint."""
     requested_model_name = request.model
 
-    # Resolve access token before validating, matching the previous behavior.
-    api_key = resolve_api_key(ALCF_CREDENTIAL, request.api_key)
-
     if requested_model_name not in supported_alcf_models:
         raise ValueError(
             f"Model '{requested_model_name}' is not supported on ALCF. "
             f"Supported models: {supported_alcf_models}"
         )
+
+    api_key = resolve_api_key(ALCF_CREDENTIAL, request.api_key)
 
     base_url = _resolve_base_url(requested_model_name, request.base_url)
     wire_model = _normalize_alcf_model(requested_model_name)
@@ -99,7 +98,9 @@ def prepare(request: ModelRequest) -> PreparedModel:
 SPEC = EndpointSpec(
     name="alcf",
     protocol=PROTOCOL,
-    matches=lambda model: model in supported_alcf_models,
+    # Reserve the full alcf: namespace so invalid catalog entries fail here
+    # rather than falling through to a configured vLLM/custom endpoint.
+    matches=lambda model: model.startswith(ALCF_MODEL_PREFIX),
     prepare=prepare,
     protocol_build=openai_compatible.build,
     credential=ALCF_CREDENTIAL,

--- a/src/chemgraph/models/endpoints/argo.py
+++ b/src/chemgraph/models/endpoints/argo.py
@@ -1,9 +1,8 @@
-"""Argo endpoints (hosted Argo API and shim/proxy/custom OpenAI-compatible).
+"""Argo endpoints for its Anthropic-native and OpenAI-compatible protocols.
 
-Owns everything Argo-specific: the wire-name maps, ``CHEMGRAPH_ARGO_MODEL_FORMAT``
-handling, localhost detection, prefix removal, Claude streaming, minimal-parameter
-models, Argo ``user`` payload, and the ``supports_structured_output=False``
-capability. All logic is moved verbatim from the previous ``models/openai.py``.
+Claude-prefixed Argo models use Anthropic Messages. Other Argo models use the
+OpenAI-compatible chat-completions interface. This module owns their shared
+wire-name mapping, credential resolution, base URLs, and endpoint quirks.
 """
 
 from __future__ import annotations
@@ -21,9 +20,11 @@ from chemgraph.models.endpoints.openai_direct import (
     assemble_client_kwargs,
     validate_reasoning_effort,
 )
-from chemgraph.models.protocols import openai_compatible
+from chemgraph.models.protocols import anthropic_native, openai_compatible
 from chemgraph.models.supported_models import (
+    ARGO_DEFAULT_ANTHROPIC_BASE_URL,
     ARGO_DEFAULT_BASE_URL,
+    MODELS_WITHOUT_TEMPERATURE,
     supported_argo_models,
 )
 from chemgraph.utils.config_utils import normalize_openai_base_url
@@ -31,7 +32,8 @@ from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
 
-PROTOCOL = "openai_compatible"
+OPENAI_PROTOCOL = "openai_compatible"
+ANTHROPIC_PROTOCOL = "anthropic_native"
 
 ARGO_PREFIX = "argo:"
 
@@ -68,6 +70,10 @@ ARGO_MODEL_MAP = {
     "argo:gemini-3.1-flash-lite": "gemini31flashlite",
     "argo:gemini-3.5-flash": "gemini35flash",
     # Claude via Argo
+    "argo:claude-sonnet-5": "claudesonnet5",
+    "argo:claude-opus-5": "claudeopus5",
+    "argo:claude-opus-4.8": "claudeopus48",
+    "argo:claude-opus-4.7": "claudeopus47",
     "argo:claude-opus-4.6": "claudeopus46",
     "argo:claude-opus-4.5": "claudeopus45",
     "argo:claude-opus-4.1": "claudeopus41",
@@ -83,8 +89,7 @@ ARGO_LOCAL_OPENAI_MODEL_MAP = {
     "argo:gpt-5.4": "GPT-5.4",
 }
 
-# Argo authenticates via the 'user' field, not an API key. A non-empty
-# placeholder is still required because ChatOpenAI demands a value.
+# Argo expects the Argonne username in the client library's API-key field.
 ARGO_CREDENTIAL = CredentialPolicy(env_var="OPENAI_API_KEY", required=False)
 
 
@@ -92,8 +97,8 @@ def _normalize_argo_model(model_name: str, base_url: str | None) -> str:
     """Normalize an ``argo:``-prefixed model name for the target endpoint.
 
     * Hosted Argo API endpoints use internal wire names via ``ARGO_MODEL_MAP``.
-    * Argo shim, ArgoProxy, and custom OpenAI-compatible endpoints strip the
-      ``argo:`` prefix and keep the OpenAI-style name.
+    * Argo shim, ArgoProxy, and custom endpoints strip the ``argo:`` prefix and
+      keep the client-facing model name.
     """
     if not model_name.startswith(ARGO_PREFIX):
         return model_name
@@ -111,7 +116,7 @@ def _normalize_argo_model(model_name: str, base_url: str | None) -> str:
     if is_local_http_endpoint(base_url):
         stripped = _normalize_argo_local_openai_model(model_name)
         logger.info(
-            "Using OpenAI-style Argo model for local endpoint '%s': '%s' -> '%s'",
+            "Using local Argo model for endpoint '%s': '%s' -> '%s'",
             base_url,
             model_name,
             stripped,
@@ -148,7 +153,7 @@ def _normalize_argo_wire_model(model_name: str) -> str:
 
 
 def _resolve_argo_api_key(request: ModelRequest) -> str:
-    """Resolve the value passed as the ChatOpenAI api_key for Argo routes.
+    """Resolve the value passed in the API-key field for Argo routes.
 
     Mirrors the previous ``load_openai_model``: explicit key, else
     ``OPENAI_API_KEY``, else the argo user / ``ARGO_USER`` / ``"chemgraph"``
@@ -162,8 +167,36 @@ def _resolve_argo_api_key(request: ModelRequest) -> str:
     return api_key
 
 
-def prepare(request: ModelRequest) -> PreparedModel:
-    """Prepare an ``argo:`` model for hosted, shim, or custom endpoints."""
+def _normalize_argo_anthropic_base_url(base_url: str | None) -> str:
+    """Return an API root suitable for ``ChatAnthropic``.
+
+    Existing Argo configuration commonly points at the OpenAI-compatible
+    ``/v1`` root (or the legacy resource-chat URL). Normalize those forms and
+    remove the trailing ``/v1`` because ``ChatAnthropic`` appends
+    ``/v1/messages`` itself.
+    """
+    normalized = normalize_openai_base_url(base_url)
+    if not normalized:
+        return ARGO_DEFAULT_ANTHROPIC_BASE_URL
+
+    normalized = normalized.rstrip("/")
+    if normalized.endswith("/v1"):
+        normalized = normalized.removesuffix("/v1")
+    return normalized
+
+
+def is_argo_anthropic_model(model: str) -> bool:
+    """Return whether an Argo model should use Anthropic Messages."""
+    return model.startswith("argo:claude-")
+
+
+def is_argo_openai_model(model: str) -> bool:
+    """Return whether an Argo model should use OpenAI chat completions."""
+    return model.startswith(ARGO_PREFIX) and not is_argo_anthropic_model(model)
+
+
+def prepare_openai(request: ModelRequest) -> PreparedModel:
+    """Prepare a non-Claude ``argo:`` model for OpenAI-compatible transport."""
     requested_model_name = request.model
     base_url = normalize_openai_base_url(request.base_url)
 
@@ -206,19 +239,67 @@ def prepare(request: ModelRequest) -> PreparedModel:
         argo_user_for_model_kwargs=argo_user if is_argo_endpoint else None,
     )
     return PreparedModel(
-        endpoint_name="argo",
-        protocol=PROTOCOL,
+        endpoint_name="argo_openai",
+        protocol=OPENAI_PROTOCOL,
         client_kwargs=client_kwargs,
         reasoning_effort=request.reasoning_effort,
         supports_structured_output=False,
     )
 
 
-SPEC = EndpointSpec(
-    name="argo",
-    protocol=PROTOCOL,
-    matches=lambda model: model.startswith(ARGO_PREFIX),
-    prepare=prepare,
+def prepare_anthropic(request: ModelRequest) -> PreparedModel:
+    """Prepare an Argo Claude model for Anthropic-native transport."""
+    requested_model_name = request.model
+    validate_reasoning_effort(requested_model_name, request.reasoning_effort)
+
+    if requested_model_name not in supported_argo_models:
+        raise ValueError(
+            f"Unsupported model '{requested_model_name}'. "
+            f"Supported models are: {supported_argo_models}."
+        )
+
+    base_url = _normalize_argo_anthropic_base_url(request.base_url)
+    api_key = _resolve_argo_api_key(request)
+    wire_model = _normalize_argo_model(requested_model_name, base_url)
+
+    logger.info("Using Argo Anthropic base URL: %s", base_url)
+    client_kwargs = dict(
+        model=wire_model,
+        api_key=api_key,
+        base_url=base_url,
+        max_tokens=4000,
+        streaming=True,
+    )
+    if requested_model_name not in MODELS_WITHOUT_TEMPERATURE:
+        client_kwargs["temperature"] = request.temperature
+
+    return PreparedModel(
+        endpoint_name="argo_anthropic",
+        protocol=ANTHROPIC_PROTOCOL,
+        client_kwargs=client_kwargs,
+        reasoning_effort=request.reasoning_effort,
+        supports_structured_output=False,
+    )
+
+
+ANTHROPIC_SPEC = EndpointSpec(
+    name="argo_anthropic",
+    protocol=ANTHROPIC_PROTOCOL,
+    matches=is_argo_anthropic_model,
+    prepare=prepare_anthropic,
+    protocol_build=anthropic_native.build,
+    credential=ARGO_CREDENTIAL,
+)
+
+OPENAI_SPEC = EndpointSpec(
+    name="argo_openai",
+    protocol=OPENAI_PROTOCOL,
+    matches=is_argo_openai_model,
+    prepare=prepare_openai,
     protocol_build=openai_compatible.build,
     credential=ARGO_CREDENTIAL,
 )
+
+# Backward compatibility for ``load_openai_model``, whose documented return
+# type remains ChatOpenAI for one release.
+SPEC = OPENAI_SPEC

--- a/src/chemgraph/models/endpoints/argo.py
+++ b/src/chemgraph/models/endpoints/argo.py
@@ -70,7 +70,6 @@ ARGO_MODEL_MAP = {
     "argo:gemini-3.1-flash-lite": "gemini31flashlite",
     "argo:gemini-3.5-flash": "gemini35flash",
     # Claude via Argo
-    "argo:claude-sonnet-5": "claudesonnet5",
     "argo:claude-opus-5": "claudeopus5",
     "argo:claude-opus-4.8": "claudeopus48",
     "argo:claude-opus-4.7": "claudeopus47",

--- a/src/chemgraph/models/endpoints/codex.py
+++ b/src/chemgraph/models/endpoints/codex.py
@@ -1,0 +1,43 @@
+"""Codex endpoint (own-client protocol).
+
+Codex keeps its existing client (``load_codex_model``), which owns ``codex:``
+prefix stripping and ChatGPT subscription authentication. The model is immutable
+once created, so no temperature or sampling parameters are forwarded.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.codex import CODEX_MODEL_PREFIX
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+)
+from chemgraph.models.protocols import codex_native
+
+PROTOCOL = "codex"
+
+# Subscription-backed; authentication is validated inside the loader.
+CODEX_CREDENTIAL = CredentialPolicy(required=False)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a ``codex:`` model. Authentication stays inside the loader."""
+    client_kwargs = dict(model_name=request.model)
+    return PreparedModel(
+        endpoint_name="codex",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="codex",
+    protocol=PROTOCOL,
+    matches=lambda model: model.startswith(CODEX_MODEL_PREFIX),
+    prepare=prepare,
+    protocol_build=codex_native.build,
+    credential=CODEX_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/groq.py
+++ b/src/chemgraph/models/endpoints/groq.py
@@ -1,0 +1,57 @@
+"""Groq endpoint (own-client protocol).
+
+Groq keeps its existing client (``load_groq_model``), which owns ``groq:``
+prefix stripping, ``GROQ_API_KEY`` handling, and retry-on-auth. This spec routes
+``groq:`` models to that loader via the ``groq`` protocol builder.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+)
+from chemgraph.models.protocols import groq_native
+
+PROTOCOL = "groq"
+
+GROQ_PREFIX = "groq:"
+
+# The loader resolves GROQ_API_KEY itself (with an interactive prompt); the
+# policy is declarative metadata for CLI/UI key checks.
+GROQ_CREDENTIAL = CredentialPolicy(
+    env_var="GROQ_API_KEY",
+    required=True,
+    interactive_prompt=True,
+)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a ``groq:`` model. Key handling stays inside the loader."""
+    client_kwargs = dict(
+        model_name=request.model,
+        temperature=request.temperature,
+    )
+    if request.api_key is not None:
+        client_kwargs["api_key"] = request.api_key
+    if request.base_url is not None:
+        client_kwargs["base_url"] = request.base_url
+
+    return PreparedModel(
+        endpoint_name="groq",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="groq",
+    protocol=PROTOCOL,
+    matches=lambda model: model.startswith(GROQ_PREFIX),
+    prepare=prepare,
+    protocol_build=groq_native.build,
+    credential=GROQ_CREDENTIAL,
+)

--- a/src/chemgraph/models/endpoints/ollama.py
+++ b/src/chemgraph/models/endpoints/ollama.py
@@ -1,0 +1,45 @@
+"""Ollama endpoint (own-client protocol).
+
+Ollama keeps its existing client (``load_ollama_model``), which validates the
+requested model against the curated catalog. Local models need no API key.
+"""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+)
+from chemgraph.models.protocols import ollama_native
+from chemgraph.models.supported_models import supported_ollama_models
+
+PROTOCOL = "ollama"
+
+# Local endpoint; no credential required.
+OLLAMA_CREDENTIAL = CredentialPolicy(required=False)
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare a curated Ollama model."""
+    client_kwargs = dict(
+        model_name=request.model,
+        temperature=request.temperature,
+    )
+    return PreparedModel(
+        endpoint_name="ollama",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="ollama",
+    protocol=PROTOCOL,
+    matches=lambda model: model in supported_ollama_models,
+    prepare=prepare,
+    protocol_build=ollama_native.build,
+    credential=OLLAMA_CREDENTIAL,
+)

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -1,30 +1,140 @@
 """Shared model-loading utility for ChemGraph.
 
-Provides a single ``load_chat_model`` function that detects the provider
-for a given model name and returns a LangChain ``BaseChatModel`` instance.
-This avoids duplicating provider-detection logic across the agent and
-evaluation modules.
+Provides a single ``load_chat_model`` function that detects the endpoint for a
+given model name and returns a LangChain ``BaseChatModel`` instance. This is the
+only model-routing entry point; the pipeline is::
+
+    caller -> load_chat_model -> endpoint spec -> protocol builder -> client
+
+Endpoint specs own base URLs, credentials, model-name transforms, defaults, and
+per-model quirks. Protocol builders own the sole client-construction sites.
 """
+
+from __future__ import annotations
 
 from typing import Optional
 
-from chemgraph.models.alcf_endpoints import load_alcf_model
-from chemgraph.models.anthropic import load_anthropic_model
-from chemgraph.models.codex import load_codex_model
-from chemgraph.models.gemini import load_gemini_model
-from chemgraph.models.groq import load_groq_model
-from chemgraph.models.local_model import load_ollama_model
-from chemgraph.models.openai import load_openai_model
-from chemgraph.models.openrouter import load_openrouter_model
+from chemgraph.models.endpoints import ModelRequest, PreparedModel
+from chemgraph.models.endpoints import alcf as alcf_ep
+from chemgraph.models.endpoints import anthropic_direct as anthropic_ep
+from chemgraph.models.endpoints import argo as argo_ep
+from chemgraph.models.endpoints import codex as codex_ep
+from chemgraph.models.endpoints import google_direct as google_ep
+from chemgraph.models.endpoints import groq as groq_ep
+from chemgraph.models.endpoints import ollama as ollama_ep
+from chemgraph.models.endpoints import openai_direct as openai_ep
+from chemgraph.models.endpoints import openrouter as openrouter_ep
+from chemgraph.models.endpoints import vllm as vllm_ep
 from chemgraph.models.settings import LLMSettings
-from chemgraph.models.supported_models import (
-    supported_alcf_models,
-    supported_anthropic_models,
-    supported_argo_models,
-    supported_gemini_models,
-    supported_ollama_models,
-    supported_openai_models,
+
+# Ordered endpoint registry. Resolution preserves the historical dispatch order:
+# codex -> openrouter -> argo -> curated ALCF -> direct OpenAI -> direct
+# Anthropic -> direct Gemini -> Ollama -> groq. Prefix routes (``matches`` on a
+# prefix) run before catalog checks, so names such as ``openrouter:openai/o3``
+# cannot be misclassified. The vLLM/custom fallback is *not* in this list; it is
+# selected only via ``vllm.can_handle`` as a last resort.
+_ENDPOINT_REGISTRY = (
+    codex_ep.SPEC,
+    openrouter_ep.SPEC,
+    argo_ep.SPEC,
+    alcf_ep.SPEC,
+    openai_ep.SPEC,
+    anthropic_ep.SPEC,
+    google_ep.SPEC,
+    ollama_ep.SPEC,
+    groq_ep.SPEC,
 )
+
+
+def _build_request(
+    model_name: str | None,
+    temperature: float,
+    base_url: Optional[str],
+    api_key: Optional[str],
+    argo_user: Optional[str],
+    reasoning_effort: Optional[str],
+    settings: LLMSettings | None,
+) -> ModelRequest:
+    """Resolve explicit arguments and settings into a ``ModelRequest``.
+
+    Settings take precedence over the individual arguments when supplied,
+    preserving the historical behavior of ``load_chat_model``.
+    """
+    if settings is not None:
+        model_name = settings.model
+        base_url = settings.base_url
+        api_key = settings.api_key
+        argo_user = settings.argo_user
+        if settings.temperature is not None:
+            temperature = settings.temperature
+        settings_reasoning = getattr(settings, "reasoning_effort", None)
+        if settings_reasoning is not None:
+            reasoning_effort = settings_reasoning
+
+    if model_name is None:
+        raise ValueError("load_chat_model requires model_name or settings")
+
+    return ModelRequest(
+        model=model_name,
+        temperature=temperature,
+        base_url=base_url,
+        api_key=api_key,
+        argo_user=argo_user,
+        reasoning_effort=reasoning_effort,
+        settings=settings,
+    )
+
+
+def _select_endpoint(request: ModelRequest):
+    """Return the first endpoint spec whose ``matches`` accepts the model.
+
+    Falls back to the vLLM/custom endpoint only when a custom base URL is
+    available. Raises ``ValueError`` for an otherwise unknown model.
+    """
+    for spec in _ENDPOINT_REGISTRY:
+        if spec.matches(request.model):
+            return spec
+
+    if vllm_ep.can_handle(request):
+        return vllm_ep.SPEC
+
+    raise ValueError(
+        f"Model '{request.model}' not found in any supported model list. "
+        "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
+        "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama."
+    )
+
+
+def load_chat_model_prepared(
+    model_name: str | None = None,
+    temperature: float = 0.0,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+    argo_user: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
+    *,
+    settings: LLMSettings | None = None,
+) -> tuple["object", PreparedModel]:
+    """Load a chat model and return it alongside its resolved metadata.
+
+    Returns a ``(client, PreparedModel)`` tuple so callers such as
+    ``ChemGraph`` can read the effective reasoning effort and structured-output
+    capability without re-deriving provider facts. ``load_chat_model`` is the
+    thin wrapper that returns only the client.
+    """
+    request = _build_request(
+        model_name,
+        temperature,
+        base_url,
+        api_key,
+        argo_user,
+        reasoning_effort,
+        settings,
+    )
+    spec = _select_endpoint(request)
+    prepared = spec.prepare(request)
+    client = spec.protocol_build(prepared.client_kwargs)
+    return client, prepared
 
 
 def load_chat_model(
@@ -33,26 +143,29 @@ def load_chat_model(
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
     argo_user: Optional[str] = None,
+    reasoning_effort: Optional[str] = None,
     *,
     settings: LLMSettings | None = None,
 ):
-    """Load a LangChain chat model by provider auto-detection.
+    """Load a LangChain chat model by endpoint auto-detection.
 
     Parameters
     ----------
     model_name : str, optional
-        Model name from any supported provider list.
+        Model name from any supported endpoint.
     temperature : float
         Sampling temperature (default 0.0 for deterministic output).
     base_url : str, optional
-        Provider base URL override.
+        Endpoint base URL override.
     api_key : str, optional
-        API key override (falls back to environment variables).
+        API key override (falls back to endpoint-specific environment variables).
     argo_user : str, optional
         Argo user identifier.
+    reasoning_effort : str, optional
+        Reasoning effort for models that support it (validated per endpoint).
     settings : LLMSettings, optional
         Canonical endpoint settings. When provided, this overrides
-        model_name/base_url/api_key/argo_user.
+        model_name/base_url/api_key/argo_user/reasoning_effort.
 
     Returns
     -------
@@ -62,60 +175,15 @@ def load_chat_model(
     Raises
     ------
     ValueError
-        If the model name is not found in any supported provider list.
+        If the model name is not found in any supported endpoint.
     """
-    if settings is not None:
-        model_name = settings.model
-        base_url = settings.base_url
-        api_key = settings.api_key
-        argo_user = settings.argo_user
-        if settings.temperature is not None:
-            temperature = settings.temperature
-
-    if model_name is None:
-        raise ValueError("load_chat_model requires model_name or settings")
-
-    if model_name.startswith("codex:"):
-        return load_codex_model(model_name)
-    elif model_name.startswith("openrouter:"):
-        return load_openrouter_model(
-            model_name=model_name,
-            api_key=api_key,
-            base_url=base_url,
-            temperature=temperature,
-        )
-    elif model_name in supported_openai_models or model_name in supported_argo_models:
-        kwargs = {
-            "model_name": model_name,
-            "temperature": temperature,
-            "base_url": base_url,
-        }
-        if api_key is not None:
-            kwargs["api_key"] = api_key
-        if argo_user is not None:
-            kwargs["argo_user"] = argo_user
-        return load_openai_model(**kwargs)
-    elif model_name in supported_ollama_models:
-        return load_ollama_model(model_name=model_name, temperature=temperature)
-    elif model_name in supported_alcf_models:
-        return load_alcf_model(
-            model_name=model_name, base_url=base_url, api_key=api_key
-        )
-    elif model_name in supported_anthropic_models:
-        return load_anthropic_model(
-            model_name=model_name, api_key=api_key, temperature=temperature
-        )
-    elif model_name in supported_gemini_models:
-        return load_gemini_model(
-            model_name=model_name, api_key=api_key, temperature=temperature
-        )
-    elif model_name.startswith("groq:"):
-        return load_groq_model(
-            model_name=model_name, api_key=api_key, temperature=temperature
-        )
-    else:
-        raise ValueError(
-            f"Model '{model_name}' not found in any supported model list. "
-            "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
-            "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama."
-        )
+    client, _ = load_chat_model_prepared(
+        model_name=model_name,
+        temperature=temperature,
+        base_url=base_url,
+        api_key=api_key,
+        argo_user=argo_user,
+        reasoning_effort=reasoning_effort,
+        settings=settings,
+    )
+    return client

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -28,15 +28,17 @@ from chemgraph.models.endpoints import vllm as vllm_ep
 from chemgraph.models.settings import LLMSettings
 
 # Ordered endpoint registry. Resolution preserves the historical dispatch order:
-# codex -> openrouter -> argo -> curated ALCF -> direct OpenAI -> direct
-# Anthropic -> direct Gemini -> Ollama -> groq. Prefix routes (``matches`` on a
-# prefix) run before catalog checks, so names such as ``openrouter:openai/o3``
-# cannot be misclassified. The vLLM/custom fallback is *not* in this list; it is
-# selected only via ``vllm.can_handle`` as a last resort.
+# codex -> openrouter -> Argo Anthropic -> Argo OpenAI -> curated ALCF ->
+# direct OpenAI -> direct Anthropic -> direct Gemini -> Ollama -> groq. Prefix
+# routes (``matches`` on a prefix) run before catalog checks, so names such as
+# ``openrouter:openai/o3`` cannot be misclassified. The vLLM/custom fallback is
+# *not* in this list; it is selected only via ``vllm.can_handle`` as a last
+# resort.
 _ENDPOINT_REGISTRY = (
     codex_ep.SPEC,
     openrouter_ep.SPEC,
-    argo_ep.SPEC,
+    argo_ep.ANTHROPIC_SPEC,
+    argo_ep.OPENAI_SPEC,
     alcf_ep.SPEC,
     openai_ep.SPEC,
     anthropic_ep.SPEC,

--- a/src/chemgraph/models/openai.py
+++ b/src/chemgraph/models/openai.py
@@ -1,8 +1,9 @@
 """Deprecated compatibility shim for OpenAI / Argo model loading.
 
 The construction logic now lives in ``chemgraph.models.endpoints.openai_direct``
-and ``chemgraph.models.endpoints.argo`` behind the shared protocol builder.
-Prefer ``chemgraph.models.loader.load_chat_model``.
+and ``chemgraph.models.endpoints.argo`` behind shared protocol builders. Prefer
+``chemgraph.models.loader.load_chat_model``, which routes Argo Claude models
+through the Anthropic-native protocol.
 
 This module keeps the previous public surface -- ``load_openai_model`` and the
 ``_normalize_argo_model`` helper -- for one release.
@@ -46,8 +47,9 @@ def load_openai_model(
 ) -> ChatOpenAI:
     """Load an OpenAI or Argo chat model (deprecated).
 
-    Delegates to the ``openai_direct`` or ``argo`` endpoint depending on the
-    model name. The signature is preserved for backward compatibility.
+    Delegates to the ``openai_direct`` or Argo OpenAI-compatible endpoint. The
+    historical ChatOpenAI return type and signature are preserved for backward
+    compatibility.
     """
     warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
 

--- a/src/chemgraph/models/protocols/codex_native.py
+++ b/src/chemgraph/models/protocols/codex_native.py
@@ -1,0 +1,19 @@
+"""The only production construction site for the Codex client.
+
+Codex keeps its own loader (``load_codex_model``) with its subscription
+authentication. This builder is the sole call site: the endpoint packs the
+loader's arguments into ``client_kwargs`` and hands them here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from chemgraph.models.codex import load_codex_model
+
+
+def build(client_kwargs: dict[str, Any]) -> BaseChatModel:
+    """Construct a Codex chat model from prepared keyword arguments."""
+    return load_codex_model(**client_kwargs)

--- a/src/chemgraph/models/protocols/groq_native.py
+++ b/src/chemgraph/models/protocols/groq_native.py
@@ -1,0 +1,19 @@
+"""The only production construction site for the Groq client.
+
+Groq keeps its own loader (``load_groq_model``) with its API-key handling and
+retry-on-auth logic. This builder is the sole call site: the endpoint packs the
+loader's arguments into ``client_kwargs`` and hands them here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from chemgraph.models.groq import load_groq_model
+
+
+def build(client_kwargs: dict[str, Any]) -> BaseChatModel:
+    """Construct a Groq chat model from prepared keyword arguments."""
+    return load_groq_model(**client_kwargs)

--- a/src/chemgraph/models/protocols/ollama_native.py
+++ b/src/chemgraph/models/protocols/ollama_native.py
@@ -1,0 +1,19 @@
+"""The only production construction site for the Ollama client.
+
+Ollama keeps its own loader (``load_ollama_model``) with its curated-catalog
+validation. This builder is the sole call site: the endpoint packs the loader's
+arguments into ``client_kwargs`` and hands them here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+
+from chemgraph.models.local_model import load_ollama_model
+
+
+def build(client_kwargs: dict[str, Any]) -> BaseChatModel:
+    """Construct an Ollama chat model from prepared keyword arguments."""
+    return load_ollama_model(**client_kwargs)

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -150,12 +150,16 @@ supported_openrouter_models = [
     "openrouter:minimax/minimax-m2.7",
 ]
 
-# Default Argo API base URL (used when no --base-url is provided).
+# Default Argo OpenAI-compatible API base URL.
 ARGO_DEFAULT_BASE_URL = "https://apps.inside.anl.gov/argoapi/v1"
 
+# Default Argo Anthropic-native API base URL. ChatAnthropic appends
+# ``/v1/messages`` to this root.
+ARGO_DEFAULT_ANTHROPIC_BASE_URL = "https://apps.inside.anl.gov/argoapi"
+
 # Argo models -- all use the "argo:" prefix.
-# Which endpoint they hit depends on --base-url / config.
-# Default: ARGO_DEFAULT_BASE_URL (Argo API).
+# Claude models use the Anthropic-native protocol; all others use the
+# OpenAI-compatible protocol. ``--base-url`` / config may override either URL.
 supported_argo_models = [
     # GPT family
     "argo:gpt-4o",
@@ -197,7 +201,7 @@ supported_argo_models = [
     "argo:claude-sonnet-4.5",
 ]
 
-# Exact Argo model routes that require minimal ChatOpenAI construction.
+# Exact Argo model routes that require minimal client construction.
 # Optional sampling parameters are omitted for every entry in this set. Add
 # entries only after validating them against the deployed endpoint.
 MODELS_WITHOUT_TEMPERATURE = frozenset(

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -214,6 +214,9 @@ MODELS_WITHOUT_TEMPERATURE = frozenset(
         "argo:gpt-5",
         "argo:gpt-5-mini",
         "argo:gpt-5-nano",
+        "argo:claude-opus-5",
+        "argo:claude-opus-4.8",
+        "argo:claude-opus-4.7",
 
     }
 )

--- a/tests/test_agent_logging.py
+++ b/tests/test_agent_logging.py
@@ -3,6 +3,19 @@ import shutil
 import pytest
 from unittest.mock import patch, Mock
 from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.models.endpoints import PreparedModel
+
+
+def _prepared():
+    """Mock ``load_chat_model_prepared``: return ``(client, PreparedModel)``."""
+    return (
+        Mock(),
+        PreparedModel(
+            endpoint_name="test",
+            protocol="openai_compatible",
+            client_kwargs={},
+        ),
+    )
 
 
 @pytest.fixture
@@ -24,10 +37,10 @@ def clean_env():
 
 def test_init_generates_log_dir(clean_env):
     with (
-        patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load,
+        patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load,
         patch("chemgraph.agent.llm_agent.construct_single_agent_graph") as mock_graph,
     ):
-        mock_load.return_value = Mock()
+        mock_load.return_value = _prepared()
         mock_graph.return_value = Mock()
 
         agent = ChemGraph()
@@ -44,10 +57,10 @@ def test_init_generates_log_dir(clean_env):
 
 def test_init_respects_env_var(clean_env):
     with (
-        patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load,
+        patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load,
         patch("chemgraph.agent.llm_agent.construct_single_agent_graph") as mock_graph,
     ):
-        mock_load.return_value = Mock()
+        mock_load.return_value = _prepared()
         mock_graph.return_value = Mock()
 
         test_dir = "/tmp/test_chemgraph_logs_custom"

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 from chemgraph.agent.llm_agent import ChemGraph
 from chemgraph.agent.turn import TurnResult, serialize_state
 from chemgraph.memory.store import SessionStore
+from chemgraph.models.endpoints import PreparedModel
 
 
 # ------------------------------------------------------------------
@@ -80,10 +81,17 @@ class _GraphStreamCompatibleWorkflow:
 def mock_agent_patches():
     """Patch LLM loading and graph streaming for fast agent creation."""
     with (
-        patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load,
+        patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load,
         patch("chemgraph.agent.llm_agent.construct_single_agent_graph") as mock_constructor,
     ):
-        mock_load.return_value = Mock()
+        mock_load.return_value = (
+            Mock(),
+            PreparedModel(
+                endpoint_name="test",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        )
         workflow = _GraphStreamCompatibleWorkflow()
         mock_constructor.return_value = workflow
         yield mock_load, workflow

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -21,6 +21,7 @@ from chemgraph.models.codex import (
     _strip_codex_prefix,
 )
 from chemgraph.models import loader
+from chemgraph.models.protocols import codex_native
 
 
 class _FakeCodexConfig:
@@ -261,7 +262,7 @@ def test_codex_adapter_runs_existing_single_agent_tool_loop(fake_codex_sdk):
 
 def test_shared_loader_routes_codex_prefix(monkeypatch):
     monkeypatch.setattr(
-        loader,
+        codex_native,
         "load_codex_model",
         lambda model_name: ("codex-model", model_name),
     )
@@ -287,7 +288,7 @@ def test_chemgraph_routes_codex_to_supported_workflow(
 ):
     captured = {}
     monkeypatch.setattr(
-        llm_agent,
+        codex_native,
         "load_codex_model",
         lambda model_name: ("codex-model", model_name),
     )

--- a/tests/test_endpoints_route_matrix.py
+++ b/tests/test_endpoints_route_matrix.py
@@ -1,9 +1,8 @@
-"""Route-matrix parity tests for the endpoint × protocol layer (PR 1).
+"""Route-matrix tests for the endpoint × protocol layer.
 
 Each case exercises an endpoint's ``prepare`` directly and asserts the resolved
 endpoint name, protocol, base URL, wire model name, credential source, and
-final client kwargs. These lock in behavior parity with the pre-refactor
-provider loaders before the loader and agent are migrated in PR 2.
+final client kwargs, including protocol-specific Argo routing.
 """
 
 from __future__ import annotations
@@ -22,6 +21,7 @@ from chemgraph.models.supported_models import (
     ALCF_DEFAULT_BASE_URL,
     ALCF_METIS_BASE_URL,
     ALCF_MINERVA_BASE_URL,
+    ARGO_DEFAULT_ANTHROPIC_BASE_URL,
     ARGO_DEFAULT_BASE_URL,
     OPENROUTER_DEFAULT_BASE_URL,
 )
@@ -73,10 +73,10 @@ def test_openai_direct_rejects_unknown_model():
 
 
 def test_argo_hosted_route_uses_wire_name_and_user_payload():
-    prepared = argo_ep.prepare(
+    prepared = argo_ep.prepare_openai(
         ModelRequest(model="argo:gpt-4o", base_url=ARGO_HOSTED_URL, argo_user="alice")
     )
-    assert prepared.endpoint_name == "argo"
+    assert prepared.endpoint_name == "argo_openai"
     assert prepared.protocol == "openai_compatible"
     assert prepared.supports_structured_output is False
     kwargs = prepared.client_kwargs
@@ -87,19 +87,63 @@ def test_argo_hosted_route_uses_wire_name_and_user_payload():
 
 
 def test_argo_defaults_base_url_when_absent():
-    prepared = argo_ep.prepare(ModelRequest(model="argo:gpt-4o"))
+    prepared = argo_ep.prepare_openai(ModelRequest(model="argo:gpt-4o"))
     assert prepared.client_kwargs["base_url"] == ARGO_DEFAULT_BASE_URL
 
 
-def test_argo_claude_model_streams():
-    prepared = argo_ep.prepare(
-        ModelRequest(model="argo:claude-sonnet-4.6", base_url=ARGO_HOSTED_URL)
+def test_argo_claude_uses_anthropic_protocol_and_wire_name():
+    prepared = argo_ep.prepare_anthropic(
+        ModelRequest(
+            model="argo:claude-opus-4.8",
+            base_url=ARGO_HOSTED_URL,
+            argo_user="alice",
+        )
     )
-    assert prepared.client_kwargs["streaming"] is True
+    assert prepared.endpoint_name == "argo_anthropic"
+    assert prepared.protocol == "anthropic_native"
+    assert prepared.supports_structured_output is False
+    assert prepared.client_kwargs == {
+        "model": "claudeopus48",
+        "api_key": "alice",
+        "base_url": ARGO_DEFAULT_ANTHROPIC_BASE_URL,
+        "max_tokens": 4000,
+        "streaming": True,
+        "temperature": 0.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "configured_url, expected_url",
+    [
+        (ARGO_HOSTED_URL, ARGO_DEFAULT_ANTHROPIC_BASE_URL),
+        (
+            "https://apps.inside.anl.gov/argoapi/api/v1/resource/chat/",
+            ARGO_DEFAULT_ANTHROPIC_BASE_URL,
+        ),
+        ("http://localhost:8080/v1", "http://localhost:8080"),
+    ],
+)
+def test_argo_anthropic_normalizes_base_url(configured_url, expected_url):
+    prepared = argo_ep.prepare_anthropic(
+        ModelRequest(
+            model="argo:claude-opus-4.8",
+            base_url=configured_url,
+            argo_user="alice",
+        )
+    )
+    assert prepared.client_kwargs["base_url"] == expected_url
+
+
+def test_argo_anthropic_never_uses_anthropic_api_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-secret")
+    prepared = argo_ep.prepare_anthropic(
+        ModelRequest(model="argo:claude-opus-4.8", argo_user="alice")
+    )
+    assert prepared.client_kwargs["api_key"] == "alice"
 
 
 def test_argo_minimal_parameter_model_omits_sampling():
-    prepared = argo_ep.prepare(
+    prepared = argo_ep.prepare_openai(
         ModelRequest(model="argo:gpt-5", base_url=ARGO_HOSTED_URL)
     )
     kwargs = prepared.client_kwargs
@@ -111,7 +155,7 @@ def test_argo_minimal_parameter_model_omits_sampling():
 
 
 def test_argo_compatible_route_strips_prefix_for_local_shim():
-    prepared = argo_ep.prepare(
+    prepared = argo_ep.prepare_openai(
         ModelRequest(model="argo:gpt-4.1-mini", base_url="http://localhost:8080/v1")
     )
     # A non-argoapi custom endpoint keeps the OpenAI-style name (prefix

--- a/tests/test_endpoints_route_matrix.py
+++ b/tests/test_endpoints_route_matrix.py
@@ -108,7 +108,6 @@ def test_argo_claude_uses_anthropic_protocol_and_wire_name():
         "base_url": ARGO_DEFAULT_ANTHROPIC_BASE_URL,
         "max_tokens": 4000,
         "streaming": True,
-        "temperature": 0.0,
     }
 
 

--- a/tests/test_graph_constructors.py
+++ b/tests/test_graph_constructors.py
@@ -1,5 +1,18 @@
 import pytest
 from chemgraph.agent.llm_agent import ChemGraph
+from chemgraph.models.endpoints import PreparedModel
+
+
+def _fake_prepared(**_kwargs):
+    """Mock ``load_chat_model_prepared``: return ``(client, PreparedModel)``."""
+    return (
+        "FAKE_LLM",
+        PreparedModel(
+            endpoint_name="test",
+            protocol="openai_compatible",
+            client_kwargs={},
+        ),
+    )
 
 
 WORKFLOWS = [
@@ -43,8 +56,8 @@ def test_constructor_is_called(monkeypatch, workflow_type):
 
     # Ensure model loading is deterministic and doesn't call external APIs
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda model_name, temperature, base_url=None: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     # For MCP workflows some constructors expect tools; pass a non-empty list
@@ -79,8 +92,8 @@ def test_single_agent_initialization_injects_calculator_availability(monkeypatch
         fake_constructor,
     )
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda model_name, temperature, base_url=None: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     cg = ChemGraph(

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -5,6 +5,19 @@ from langchain_core.messages import AIMessage
 
 from chemgraph.agent import llm_agent
 from chemgraph.agent.llm_agent import ChemGraph, PromptConfig
+from chemgraph.models.endpoints import PreparedModel
+
+
+def _fake_prepared(**_kwargs):
+    """Mock ``load_chat_model_prepared``: return ``(client, PreparedModel)``."""
+    return (
+        "FAKE_LLM",
+        PreparedModel(
+            endpoint_name="test",
+            protocol="openai_compatible",
+            client_kwargs={},
+        ),
+    )
 
 
 class _DummyTool:
@@ -66,8 +79,8 @@ def test_graph_constructor_is_called(
 
     monkeypatch.setattr(f"chemgraph.agent.llm_agent.{constructor_attr}", fake_constructor)
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     cg = ChemGraph(
@@ -94,8 +107,8 @@ async def test_graph_backed_run_uses_astream_and_emits_events(monkeypatch, tmp_p
         lambda *_args, **_kwargs: workflow,
     )
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     cg = ChemGraph(
@@ -132,8 +145,8 @@ def test_single_agent_initialization_injects_calculator_availability(monkeypatch
         fake_constructor,
     )
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     cg = ChemGraph(
@@ -166,8 +179,8 @@ def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tm
         fake_constructor,
     )
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     cg = ChemGraph(
@@ -214,8 +227,8 @@ async def test_main_agent_rejects_one_shot_run(monkeypatch, tmp_path):
         lambda *_args, **_kwargs: _FakeWorkflow(),
     )
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
     cg = ChemGraph(
         model_name="gpt-4o-mini",
@@ -238,8 +251,8 @@ def test_rag_and_xanes_default_prompts_are_preserved(monkeypatch, tmp_path):
     monkeypatch.setattr("chemgraph.agent.llm_agent.construct_rag_agent_graph", fake_constructor)
     monkeypatch.setattr("chemgraph.agent.llm_agent.construct_single_agent_xanes_graph", fake_constructor)
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: "FAKE_LLM",
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        _fake_prepared,
     )
 
     ChemGraph(

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -8,6 +8,24 @@ from langchain_core.messages import AIMessage
 from chemgraph.agent.events import SUBAGENT_METADATA_KEY
 from chemgraph.agent.llm_agent import ChemGraph
 from chemgraph.agent.turn import _TurnEventCallback
+from chemgraph.models.endpoints import PreparedModel
+
+
+def _prepared(llm=None, *, supports_structured_output=True):
+    """Return a ``(client, PreparedModel)`` tuple matching the loader seam.
+
+    ``ChemGraph.__init__`` now calls ``load_chat_model_prepared``; tests mock
+    that seam and must return the same 2-tuple shape.
+    """
+    return (
+        llm if llm is not None else Mock(),
+        PreparedModel(
+            endpoint_name="test",
+            protocol="openai_compatible",
+            client_kwargs={},
+            supports_structured_output=supports_structured_output,
+        ),
+    )
 
 
 @pytest.fixture
@@ -16,8 +34,8 @@ def mock_llm():
 
 
 def test_chemgraph_initialization(tmp_path):
-    with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load:
-        mock_load.return_value = Mock()
+    with patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load:
+        mock_load.return_value = _prepared()
         agent = ChemGraph(
             model_name="gpt-4o-mini",
             enable_memory=False,
@@ -37,8 +55,8 @@ def test_chemgraph_initialization(tmp_path):
 def test_gpt56_reasoning_effort_is_passed_to_loader(
     tmp_path, model_name, reasoning_effort, expected_effort
 ):
-    with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load:
-        mock_load.return_value = Mock()
+    with patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load:
+        mock_load.return_value = _prepared()
         agent = ChemGraph(
             model_name=model_name,
             reasoning_effort=reasoning_effort,
@@ -51,15 +69,15 @@ def test_gpt56_reasoning_effort_is_passed_to_loader(
 
 
 def test_reasoning_effort_is_not_passed_to_sonnet5(tmp_path):
-    with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_load:
-        mock_load.return_value = Mock()
+    with patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load:
+        mock_load.return_value = _prepared()
         agent = ChemGraph(
             model_name="argo:claude-sonnet-5",
             enable_memory=False,
             log_dir=str(tmp_path / "logs"),
         )
 
-    assert "reasoning_effort" not in mock_load.call_args.kwargs
+    assert mock_load.call_args.kwargs["reasoning_effort"] is None
     assert agent.reasoning_effort is None
 
 
@@ -77,14 +95,16 @@ def test_reasoning_effort_rejects_invalid_value(reasoning_effort):
 
 
 def test_agent_query(mock_llm, tmp_path):
-    with patch("chemgraph.agent.llm_agent.load_openai_model") as mock_init_load, patch(
-        "chemgraph.models.loader.load_openai_model"
+    with patch(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared"
+    ) as mock_init_load, patch(
+        "chemgraph.agent.turn.load_chat_model"
     ) as mock_turn_load:
         # Set up the mock chain
         mock_chain = Mock()
         mock_chain.invoke.return_value = AIMessage(content="Test response")
         mock_llm.bind_tools.return_value = mock_chain
-        mock_init_load.return_value = mock_llm
+        mock_init_load.return_value = _prepared(mock_llm)
         mock_turn_load.return_value = mock_llm
 
         agent = ChemGraph(
@@ -268,8 +288,8 @@ async def test_cli_trace_events_are_emitted_from_astream_path(monkeypatch, tmp_p
         lambda *_args, **_kwargs: FakeWorkflow(),
     )
     monkeypatch.setattr(
-        "chemgraph.agent.llm_agent.load_openai_model",
-        lambda **_kwargs: Mock(),
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        lambda **_kwargs: _prepared(),
     )
 
     trace = CLIRunTrace(

--- a/tests/test_loader_pr2.py
+++ b/tests/test_loader_pr2.py
@@ -68,6 +68,7 @@ def _route(model: str, **kwargs) -> str:
         ("codex:gpt-5", "codex"),
         ("openrouter:openai/o3", "openrouter"),  # prefix wins over OpenAI catalog
         ("argo:gpt-4o", "argo"),
+        ("alcf:nemotron-3-ultra", "alcf"),
         ("gpt-4o", "openai_direct"),
         ("claude-3-5-sonnet-20241022", "anthropic_direct"),
         ("gemini-2.5-pro", "google_direct"),
@@ -94,6 +95,20 @@ def test_known_provider_error_does_not_fall_through_to_vllm(monkeypatch):
     monkeypatch.setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
     with pytest.raises(ValueError, match="Anthropic|API key|ANTHROPIC"):
         load_chat_model(model_name="claude-3-5-sonnet-20241022")
+
+
+def test_invalid_alcf_model_never_falls_through_to_vllm(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+
+    assert _route("alcf:not-in-catalog", api_key="dummy-alcf-token") == "alcf"
+    with patch("chemgraph.models.endpoints.alcf.resolve_api_key") as resolve_key:
+        with pytest.raises(ValueError, match="not supported on ALCF"):
+            load_chat_model(
+                model_name="alcf:not-in-catalog",
+                api_key="dummy-alcf-token",
+            )
+
+    resolve_key.assert_not_called()
 
 
 # --- Credential forwarding --------------------------------------------------

--- a/tests/test_loader_pr2.py
+++ b/tests/test_loader_pr2.py
@@ -67,7 +67,8 @@ def _route(model: str, **kwargs) -> str:
     [
         ("codex:gpt-5", "codex"),
         ("openrouter:openai/o3", "openrouter"),  # prefix wins over OpenAI catalog
-        ("argo:gpt-4o", "argo"),
+        ("argo:gpt-4o", "argo_openai"),
+        ("argo:claude-opus-4.8", "argo_anthropic"),
         ("alcf:nemotron-3-ultra", "alcf"),
         ("gpt-4o", "openai_direct"),
         ("claude-3-5-sonnet-20241022", "anthropic_direct"),
@@ -78,6 +79,44 @@ def _route(model: str, **kwargs) -> str:
 )
 def test_registry_resolves_expected_endpoint(model, expected_endpoint):
     assert _route(model) == expected_endpoint
+
+
+def test_argo_models_build_protocol_specific_clients():
+    from langchain_anthropic import ChatAnthropic
+    from langchain_openai import ChatOpenAI
+
+    claude_client, claude_prepared = load_chat_model_prepared(
+        model_name="argo:claude-opus-4.8",
+        argo_user="alice",
+    )
+    gpt_client, gpt_prepared = load_chat_model_prepared(
+        model_name="argo:gpt-4o",
+        argo_user="alice",
+    )
+
+    assert isinstance(claude_client, ChatAnthropic)
+    assert claude_prepared.protocol == "anthropic_native"
+    assert claude_prepared.client_kwargs["model"] == "claudeopus48"
+    assert claude_prepared.client_kwargs["base_url"].endswith("/argoapi")
+    assert isinstance(gpt_client, ChatOpenAI)
+    assert gpt_prepared.protocol == "openai_compatible"
+    assert gpt_prepared.client_kwargs["model"] == "gpt4o"
+    assert gpt_prepared.client_kwargs["base_url"].endswith("/argoapi/v1")
+
+
+def test_deprecated_openai_loader_preserves_argo_claude_chatopenai():
+    from langchain_openai import ChatOpenAI
+
+    from chemgraph.models.openai import load_openai_model
+
+    with pytest.warns(DeprecationWarning, match="load_openai_model is deprecated"):
+        client = load_openai_model(
+            model_name="argo:claude-opus-4.8",
+            temperature=0.0,
+            argo_user="alice",
+        )
+
+    assert isinstance(client, ChatOpenAI)
 
 
 def test_unknown_model_with_base_url_falls_to_vllm():

--- a/tests/test_loader_pr2.py
+++ b/tests/test_loader_pr2.py
@@ -1,0 +1,182 @@
+"""PR 2 regression tests for the single-loader migration (issue #201).
+
+These lock in the behaviors PR 2 promised beyond the endpoint-level route
+matrix (which already covers per-endpoint ``prepare`` parity):
+
+- The ordered endpoint registry resolves each family to the right endpoint,
+  with prefix routes winning over catalog checks.
+- The vLLM/custom fallback is chosen only when a base URL is available, and
+  recognized-provider errors never fall through to it.
+- Explicit credentials are forwarded and override the environment.
+- ``reasoning_effort`` flows through ``load_chat_model`` to the endpoint.
+- ``ChemGraph`` forwards an explicit OpenAI ``api_key`` (previously dropped).
+- ``run_turn`` and the judge share the same loader seam.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.loader import (
+    _build_request,
+    _select_endpoint,
+    load_chat_model,
+    load_chat_model_prepared,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_provider_env(monkeypatch):
+    """Isolate credential/URL resolution from the developer's environment."""
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "ALCF_ACCESS_TOKEN",
+        "OPENROUTER_API_KEY",
+        "GROQ_API_KEY",
+        "VLLM_API_KEY",
+        "VLLM_BASE_URL",
+        "ARGO_USER",
+        "CHEMGRAPH_ARGO_MODEL_FORMAT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _route(model: str, **kwargs) -> str:
+    request = _build_request(
+        model,
+        0.0,
+        kwargs.get("base_url"),
+        kwargs.get("api_key"),
+        kwargs.get("argo_user"),
+        kwargs.get("reasoning_effort"),
+        None,
+    )
+    return _select_endpoint(request).name
+
+
+# --- Ordered registry resolution -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "model, expected_endpoint",
+    [
+        ("codex:gpt-5", "codex"),
+        ("openrouter:openai/o3", "openrouter"),  # prefix wins over OpenAI catalog
+        ("argo:gpt-4o", "argo"),
+        ("gpt-4o", "openai_direct"),
+        ("claude-3-5-sonnet-20241022", "anthropic_direct"),
+        ("gemini-2.5-pro", "google_direct"),
+        ("llama3.2", "ollama"),
+        ("groq:llama-3.1-8b-instant", "groq"),
+    ],
+)
+def test_registry_resolves_expected_endpoint(model, expected_endpoint):
+    assert _route(model) == expected_endpoint
+
+
+def test_unknown_model_with_base_url_falls_to_vllm():
+    assert _route("my-local-model", base_url="http://localhost:8000/v1") == "vllm"
+
+
+def test_unknown_model_without_endpoint_raises():
+    with pytest.raises(ValueError, match="not found in any supported model list"):
+        _select_endpoint(ModelRequest(model="totally-unknown-model"))
+
+
+def test_known_provider_error_does_not_fall_through_to_vllm(monkeypatch):
+    # A recognized model whose credential is missing must raise its own error,
+    # even when a vLLM base URL is configured -- it must not be retried as vLLM.
+    monkeypatch.setenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+    with pytest.raises(ValueError, match="Anthropic|API key|ANTHROPIC"):
+        load_chat_model(model_name="claude-3-5-sonnet-20241022")
+
+
+# --- Credential forwarding --------------------------------------------------
+
+
+def test_openrouter_never_uses_openai_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-should-not-be-used")
+    with pytest.raises(ValueError, match="OpenRouter API key not found"):
+        load_chat_model(model_name="openrouter:moonshotai/kimi-k3")
+
+
+def test_explicit_openai_key_is_forwarded_and_overrides_env(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-from-env")
+    _client, prepared = load_chat_model_prepared(
+        model_name="gpt-4o", api_key="sk-explicit"
+    )
+    assert prepared.client_kwargs["api_key"] == "sk-explicit"
+
+
+# --- reasoning_effort flow --------------------------------------------------
+
+
+def test_reasoning_effort_flows_to_argo_reasoning_model():
+    _client, prepared = load_chat_model_prepared(
+        model_name="argo:gpt-5.6-sol",
+        base_url="https://apps.inside.anl.gov/argoapi/v1",
+        reasoning_effort="high",
+    )
+    assert prepared.reasoning_effort == "high"
+    assert prepared.client_kwargs.get("reasoning_effort") == "high"
+
+
+# --- ChemGraph forwards explicit OpenAI api_key ----------------------------
+
+
+def test_chemgraph_forwards_explicit_openai_api_key(tmp_path):
+    captured = {}
+
+    def _fake_prepared(**kwargs):
+        captured.update(kwargs)
+        from chemgraph.models.endpoints import PreparedModel
+
+        return (
+            object(),
+            PreparedModel(
+                endpoint_name="openai_direct",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        )
+
+    from chemgraph.agent.llm_agent import ChemGraph
+
+    with patch(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared", _fake_prepared
+    ), patch("chemgraph.agent.llm_agent.construct_single_agent_graph", lambda *a, **k: object()):
+        ChemGraph(
+            model_name="gpt-4o-mini",
+            api_key="sk-explicit-agent",
+            enable_memory=False,
+            log_dir=str(tmp_path / "logs"),
+        )
+
+    assert captured["api_key"] == "sk-explicit-agent"
+
+
+# --- Custom endpoint is consistent across run_turn and the judge -----------
+
+
+def test_run_turn_and_judge_use_the_same_loader_seam():
+    # The judge loads through load_chat_model directly; run_turn loads through
+    # _load_turn_llm, which also delegates to load_chat_model. Both resolve an
+    # unknown model with a base URL to the same vLLM endpoint.
+    from chemgraph.agent.turn import _load_turn_llm
+
+    with patch("chemgraph.agent.turn.load_chat_model") as mock_turn_load:
+        mock_turn_load.return_value = "TURN_LLM"
+        result = _load_turn_llm(
+            model_name="my-local-model",
+            base_url="http://localhost:8000/v1",
+            api_key=None,
+            argo_user=None,
+        )
+    assert result == "TURN_LLM"
+    # _load_turn_llm passes settings (not positional model_name) to the loader.
+    assert mock_turn_load.call_args.kwargs["settings"].model == "my-local-model"

--- a/tests/test_protocol_construction_guard.py
+++ b/tests/test_protocol_construction_guard.py
@@ -1,39 +1,48 @@
 """Guard: chat clients are constructed only in the protocol builders.
 
-After PR 1, no module under ``chemgraph/models`` may construct ``ChatOpenAI``,
-``ChatAnthropic``, or ``ChatGoogleGenerativeAI`` except the corresponding
-``protocols/*`` builder. (Agent-layer call sites in ``chemgraph/agent`` are
-migrated in PR 2 and are intentionally out of scope for this guard.)
+After PR 2, no module under ``chemgraph/models`` or ``chemgraph/agent`` may
+construct ``ChatOpenAI``, ``ChatAnthropic``, or ``ChatGoogleGenerativeAI``
+except the corresponding ``protocols/*`` builder. The agent layer now routes all
+model loading through ``load_chat_model`` / ``load_chat_model_prepared``.
 """
 
 from __future__ import annotations
 
 import pathlib
 
-MODELS_DIR = pathlib.Path(__file__).resolve().parents[1] / "src" / "chemgraph" / "models"
+CHEMGRAPH_DIR = pathlib.Path(__file__).resolve().parents[1] / "src" / "chemgraph"
+
+# Directories scanned for stray client construction.
+SCANNED_DIRS = (
+    CHEMGRAPH_DIR / "models",
+    CHEMGRAPH_DIR / "agent",
+)
 
 # Each client class may be constructed only in its designated builder file.
+# Paths are relative to ``src/chemgraph``.
 ALLOWED = {
-    "ChatOpenAI(": "protocols/openai_compatible.py",
-    "ChatAnthropic(": "protocols/anthropic_native.py",
-    "ChatGoogleGenerativeAI(": "protocols/google_native.py",
+    "ChatOpenAI(": "models/protocols/openai_compatible.py",
+    "ChatAnthropic(": "models/protocols/anthropic_native.py",
+    "ChatGoogleGenerativeAI(": "models/protocols/google_native.py",
 }
 
 
 def _offenders(needle: str, allowed_rel: str) -> list[str]:
-    allowed = (MODELS_DIR / allowed_rel).resolve()
+    allowed = (CHEMGRAPH_DIR / allowed_rel).resolve()
     hits: list[str] = []
-    for path in MODELS_DIR.rglob("*.py"):
-        if path.resolve() == allowed:
-            continue
-        text = path.read_text(encoding="utf-8")
-        for lineno, line in enumerate(text.splitlines(), start=1):
-            if needle in line:
-                hits.append(f"{path.relative_to(MODELS_DIR)}:{lineno}: {line.strip()}")
+    for scanned in SCANNED_DIRS:
+        for path in scanned.rglob("*.py"):
+            if path.resolve() == allowed:
+                continue
+            text = path.read_text(encoding="utf-8")
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if needle in line:
+                    rel = path.relative_to(CHEMGRAPH_DIR)
+                    hits.append(f"{rel}:{lineno}: {line.strip()}")
     return hits
 
 
-def test_no_direct_client_construction_in_models():
+def test_no_direct_client_construction_in_models_and_agent():
     problems: list[str] = []
     for needle, allowed_rel in ALLOWED.items():
         problems.extend(_offenders(needle, allowed_rel))


### PR DESCRIPTION
## Summary

Second of three PRs for #201. This makes load_chat_model the single model-dispatch site and routes the agent layer through it, so agent code no longer constructs LangChain clients directly.

Builds on PR #204, which introduced the protocol × endpoint foundation.

    caller → load_chat_model → endpoint spec → protocol builder → client

## What changed

### Central loader

- Rebuilt models/loader.py around an ordered EndpointSpec registry:
  codex → openrouter → Argo Anthropic → Argo OpenAI → ALCF → OpenAI → Anthropic → Gemini → Ollama → groq.
- Prefix routes run before catalog checks, preventing prefixed models from being misclassified.
- vLLM/custom routing is used only as the final fallback when a custom base URL is available. Errors from recognized providers propagate instead of falling through.
- Added load_chat_model_prepared to return the client with PreparedModel metadata.
- Added native protocol builders and endpoint specs for Codex, Groq, and Ollama.

### Provider routing fixes

- Reserved the alcf: namespace before the vLLM fallback. Invalid ALCF names now fail in the ALCF endpoint before credential resolution, preventing provider credentials from crossing into a custom endpoint.
- Split Argo into protocol-specific routes:
  - argo:claude-* uses ChatAnthropic and the Anthropic Messages endpoint at /v1/messages.
  - All other argo:* models use ChatOpenAI and the OpenAI-compatible chat-completions endpoint.
- Added the hosted Argo wire mappings for Claude Opus 5, 4.8, and 4.7.
- Normalized existing Argo /v1 and legacy resource-chat URLs to the Anthropic API root for Claude models.
- Kept the deprecated load_openai_model shim returning ChatOpenAI for backward compatibility.

### Agent migration

- Replaced provider-specific construction in ChemGraph.__init__ with one load_chat_model_prepared call.
- Read structured-output support from PreparedModel instead of re-deriving provider behavior in the agent.
- Forward explicit OpenAI API keys through the loader; the previous custom-endpoint branch dropped them.
- Removed the direct ChatOpenAI fallback from turn.py. run_turn and the judge now share the loader seam.
- Retained the existing Codex workflow restriction and caller-side reasoning-effort behavior.

## Verification

- Lint check passes in CI.
- 51 focused loader, endpoint-route, normalization, and client-construction tests pass.
- The construction guard confirms ChatOpenAI, ChatAnthropic, and ChatGoogleGenerativeAI are constructed only under models/protocols.
- Added regressions for ordered routing, provider-error boundaries, ALCF namespace reservation, Argo protocol selection and URL normalization, credential isolation, explicit-key forwarding, and shared agent loader seams.

## Scope / non-goals

- PR3 will handle configuration and authentication cleanup, including dedicated Argo and vLLM settings.
- PR3 will centralize reasoning-effort validation/defaulting so PreparedModel reports the effective value consistently.
- Academy remains out of scope and continues to inherit model loading through LLMSettings.