### PR TITLE
fix(ui): attribute artifacts to the exchange that produced them

### DIFF
--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -7,7 +7,7 @@ from langchain_core.tools import tool
 from ase.data import chemical_symbols as _chemical_symbols
 
 from chemgraph.schemas.ase_input import ASEOutputSchema
-from chemgraph.tools.ase_core import _resolve_existing_path
+from chemgraph.tools.ase_core import _resolve_existing_path, _resolve_path
 from chemgraph.tools.ase_tools import is_linear_molecule
 
 
@@ -348,6 +348,9 @@ def generate_html(
     results_json_path = _resolve_existing_path(results_json_path)
     if xyz_path is not None:
         xyz_path = _resolve_existing_path(xyz_path)
+    # The report is a run artifact too: a bare "report.html" must land in
+    # the session log dir, not whatever directory the server started in.
+    output_path = _resolve_path(output_path)
 
     # Validate results_json_path exists
     if not os.path.isfile(results_json_path):

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -29,6 +29,7 @@ from chemgraph.utils.config_utils import (
     get_base_url_for_model_from_nested_config,
 )
 
+from ui import artifacts as artifact_utils
 from ui.agent_manager import initialize_agent
 from ui.branding import LOGO_IMAGES, first_existing_asset
 from ui.config import load_config
@@ -118,6 +119,37 @@ def _ensure_chat_log_dir() -> str:
     os.makedirs(chat_log_dir, exist_ok=True)
     os.environ["CHEMGRAPH_LOG_DIR"] = chat_log_dir
     return chat_log_dir
+
+
+def _activate_turn_dir(chat_log_dir: Optional[str], turn_index: int) -> Optional[str]:
+    """Create and activate a per-query subdirectory for run artifacts.
+
+    Tool artifact names are deterministic per molecule
+    (``water_opt.traj``, ``frequencies_water.csv``, ...), so a later query
+    on the same molecule would overwrite an earlier query's files in a
+    shared directory and retroactively change what that exchange
+    displays. Giving every query its own subdirectory makes the recorded
+    per-exchange artifact lists permanent.
+
+    Parameters
+    ----------
+    chat_log_dir : str, optional
+        The chat's log directory.
+    turn_index : int
+        One-based index of the query within the chat.
+
+    Returns
+    -------
+    str or None
+        The activated turn directory (also set as ``CHEMGRAPH_LOG_DIR``).
+    """
+    if not chat_log_dir:
+        return None
+    suffix = str(uuid.uuid4())[:4]
+    turn_dir = str(Path(chat_log_dir) / f"turn_{turn_index:03d}_{suffix}")
+    os.makedirs(turn_dir, exist_ok=True)
+    os.environ["CHEMGRAPH_LOG_DIR"] = turn_dir
+    return turn_dir
 
 
 def _resolve_structured_output_for_model(
@@ -442,8 +474,11 @@ def _load_session(session_id: str) -> None:
         st.sidebar.error(f"Session '{session_id}' not found.")
         return
 
-    # Rebuild conversation_history from stored messages
-    st.session_state.conversation_history = session_to_conversation_history(session)
+    # Rebuild conversation_history from stored messages, then re-attach the
+    # per-exchange artifact lists recorded in the log-dir manifest.
+    history = session_to_conversation_history(session)
+    artifact_utils.attach_artifacts_to_history(history, session.log_dir)
+    st.session_state.conversation_history = history
     st.session_state.current_session_id = session.session_id
     st.session_state.session_created = True
     st.session_state.query_input = ""
@@ -453,6 +488,8 @@ def _load_session(session_id: str) -> None:
     st.session_state.current_chat_log_dir = session.log_dir
     if session.log_dir:
         os.environ["CHEMGRAPH_LOG_DIR"] = session.log_dir
+    # A pending question belongs to the abandoned chat, not this one.
+    _clear_interrupt_state()
 
 
 def _active_session_metadata() -> tuple[str, str]:
@@ -691,25 +728,68 @@ def _render_single_exchange(idx: int, entry: dict, thread_id: int) -> None:
     # Find final AI response
     final_answer = _extract_final_answer(messages)
 
+    # Artifact kinds recorded for this exchange (None = legacy entry)
+    artifact_kinds = _entry_artifact_kinds(entry)
+
     # Display the AI response with visualizations
     with st.chat_message("assistant"):
         if final_answer:
             _render_markdown_with_math(final_answer)
 
         # Structure visualisation
-        html_filename = find_html_filename(messages)
+        if artifact_kinds is not None:
+            reports = artifact_kinds.get(artifact_utils.REPORTS, [])
+            html_filename = reports[-1] if reports else None
+            if html_filename is None:
+                # Reports written to an absolute path outside the log dir
+                # are not in the manifest; accept them when they exist.
+                candidate = find_html_filename(messages)
+                if (
+                    candidate
+                    and os.path.isabs(candidate)
+                    and os.path.exists(candidate)
+                ):
+                    html_filename = candidate
+        else:
+            html_filename = find_html_filename(messages)
         _render_structure_section(idx, messages, final_answer, entry, html_filename)
 
         # HTML report
         if html_filename:
             _render_html_report(idx, html_filename, messages, entry)
 
-        # IR spectrum
-        if is_infrared_requested(messages):
+        # IR spectrum: prefer the exchange's recorded artifacts; fall back to
+        # keyword sniffing only for legacy entries without a manifest.
+        if artifact_kinds is not None:
+            if artifact_kinds.get(artifact_utils.IR_PLOTS) or artifact_kinds.get(
+                artifact_utils.FREQUENCY_TABLES
+            ):
+                _render_ir_spectrum(idx, messages, entry)
+        elif is_infrared_requested(messages):
             _render_ir_spectrum(idx, messages, entry)
 
         # Debug expander
         _render_verbose_info(idx, messages, entry)
+
+
+def _entry_artifact_kinds(entry: dict) -> Optional[dict[str, list[str]]]:
+    """Return classified artifacts for an exchange, or ``None`` for legacy entries.
+
+    Parameters
+    ----------
+    entry : dict
+        Conversation-history entry.
+
+    Returns
+    -------
+    dict[str, list[str]] or None
+        Artifact buckets from the run manifest, or ``None`` when the entry
+        predates per-exchange artifact tracking.
+    """
+    files = entry.get("artifacts")
+    if files is None:
+        return None
+    return artifact_utils.classify_artifacts(files)
 
 
 def _extract_final_answer(messages: list) -> str:
@@ -788,29 +868,71 @@ def _render_structure_section(
             structure["positions"],
             title=f"Molecular Structure (Query {idx})",
         )
-    else:
-        structure_from_text = extract_molecular_structure(final_answer)
-        if structure_from_text:
+        return
+
+    structure_from_text = extract_molecular_structure(final_answer)
+    if structure_from_text:
+        display_molecular_structure(
+            structure_from_text["atomic_numbers"],
+            structure_from_text["positions"],
+            title=f"Structure from Response {idx}",
+        )
+        return
+    if html_filename:
+        return
+
+    xyz_path = _exchange_structure_path(messages, entry, final_answer)
+    if xyz_path:
+        try:
+            atoms = ase_read(xyz_path)
+            # Include the exchange index: viewer widget keys derive from
+            # the title, and two exchanges can share a file basename.
             display_molecular_structure(
-                structure_from_text["atomic_numbers"],
-                structure_from_text["positions"],
-                title=f"Structure from Response {idx}",
+                atoms.get_atomic_numbers().tolist(),
+                atoms.get_positions().tolist(),
+                title=f"Structure from {Path(xyz_path).name} (Query {idx})",
             )
-        elif not html_filename:
-            if has_structure_signal(messages, entry.get("query", ""), final_answer):
-                log_dir = _artifact_log_dir(messages, entry)
-                if log_dir and os.path.isdir(log_dir):
-                    latest_xyz = find_latest_xyz_file_in_dir(log_dir)
-                    if latest_xyz:
-                        try:
-                            atoms = ase_read(latest_xyz)
-                            display_molecular_structure(
-                                atoms.get_atomic_numbers().tolist(),
-                                atoms.get_positions().tolist(),
-                                title=f"Structure from {Path(latest_xyz).name}",
-                            )
-                        except Exception as exc:
-                            st.warning(f"Failed to load XYZ structure: {exc}")
+        except Exception as exc:
+            st.warning(f"Failed to load XYZ structure: {exc}")
+
+
+def _exchange_structure_path(
+    messages: list, entry: dict, final_answer: str
+) -> Optional[str]:
+    """Return the XYZ file to show for an exchange, or ``None``.
+
+    Entries with a recorded artifact list only ever show their own
+    structures.  Legacy entries fall back to the newest XYZ in the entry's
+    log directory, gated on the old keyword heuristic.
+
+    Parameters
+    ----------
+    messages : list
+        Message-like objects from the exchange.
+    entry : dict
+        Conversation-history entry.
+    final_answer : str
+        Final assistant answer text.
+
+    Returns
+    -------
+    str or None
+        Path to the structure file for this exchange.
+    """
+    artifact_kinds = _entry_artifact_kinds(entry)
+    if artifact_kinds is not None:
+        structures = artifact_kinds.get(artifact_utils.STRUCTURES, [])
+        if not structures:
+            return None
+        path = _resolve_artifact_path(structures[-1], entry.get("log_dir"))
+        return path if os.path.exists(path) else None
+
+    if not has_structure_signal(messages, entry.get("query", ""), final_answer):
+        return None
+    log_dir = _artifact_log_dir(messages, entry)
+    if log_dir and os.path.isdir(log_dir):
+        return find_latest_xyz_file_in_dir(log_dir)
+    return None
 
 
 def _render_html_report(
@@ -879,7 +1001,23 @@ def _artifact_log_dir(messages: list, entry: dict) -> Optional[str]:
     entry_log_dir = entry.get("log_dir")
     if entry_log_dir:
         return entry_log_dir
-    return extract_log_dir_from_messages(messages)
+
+    # Fallback for legacy entries: paths mentioned in messages.  Only accept
+    # directories inside the UI log root -- anything else (e.g. the launch
+    # directory) is full of files from unrelated runs and showing one of
+    # those is worse than showing nothing.
+    candidate = extract_log_dir_from_messages(messages)
+    if not candidate:
+        return None
+    root = st.session_state.get("ui_log_root")
+    if not root:
+        return None
+    try:
+        if Path(candidate).resolve().is_relative_to(Path(root).resolve()):
+            return candidate
+    except OSError:
+        return None
+    return None
 
 
 def _latest_artifact_path(directory: Optional[str], pattern: str) -> Optional[str]:
@@ -957,7 +1095,11 @@ def _is_linear_geometry(atoms) -> bool:
     return moments[0] < 1e-3 * moments[-1]
 
 
-def _num_nonvibrational_modes(total_modes: int, log_dir: Optional[str]) -> int:
+def _num_nonvibrational_modes(
+    total_modes: int,
+    log_dir: Optional[str],
+    structure_path: Optional[str] = None,
+) -> int:
     """Return how many legacy translational/rotational rows to skip.
 
     Current frequency CSV files contain only molecular vibrations.  Legacy
@@ -970,16 +1112,20 @@ def _num_nonvibrational_modes(total_modes: int, log_dir: Optional[str]) -> int:
         Total number of rows in the frequency table.
     log_dir : str, optional
         Directory to search for a structure file used to test linearity.
+    structure_path : str, optional
+        Structure file recorded for the exchange; preferred over searching
+        *log_dir* so the geometry matches the frequency table.
 
     Returns
     -------
     int
         Number of leading modes to discard.
     """
-    if not log_dir:
-        return 0
-
-    xyz = find_latest_xyz_file_in_dir(log_dir)
+    xyz = structure_path
+    if not xyz:
+        if not log_dir:
+            return 0
+        xyz = find_latest_xyz_file_in_dir(log_dir)
     if not xyz:
         return 0
 
@@ -1019,19 +1165,43 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
         Conversation-history entry.
     """
     log_dir = _artifact_log_dir(messages, entry)
-    ir_path = _latest_artifact_path(log_dir, "ir_spectrum*.png")
-    freq_path = _latest_artifact_path(log_dir, "frequencies*.csv")
+    artifact_kinds = _entry_artifact_kinds(entry)
+    if artifact_kinds is not None:
+        # Use exactly the files this exchange produced.
+        ir_files = artifact_kinds.get(artifact_utils.IR_PLOTS, [])
+        freq_files = artifact_kinds.get(artifact_utils.FREQUENCY_TABLES, [])
+        ir_path = (
+            _resolve_artifact_path(ir_files[-1], log_dir) if ir_files else None
+        )
+        freq_path = (
+            _resolve_artifact_path(freq_files[-1], log_dir) if freq_files else None
+        )
+    else:
+        # Legacy entries: newest match in the entry's own log directory.
+        ir_path = _latest_artifact_path(log_dir, "ir_spectrum*.png")
+        freq_path = _latest_artifact_path(log_dir, "frequencies*.csv")
 
     if not ir_path and not freq_path:
         st.warning("IR spectrum not found.")
         return
 
-    with st.expander("\U0001f50d IR Spectrum", expanded=True):
+    # vib/thermo runs record frequencies but no spectrum -- label honestly.
+    label = (
+        "\U0001f50d IR Spectrum"
+        if ir_path or artifact_kinds is None
+        else "\U0001f50d Vibrational Modes"
+    )
+    with st.expander(label, expanded=True):
         col1, col2 = st.columns(2, border=True)
 
         with col1:
             if ir_path and os.path.exists(ir_path):
                 st.image(ir_path)
+            elif artifact_kinds is not None:
+                st.caption(
+                    "This run computed vibrational modes; no IR spectrum "
+                    "was requested."
+                )
             else:
                 st.warning("IR spectrum plot not found.")
 
@@ -1045,7 +1215,14 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
                 index_col=False,
                 names=["filename", "frequency"],
             )
-            n_skip = _num_nonvibrational_modes(len(df), log_dir)
+            exchange_xyz = None
+            if artifact_kinds is not None:
+                structures = artifact_kinds.get(artifact_utils.STRUCTURES, [])
+                if structures:
+                    exchange_xyz = _resolve_artifact_path(structures[-1], log_dir)
+            n_skip = _num_nonvibrational_modes(
+                len(df), log_dir, structure_path=exchange_xyz
+            )
             modes = df.iloc[n_skip:] if len(df) > n_skip else df
 
             if modes.empty:
@@ -1076,7 +1253,10 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
                 key=f"ir_frequency_select_{idx}",
             )
             traj_file = str(modes.loc[freq_options[selected_freq]]["filename"])
-            traj_path = _resolve_artifact_path(traj_file, log_dir)
+            # The CSV lists bare trajectory names; they live next to the CSV
+            # (the run's own turn directory), not at the chat-dir root.
+            traj_base = str(Path(freq_path).parent) if freq_path else log_dir
+            traj_path = _resolve_artifact_path(traj_file, traj_base)
             if not os.path.exists(traj_path):
                 st.warning(f"Trajectory file '{traj_file}' not found.")
             elif not STMOL_AVAILABLE:
@@ -1195,6 +1375,8 @@ def _clear_interrupt_state() -> None:
     st.session_state.pending_interrupt_model = None
     st.session_state.pending_interrupt_workflow = None
     st.session_state.pending_interrupt_log_dir = None
+    st.session_state.pending_interrupt_turn_dir = None
+    st.session_state.pending_interrupt_artifact_snapshot = None
     st.session_state.interrupt_count = 0
     st.session_state.interrupt_exchanges = []
 
@@ -1435,9 +1617,11 @@ def _handle_query_submission(
     st.session_state.last_run_error = None
     st.session_state.last_run_result = None
 
-    # Agent setup (mirroring agent.run() preamble)
-    if agent.log_dir:
-        os.environ["CHEMGRAPH_LOG_DIR"] = agent.log_dir
+    # Agent setup (mirroring agent.run() preamble). Tools write into a
+    # per-query turn directory inside the chat log dir.
+    turn_dir = _activate_turn_dir(
+        agent.log_dir, len(st.session_state.conversation_history) + 1
+    )
     try:
         agent._ensure_session(trimmed_query)
     except Exception:
@@ -1451,6 +1635,10 @@ def _handle_query_submission(
             prev_msg_count = len(snapshot.values.get("messages", []))
     except Exception:
         pass
+
+    # Snapshot the log dir so files created by this run can be attributed
+    # to exactly this exchange.
+    artifact_snapshot = artifact_utils.snapshot_mtimes(agent.log_dir)
 
     # Show the user's message immediately
     with st.chat_message("user"):
@@ -1494,6 +1682,12 @@ def _handle_query_submission(
             except Exception:
                 pass
 
+            run_artifacts = artifact_utils.collect_new_files(
+                agent.log_dir, artifact_snapshot
+            )
+            artifact_utils.append_manifest_entry(
+                agent.log_dir, trimmed_query, run_artifacts
+            )
             st.session_state.last_run_result = result
             st.session_state.conversation_history.append(
                 {
@@ -1501,6 +1695,7 @@ def _handle_query_submission(
                     "result": result,
                     "thread_id": thread_id,
                     "log_dir": agent.log_dir,
+                    "artifacts": run_artifacts,
                 }
             )
             _save_exchange_to_store(trimmed_query, result)
@@ -1515,6 +1710,7 @@ def _handle_query_submission(
             st.session_state.pending_interrupt_query = trimmed_query
             st.session_state.pending_interrupt_thread_id = thread_id
             st.session_state.pending_interrupt_prev_msg_count = prev_msg_count
+            st.session_state.pending_interrupt_artifact_snapshot = artifact_snapshot
             st.session_state.pending_interrupt_model = st.session_state.get(
                 "active_model"
             )
@@ -1522,6 +1718,7 @@ def _handle_query_submission(
                 "active_workflow"
             )
             st.session_state.pending_interrupt_log_dir = agent.log_dir
+            st.session_state.pending_interrupt_turn_dir = turn_dir
             st.session_state.interrupt_count = 1
             st.session_state.interrupt_exchanges = []
             st.rerun()
@@ -1554,8 +1751,10 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
         st.error("Agent was re-initialized. Please submit your query again.")
         _clear_interrupt_state()
         return
-    if agent.log_dir:
-        os.environ["CHEMGRAPH_LOG_DIR"] = agent.log_dir
+    # Resume inside the same turn directory the interrupted query used.
+    resume_dir = st.session_state.get("pending_interrupt_turn_dir") or agent.log_dir
+    if resume_dir:
+        os.environ["CHEMGRAPH_LOG_DIR"] = resume_dir
 
     MAX_INTERRUPTS = 10
 
@@ -1603,6 +1802,17 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
             new_msgs = all_msgs[prev_msg_count:]
             final_result = {"messages": new_msgs}
 
+            run_log_dir = (
+                st.session_state.get("pending_interrupt_log_dir") or agent.log_dir
+            )
+            run_artifacts = artifact_utils.collect_new_files(
+                run_log_dir,
+                st.session_state.get("pending_interrupt_artifact_snapshot") or {},
+            )
+            artifact_utils.append_manifest_entry(
+                run_log_dir, original_query, run_artifacts
+            )
+
             exchanges = list(st.session_state.interrupt_exchanges)
             st.session_state.last_run_result = final_result
             st.session_state.conversation_history.append(
@@ -1610,9 +1820,9 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
                     "query": original_query,
                     "result": final_result,
                     "thread_id": thread_id,
-                    "log_dir": st.session_state.get("pending_interrupt_log_dir")
-                    or agent.log_dir,
+                    "log_dir": run_log_dir,
                     "interrupt_exchanges": exchanges,
+                    "artifacts": run_artifacts,
                 }
             )
             _save_exchange_to_store(original_query, final_result)

--- a/src/ui/artifacts.py
+++ b/src/ui/artifacts.py
@@ -1,0 +1,212 @@
+"""Per-exchange artifact attribution for the ChemGraph Streamlit UI.
+
+All queries in a chat share one log directory, so "newest file in the
+directory" heuristics attribute artifacts from later queries (or stale
+files from unrelated runs) to earlier exchanges.  Instead, the UI
+snapshots the log directory before each agent run and records exactly
+which files the run created or modified.  That per-exchange file list is
+stored on the conversation entry and appended to a JSON manifest inside
+the log directory so restored sessions keep the correct attribution.
+
+Every function is Streamlit-free so it can be unit-tested without a
+running Streamlit runtime.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = "ui_artifacts.json"
+
+# Classification buckets, in the order the UI renders them.
+STRUCTURES = "structures"
+IR_PLOTS = "ir_plots"
+FREQUENCY_TABLES = "frequency_tables"
+MODE_TRAJECTORIES = "mode_trajectories"
+REPORTS = "reports"
+IMAGES = "images"
+DATA = "data"
+OTHER = "other"
+
+
+def snapshot_mtimes(log_dir: Optional[str]) -> dict[str, float]:
+    """Return ``{relative_path: mtime}`` for every file under *log_dir*.
+
+    Parameters
+    ----------
+    log_dir : str, optional
+        Chat log directory.  ``None`` or a missing directory yields ``{}``.
+
+    Returns
+    -------
+    dict[str, float]
+        Relative file paths mapped to modification times.
+    """
+    if not log_dir or not os.path.isdir(log_dir):
+        return {}
+    base = Path(log_dir)
+    snapshot: dict[str, float] = {}
+    for path in base.rglob("*"):
+        if not path.is_file() or path.name == MANIFEST_FILENAME:
+            continue
+        try:
+            snapshot[path.relative_to(base).as_posix()] = path.stat().st_mtime
+        except OSError:
+            continue
+    return snapshot
+
+
+def collect_new_files(
+    log_dir: Optional[str], before: dict[str, float]
+) -> list[str]:
+    """Return files created or modified since the *before* snapshot.
+
+    Parameters
+    ----------
+    log_dir : str, optional
+        Chat log directory.
+    before : dict[str, float]
+        Snapshot taken with :func:`snapshot_mtimes` before the run.
+
+    Returns
+    -------
+    list[str]
+        Relative paths of new/changed files, oldest first.
+    """
+    after = snapshot_mtimes(log_dir)
+    changed = [
+        rel
+        for rel, mtime in after.items()
+        if rel not in before or mtime != before[rel]
+    ]
+    changed.sort(key=lambda rel: after[rel])
+    return changed
+
+
+def classify_artifacts(files: list[str]) -> dict[str, list[str]]:
+    """Group artifact paths by kind, preserving input (chronological) order.
+
+    Parameters
+    ----------
+    files : list[str]
+        Relative artifact paths from :func:`collect_new_files`.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        Non-empty buckets keyed by the module-level kind constants.
+    """
+    kinds: dict[str, list[str]] = {}
+
+    def _add(kind: str, rel: str) -> None:
+        kinds.setdefault(kind, []).append(rel)
+
+    for rel in files:
+        name = Path(rel).name.lower()
+        if name.endswith(".xyz"):
+            _add(STRUCTURES, rel)
+        elif name.endswith(".png") and name.startswith("ir_spectrum"):
+            _add(IR_PLOTS, rel)
+        elif name.endswith(".csv") and name.startswith("frequencies"):
+            _add(FREQUENCY_TABLES, rel)
+        elif fnmatch.fnmatch(name, "*_vib.*.traj"):
+            _add(MODE_TRAJECTORIES, rel)
+        elif name.endswith((".html", ".htm")):
+            _add(REPORTS, rel)
+        elif name.endswith(".png"):
+            _add(IMAGES, rel)
+        elif name.endswith((".json", ".csv")):
+            _add(DATA, rel)
+        else:
+            _add(OTHER, rel)
+    return kinds
+
+
+def append_manifest_entry(
+    log_dir: Optional[str], query: str, files: list[str]
+) -> None:
+    """Append one exchange's artifact list to the log-dir manifest.
+
+    Best-effort: any I/O failure is logged and swallowed so persistence
+    problems never break the chat flow.
+
+    Parameters
+    ----------
+    log_dir : str, optional
+        Chat log directory.
+    query : str
+        User query that produced the artifacts.
+    files : list[str]
+        Relative artifact paths for the exchange.
+    """
+    if not log_dir:
+        return
+    entries = load_manifest(log_dir)
+    entries.append({"query": query, "files": list(files)})
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        manifest_path = Path(log_dir) / MANIFEST_FILENAME
+        manifest_path.write_text(
+            json.dumps({"exchanges": entries}, indent=2), encoding="utf-8"
+        )
+    except OSError as exc:
+        logger.warning("Failed to write artifact manifest: %s", exc)
+
+
+def load_manifest(log_dir: Optional[str]) -> list[dict]:
+    """Return the manifest exchange list for *log_dir* (``[]`` on any problem).
+
+    Parameters
+    ----------
+    log_dir : str, optional
+        Chat log directory.
+
+    Returns
+    -------
+    list[dict]
+        Entries of the form ``{"query": str, "files": [str, ...]}``.
+    """
+    if not log_dir:
+        return []
+    manifest_path = Path(log_dir) / MANIFEST_FILENAME
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    exchanges = data.get("exchanges") if isinstance(data, dict) else None
+    if not isinstance(exchanges, list):
+        return []
+    return [
+        entry
+        for entry in exchanges
+        if isinstance(entry, dict) and isinstance(entry.get("files"), list)
+    ]
+
+
+def attach_artifacts_to_history(history: list[dict], log_dir: Optional[str]) -> None:
+    """Attach manifest artifact lists to restored conversation entries.
+
+    Entries and manifest records are appended in the same order, so they
+    are matched positionally with the query text as a safety check; on the
+    first mismatch the remaining entries are left untouched and fall back
+    to legacy directory-based rendering.
+
+    Parameters
+    ----------
+    history : list[dict]
+        Conversation-history entries rebuilt from a stored session.
+    log_dir : str, optional
+        Session log directory containing the manifest.
+    """
+    manifest = load_manifest(log_dir)
+    for entry, record in zip(history, manifest):
+        if entry.get("query") != record.get("query"):
+            break
+        entry["artifacts"] = list(record.get("files", []))

--- a/src/ui/file_utils.py
+++ b/src/ui/file_utils.py
@@ -9,7 +9,7 @@ stale artifacts from earlier sessions.  Per-exchange attribution lives in
 
 import os
 import re
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Optional
 
 
@@ -41,6 +41,49 @@ def find_latest_xyz_file_in_dir(directory: str) -> Optional[str]:
     return latest_path
 
 
+_WINDOWS_DRIVE_RE = re.compile(r"[A-Za-z]:[\\/]")
+
+
+def _is_absolute_output_path(path: str) -> bool:
+    """Return whether *path* is absolute on the platform it came from.
+
+    Agent messages can quote paths from either path flavor (e.g. a stored
+    session moved between machines), so Windows drive paths are accepted
+    even when the app runs on POSIX -- non-existent ones are discarded by
+    the callers' existence/containment checks.
+
+    Parameters
+    ----------
+    path : str
+        Extracted path candidate.
+
+    Returns
+    -------
+    bool
+        ``True`` for POSIX-absolute or Windows drive-absolute paths.
+    """
+    return os.path.isabs(path) or bool(_WINDOWS_DRIVE_RE.match(path))
+
+
+def _parent_directory(path: str) -> str:
+    """Return the parent directory of *path*, honoring its path flavor.
+
+    Parameters
+    ----------
+    path : str
+        Absolute file path (POSIX or Windows form).
+
+    Returns
+    -------
+    str
+        Parent directory in the same form.
+    """
+    if _WINDOWS_DRIVE_RE.match(path):
+        # PureWindowsPath understands backslashes on every platform.
+        return str(PureWindowsPath(path).parent)
+    return str(Path(path).parent)
+
+
 def extract_log_dir_from_messages(messages: Any) -> Optional[str]:
     """Extract a log directory from messages that reference output files.
 
@@ -56,11 +99,16 @@ def extract_log_dir_from_messages(messages: Any) -> Optional[str]:
     """
     if not messages:
         return None
+    # Absolute POSIX (/run/dir/file.ext) or Windows drive
+    # (C:\run\dir\file.ext, C:/run/dir/file.ext) paths. The boundary
+    # prefix keeps slashes inside relative paths and URLs from matching.
+    _abs = r"(?:/|[A-Za-z]:[\\/])"
+    _start = r"(?:^|[\s'\"`=(,])"
     patterns = [
-        r"(/[^\s'\"`]+?\.json)",
-        r"(/[^\s'\"`]+?\.xyz)",
-        r"(/[^\s'\"`]+?\.html)",
-        r"(/[^\s'\"`]+?\.csv)",
+        rf"{_start}({_abs}[^\s'\"`]+?\.json)",
+        rf"{_start}({_abs}[^\s'\"`]+?\.xyz)",
+        rf"{_start}({_abs}[^\s'\"`]+?\.html)",
+        rf"{_start}({_abs}[^\s'\"`]+?\.csv)",
     ]
 
     def _scan_value(value: Any) -> Optional[str]:
@@ -81,8 +129,8 @@ def extract_log_dir_from_messages(messages: Any) -> Optional[str]:
                 match = re.search(pattern, value)
                 if match:
                     path = match.group(1)
-                    if os.path.isabs(path):
-                        return str(Path(path).parent)
+                    if _is_absolute_output_path(path):
+                        return _parent_directory(path)
         elif isinstance(value, dict):
             for v in value.values():
                 found = _scan_value(v)

--- a/src/ui/file_utils.py
+++ b/src/ui/file_utils.py
@@ -1,85 +1,16 @@
 """File-system helpers for the ChemGraph Streamlit UI.
 
-Functions for resolving output paths, finding XYZ files, checking file
-recency, and extracting directory paths from agent messages.
+Functions for finding XYZ files and extracting directory paths from agent
+messages.  Helpers that searched the current working directory or the
+global ``CHEMGRAPH_LOG_DIR`` were removed on purpose: they picked up
+stale artifacts from earlier sessions.  Per-exchange attribution lives in
+:mod:`ui.artifacts`.
 """
 
 import os
 import re
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Optional
-
-
-def resolve_output_path(path: str) -> str:
-    """Resolve output paths relative to CHEMGRAPH_LOG_DIR when set.
-
-    Parameters
-    ----------
-    path : str
-        Absolute or relative output path.
-
-    Returns
-    -------
-    str
-        Resolved output path.
-    """
-    if not path:
-        return path
-    if os.path.isabs(path):
-        return path
-    log_dir = os.environ.get("CHEMGRAPH_LOG_DIR")
-    if log_dir:
-        return os.path.join(log_dir, path)
-    return path
-
-
-def changed_recently(path: str = "ir_spectrum.png", window_seconds: int = 300) -> bool:
-    """Return True if a file was modified within a recent time window.
-
-    Parameters
-    ----------
-    path : str, optional
-        File path to inspect.
-    window_seconds : int, optional
-        Recency window in seconds.
-
-    Returns
-    -------
-    bool
-        ``True`` when the file exists and is recent.
-    """
-    p = Path(resolve_output_path(path))
-    if not p.exists():
-        return False
-
-    mtime = datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc)
-    now = datetime.now(timezone.utc)
-    return (now - mtime) <= timedelta(seconds=window_seconds)
-
-
-def find_latest_xyz_file() -> Optional[str]:
-    """Find the most recently modified ``.xyz`` file in the log dir or cwd."""
-    search_dirs: list[str] = []
-    log_dir = os.environ.get("CHEMGRAPH_LOG_DIR")
-    if log_dir:
-        search_dirs.append(log_dir)
-    search_dirs.append(os.getcwd())
-
-    latest_path: Optional[str] = None
-    latest_mtime = -1.0
-    for base in search_dirs:
-        if not base or not os.path.isdir(base):
-            continue
-        for path in Path(base).rglob("*.xyz"):
-            try:
-                mtime = path.stat().st_mtime
-            except OSError:
-                continue
-            if mtime > latest_mtime:
-                latest_mtime = mtime
-                latest_path = str(path)
-    return latest_path
 
 
 def find_latest_xyz_file_in_dir(directory: str) -> Optional[str]:

--- a/src/ui/file_utils.py
+++ b/src/ui/file_utils.py
@@ -9,7 +9,7 @@ stale artifacts from earlier sessions.  Per-exchange attribution lives in
 
 import os
 import re
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Optional
 
 
@@ -48,9 +48,10 @@ def _is_absolute_output_path(path: str) -> bool:
     """Return whether *path* is absolute on the platform it came from.
 
     Agent messages can quote paths from either path flavor (e.g. a stored
-    session moved between machines), so Windows drive paths are accepted
-    even when the app runs on POSIX -- non-existent ones are discarded by
-    the callers' existence/containment checks.
+    session moved between machines), so both flavors are checked
+    explicitly -- ``os.path.isabs`` would answer only for the platform
+    the app happens to run on. Non-existent paths are discarded by the
+    callers' existence/containment checks.
 
     Parameters
     ----------
@@ -62,11 +63,16 @@ def _is_absolute_output_path(path: str) -> bool:
     bool
         ``True`` for POSIX-absolute or Windows drive-absolute paths.
     """
-    return os.path.isabs(path) or bool(_WINDOWS_DRIVE_RE.match(path))
+    return path.startswith("/") or bool(_WINDOWS_DRIVE_RE.match(path))
 
 
 def _parent_directory(path: str) -> str:
     """Return the parent directory of *path*, honoring its path flavor.
+
+    Uses the Pure* path classes so the result keeps the flavor of the
+    input on every platform: ``pathlib.Path`` would rewrite a POSIX path
+    to backslashes when running on Windows (and cannot split a Windows
+    path when running on POSIX).
 
     Parameters
     ----------
@@ -79,9 +85,8 @@ def _parent_directory(path: str) -> str:
         Parent directory in the same form.
     """
     if _WINDOWS_DRIVE_RE.match(path):
-        # PureWindowsPath understands backslashes on every platform.
         return str(PureWindowsPath(path).parent)
-    return str(Path(path).parent)
+    return str(PurePosixPath(path).parent)
 
 
 def extract_log_dir_from_messages(messages: Any) -> Optional[str]:

--- a/src/ui/state.py
+++ b/src/ui/state.py
@@ -40,6 +40,8 @@ def init_session_state() -> None:
         "pending_interrupt_model": None,  # str: model active when query started
         "pending_interrupt_workflow": None,  # str: workflow active when query started
         "pending_interrupt_log_dir": None,  # str: log dir active when query started
+        "pending_interrupt_turn_dir": None,  # str: per-query artifact dir of the run
+        "pending_interrupt_artifact_snapshot": None,  # dict: log-dir snapshot at query start
         "interrupt_count": 0,  # int: safety counter for sequential interrupts
         "interrupt_exchanges": [],  # list of {"question": str, "answer": str}
     }

