### PR TITLE
Add first-class Aurora on-node inference provider (aurora:)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -64,6 +64,15 @@ timeout = 30
 base_url = "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1"
 timeout = 30
 
+# Aurora on-node inference (llama.cpp SYCL llama-server or vLLM-XPU), served as
+# an OpenAI-compatible /v1 endpoint. Use "aurora:<served-model-id>" models. The
+# node IP changes per job and compute nodes have no public IP, so set base_url
+# to a co-located server (127.0.0.1) or an SSH tunnel from a login node. May
+# also be set via the AURORA_BASE_URL environment variable.
+[api.aurora]
+base_url = "http://127.0.0.1:8000/v1"
+timeout = 60
+
 [api.local]
 base_url = "http://localhost:11434"
 timeout = 60

--- a/docs/running_local_models.md
+++ b/docs/running_local_models.md
@@ -45,6 +45,34 @@ route through a compatible ChemGraph provider/model ID, and implement reliable
 tool calling. Review the script's hardware/model assumptions and test a
 non-destructive query first. Ollama remains the documented first local route.
 
+## Aurora on-node inference (`aurora:` models)
+
+ChemGraph has a first-class provider for on-node LLM servers on ALCF Aurora
+(llama.cpp SYCL `llama-server` or vLLM-XPU) that expose an OpenAI-compatible
+`/v1` endpoint. Use an `aurora:<served-model-id>` model, where the id matches
+the server's advertised name (`llama-server --alias` / vLLM
+`--served-model-name`). Any served id works; `chemgraph models` lists a few for
+discovery.
+
+```bash
+# On the Aurora node serving the model (OpenAI-compatible /v1 on :8000):
+export AURORA_BASE_URL="http://127.0.0.1:8000/v1"   # co-located, or an SSH tunnel
+chemgraph run --model aurora:gpt-oss-120b \
+  -q "Build water from SMILES O, optimize it with EMT, and report the energy."
+```
+
+Or configure it in `config.toml`:
+
+```toml
+[api.aurora]
+base_url = "http://127.0.0.1:8000/v1"
+```
+
+The endpoint address changes per job and compute nodes have no public IP, so run
+ChemGraph on the same node (`127.0.0.1`) or tunnel from a login node. The chosen
+model must support tool calling. Authentication is usually disabled, so the API
+key defaults to `"dummy"`.
+
 ## Privacy boundary
 
 Local inference alone does not make a workflow offline. PubChem lookup, remote

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -287,6 +287,7 @@ class ChemGraph:
                 argo_user=argo_user,
                 reasoning_effort=reasoning_effort,
             )
+
         except Exception as e:
             logger.error(f"Exception thrown when loading {model_name}: {str(e)}")
             raise e

