### PR TITLE
Improve invalid calculator_type error to list accepted field values

### DIFF
--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -100,6 +100,39 @@ def _calculator_key(name: str) -> str:
     return _CALCULATOR_ALIASES.get(normalized, normalized[:4])
 
 
+def _accepted_calculator_types(calc_class: Type[BaseModel]) -> list[str]:
+    """Return the accepted ``calculator_type`` values for a calculator class.
+
+    The agent must supply the ``calculator_type`` *field value* (e.g. ``"emt"``),
+    not the class name (``"EMTCalc"``). This reads the value(s) allowed by the
+    class's ``calculator_type`` field -- the members of a ``Literal`` when the
+    field is constrained, otherwise its default -- so error messages can name
+    what a caller should actually pass.
+    """
+    import typing
+
+    field = getattr(calc_class, "model_fields", {}).get("calculator_type")
+    if field is None:
+        return []
+    annotation = getattr(field, "annotation", None)
+    if typing.get_origin(annotation) is typing.Literal:
+        return [str(v) for v in typing.get_args(annotation)]
+    default = getattr(field, "default", None)
+    return [str(default)] if isinstance(default, str) and default else []
+
+
+def _accepted_calculator_type_hint(
+    calculator_classes: List[Type[BaseModel]],
+) -> str:
+    """Build a human/agent-friendly list of accepted ``calculator_type`` values."""
+    values: list[str] = []
+    for calc_class in calculator_classes:
+        for value in _accepted_calculator_types(calc_class):
+            if value not in values:
+                values.append(value)
+    return ", ".join(repr(v) for v in values)
+
+
 # Define all possible calculator classes
 _all_calculator_classes: List[Optional[Type[BaseModel]]] = [
     FAIRChemCalc,
@@ -171,9 +204,11 @@ def _coerce_calculator_payload(data: Any) -> Any:
 
         calc_key = _calculator_key(calc_name)
         if calc_key not in available_calcs:
+            accepted = _accepted_calculator_type_hint(available_calculator_classes)
             raise ValueError(
-                f"Calculator {calc_name} is not an allowed or available calculator. "
-                f"Available calculators are: {available_calc_names}"
+                f"Calculator {calc_name!r} is not an allowed or available "
+                "calculator. Set 'calculator_type' to one of these accepted "
+                f"values: {accepted} (available calculators: {available_calc_names})."
             )
 
         calculator_class = available_calcs[calc_key]
@@ -187,9 +222,11 @@ def _coerce_calculator_payload(data: Any) -> Any:
         calc_type_name = calc.__class__.__name__
         calc_key = _calculator_key(calc_type_name.removesuffix("Calc"))
         if calc_key not in available_calcs:
+            accepted = _accepted_calculator_type_hint(available_calculator_classes)
             raise ValueError(
-                f"Calculator {calc_type_name} is not an allowed or available calculator. "
-                f"Available calculators are: {available_calc_names}"
+                f"Calculator {calc_type_name} is not an allowed or available "
+                "calculator. Set 'calculator_type' to one of these accepted "
+                f"values: {accepted} (available calculators: {available_calc_names})."
             )
     return data
 

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -42,6 +42,24 @@ def test_default_calculator_is_in_detected_available_calculators():
     assert default in context
 
 
+def test_invalid_calculator_type_error_lists_accepted_values():
+    # Regression: the error used to list class names (e.g. "EMTCalc"), which
+    # misled agents into passing the class name as calculator_type. It should
+    # instead name the accepted calculator_type field values (e.g. "emt").
+    from chemgraph.schemas.ase_input import ASEInputSchema
+
+    with pytest.raises(ValidationError) as excinfo:
+        ASEInputSchema(
+            input_structure_file="water.xyz",
+            driver="opt",
+            calculator={"calculator_type": "EMTCalc"},
+        )
+
+    message = str(excinfo.value)
+    assert "accepted values" in message
+    assert "'emt'" in message
+
+
 @pytest.mark.skipif(
     importlib.util.find_spec("mace") is None, reason="MACE not installed"
 )


### PR DESCRIPTION
<!--
Thanks for contributing! Keep PRs small and focused — one logical change.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

Fixes a misleading error message that could send tool-calling agents into a
retry loop.

When an invalid `calculator_type` is supplied, the previous error listed
calculator *class names* (e.g. `['MaceCalc', 'EMTCalc']`), but the schema field
actually expects a *field value* (`'emt'`, `'mace_mp'`, `'mace_off'`,
`'mace_anicc'`). A tool-calling LLM that passed `"EMTCalc"` would read the error,
see `EMTCalc` in the list, and retry with the same wrong value — looping until
the recursion limit.

The message now lists the accepted field values so an agent can self-correct:

```
Calculator 'EMTCalc' is not an allowed or available calculator.
Set 'calculator_type' to one of these accepted values: 'emt', 'mace_mp', 'mace_off', 'mace_anicc'
(available calculators: ['MaceCalc', 'EMTCalc']).
```

Files: `src/chemgraph/schemas/ase_input.py`, `tests/test_calculators.py`.

## Related issues

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- Added a regression test:
  `tests/test_calculators.py::test_invalid_calculator_type_error_lists_accepted_values`.
- `ruff check .` and `pytest tests/ -k "not tblite"` pass.
- Verified live: with the fix, a tool-calling agent that passed `"EMTCalc"`
  self-corrected to `"emt"` on the next call and completed the EMT optimization.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [ ] Updated docs / README for any user-facing change