--- a/tests/test_ui_artifacts.py
+++ b/tests/test_ui_artifacts.py
@@ -1,0 +1,126 @@
+"""Tests for per-exchange artifact attribution (ui.artifacts)."""
+
+import json
+import os
+
+from ui import artifacts
+
+
+def _touch(path, mtime=None, content="x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+def test_snapshot_skips_manifest_and_handles_missing_dir(tmp_path):
+    _touch(tmp_path / "a.xyz", mtime=10)
+    _touch(tmp_path / "sub" / "b.csv", mtime=20)
+    _touch(tmp_path / artifacts.MANIFEST_FILENAME)
+
+    snapshot = artifacts.snapshot_mtimes(str(tmp_path))
+
+    assert set(snapshot) == {"a.xyz", "sub/b.csv"}
+    assert artifacts.snapshot_mtimes(None) == {}
+    assert artifacts.snapshot_mtimes(str(tmp_path / "missing")) == {}
+
+
+def test_collect_new_files_reports_only_this_runs_files(tmp_path):
+    stale = _touch(tmp_path / "stale.xyz", mtime=10)
+    modified = _touch(tmp_path / "rewritten.csv", mtime=20)
+    before = artifacts.snapshot_mtimes(str(tmp_path))
+
+    # Simulate a run: one new file, one rewritten file, one untouched file.
+    _touch(tmp_path / "new.xyz", mtime=40)
+    _touch(modified, mtime=50)
+
+    changed = artifacts.collect_new_files(str(tmp_path), before)
+
+    assert changed == ["new.xyz", "rewritten.csv"]
+    assert stale.name not in changed
+
+
+def test_collect_new_files_orders_by_mtime(tmp_path):
+    before = artifacts.snapshot_mtimes(str(tmp_path))
+    _touch(tmp_path / "later.png", mtime=200)
+    _touch(tmp_path / "earlier.xyz", mtime=100)
+
+    assert artifacts.collect_new_files(str(tmp_path), before) == [
+        "earlier.xyz",
+        "later.png",
+    ]
+
+
+def test_classify_artifacts_buckets_by_kind():
+    kinds = artifacts.classify_artifacts(
+        [
+            "water_opt.xyz",
+            "ir_spectrum_methanol.png",
+            "frequencies_methanol.csv",
+            "methanol_vib.3.traj",
+            "report.html",
+            "convergence.png",
+            "output.json",
+            "notes.txt",
+        ]
+    )
+
+    assert kinds[artifacts.STRUCTURES] == ["water_opt.xyz"]
+    assert kinds[artifacts.IR_PLOTS] == ["ir_spectrum_methanol.png"]
+    assert kinds[artifacts.FREQUENCY_TABLES] == ["frequencies_methanol.csv"]
+    assert kinds[artifacts.MODE_TRAJECTORIES] == ["methanol_vib.3.traj"]
+    assert kinds[artifacts.REPORTS] == ["report.html"]
+    assert kinds[artifacts.IMAGES] == ["convergence.png"]
+    assert kinds[artifacts.DATA] == ["output.json"]
+    assert kinds[artifacts.OTHER] == ["notes.txt"]
+
+
+def test_manifest_round_trip(tmp_path):
+    artifacts.append_manifest_entry(str(tmp_path), "optimize water", ["water.xyz"])
+    artifacts.append_manifest_entry(
+        str(tmp_path), "IR of methanol", ["ir_spectrum_methanol.png"]
+    )
+
+    entries = artifacts.load_manifest(str(tmp_path))
+
+    assert entries == [
+        {"query": "optimize water", "files": ["water.xyz"]},
+        {"query": "IR of methanol", "files": ["ir_spectrum_methanol.png"]},
+    ]
+
+
+def test_load_manifest_tolerates_garbage(tmp_path):
+    assert artifacts.load_manifest(None) == []
+    assert artifacts.load_manifest(str(tmp_path)) == []
+
+    manifest = tmp_path / artifacts.MANIFEST_FILENAME
+    manifest.write_text("not json")
+    assert artifacts.load_manifest(str(tmp_path)) == []
+
+    manifest.write_text(json.dumps({"exchanges": [{"query": "q"}, "bad", 3]}))
+    assert artifacts.load_manifest(str(tmp_path)) == []
+
+
+def test_attach_artifacts_matches_by_order_and_query(tmp_path):
+    artifacts.append_manifest_entry(str(tmp_path), "q1", ["a.xyz"])
+    artifacts.append_manifest_entry(str(tmp_path), "q2", ["b.xyz"])
+    history = [{"query": "q1"}, {"query": "q2"}, {"query": "q3"}]
+
+    artifacts.attach_artifacts_to_history(history, str(tmp_path))
+
+    assert history[0]["artifacts"] == ["a.xyz"]
+    assert history[1]["artifacts"] == ["b.xyz"]
+    assert "artifacts" not in history[2]
+
+
+def test_attach_artifacts_stops_on_query_mismatch(tmp_path):
+    artifacts.append_manifest_entry(str(tmp_path), "other query", ["a.xyz"])
+    artifacts.append_manifest_entry(str(tmp_path), "q2", ["b.xyz"])
+    history = [{"query": "q1"}, {"query": "q2"}]
+
+    artifacts.attach_artifacts_to_history(history, str(tmp_path))
+
+    # Positional correspondence is broken, so nothing is attached.
+    assert "artifacts" not in history[0]
+    assert "artifacts" not in history[1]

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -1,5 +1,6 @@
 from contextlib import nullcontext
 import os
+from pathlib import Path
 
 from chemgraph.models.supported_models import supported_argo_models
 from ui._pages import main_interface as main_ui
@@ -428,6 +429,127 @@ def test_artifact_log_dir_prefers_conversation_entry():
     entry = {"log_dir": "/current/chat"}
 
     assert main_ui._artifact_log_dir(messages, entry) == "/current/chat"
+
+
+def test_entry_artifact_kinds_distinguishes_legacy_and_recorded_entries():
+    assert main_ui._entry_artifact_kinds({}) is None
+    assert main_ui._entry_artifact_kinds({"artifacts": []}) == {}
+
+    kinds = main_ui._entry_artifact_kinds(
+        {"artifacts": ["water.xyz", "ir_spectrum_water.png"]}
+    )
+    assert kinds["structures"] == ["water.xyz"]
+    assert kinds["ir_plots"] == ["ir_spectrum_water.png"]
+
+
+def test_exchange_structure_path_uses_own_artifacts_not_newest(tmp_path):
+    own = tmp_path / "mol.xyz"
+    own.write_text("1\n\nH 0 0 0\n")
+    stale = tmp_path / "stale.xyz"
+    stale.write_text("1\n\nHe 0 0 0\n")
+    os.utime(own, (1, 1))
+    os.utime(stale, (99, 99))  # newer file from another query
+
+    entry = {"artifacts": ["mol.xyz"], "log_dir": str(tmp_path)}
+
+    assert main_ui._exchange_structure_path([], entry, "") == str(own)
+
+
+def test_exchange_structure_path_empty_artifacts_never_falls_back(tmp_path):
+    (tmp_path / "stale.xyz").write_text("1\n\nHe 0 0 0\n")
+    entry = {
+        "artifacts": [],
+        "log_dir": str(tmp_path),
+        "query": "optimize the geometry of water",
+    }
+
+    assert main_ui._exchange_structure_path([], entry, "") is None
+
+
+def test_exchange_structure_path_legacy_entry_uses_dir_scan(monkeypatch, tmp_path):
+    monkeypatch.setattr(main_ui, "has_structure_signal", lambda *a: True)
+    monkeypatch.setattr(
+        main_ui, "find_latest_xyz_file_in_dir", lambda d: f"{d}/found.xyz"
+    )
+    entry = {"log_dir": str(tmp_path), "query": "optimize water"}
+
+    assert main_ui._exchange_structure_path([], entry, "") == f"{tmp_path}/found.xyz"
+
+
+def test_artifact_log_dir_rejects_fallback_outside_ui_log_root(
+    monkeypatch, tmp_path
+):
+    fake_st = _FakeStreamlit()
+    root = tmp_path / "cg_logs"
+    inside = root / "ui_session_1"
+    inside.mkdir(parents=True)
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    fake_st.session_state.ui_log_root = str(root)
+    monkeypatch.setattr(main_ui, "st", fake_st)
+
+    inside_msg = [{"content": f"saved to {inside / 'output.json'}"}]
+    outside_msg = [{"content": f"saved to {outside / 'output.json'}"}]
+
+    assert main_ui._artifact_log_dir(inside_msg, {}) == str(inside)
+    assert main_ui._artifact_log_dir(outside_msg, {}) is None
+    # An explicit entry log_dir always wins and is never filtered.
+    assert main_ui._artifact_log_dir(outside_msg, {"log_dir": "/current"}) == "/current"
+
+
+def test_num_nonvibrational_modes_prefers_exchange_structure(monkeypatch, tmp_path):
+    from ase import Atoms
+
+    water = Atoms("H2O", positions=[[0, 0.76, 0.59], [0, -0.76, 0.59], [0, 0, 0]])
+    co2 = Atoms("CO2", positions=[[0, 0, 0], [0, 0, 1.16], [0, 0, -1.16]])
+
+    read_paths = []
+
+    def fake_read(path):
+        read_paths.append(path)
+        return water if path == "own.xyz" else co2
+
+    monkeypatch.setattr(main_ui, "ase_read", fake_read)
+    monkeypatch.setattr(
+        main_ui, "find_latest_xyz_file_in_dir", lambda _d: "newest.xyz"
+    )
+
+    # With an exchange structure the directory is never scanned.
+    assert main_ui._num_nonvibrational_modes(9, "/logs", structure_path="own.xyz") == 6
+    assert read_paths == ["own.xyz"]
+
+
+def test_activate_turn_dir_gives_each_query_its_own_artifact_dir(
+    monkeypatch, tmp_path
+):
+    first = main_ui._activate_turn_dir(str(tmp_path), 1)
+    second = main_ui._activate_turn_dir(str(tmp_path), 2)
+
+    assert first != second
+    assert os.path.isdir(first) and os.path.isdir(second)
+    assert os.environ["CHEMGRAPH_LOG_DIR"] == second
+    assert Path(first).parent == tmp_path
+    assert main_ui._activate_turn_dir(None, 3) is None
+    monkeypatch.delenv("CHEMGRAPH_LOG_DIR", raising=False)
+
+
+def test_turn_dirs_keep_same_named_artifacts_distinct(tmp_path):
+    """Two runs producing water_opt.traj must not collide in the manifest."""
+    from ui import artifacts
+
+    chat_dir = tmp_path
+    before1 = artifacts.snapshot_mtimes(str(chat_dir))
+    (chat_dir / "turn_001").mkdir()
+    (chat_dir / "turn_001" / "water_opt.traj").write_text("run1")
+    run1 = artifacts.collect_new_files(str(chat_dir), before1)
+
+    before2 = artifacts.snapshot_mtimes(str(chat_dir))
+    (chat_dir / "turn_002").mkdir()
+    (chat_dir / "turn_002" / "water_opt.traj").write_text("run2")
+    run2 = artifacts.collect_new_files(str(chat_dir), before2)
+
+    assert run1 == ["turn_001/water_opt.traj"]
+    assert run2 == ["turn_002/water_opt.traj"]
 
 
 def test_start_new_chat_clears_history_agent_and_log_dir(monkeypatch):

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -476,6 +476,25 @@ def test_exchange_structure_path_legacy_entry_uses_dir_scan(monkeypatch, tmp_pat
     assert main_ui._exchange_structure_path([], entry, "") == f"{tmp_path}/found.xyz"
 
 
+def test_extract_log_dir_handles_windows_and_posix_paths():
+    from ui.file_utils import extract_log_dir_from_messages
+
+    windows_msg = [
+        {"content": r"saved to C:\Users\me\cg_logs\ui_session_1\output.json"}
+    ]
+    posix_msg = [{"content": "saved to /home/me/cg_logs/ui_session_1/output.json"}]
+    relative_msg = [{"content": "saved to cg_logs/ui_session_1/output.json"}]
+
+    assert (
+        extract_log_dir_from_messages(windows_msg)
+        == r"C:\Users\me\cg_logs\ui_session_1"
+    )
+    assert (
+        extract_log_dir_from_messages(posix_msg) == "/home/me/cg_logs/ui_session_1"
+    )
+    assert extract_log_dir_from_messages(relative_msg) is None
+
+
 def test_artifact_log_dir_rejects_fallback_outside_ui_log_root(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## Problem

All queries in a chat share one log directory, and the UI re-discovered artifacts on every rerun by taking the **newest matching file** per pattern (`find_latest_xyz_file_in_dir`, `_latest_artifact_path`). Consequences users actually hit:

- After a second query, **earlier exchanges show the later query's molecule / IR spectrum / frequency table**.
- The regex fallback (`extract_log_dir_from_messages`) could resolve to the launch directory and recursively glob it, surfacing **stale files from unrelated sessions** (the repo root full of `water.xyz`, `ir_spectrum.png`, … is the tell).
- The IR panel was gated on the word "ir" appearing in messages, and report filenames came from a loose `.html` regex over message text.

## Fix

Attribute artifacts to the exchange that produced them, once, at run time:

- `ui/artifacts.py`: snapshot the log dir's mtimes before each agent run, diff after it, and record exactly the files the run created/modified. Streamlit-free and unit-tested.
- The per-exchange file list is stored on the conversation entry, appended to a `ui_artifacts.json` manifest in the chat log dir, and re-attached when a stored session is loaded.
- Structure / IR / frequency renderers consume the recorded list. "Newest in dir" scanning survives only for legacy entries without a manifest, strictly scoped to the entry's own log dir.
- The message-regex log-dir fallback now only accepts directories inside the UI log root — showing nothing beats showing the wrong molecule.
- The IR panel is gated on recorded IR artifacts instead of keyword sniffing (legacy entries keep the old path), and frequency-table mode trimming uses the exchange's own geometry.
- Deleted the dead CWD-globbing helpers (`find_latest_xyz_file`, `changed_recently`, `resolve_output_path`) that embodied the old behavior.

## Tests

- New `tests/test_ui_artifacts.py` (snapshot/diff, classification, manifest round-trip, session re-attachment).
- New regressions in `tests/test_ui_main_interface.py`: an exchange never renders another exchange's newer file; empty artifact list never falls back to directory scans; out-of-root fallback dirs are rejected.
- `ruff check .` and `pytest tests/ -k "not tblite"` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