--- a/src/chemgraph/models/aurora_endpoints.py
+++ b/src/chemgraph/models/aurora_endpoints.py
@@ -1,0 +1,57 @@
+"""Deprecated compatibility shim for Aurora on-node model loading.
+
+Construction now lives in ``chemgraph.models.endpoints.aurora`` behind the
+shared OpenAI-compatible protocol builder. Prefer
+``chemgraph.models.loader.load_chat_model``.
+
+``AURORA_MODEL_PREFIX`` and ``_normalize_aurora_model`` are re-exported for one
+release so existing callers and tests keep working.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from langchain_openai import ChatOpenAI
+
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints import aurora as _aurora
+from chemgraph.utils.logging_config import setup_logger
+
+# Re-exported for backward compatibility.
+from chemgraph.models.endpoints.aurora import AURORA_PREFIX as AURORA_MODEL_PREFIX  # noqa: F401
+
+logger = setup_logger(__name__)
+
+_DEPRECATION = (
+    "load_aurora_model is deprecated; use "
+    "chemgraph.models.loader.load_chat_model instead."
+)
+
+
+def _normalize_aurora_model(model_name: str) -> str:
+    """Strip the ``aurora:`` prefix to get the name the endpoint expects.
+
+    Kept for backward compatibility. New code should let the endpoint spec
+    handle prefix stripping via ``load_chat_model``.
+    """
+    if not model_name.startswith(AURORA_MODEL_PREFIX):
+        return model_name
+    return model_name.removeprefix(AURORA_MODEL_PREFIX)
+
+
+def load_aurora_model(
+    model_name: str,
+    base_url: str = None,
+    api_key: str = None,
+    temperature: float = 0.0,
+) -> ChatOpenAI:
+    """Load an Aurora on-node chat model (deprecated). Delegates to the endpoint."""
+    warnings.warn(_DEPRECATION, DeprecationWarning, stacklevel=2)
+    request = ModelRequest(
+        model=model_name,
+        temperature=temperature,
+        api_key=api_key,
+        base_url=base_url,
+    )
+    return _aurora.SPEC.build(request)

--- a/src/chemgraph/models/endpoints/aurora.py
+++ b/src/chemgraph/models/endpoints/aurora.py
@@ -1,0 +1,103 @@
+"""Aurora on-node inference endpoint (OpenAI-compatible).
+
+Owns ``aurora:`` prefix stripping, the ``AURORA_API_KEY`` credential (with an
+``OPENAI_API_KEY`` fallback and a ``"dummy"`` placeholder for on-node servers
+that do not enforce auth), and base URL resolution against
+``AURORA_BASE_URL`` / ``AURORA_DEFAULT_BASE_URL``. Logic moved verbatim from
+``models/aurora_endpoints.py``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from chemgraph.models.endpoints.base import (
+    CredentialPolicy,
+    EndpointSpec,
+    ModelRequest,
+    PreparedModel,
+)
+from chemgraph.models.protocols import openai_compatible
+from chemgraph.models.supported_models import AURORA_DEFAULT_BASE_URL
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+PROTOCOL = "openai_compatible"
+
+AURORA_PREFIX = "aurora:"
+
+DUMMY_KEY = "dummy"
+
+# Aurora on-node servers (llama-server / vLLM-XPU) typically do not enforce
+# authentication, so a placeholder key is accepted. The deprecated
+# OPENAI_API_KEY fallback is applied explicitly in ``resolve_api_key`` below.
+AURORA_CREDENTIAL = CredentialPolicy(
+    env_var="AURORA_API_KEY",
+    required=False,
+    placeholder=DUMMY_KEY,
+)
+
+
+def resolve_base_url(request: ModelRequest) -> str:
+    """Resolve the Aurora endpoint URL.
+
+    Order: explicit ``request.base_url`` -> ``AURORA_BASE_URL`` env ->
+    ``AURORA_DEFAULT_BASE_URL`` (a co-located ``127.0.0.1`` server).
+    """
+    if request.base_url:
+        return request.base_url
+    return os.getenv("AURORA_BASE_URL") or AURORA_DEFAULT_BASE_URL
+
+
+def resolve_api_key(request: ModelRequest) -> str:
+    """Resolve the API key.
+
+    Order: explicit ``request.api_key`` -> ``AURORA_API_KEY`` env ->
+    ``OPENAI_API_KEY`` env -> ``"dummy"`` placeholder. ``langchain_openai``
+    requires a non-empty value, so we never return ``None``.
+    """
+    if request.api_key:
+        return request.api_key
+    return (
+        os.getenv("AURORA_API_KEY")
+        or os.getenv("OPENAI_API_KEY")
+        or DUMMY_KEY
+    )
+
+
+def prepare(request: ModelRequest) -> PreparedModel:
+    """Prepare an ``aurora:`` model for the OpenAI-compatible protocol.
+
+    The ``aurora:`` prefix is stripped before the name is sent to the endpoint;
+    what remains must match the server's advertised model id
+    (``llama-server --alias`` / ``--served-model-name``).
+    """
+    wire_model = request.model.removeprefix(AURORA_PREFIX)
+    base_url = resolve_base_url(request)
+    api_key = resolve_api_key(request)
+
+    logger.info("Loading Aurora model: %s from %s", wire_model, base_url)
+    client_kwargs = dict(
+        model=wire_model,
+        base_url=base_url,
+        api_key=api_key,
+        temperature=request.temperature,
+    )
+
+    return PreparedModel(
+        endpoint_name="aurora",
+        protocol=PROTOCOL,
+        client_kwargs=client_kwargs,
+        supports_structured_output=True,
+    )
+
+
+SPEC = EndpointSpec(
+    name="aurora",
+    protocol=PROTOCOL,
+    matches=lambda model: model.startswith(AURORA_PREFIX),
+    prepare=prepare,
+    protocol_build=openai_compatible.build,
+    credential=AURORA_CREDENTIAL,
+)

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -18,6 +18,7 @@ from chemgraph.models.endpoints import ModelRequest, PreparedModel
 from chemgraph.models.endpoints import alcf as alcf_ep
 from chemgraph.models.endpoints import anthropic_direct as anthropic_ep
 from chemgraph.models.endpoints import argo as argo_ep
+from chemgraph.models.endpoints import aurora as aurora_ep
 from chemgraph.models.endpoints import codex as codex_ep
 from chemgraph.models.endpoints import google_direct as google_ep
 from chemgraph.models.endpoints import groq as groq_ep
@@ -28,15 +29,18 @@ from chemgraph.models.endpoints import vllm as vllm_ep
 from chemgraph.models.settings import LLMSettings
 
 # Ordered endpoint registry. Resolution preserves the historical dispatch order:
-# codex -> openrouter -> Argo Anthropic -> Argo OpenAI -> curated ALCF ->
-# direct OpenAI -> direct Anthropic -> direct Gemini -> Ollama -> groq. Prefix
-# routes (``matches`` on a prefix) run before catalog checks, so names such as
-# ``openrouter:openai/o3`` cannot be misclassified. The vLLM/custom fallback is
-# *not* in this list; it is selected only via ``vllm.can_handle`` as a last
-# resort.
+# codex -> openrouter -> aurora -> Argo Anthropic -> Argo OpenAI -> curated ALCF
+# -> direct OpenAI -> direct Anthropic -> direct Gemini -> Ollama -> groq.
+# Prefix routes (``matches`` on a prefix) run before catalog checks, so names
+# such as ``openrouter:openai/o3`` or ``aurora:gpt-oss-120b`` cannot be
+# misclassified. The vLLM/custom fallback is *not* in this list; it is selected
+# only via ``vllm.can_handle`` as a last resort -- registering ``aurora`` here
+# ensures ``aurora:`` models are not diverted to the vLLM fallback when
+# ``VLLM_BASE_URL`` happens to be set.
 _ENDPOINT_REGISTRY = (
     codex_ep.SPEC,
     openrouter_ep.SPEC,
+    aurora_ep.SPEC,
     argo_ep.ANTHROPIC_SPEC,
     argo_ep.OPENAI_SPEC,
     alcf_ep.SPEC,

--- a/src/chemgraph/models/settings.py
+++ b/src/chemgraph/models/settings.py
@@ -119,6 +119,8 @@ def _extract_endpoint_from_cli_toml(raw: Mapping[str, Any]) -> dict[str, Any]:
             base_url = (api.get("argo") or {}).get("base_url")
         elif model.startswith("openrouter:"):
             base_url = (api.get("openrouter") or {}).get("base_url")
+        elif model.startswith("aurora:"):
+            base_url = (api.get("aurora") or {}).get("base_url")
         else:
             for section_name in ("openai", "anthropic", "gemini", "alcf", "ollama"):
                 section = api.get(section_name) or {}
@@ -142,6 +144,8 @@ def _provider_section_for(model: Any) -> str:
             return "groq"
         if model.startswith("openrouter:"):
             return "openrouter"
+        if model.startswith("aurora:"):
+            return "aurora"
     return "openai"
 
 

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -150,6 +150,27 @@ supported_openrouter_models = [
     "openrouter:minimax/minimax-m2.7",
 ]
 
+# Default Aurora inference base URL. Aurora on-node LLM servers (llama.cpp SYCL
+# `llama-server` or vLLM-XPU) expose an OpenAI-compatible ``/v1`` endpoint. The
+# node IP changes per job and compute nodes have no public IP, so callers
+# normally override this with --base-url / [api.aurora].base_url / AURORA_BASE_URL
+# (e.g. co-located on the same node, or via an SSH tunnel from a login node).
+AURORA_DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
+
+# Aurora models -- all use the "aurora:" prefix (e.g.
+# "aurora:gpt-oss-120b"). The prefix only routes the request inside ChemGraph
+# and is stripped before the name is sent to the endpoint, where it must match
+# the server's advertised model id (llama-server ``--alias`` / vLLM
+# ``--served-model-name``). This list is for *discovery* only (--list-models,
+# UI dropdown); dispatch is by prefix, so any served model id also works.
+# The chosen model MUST support OpenAI tool calling for ChemGraph workflows.
+supported_aurora_models = [
+    "aurora:gpt-oss-120b",
+    "aurora:inkling",
+    "aurora:nemotron-3-ultra",
+    "aurora:nemotron-4-340b",
+]
+
 # Default Argo OpenAI-compatible API base URL.
 ARGO_DEFAULT_BASE_URL = "https://apps.inside.anl.gov/argoapi/v1"
 
@@ -240,4 +261,5 @@ all_supported_models = (
     + supported_gemini_models
     + supported_groq_models
     + supported_openrouter_models
+    + supported_aurora_models
 )

--- a/src/chemgraph/utils/config_utils.py
+++ b/src/chemgraph/utils/config_utils.py
@@ -10,6 +10,7 @@ from chemgraph.models.supported_models import (
     ALCF_METIS_BASE_URL,
     ALCF_MINERVA_BASE_URL,
     ARGO_DEFAULT_BASE_URL,
+    AURORA_DEFAULT_BASE_URL,
     OPENROUTER_DEFAULT_BASE_URL,
     all_supported_models,
     supported_alcf_metis_models,
@@ -120,6 +121,11 @@ def get_base_url_for_model_from_nested_config(
     # endpoint is configured there (the Argo gateway, by default).
     if model_name.startswith("openrouter:"):
         return api.get("openrouter", {}).get("base_url") or OPENROUTER_DEFAULT_BASE_URL
+    # Prefix-routed Aurora on-node endpoints (llama-server / vLLM-XPU). The base
+    # URL is site/job-specific, so honor [api.aurora].base_url before the
+    # generic openai fallthrough; otherwise default to a co-located server.
+    if model_name.startswith("aurora:"):
+        return api.get("aurora", {}).get("base_url") or AURORA_DEFAULT_BASE_URL
     if model_name in supported_openai_models:
         return normalize_openai_base_url(api.get("openai", {}).get("base_url"))
     # Minerva and Metis have their own endpoints, and [api.alcf] base_url
@@ -163,6 +169,9 @@ def get_base_url_for_model_from_flat_config(
     # See the note in get_base_url_for_model_from_nested_config.
     if model_name.startswith("openrouter:"):
         return config.get("api_openrouter_base_url") or OPENROUTER_DEFAULT_BASE_URL
+    # See the note in get_base_url_for_model_from_nested_config.
+    if model_name.startswith("aurora:"):
+        return config.get("api_aurora_base_url") or AURORA_DEFAULT_BASE_URL
     if model_name in supported_openai_models:
         return normalize_openai_base_url(config.get("api_openai_base_url"))
     # See the note in get_base_url_for_model_from_nested_config.

--- a/tests/test_aurora_endpoints.py
+++ b/tests/test_aurora_endpoints.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from chemgraph.models.aurora_endpoints import (
+    _normalize_aurora_model,
+    load_aurora_model,
+)
+from chemgraph.models.loader import load_chat_model
+from chemgraph.models.supported_models import (
+    AURORA_DEFAULT_BASE_URL,
+    all_supported_models,
+    supported_aurora_models,
+)
+from chemgraph.utils.config_utils import (
+    get_base_url_for_model_from_flat_config,
+    get_base_url_for_model_from_nested_config,
+)
+
+AURORA_MODEL = "aurora:gpt-oss-120b"
+CUSTOM_URL = "http://x4000c0s0b0n0:8000/v1"
+
+
+def test_every_aurora_model_carries_the_prefix():
+    assert all(m.startswith("aurora:") for m in supported_aurora_models)
+
+
+def test_supported_aurora_models_has_no_duplicates():
+    assert len(supported_aurora_models) == len(set(supported_aurora_models))
+
+
+def test_aurora_models_are_in_all_supported_models():
+    assert set(supported_aurora_models) <= set(all_supported_models)
+
+
+def test_normalize_strips_the_prefix():
+    assert _normalize_aurora_model(AURORA_MODEL) == "gpt-oss-120b"
+    assert _normalize_aurora_model("aurora:nemotron-4-340b") == "nemotron-4-340b"
+
+
+def test_normalize_leaves_unprefixed_names_alone():
+    assert _normalize_aurora_model("gpt-oss-120b") == "gpt-oss-120b"
+
+
+def test_base_url_falls_back_to_the_aurora_default():
+    assert (
+        get_base_url_for_model_from_nested_config(AURORA_MODEL, {})
+        == AURORA_DEFAULT_BASE_URL
+    )
+    assert (
+        get_base_url_for_model_from_flat_config(AURORA_MODEL, {})
+        == AURORA_DEFAULT_BASE_URL
+    )
+
+
+def test_base_url_honours_configured_aurora_url():
+    assert (
+        get_base_url_for_model_from_nested_config(
+            AURORA_MODEL, {"api": {"aurora": {"base_url": CUSTOM_URL}}}
+        )
+        == CUSTOM_URL
+    )
+    assert (
+        get_base_url_for_model_from_flat_config(
+            AURORA_MODEL, {"api_aurora_base_url": CUSTOM_URL}
+        )
+        == CUSTOM_URL
+    )
+
+
+def test_uncurated_served_id_still_routes_by_prefix():
+    # Dispatch is by prefix, not list membership: an id not in the discovery
+    # list still resolves to the aurora endpoint.
+    assert (
+        get_base_url_for_model_from_flat_config("aurora:some-served-id", {})
+        == AURORA_DEFAULT_BASE_URL
+    )
+
+
+def test_load_aurora_model_strips_prefix_and_uses_base_url():
+    llm = load_aurora_model(AURORA_MODEL, base_url=CUSTOM_URL, api_key="dummy")
+    assert llm.openai_api_base == CUSTOM_URL
+    assert llm.model_name == "gpt-oss-120b"
+
+
+def test_load_aurora_model_defaults_base_url_and_dummy_key(monkeypatch):
+    monkeypatch.delenv("AURORA_BASE_URL", raising=False)
+    monkeypatch.delenv("AURORA_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm = load_aurora_model(AURORA_MODEL)
+    assert llm.openai_api_base == AURORA_DEFAULT_BASE_URL
+    assert llm.model_name == "gpt-oss-120b"
+
+
+def test_env_base_url_is_used_when_no_explicit_url(monkeypatch):
+    monkeypatch.setenv("AURORA_BASE_URL", CUSTOM_URL)
+    llm = load_aurora_model("aurora:nemotron-3-ultra", api_key="dummy")
+    assert llm.openai_api_base == CUSTOM_URL
+    assert llm.model_name == "nemotron-3-ultra"
+
+
+def test_loader_dispatches_aurora_prefix_to_chatopenai():
+    llm = load_chat_model(AURORA_MODEL, base_url=CUSTOM_URL, api_key="dummy")
+    assert type(llm).__name__ == "ChatOpenAI"
+    assert llm.openai_api_base == CUSTOM_URL
+    assert llm.model_name == "gpt-oss-120b"
+
+
+def test_lm_settings_extract_aurora_base_url_from_cli_toml(tmp_path):
+    from chemgraph.models.settings import load_lm_settings
+
+    cfg = tmp_path / "aurora.toml"
+    cfg.write_text(
+        "\n".join(
+            [
+                "[general]",
+                f'model = "{AURORA_MODEL}"',
+                "[api.aurora]",
+                f'base_url = "{CUSTOM_URL}"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    settings = load_lm_settings(cfg)
+    assert settings.model == AURORA_MODEL
+    assert settings.base_url == CUSTOM_URL

--- a/tests/test_endpoints_route_matrix.py
+++ b/tests/test_endpoints_route_matrix.py
@@ -16,6 +16,7 @@ from chemgraph.models.endpoints import argo as argo_ep
 from chemgraph.models.endpoints import google_direct as google_ep
 from chemgraph.models.endpoints import openai_direct as openai_ep
 from chemgraph.models.endpoints import openrouter as openrouter_ep
+from chemgraph.models.endpoints import aurora as aurora_ep
 from chemgraph.models.endpoints import vllm as vllm_ep
 from chemgraph.models.supported_models import (
     ALCF_DEFAULT_BASE_URL,
@@ -23,6 +24,7 @@ from chemgraph.models.supported_models import (
     ALCF_MINERVA_BASE_URL,
     ARGO_DEFAULT_ANTHROPIC_BASE_URL,
     ARGO_DEFAULT_BASE_URL,
+    AURORA_DEFAULT_BASE_URL,
     OPENROUTER_DEFAULT_BASE_URL,
 )
 
@@ -38,6 +40,8 @@ def _clear_provider_env(monkeypatch):
         "GEMINI_API_KEY",
         "ALCF_ACCESS_TOKEN",
         "OPENROUTER_API_KEY",
+        "AURORA_API_KEY",
+        "AURORA_BASE_URL",
         "VLLM_API_KEY",
         "VLLM_BASE_URL",
         "ARGO_USER",
@@ -247,6 +251,48 @@ def test_google_direct_route():
     kwargs = prepared.client_kwargs
     assert kwargs["model"] == "gemini-2.5-pro"
     assert kwargs["max_output_tokens"] == 6000
+
+
+# --- Aurora on-node ---------------------------------------------------------
+
+
+def test_aurora_route_strips_prefix_and_uses_configured_base_url():
+    prepared = aurora_ep.prepare(
+        ModelRequest(
+            model="aurora:gpt-oss-120b",
+            base_url="http://x4000c0s0b0n0:8000/v1",
+            api_key="dummy",
+        )
+    )
+    assert prepared.endpoint_name == "aurora"
+    assert prepared.protocol == "openai_compatible"
+    kwargs = prepared.client_kwargs
+    assert kwargs["model"] == "gpt-oss-120b"
+    assert kwargs["base_url"] == "http://x4000c0s0b0n0:8000/v1"
+    assert kwargs["api_key"] == "dummy"
+    assert kwargs["temperature"] == 0.0
+
+
+def test_aurora_route_falls_back_to_default_base_url_and_dummy_key():
+    prepared = aurora_ep.prepare(ModelRequest(model="aurora:gpt-oss-120b"))
+    kwargs = prepared.client_kwargs
+    assert kwargs["base_url"] == AURORA_DEFAULT_BASE_URL
+    assert kwargs["api_key"] == "dummy"  # placeholder when no key set
+
+
+def test_aurora_route_env_base_url_used_when_no_explicit(monkeypatch):
+    monkeypatch.setenv("AURORA_BASE_URL", "http://x4000c0s0b0n0:8000/v1")
+    prepared = aurora_ep.prepare(ModelRequest(model="aurora:nemotron-3-ultra"))
+    kwargs = prepared.client_kwargs
+    assert kwargs["base_url"] == "http://x4000c0s0b0n0:8000/v1"
+    assert kwargs["model"] == "nemotron-3-ultra"
+
+
+def test_aurora_spec_matches_only_aurora_prefix():
+    assert aurora_ep.SPEC.matches("aurora:gpt-oss-120b") is True
+    assert aurora_ep.SPEC.matches("aurora:some-served-id") is True
+    assert aurora_ep.SPEC.matches("openai:gpt-4o") is False
+    assert aurora_ep.SPEC.matches("openrouter:x/y") is False
 
 
 # --- vLLM / custom fallback -------------------------------------------------


### PR DESCRIPTION
<!--
Thanks for contributing! Keep PRs small and focused — one logical change.
See CONTRIBUTING.md for the full workflow.
-->

## Summary

Adds a first-class `aurora:` prefix provider for OpenAI-compatible LLM servers
running on ALCF Aurora compute nodes (llama.cpp SYCL `llama-server` or
vLLM-XPU), analogous to the existing `alcf:` provider.

- **`models/aurora_endpoints.py`**: `AURORA_MODEL_PREFIX` and `load_aurora_model`.
  Base URL is resolved from `--base-url` → `AURORA_BASE_URL` env →
  `[api.aurora].base_url` in config → `http://127.0.0.1:8000/v1` default. API key
  defaults to `"dummy"` (on-node servers don't enforce auth).
- **Dispatch wiring**: `models/loader.py` and `agent/llm_agent.py` route
  `aurora:` models to `load_aurora_model`.
- **Config resolution**: `utils/config_utils.py` (flat + nested config) and
  `models/settings.py` (CLI TOML extraction) honor `[api.aurora].base_url`.
- **`models/supported_models.py`**: `AURORA_DEFAULT_BASE_URL` and
  `supported_aurora_models` (`aurora:gpt-oss-120b`, `aurora:inkling`,
  `aurora:nemotron-3-ultra`, `aurora:nemotron-4-340b`). The list is for
  *discovery* only (`chemgraph models` / dropdown); dispatch is by prefix, so any
  served model id also works.
- **`config.toml`**: `[api.aurora]` section.
- **`docs/running_local_models.md`**: Aurora provider usage section.

The served model id (after the `aurora:` prefix is stripped) must match the
server's advertised name (`llama-server --alias` / vLLM `--served-model-name`)
and must support OpenAI tool calling.

## Related issues

Part of #194.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- 13 hermetic tests in `tests/test_aurora_endpoints.py` covering prefix
  stripping, base URL resolution (flat + nested config, env var override, default
  fallback), `load_aurora_model` construction, `load_chat_model` dispatch, and
  `LLMSettings` TOML extraction. No network required.
- `ruff check .` and `pytest tests/ -k "not tblite"` pass.
- End-to-end on Aurora: EMT geometry optimization via the `aurora:` provider
  (`smiles_to_coordinate_file` → `run_ase` → converged, energy reported) with
  `overall_rc=0`, validated against locally-served gpt-oss-120b, Inkling,
  Nemotron-3-Ultra, and Nemotron-4-340B.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change
