### PR TITLE
feat(ui): provider-first setup with in-UI Globus login for ALCF

### DIFF
--- a/docs/streamlit_web_interface.md
+++ b/docs/streamlit_web_interface.md
@@ -36,9 +36,25 @@ for artifact volumes and other modes.
 
 ## Configure the interface
 
+On first launch (no provider configured) the chat page shows a setup screen
+with four paths:
+
+- **Argo (Argonne)** — enter your ANL domain username; no API key. Works on
+  the lab network or VPN.
+- **Your own API key** — OpenAI, Anthropic, Google Gemini, Groq, or
+  OpenRouter; the key is applied to the server process environment only.
+- **ALCF Inference** — click *Log in with Globus*, sign in, and paste the
+  authorization code back; tokens are cached under `~/.chemgraph/` and
+  refreshed automatically. A token from ALCF's `inference_auth_token.py`
+  helper (or an exported `ALCF_ACCESS_TOKEN`) is picked up automatically.
+- **Local (Ollama)** — point at a running OpenAI-compatible server.
+
+The **Configuration → Providers** tab offers the same per-provider cards
+afterwards: readiness status, credentials, endpoint settings, and a model
+picker with one-click activation.
+
 When started from the checkout, the app's default configuration path is the
-repository-root `config.toml`. The model and workflow can then be changed in the
-sidebar. The interface exposes these workflow choices:
+repository-root `config.toml`. The interface exposes these workflow choices:
 
 - `single_agent`
 - `multi_agent`

--- a/src/chemgraph/models/local_model.py
+++ b/src/chemgraph/models/local_model.py
@@ -2,7 +2,9 @@ from langchain_ollama import ChatOllama
 from chemgraph.models.supported_models import supported_ollama_models
 
 
-def load_ollama_model(model_name: str, temperature: float) -> ChatOllama:
+def load_ollama_model(
+    model_name: str, temperature: float, base_url: str = None
+) -> ChatOllama:
     """Load an Ollama chat model into LangChain.
 
     This function loads a local Ollama model and configures it for use with
@@ -18,6 +20,9 @@ def load_ollama_model(model_name: str, temperature: float) -> ChatOllama:
         Controls the randomness of the generated text. Higher values (e.g., 0.8)
         make the output more random, while lower values (e.g., 0.2) make it more
         deterministic.
+    base_url : str, optional
+        Ollama server URL (e.g. from ``[api.local]`` in config.toml).
+        Defaults to ChatOllama's built-in ``http://localhost:11434``.
 
     Returns
     -------
@@ -38,9 +43,9 @@ def load_ollama_model(model_name: str, temperature: float) -> ChatOllama:
             f"Unsupported model '{model_name}'. Supported models are: {supported_ollama_models}."
         )
 
-    llm = ChatOllama(
-        model=model_name,
-        temperature=temperature,
-    )
+    kwargs = {"model": model_name, "temperature": temperature}
+    if base_url:
+        kwargs["base_url"] = base_url
+    llm = ChatOllama(**kwargs)
     print(f"Successfully loaded model: {model_name}")
     return llm

--- a/src/ui/_pages/configuration.py
+++ b/src/ui/_pages/configuration.py
@@ -7,8 +7,10 @@ from typing import Any, Dict
 import streamlit as st
 import toml
 
-from chemgraph.models.supported_models import ARGO_DEFAULT_BASE_URL
+from ui import providers
 from ui.config import get_default_config, load_config, save_config
+from ui.endpoint import check_local_model_endpoint
+from ui.provider_widgets import apply_api_key, clear_api_key, render_alcf_login
 
 # ---------------------------------------------------------------------------
 # Constants shared with the main app
@@ -73,36 +75,56 @@ def get_model_options(config: Dict[str, Any]) -> list:
 
 def render() -> None:
     """Render the Configuration page."""
-    st.title("\u2699\ufe0f Configuration")
+    st.title("⚙️ Configuration")
     st.markdown(
         """
-    Edit and manage your ChemGraph configuration settings.
-    Changes only take effect when you click **Save Configuration**.
+    Connect a model provider and manage ChemGraph settings.
+    Provider actions apply immediately; other changes take effect when you
+    click **Save Configuration**.
     """
     )
 
     # Ensure config exists in session state
-    if "config" not in st.session_state:
+    if "config" not in st.session_state or st.session_state.config is None:
         st.session_state.config = load_config()
 
     # Work on a draft copy so widgets never mutate the live config.
     # The draft is written back to st.session_state.config only on Save.
-    if "_config_draft" not in st.session_state:
-        st.session_state._config_draft = copy.deepcopy(st.session_state.config)
+    # Whenever the live config changed elsewhere (first-run setup, provider
+    # activation, reload), the draft is rebased on it and the widget nonce
+    # bumps so stale widget state cannot write old values back.
+    live_config = st.session_state.config
+    if (
+        "_config_draft" not in st.session_state
+        or st.session_state.get("_config_draft_base") != live_config
+    ):
+        st.session_state._config_draft = copy.deepcopy(live_config)
+        st.session_state._config_draft_base = copy.deepcopy(live_config)
+        st.session_state._config_widget_nonce = (
+            st.session_state.get("_config_widget_nonce", 0) + 1
+        )
     draft = st.session_state._config_draft
 
     # ----- Tabs -----
-    tab1, tab2, tab3 = st.tabs(
-        ["\U0001f527 General Settings", "\U0001f517 API Settings", "\U0001f4dd Raw TOML"]
+    tab_providers, tab_general, tab_chem, tab_toml = st.tabs(
+        [
+            "\U0001f50c Providers",
+            "\U0001f527 General",
+            "\U0001f9ea Chemistry",
+            "\U0001f4dd Raw TOML",
+        ]
     )
 
-    with tab1:
+    with tab_providers:
+        _render_providers(draft)
+
+    with tab_general:
         _render_general_settings(draft)
 
-    with tab2:
-        _render_api_settings(draft)
+    with tab_chem:
+        _render_chemistry_settings(draft)
 
-    with tab3:
+    with tab_toml:
         _render_raw_toml(draft)
 
     # ----- Action buttons -----
@@ -113,7 +135,265 @@ def render() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Internal renderers
+# Provider cards
+# ---------------------------------------------------------------------------
+
+
+def _wkey(base: str) -> str:
+    """Return a draft-generation-scoped widget key.
+
+    Parameters
+    ----------
+    base : str
+        Stable widget key base.
+
+    Returns
+    -------
+    str
+        Key suffixed with the draft nonce, so widgets are recreated from
+        the draft whenever it is rebased on an externally changed config.
+    """
+    return f"{base}_{st.session_state.get('_config_widget_nonce', 0)}"
+
+
+def _activate_provider_model(draft: dict, info, model_name: str) -> None:
+    """Set *model_name* as the active model and persist immediately.
+
+    Provider activation is a deliberate action, so unlike other draft
+    edits it saves right away.
+
+    Parameters
+    ----------
+    draft : dict
+        Mutable draft configuration dictionary.
+    info : providers.ProviderInfo
+        Provider being activated.
+    model_name : str
+        Model to activate.
+    """
+    draft["general"]["model"] = model_name
+    providers.align_base_url_for_provider(draft, info.id)
+    st.session_state.config = copy.deepcopy(draft)
+    if save_config(st.session_state.config):
+        st.toast(f"Now using {model_name}", icon="✅")
+    st.rerun()
+
+
+def _render_providers(draft: dict) -> None:
+    """Render one status card per provider.
+
+    Parameters
+    ----------
+    draft : dict
+        Mutable draft configuration dictionary.
+    """
+    st.caption(
+        "Configure at least one way to reach an LLM. "
+        "✅ = ready to use, ○ = needs setup."
+    )
+    st.warning(
+        "**Shared deployments:** API keys are set as process-wide "
+        "environment variables. On multi-user Streamlit servers they may "
+        "be visible to other sessions; configure keys via server-side "
+        "environment variables instead.",
+        icon="⚠️",
+    )
+
+    active_model = draft["general"].get("model", "")
+    active_info = providers.provider_for_model(active_model)
+
+    for status in providers.all_provider_statuses(draft):
+        info = status.info
+        badge = "✅" if status.ready else "○"
+        is_active = active_info is not None and active_info.id == info.id
+        title = f"{badge} {info.icon} {info.label}"
+        if is_active:
+            title += "  • active"
+        with st.expander(title, expanded=is_active and not status.ready):
+            st.caption(info.help_text)
+            if info.auth_kind == "argo":
+                _render_argo_card(draft, info, status)
+            elif info.auth_kind == "api_key":
+                _render_api_key_card(draft, info, status)
+            elif info.auth_kind == "globus":
+                _render_alcf_card(draft, info, status)
+            elif info.auth_kind == "endpoint":
+                _render_vllm_card(draft, info, status)
+            else:
+                _render_local_card(draft, info, status)
+            _render_model_picker(draft, info, status, active_model)
+
+
+def _render_argo_card(draft: dict, info, status) -> None:
+    """Render the Argo gateway card (username, no API key)."""
+    argo_section = draft["api"].setdefault("argo", {})
+    current = (
+        argo_section.get("argo_user")
+        or argo_section.get("user")
+        or draft["api"].get("openai", {}).get("argo_user", "")
+    )
+    user = st.text_input(
+        "ANL username",
+        value=current,
+        key=_wkey("provider_argo_user"),
+        help=(
+            "Your Argonne domain username. Requests to the Argo gateway "
+            "are attributed to it; no API key is needed."
+        ),
+    ).strip()
+    if user != current:
+        argo_section["argo_user"] = user
+        st.session_state.config["api"].setdefault("argo", {})[
+            "argo_user"
+        ] = user
+        save_config(st.session_state.config)
+        st.rerun()
+    st.caption(status.detail)
+    _render_endpoint_settings(draft, "argo", key_prefix="argo")
+
+
+def _render_api_key_card(draft: dict, info, status) -> None:
+    """Render a card for an API-key provider."""
+    env_var = info.env_var or ""
+    key_set = bool(os.environ.get(env_var))
+    if key_set:
+        st.success(f"${env_var} is set for this session.")
+    key_value = st.text_input(
+        f"{info.label} API key",
+        value="",
+        type="password",
+        key=f"provider_key_{info.id}",
+        help=(
+            f"Applied to this Streamlit process as ${env_var}; "
+            "not written to config.toml."
+        ),
+    )
+    col_apply, col_clear = st.columns(2)
+    with col_apply:
+        if st.button("Apply key", key=f"provider_apply_{info.id}"):
+            if apply_api_key(env_var, key_value):
+                st.rerun()
+            else:
+                st.info("Enter a key first.")
+    with col_clear:
+        if key_set and st.button("Clear key", key=f"provider_clear_{info.id}"):
+            clear_api_key(env_var)
+            st.rerun()
+    if info.config_section:
+        _render_endpoint_settings(draft, info.config_section, key_prefix=info.id)
+
+
+def _render_alcf_card(draft: dict, info, status) -> None:
+    """Render the ALCF inference card with the in-UI Globus login."""
+    render_alcf_login(key_prefix="config")
+    st.caption(
+        "Models on the Minerva and Metis clusters are routed to their own "
+        "endpoints automatically; the URL below is the Sophia default."
+    )
+    _render_endpoint_settings(draft, "alcf", key_prefix="alcf")
+
+
+def _render_local_card(draft: dict, info, status) -> None:
+    """Render the local/Ollama card with a live reachability probe."""
+    _render_endpoint_settings(draft, "local", key_prefix="local")
+    base_url = draft["api"].get("local", {}).get("base_url")
+    probe = check_local_model_endpoint(base_url)
+    if probe["ok"]:
+        st.success(f"Endpoint: {probe['message']}")
+    else:
+        st.error(f"Endpoint: {probe['message']}")
+
+
+def _render_vllm_card(draft: dict, info, status) -> None:
+    """Render custom OpenAI-compatible endpoint settings."""
+    api = draft.setdefault("api", {})
+    section = api.get("vllm", {})
+    if not isinstance(section, dict):
+        section = {}
+    base_url = st.text_input(
+        "Base URL",
+        value=section.get("base_url", ""),
+        key=_wkey("endpoint_url_vllm"),
+        help="OpenAI-compatible API root, for example http://localhost:8000/v1.",
+    )
+    _update_vllm_config(api, base_url)
+    st.caption(status.detail)
+
+
+def _update_vllm_config(api: dict, base_url: str) -> None:
+    """Preserve an absent legacy vLLM section until a URL is supplied."""
+    if "vllm" in api or base_url.strip():
+        api.setdefault("vllm", {})["base_url"] = base_url
+
+
+def _render_endpoint_settings(draft: dict, section: str, key_prefix: str) -> None:
+    """Render base-URL/timeout inputs for one ``[api.*]`` section.
+
+    Parameters
+    ----------
+    draft : dict
+        Mutable draft configuration dictionary.
+    section : str
+        Key under ``config["api"]``.
+    key_prefix : str
+        Unique widget-key prefix.
+    """
+    api_section = draft["api"].setdefault(section, {})
+    with st.popover("Endpoint settings"):
+        api_section["base_url"] = st.text_input(
+            "Base URL",
+            value=api_section.get("base_url", ""),
+            key=_wkey(f"endpoint_url_{key_prefix}"),
+        )
+        api_section["timeout"] = st.number_input(
+            "Timeout (seconds)",
+            min_value=1,
+            max_value=300,
+            value=int(api_section.get("timeout", 30)),
+            key=_wkey(f"endpoint_timeout_{key_prefix}"),
+        )
+
+
+def _render_model_picker(draft: dict, info, status, active_model: str) -> None:
+    """Render the per-provider model selector and activation button."""
+    st.markdown("---")
+    col_model, col_use = st.columns([3, 1], vertical_alignment="bottom")
+    with col_model:
+        if info.models:
+            options = list(info.models)
+            index = (
+                options.index(active_model) if active_model in options else 0
+            )
+            selected = st.selectbox(
+                "Model",
+                options,
+                index=index,
+                key=_wkey(f"provider_model_{info.id}"),
+            )
+        else:
+            selected = st.text_input(
+                "Model",
+                value=(
+                    active_model
+                    if providers.provider_for_model(active_model) is not None
+                    and providers.provider_for_model(active_model).id == info.id
+                    else info.default_model
+                ),
+                key=_wkey(f"provider_model_{info.id}"),
+            ).strip()
+    with col_use:
+        if st.button(
+            "Use",
+            key=f"provider_use_{info.id}",
+            disabled=not status.ready or not selected,
+            help=None if status.ready else status.detail,
+            use_container_width=True,
+        ):
+            _activate_provider_model(draft, info, selected)
+
+
+# ---------------------------------------------------------------------------
+# General / chemistry / raw TOML tabs
 # ---------------------------------------------------------------------------
 
 
@@ -132,24 +412,39 @@ def _render_general_settings(config: dict) -> None:
     with col1:
         st.write("**Model & Workflow**")
         model_options = get_model_options(config)
+        current_model = config["general"]["model"]
+        # Keep whatever is active selectable, even when it is not in the
+        # curated list (custom IDs, prefix-routed Groq models, ...).
+        if current_model and current_model not in model_options:
+            model_options = [current_model] + model_options
         config["general"]["model"] = st.selectbox(
             "Model",
             model_options,
             index=(
-                model_options.index(config["general"]["model"])
-                if config["general"]["model"] in model_options
+                model_options.index(current_model)
+                if current_model in model_options
                 else 0
             ),
-            key="config_model",
+            key=_wkey("config_model"),
         )
-        config_custom_model = st.text_input(
+        custom_model = st.text_input(
             "Custom model ID (optional)",
             value="",
-            key="config_custom_model",
+            key=_wkey("config_custom_model"),
             help="Enter any provider/model identifier not listed above.",
         ).strip()
-        if config_custom_model:
-            config["general"]["model"] = config_custom_model
+        if st.button(
+            "Apply custom model",
+            key="config_custom_model_apply",
+            disabled=not custom_model,
+        ):
+            config["general"]["model"] = custom_model
+            # Recreate the widgets from the draft so the sticky selectbox
+            # state cannot overwrite the custom model on the next render.
+            st.session_state._config_widget_nonce = (
+                st.session_state.get("_config_widget_nonce", 0) + 1
+            )
+            st.rerun()
 
         config["general"]["workflow"] = normalize_workflow_name(
             config["general"]["workflow"]
@@ -162,7 +457,7 @@ def _render_general_settings(config: dict) -> None:
                 if config["general"]["workflow"] in WORKFLOW_OPTIONS
                 else 0
             ),
-            key="config_workflow",
+            key=_wkey("config_workflow"),
         )
 
         config["general"]["output"] = st.selectbox(
@@ -173,29 +468,29 @@ def _render_general_settings(config: dict) -> None:
                 if config["general"]["output"] in ["state", "last_message"]
                 else 0
             ),
-            key="config_output",
+            key=_wkey("config_output"),
         )
 
         config["general"]["structured"] = st.checkbox(
             "Structured Output",
             value=config["general"]["structured"],
-            key="config_structured",
+            key=_wkey("config_structured"),
         )
         config["general"]["report"] = st.checkbox(
             "Generate Report",
             value=config["general"]["report"],
-            key="config_report",
+            key=_wkey("config_report"),
         )
         config["general"]["human_supervised"] = st.checkbox(
             "Human Supervised",
             value=config["general"].get("human_supervised", False),
-            key="config_human_supervised",
+            key=_wkey("config_human_supervised"),
             help="Enable the ask_human tool so the agent can pause and request human input.",
         )
         config["general"]["verbose"] = st.checkbox(
             "Verbose Output",
             value=config["general"]["verbose"],
-            key="config_verbose",
+            key=_wkey("config_verbose"),
         )
 
     with col2:
@@ -205,16 +500,25 @@ def _render_general_settings(config: dict) -> None:
             min_value=1,
             max_value=1000,
             value=config["general"]["thread"],
-            key="config_thread",
+            key=_wkey("config_thread"),
         )
         config["general"]["recursion_limit"] = st.number_input(
             "Recursion Limit",
             min_value=1,
             max_value=100,
             value=config["general"]["recursion_limit"],
-            key="config_recursion",
+            key=_wkey("config_recursion"),
         )
 
+
+def _render_chemistry_settings(config: dict) -> None:
+    """Render and update chemistry configuration widgets.
+
+    Parameters
+    ----------
+    config : dict
+        Mutable draft configuration dictionary.
+    """
     st.subheader("Chemistry Settings")
 
     col3, col4 = st.columns(2)
@@ -232,22 +536,22 @@ def _render_general_settings(config: dict) -> None:
                 in ["BFGS", "L-BFGS-B", "CG", "Newton-CG"]
                 else 0
             ),
-            key="config_opt_method",
+            key=_wkey("config_opt_method"),
         )
         config["chemistry"]["optimization"]["fmax"] = st.number_input(
-            "Force Max (eV/\u00c5)",
+            "Force Max (eV/Å)",
             min_value=0.001,
             max_value=1.0,
             value=config["chemistry"]["optimization"]["fmax"],
             format="%.3f",
-            key="config_fmax",
+            key=_wkey("config_fmax"),
         )
         config["chemistry"]["optimization"]["steps"] = st.number_input(
             "Max Steps",
             min_value=1,
             max_value=1000,
             value=config["chemistry"]["optimization"]["steps"],
-            key="config_steps",
+            key=_wkey("config_steps"),
         )
 
     with col4:
@@ -271,7 +575,7 @@ def _render_general_settings(config: dict) -> None:
                 if config["chemistry"]["calculators"]["default"] in calc_options
                 else 0
             ),
-            key="config_calc_default",
+            key=_wkey("config_calc_default"),
         )
         config["chemistry"]["calculators"]["fallback"] = st.selectbox(
             "Fallback Calculator",
@@ -281,229 +585,8 @@ def _render_general_settings(config: dict) -> None:
                 if config["chemistry"]["calculators"]["fallback"] in calc_options
                 else 1
             ),
-            key="config_calc_fallback",
+            key=_wkey("config_calc_fallback"),
         )
-
-
-def _render_api_settings(config: dict) -> None:
-    """Render and update API configuration widgets.
-
-    Parameters
-    ----------
-    config : dict
-        Mutable draft configuration dictionary.
-    """
-    st.subheader("API Settings")
-
-    st.markdown("**API Keys (Session Only)**")
-    st.caption(
-        "Keys entered here are applied to this Streamlit session via environment "
-        "variables and are not saved to config.toml."
-    )
-    st.warning(
-        "**Shared deployments:** API keys are set as process-wide environment "
-        "variables. On multi-user Streamlit servers, keys set here may be "
-        "visible to other sessions in the same process. For shared "
-        "deployments, configure keys via server-side environment variables "
-        "instead.",
-        icon="\u26a0\ufe0f",
-    )
-
-    key_col1, key_col2, key_col3 = st.columns(3)
-    with key_col1:
-        openai_api_key = st.text_input(
-            "OpenAI API Key",
-            value=st.session_state.get("ui_openai_api_key", ""),
-            type="password",
-            key="ui_openai_api_key_input",
-        )
-        anthropic_api_key = st.text_input(
-            "Anthropic API Key",
-            value=st.session_state.get("ui_anthropic_api_key", ""),
-            type="password",
-            key="ui_anthropic_api_key_input",
-        )
-    with key_col2:
-        gemini_api_key = st.text_input(
-            "Gemini API Key",
-            value=st.session_state.get("ui_gemini_api_key", ""),
-            type="password",
-            key="ui_gemini_api_key_input",
-        )
-        groq_api_key = st.text_input(
-            "Groq API Key",
-            value=st.session_state.get("ui_groq_api_key", ""),
-            type="password",
-            key="ui_groq_api_key_input",
-        )
-    with key_col3:
-        alcf_access_token = st.text_input(
-            "ALCF Access Token",
-            value=st.session_state.get("ui_alcf_access_token", ""),
-            type="password",
-            key="ui_alcf_access_token_input",
-            help=(
-                "Globus OAuth access token for ALCF inference endpoints. "
-                "See https://docs.alcf.anl.gov/services/inference-endpoints/#api-access"
-            ),
-        )
-
-    key_env_map = {
-        "OPENAI_API_KEY": openai_api_key,
-        "ANTHROPIC_API_KEY": anthropic_api_key,
-        "GEMINI_API_KEY": gemini_api_key,
-        "GROQ_API_KEY": groq_api_key,
-        "ALCF_ACCESS_TOKEN": alcf_access_token,
-    }
-
-    action_col1, action_col2 = st.columns(2)
-    with action_col1:
-        if st.button("Apply API Keys", key="apply_api_keys"):
-            applied = []
-            for env_name, key_value in key_env_map.items():
-                clean_value = key_value.strip()
-                if clean_value:
-                    os.environ[env_name] = clean_value
-                    st.session_state[f"ui_{env_name.lower()}"] = clean_value
-                    applied.append(env_name)
-            if applied:
-                st.success(f"\u2705 Applied keys for: {', '.join(applied)}")
-            else:
-                st.info("No API keys entered.")
-    with action_col2:
-        if st.button("Clear Session API Keys", key="clear_api_keys"):
-            for env_name in key_env_map:
-                os.environ.pop(env_name, None)
-                st.session_state.pop(f"ui_{env_name.lower()}", None)
-                st.session_state.pop(f"ui_{env_name.lower()}_input", None)
-            st.success("\u2705 Cleared session API keys.")
-            st.rerun()
-
-    st.markdown("---")
-    api_tabs = st.tabs(
-        ["OpenAI", "Argo", "vLLM", "Anthropic", "Google", "ALCF", "Local"]
-    )
-
-    with api_tabs[0]:
-        config["api"]["openai"]["base_url"] = st.text_input(
-            "Base URL",
-            value=config["api"]["openai"]["base_url"],
-            key="config_openai_url",
-        )
-        config["api"]["openai"]["timeout"] = st.number_input(
-            "Timeout (seconds)",
-            min_value=1,
-            max_value=300,
-            value=config["api"]["openai"]["timeout"],
-            key="config_openai_timeout",
-        )
-
-    with api_tabs[1]:
-        legacy_openai = config["api"].get("openai", {})
-        argo_section = config["api"].setdefault("argo", {})
-        legacy_url = legacy_openai.get("base_url", "")
-        legacy_user = legacy_openai.get("argo_user", "")
-        argo_section["base_url"] = st.text_input(
-            "Base URL",
-            value=argo_section.get("base_url")
-            or (legacy_url if "argoapi" in legacy_url else ARGO_DEFAULT_BASE_URL),
-            key="config_argo_url",
-        )
-        argo_section["argo_user"] = st.text_input(
-            "Argo User (optional)",
-            value=argo_section.get("argo_user")
-            or argo_section.get("user")
-            or legacy_user,
-            key="config_argo_user",
-            help=(
-                "ANL domain username for Argo requests. If blank, ChemGraph "
-                "falls back to ARGO_USER."
-            ),
-        )
-
-    with api_tabs[2]:
-        vllm_section = config["api"].get("vllm", {})
-        vllm_base_url = st.text_input(
-            "Base URL (optional)",
-            value=vllm_section.get("base_url", ""),
-            key="config_vllm_url",
-            help=(
-                "Endpoint for unknown/custom OpenAI-compatible model IDs. "
-                "Leave empty to disable config-based fallback."
-            ),
-        )
-        _update_vllm_config(config["api"], vllm_base_url)
-
-    with api_tabs[3]:
-        config["api"]["anthropic"]["base_url"] = st.text_input(
-            "Base URL",
-            value=config["api"]["anthropic"]["base_url"],
-            key="config_anthropic_url",
-        )
-        config["api"]["anthropic"]["timeout"] = st.number_input(
-            "Timeout (seconds)",
-            min_value=1,
-            max_value=300,
-            value=config["api"]["anthropic"]["timeout"],
-            key="config_anthropic_timeout",
-        )
-
-    with api_tabs[4]:
-        config["api"]["google"]["base_url"] = st.text_input(
-            "Base URL",
-            value=config["api"]["google"]["base_url"],
-            key="config_google_url",
-        )
-        config["api"]["google"]["timeout"] = st.number_input(
-            "Timeout (seconds)",
-            min_value=1,
-            max_value=300,
-            value=config["api"]["google"]["timeout"],
-            key="config_google_timeout",
-        )
-
-    with api_tabs[5]:
-        alcf_section = config["api"].setdefault("alcf", {})
-        alcf_section["base_url"] = st.text_input(
-            "Base URL",
-            value=alcf_section.get(
-                "base_url",
-                "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
-            ),
-            key="config_alcf_url",
-            help="ALCF inference endpoint (vLLM-compatible). Default points to the Sophia cluster.",
-        )
-        alcf_section["timeout"] = st.number_input(
-            "Timeout (seconds)",
-            min_value=1,
-            max_value=300,
-            value=alcf_section.get("timeout", 30),
-            key="config_alcf_timeout",
-        )
-        st.caption(
-            "ALCF uses Globus OAuth for authentication. Set the **ALCF Access Token** "
-            "in the API Keys section above, or export `ALCF_ACCESS_TOKEN` in your shell."
-        )
-
-    with api_tabs[6]:
-        config["api"]["local"]["base_url"] = st.text_input(
-            "Base URL",
-            value=config["api"]["local"]["base_url"],
-            key="config_local_url",
-        )
-        config["api"]["local"]["timeout"] = st.number_input(
-            "Timeout (seconds)",
-            min_value=1,
-            max_value=300,
-            value=config["api"]["local"]["timeout"],
-            key="config_local_timeout",
-        )
-
-
-def _update_vllm_config(api: dict, base_url: str) -> None:
-    """Preserve an absent legacy vLLM section until a URL is supplied."""
-    if "vllm" in api or base_url.strip():
-        api.setdefault("vllm", {})["base_url"] = base_url
 
 
 def _render_raw_toml(config: dict) -> None:
@@ -528,7 +611,7 @@ def _render_raw_toml(config: dict) -> None:
         config_text = ""
 
     edited_config = st.text_area(
-        "TOML Content", value=config_text, height=400, key="config_raw_toml"
+        "TOML Content", value=config_text, height=400, key=_wkey("config_raw_toml")
     )
 
     if st.button("\U0001f4dd Update from TOML", key="update_from_toml"):
@@ -538,12 +621,12 @@ def _render_raw_toml(config: dict) -> None:
             # click "Save Configuration" to persist and apply the changes.
             st.session_state._config_draft = new_config
             st.success(
-                "\u2705 Draft updated from TOML.  "
+                "✅ Draft updated from TOML.  "
                 "Click **Save Configuration** to apply."
             )
             st.rerun()
         except Exception as e:
-            st.error(f"\u274c Invalid TOML syntax: {e}")
+            st.error(f"❌ Invalid TOML syntax: {e}")
 
 
 def _render_action_buttons(config: dict) -> None:
@@ -562,22 +645,22 @@ def _render_action_buttons(config: dict) -> None:
             # Apply the draft to the live session config, then persist to disk.
             st.session_state.config = copy.deepcopy(config)
             if save_config(st.session_state.config):
-                st.success("\u2705 Configuration saved to config.toml!")
+                st.success("✅ Configuration saved to config.toml!")
             else:
-                st.error("\u274c Failed to save configuration")
+                st.error("❌ Failed to save configuration")
 
     with col2:
         if st.button("\U0001f504 Reload Configuration"):
             st.session_state.config = load_config()
             st.session_state._config_draft = copy.deepcopy(st.session_state.config)
-            st.success("\u2705 Configuration reloaded!")
+            st.success("✅ Configuration reloaded!")
             st.rerun()
 
     with col3:
-        if st.button("\U0001f5d1\ufe0f Reset to Defaults"):
+        if st.button("\U0001f5d1️ Reset to Defaults"):
             st.session_state.config = get_default_config()
             st.session_state._config_draft = copy.deepcopy(st.session_state.config)
-            st.success("\u2705 Configuration reset to defaults!")
+            st.success("✅ Configuration reset to defaults!")
             st.rerun()
 
     with col4:
@@ -605,22 +688,11 @@ def _render_config_summary(config: dict) -> None:
         st.write("**Current Configuration:**")
         st.write(f"- Model: {config['general']['model']}")
         st.write(f"- Workflow: {config['general']['workflow']}")
-        st.write("- Temperature: 0.0 (optimized for tool calling)")
-        st.write("- Max Tokens: 4000")
         st.write(
             f"- Default Calculator: {config['chemistry']['calculators']['default']}"
         )
 
-        st.write("**Environment Variables:**")
-        api_keys = {
-            "OPENAI_API_KEY": "OpenAI",
-            "ANTHROPIC_API_KEY": "Anthropic",
-            "GEMINI_API_KEY": "Google",
-            "GROQ_API_KEY": "Groq",
-            "ALCF_ACCESS_TOKEN": "ALCF",
-        }
-        for env_var, provider in api_keys.items():
-            if os.getenv(env_var):
-                st.write(f"- {provider}: \u2705 Set")
-            else:
-                st.write(f"- {provider}: \u274c Not set")
+        st.write("**Providers:**")
+        for status in providers.all_provider_statuses(config):
+            mark = "✅" if status.ready else "❌"
+            st.write(f"- {status.info.label}: {mark} {status.detail}")

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -29,10 +29,13 @@ from chemgraph.utils.config_utils import (
     get_base_url_for_model_from_nested_config,
 )
 
+from ui import alcf_auth
 from ui import artifacts as artifact_utils
+from ui import providers
 from ui.agent_manager import initialize_agent
+from ui.provider_widgets import apply_api_key, render_alcf_login
 from ui.branding import LOGO_IMAGES, first_existing_asset
-from ui.config import load_config
+from ui.config import load_config, save_config
 from ui.endpoint import check_local_model_endpoint
 from ui.file_utils import (
     extract_log_dir_from_messages,
@@ -215,6 +218,10 @@ def render() -> None:
     natural-language queries using AI agents.
     """)
 
+    # ----- First-run setup -----
+    if _render_first_run_setup(config):
+        return
+
     # ----- Calculator availability sidebar -----
     _render_available_calculators_sidebar()
     _render_chat_controls()
@@ -232,6 +239,16 @@ def render() -> None:
         st.info(ui_notice)
 
     endpoint_status = check_local_model_endpoint(selected_base_url)
+
+    # Warn when the selected model's provider is not usable yet.
+    provider_info = providers.provider_for_model(selected_model)
+    if provider_info is not None:
+        provider_state = providers.provider_status(provider_info, config)
+        if not provider_state.ready:
+            st.warning(
+                f"Model **{selected_model}** needs **{provider_state.info.label}**: "
+                f"{provider_state.detail} Set it up on the ⚙️ Configuration page."
+            )
 
     # ----- Session management sidebar -----
     _render_session_sidebar()
@@ -288,6 +305,150 @@ def render() -> None:
             _handle_query_submission(
                 prompt, thread_id, endpoint_status, selected_base_url
             )
+
+
+# ---------------------------------------------------------------------------
+# First-run setup
+# ---------------------------------------------------------------------------
+
+
+def _render_first_run_setup(config: dict) -> bool:
+    """Guide new users to a working provider before showing the chat.
+
+    Rendered only while no credentialed provider is usable and the chat
+    is empty.  Returns ``True`` when the setup screen was shown (the
+    caller should stop rendering the rest of the page).
+
+    Parameters
+    ----------
+    config : dict
+        Live nested UI configuration (mutated and saved on completion).
+
+    Returns
+    -------
+    bool
+        Whether the setup screen was rendered.
+    """
+    if st.session_state.conversation_history:
+        return False
+    if st.session_state.get("_setup_skipped"):
+        return False
+    if providers.any_provider_ready(config):
+        return False
+    # A saved local-server choice counts as completed setup even though
+    # credential checks cannot prove a local server "ready".
+    configured = providers.provider_for_model(config["general"].get("model", ""))
+    if configured is not None and configured.auth_kind == "none":
+        return False
+
+    st.info(
+        "**Welcome!** Connect ChemGraph to an LLM to get started — "
+        "pick one of the options below.",
+        icon="\U0001f44b",
+    )
+
+    tab_argo, tab_key, tab_alcf, tab_local = st.tabs(
+        [
+            "\U0001f3db Argo (Argonne)",
+            "\U0001f511 Your own API key",
+            "\U0001f310 ALCF (Globus)",
+            "\U0001f4bb Local (Ollama)",
+        ]
+    )
+
+    with tab_argo:
+        info = providers.get_provider(providers.ARGO)
+        st.caption(info.help_text)
+        user = st.text_input("ANL username", key="setup_argo_user")
+        if st.button(
+            "Use Argo",
+            key="setup_argo_go",
+            type="primary",
+            disabled=not user.strip(),
+        ):
+            config["api"].setdefault("argo", {})["argo_user"] = user.strip()
+            _finish_first_run_setup(config, info)
+
+    with tab_key:
+        key_providers = [
+            p for p in providers.PROVIDERS if p.auth_kind == "api_key"
+        ]
+        chosen_label = st.selectbox(
+            "Provider",
+            [p.label for p in key_providers],
+            key="setup_key_provider",
+        )
+        chosen = next(p for p in key_providers if p.label == chosen_label)
+        st.caption(chosen.help_text)
+        key_value = st.text_input(
+            f"{chosen.label} API key",
+            type="password",
+            key="setup_api_key",
+            help=(
+                f"Applied to this session as ${chosen.env_var}; "
+                "not written to config.toml."
+            ),
+        )
+        if st.button(
+            "Apply key and start",
+            key="setup_key_go",
+            type="primary",
+            disabled=not key_value.strip(),
+        ):
+            apply_api_key(chosen.env_var, key_value)
+            _finish_first_run_setup(config, chosen)
+
+    with tab_alcf:
+        info = providers.get_provider(providers.ALCF)
+        st.caption(info.help_text)
+        if render_alcf_login(key_prefix="setup"):
+            _finish_first_run_setup(config, info)
+
+    with tab_local:
+        info = providers.get_provider(providers.OLLAMA)
+        st.caption(info.help_text)
+        base_url = st.text_input(
+            "Server URL",
+            value=config["api"]["local"]["base_url"],
+            key="setup_local_url",
+        )
+        probe = check_local_model_endpoint(base_url)
+        if probe["ok"]:
+            st.success(probe["message"])
+        else:
+            st.error(probe["message"])
+        if st.button("Use local server", key="setup_local_go", type="primary"):
+            config["api"]["local"]["base_url"] = base_url.strip()
+            _finish_first_run_setup(config, info)
+
+    st.caption(
+        "You can change providers anytime on the ⚙️ Configuration page."
+    )
+    if st.button("Skip setup for now", key="setup_skip"):
+        st.session_state._setup_skipped = True
+        st.rerun()
+    return True
+
+
+def _finish_first_run_setup(config: dict, info) -> None:
+    """Persist the chosen provider/model and enter the chat.
+
+    Parameters
+    ----------
+    config : dict
+        Live nested UI configuration.
+    info : providers.ProviderInfo
+        The chosen provider.
+    """
+    config["general"]["model"] = info.default_model
+    providers.align_base_url_for_provider(config, info.id)
+    st.session_state.config = config
+    save_config(config)
+    # Local servers stay "unproven" to any_provider_ready, so remember
+    # that setup finished to avoid re-gating the chat.
+    st.session_state._setup_skipped = True
+    st.toast(f"Ready — using {info.default_model}", icon="\U0001f680")
+    st.rerun()
 
 
 # ---------------------------------------------------------------------------
@@ -639,6 +800,13 @@ def _auto_initialize_agent(
     selected_base_url : str, optional
         Model endpoint URL.
     """
+    # ALCF models authenticate via the exported Globus token; refresh it
+    # before the loader reads it, and re-initialize when it changes.
+    alcf_token = None
+    provider_info = providers.provider_for_model(selected_model)
+    if provider_info is not None and provider_info.auth_kind == "globus":
+        alcf_token = alcf_auth.ensure_access_token()
+
     current_config = (
         selected_model,
         selected_workflow,
@@ -650,6 +818,7 @@ def _auto_initialize_agent(
         selected_base_url,
         get_argo_user_from_nested_config(config),
         st.session_state.get("current_chat_log_dir"),
+        alcf_token,
     )
 
     if st.session_state.agent is None or st.session_state.last_config != current_config:
@@ -680,6 +849,7 @@ def _auto_initialize_agent(
                     selected_base_url,
                     get_argo_user_from_nested_config(config),
                     chat_log_dir,
+                    alcf_token,
                 )
             else:
                 st.session_state.last_config = None

--- a/src/ui/alcf_auth.py
+++ b/src/ui/alcf_auth.py
@@ -1,0 +1,327 @@
+"""Globus authentication for ALCF inference endpoints, usable from the UI.
+
+Implements the same Native App OAuth flow as ALCF's official
+``inference_auth_token.py`` helper (see
+https://github.com/argonne-lcf/inference-endpoints) so users can log in
+from the browser UI instead of running a script and pasting tokens:
+
+- ``start_login`` returns a Globus URL; the user signs in and copies the
+  authorization code back into the UI; ``complete_login`` exchanges it.
+- Tokens are cached in ``~/.chemgraph/alcf_inference_tokens.json`` and
+  the access token is exported as ``ALCF_ACCESS_TOKEN`` for the model
+  loader (:mod:`chemgraph.models.alcf_endpoints`).
+- ``ensure_access_token`` silently refreshes expired access tokens with
+  the cached refresh token. Tokens created by the official helper script
+  (``~/.globus/app/.../inference_app/tokens.json``) are picked up too,
+  so users who already authenticated on the CLI never see a login.
+
+Everything except the two interactive login calls is network-free and
+Streamlit-free so it can be unit-tested.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Public Native App client and gateway (resource server) published by ALCF
+# for the inference endpoints. Same IDs as inference_auth_token.py.
+AUTH_CLIENT_ID = "58fdd3bc-e1c3-4ce5-80ea-8d6b87cfb944"
+GATEWAY_CLIENT_ID = "681c10cc-f684-4540-bcd7-0b4df3bc26ef"
+GATEWAY_SCOPE = f"https://auth.globus.org/scopes/{GATEWAY_CLIENT_ID}/action_all"
+# ALCF requires an identity from this Globus authentication policy.
+SESSION_POLICY = "83732ff2-9c42-4548-b5ce-17e498c84f6a"
+
+TOKEN_ENV = "ALCF_ACCESS_TOKEN"
+
+# ChemGraph-owned token cache (flat record, chmod 600).
+CHEMGRAPH_TOKENS_PATH = os.path.expanduser(
+    "~/.chemgraph/alcf_inference_tokens.json"
+)
+# Cache written by ALCF's official helper (globus_sdk.UserApp storage).
+HELPER_TOKENS_PATH = os.path.expanduser(
+    f"~/.globus/app/{AUTH_CLIENT_ID}/inference_app/tokens.json"
+)
+
+# Refuse tokens that expire within this margin so a request started now
+# does not die mid-flight.
+_EXPIRY_MARGIN_S = 60
+
+
+def _load_json(path: str) -> Optional[dict]:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
+def _record_from_helper_store(data: dict) -> Optional[dict]:
+    """Extract a flat token record from the UserApp storage format."""
+    nested = (
+        data.get("data", {}).get("DEFAULT", {}).get(GATEWAY_CLIENT_ID, {})
+    )
+    if isinstance(nested, dict) and nested.get("access_token"):
+        return nested
+    return None
+
+
+def read_token_record() -> tuple[Optional[dict], Optional[str]]:
+    """Return the cached token record and its source path, if any.
+
+    The ChemGraph cache wins over the helper-script cache because it is
+    the one this module keeps fresh.
+
+    Returns
+    -------
+    tuple[dict | None, str | None]
+        ``(record, path)`` or ``(None, None)`` when no cache exists.
+    """
+    data = _load_json(CHEMGRAPH_TOKENS_PATH)
+    if isinstance(data, dict) and data.get("access_token"):
+        return data, CHEMGRAPH_TOKENS_PATH
+
+    data = _load_json(HELPER_TOKENS_PATH)
+    if isinstance(data, dict):
+        record = _record_from_helper_store(data)
+        if record:
+            return record, HELPER_TOKENS_PATH
+    return None, None
+
+
+def _expires_at(record: dict) -> Optional[float]:
+    value = record.get("expires_at_seconds")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_record_valid(record: dict, now: Optional[float] = None) -> bool:
+    """Return whether a token record's access token is still usable.
+
+    Records without an expiry are treated as expired so the refresh
+    path (which learns the real expiry) runs instead.
+
+    Parameters
+    ----------
+    record : dict
+        Flat token record.
+    now : float, optional
+        Current UNIX time (defaults to ``time.time()``); test hook.
+
+    Returns
+    -------
+    bool
+        ``True`` when the access token is present and not near expiry.
+    """
+    if not record.get("access_token"):
+        return False
+    expires_at = _expires_at(record)
+    if expires_at is None:
+        return False
+    if now is None:
+        now = time.time()
+    return expires_at - now > _EXPIRY_MARGIN_S
+
+
+def save_token_record(record: dict) -> None:
+    """Persist a flat token record to the ChemGraph cache (chmod 600)."""
+    path = Path(CHEMGRAPH_TOKENS_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2), encoding="utf-8")
+    os.chmod(path, 0o600)
+
+
+def _export(record: dict) -> Optional[str]:
+    token = record.get("access_token")
+    if token:
+        os.environ[TOKEN_ENV] = token
+    return token
+
+
+def _refresh_record(record: dict) -> Optional[dict]:
+    """Exchange a refresh token for a fresh access token (network call)."""
+    refresh_token = record.get("refresh_token")
+    if not refresh_token:
+        return None
+    try:
+        import globus_sdk
+
+        client = globus_sdk.NativeAppAuthClient(AUTH_CLIENT_ID)
+        response = client.oauth2_refresh_token(refresh_token)
+        fresh = response.by_resource_server.get(GATEWAY_CLIENT_ID)
+    except Exception as exc:
+        logger.warning("ALCF token refresh failed: %s", exc)
+        return None
+    if not fresh or not fresh.get("access_token"):
+        return None
+    fresh = dict(fresh)
+    # Globus may omit the refresh token on refresh responses.
+    fresh.setdefault("refresh_token", refresh_token)
+    return fresh
+
+
+def ensure_access_token(allow_refresh: bool = True) -> Optional[str]:
+    """Return a usable ALCF access token, exporting it to the environment.
+
+    Order: existing ``ALCF_ACCESS_TOKEN`` env var, then a still-valid
+    cached record, then (optionally) a silent refresh with the cached
+    refresh token.
+
+    Parameters
+    ----------
+    allow_refresh : bool, optional
+        Permit the network refresh call for expired records.
+
+    Returns
+    -------
+    str or None
+        Access token, or ``None`` when the user must log in.
+    """
+    env_token = os.environ.get(TOKEN_ENV)
+    record, _source = read_token_record()
+
+    # A token supplied via the environment (not one this module exported
+    # from the cache) is externally managed: trust it as-is.
+    if env_token and (record is None or record.get("access_token") != env_token):
+        return env_token
+
+    if record is None:
+        return None
+    if is_record_valid(record):
+        return _export(record)
+    if not allow_refresh:
+        return None
+
+    fresh = _refresh_record(record)
+    if fresh is None:
+        return None
+    try:
+        save_token_record(fresh)
+    except OSError as exc:
+        logger.warning("Could not cache refreshed ALCF token: %s", exc)
+    return _export(fresh)
+
+
+def token_status() -> dict[str, Any]:
+    """Describe the current authentication state without network calls.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``state`` is one of ``"env"`` (token provided via environment),
+        ``"valid"``, ``"refreshable"``, or ``"logged_out"``; ``detail``
+        is a human-readable summary.
+    """
+    env_token = os.environ.get(TOKEN_ENV)
+    record, source = read_token_record()
+    # Only report "env" for externally supplied tokens; a token this
+    # module exported from the cache keeps expiry/refresh semantics.
+    if env_token and (record is None or record.get("access_token") != env_token):
+        return {
+            "state": "env",
+            "detail": f"Using token from ${TOKEN_ENV}.",
+        }
+    if record is None:
+        return {"state": "logged_out", "detail": "Not logged in."}
+    if is_record_valid(record):
+        expires_at = _expires_at(record)
+        remaining_h = (expires_at - time.time()) / 3600 if expires_at else 0
+        return {
+            "state": "valid",
+            "detail": (
+                f"Logged in (token valid for {remaining_h:.1f} h, "
+                f"cached in {source})."
+            ),
+        }
+    if record.get("refresh_token"):
+        return {
+            "state": "refreshable",
+            "detail": "Access token expired; it will refresh automatically.",
+        }
+    return {"state": "logged_out", "detail": "Cached token expired."}
+
+
+def start_login():
+    """Begin the Globus Native App flow.
+
+    Returns
+    -------
+    tuple
+        ``(client, authorize_url)``. Keep *client* around (e.g. in
+        Streamlit session state) and pass it to :func:`complete_login`
+        together with the code the user pastes back.
+    """
+    import globus_sdk
+
+    client = globus_sdk.NativeAppAuthClient(AUTH_CLIENT_ID)
+    client.oauth2_start_flow(
+        requested_scopes=GATEWAY_SCOPE,
+        refresh_tokens=True,
+    )
+    url = client.oauth2_get_authorize_url(
+        session_required_policies=[SESSION_POLICY]
+    )
+    return client, url
+
+
+def complete_login(client, auth_code: str) -> str:
+    """Exchange the pasted authorization code for tokens.
+
+    Parameters
+    ----------
+    client : globus_sdk.NativeAppAuthClient
+        Client returned by :func:`start_login`.
+    auth_code : str
+        Authorization code copied from the Globus page.
+
+    Returns
+    -------
+    str
+        The new access token (also cached and exported to the env).
+
+    Raises
+    ------
+    RuntimeError
+        When the exchange fails or returns no gateway tokens.
+    """
+    if not auth_code or not auth_code.strip():
+        raise RuntimeError("Authorization code is empty.")
+    try:
+        response = client.oauth2_exchange_code_for_tokens(auth_code.strip())
+    except Exception as exc:
+        raise RuntimeError(f"Globus rejected the authorization code: {exc}")
+    record = response.by_resource_server.get(GATEWAY_CLIENT_ID)
+    if not record or not record.get("access_token"):
+        raise RuntimeError(
+            "Globus returned no tokens for the ALCF inference gateway. "
+            "The account may not satisfy ALCF's access policy."
+        )
+    record = dict(record)
+    try:
+        save_token_record(record)
+    except OSError as exc:
+        # The one-time code is already spent; a cache-write failure must
+        # not lose the session's token.
+        logger.warning("Could not cache ALCF tokens: %s", exc)
+    token = _export(record)
+    return token
+
+
+def logout() -> None:
+    """Forget the ChemGraph-cached tokens and the exported env token.
+
+    The official helper script's own cache is left untouched.
+    """
+    os.environ.pop(TOKEN_ENV, None)
+    try:
+        os.remove(CHEMGRAPH_TOKENS_PATH)
+    except OSError:
+        pass

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -132,6 +132,10 @@ def get_default_config() -> Dict[str, Any]:
                 "base_url": "https://openrouter.ai/api/v1",
                 "timeout": 60,
             },
+            "groq": {
+                "base_url": "https://api.groq.com/openai/v1",
+                "timeout": 30,
+            },
             "local": {"base_url": "http://localhost:11434", "timeout": 60},
         },
         "chemistry": {

--- a/src/ui/provider_widgets.py
+++ b/src/ui/provider_widgets.py
@@ -1,0 +1,118 @@
+"""Reusable Streamlit widgets for provider credentials.
+
+Shared between the Configuration page and the first-run setup on the
+main page so both render identical flows (notably the ALCF Globus
+login, which needs two steps and state carried across reruns).
+"""
+
+from __future__ import annotations
+
+import os
+
+import streamlit as st
+
+from ui import alcf_auth
+
+# Session-state slots holding the NativeAppAuthClient and its sign-in URL
+# between the "start login" and "complete login" reruns. Both are global
+# (not per-page) so a login started on one page can be finished on another.
+_PENDING_CLIENT_KEY = "_alcf_pending_login_client"
+_PENDING_URL_KEY = "_alcf_pending_login_url"
+
+
+def apply_api_key(env_var: str, value: str) -> bool:
+    """Set a provider API key for this Streamlit process.
+
+    Parameters
+    ----------
+    env_var : str
+        Environment variable the model loader reads.
+    value : str
+        Key text from the input widget.
+
+    Returns
+    -------
+    bool
+        ``True`` when a non-empty key was applied.
+    """
+    clean = (value or "").strip()
+    if not clean:
+        return False
+    os.environ[env_var] = clean
+    return True
+
+
+def clear_api_key(env_var: str) -> None:
+    """Remove a provider API key from the process environment."""
+    os.environ.pop(env_var, None)
+
+
+def render_alcf_login(key_prefix: str) -> bool:
+    """Render the two-step Globus login for ALCF inference endpoints.
+
+    Parameters
+    ----------
+    key_prefix : str
+        Unique widget-key prefix (the widget set appears on two pages).
+
+    Returns
+    -------
+    bool
+        ``True`` when a login completed during this rerun.
+    """
+    status = alcf_auth.token_status()
+    pending = st.session_state.get(_PENDING_CLIENT_KEY)
+
+    if status["state"] in ("env", "valid", "refreshable") and not pending:
+        st.success(status["detail"])
+        if st.button("Log out", key=f"{key_prefix}_alcf_logout"):
+            alcf_auth.logout()
+            st.rerun()
+        return False
+
+    if pending is None:
+        st.caption(status["detail"])
+        if st.button(
+            "\U0001f510 Log in with Globus", key=f"{key_prefix}_alcf_start"
+        ):
+            try:
+                client, url = alcf_auth.start_login()
+            except Exception as exc:
+                st.error(f"Could not start the Globus flow: {exc}")
+                return False
+            st.session_state[_PENDING_CLIENT_KEY] = client
+            st.session_state[_PENDING_URL_KEY] = url
+            st.rerun()
+        return False
+
+    url = st.session_state.get(_PENDING_URL_KEY, "")
+    st.markdown(
+        f"1. [Open the Globus sign-in page]({url}) and log in with an "
+        "identity that has ALCF access.\n"
+        "2. Copy the authorization code shown at the end and paste it "
+        "below."
+    )
+    code = st.text_input(
+        "Authorization code",
+        key=f"{key_prefix}_alcf_code",
+        type="password",
+    )
+    col_ok, col_cancel = st.columns(2)
+    completed = False
+    with col_ok:
+        if st.button("Complete login", key=f"{key_prefix}_alcf_complete"):
+            try:
+                alcf_auth.complete_login(pending, code)
+            except RuntimeError as exc:
+                st.error(str(exc))
+            else:
+                st.session_state[_PENDING_CLIENT_KEY] = None
+                st.session_state[_PENDING_URL_KEY] = None
+                st.success("Logged in to ALCF inference endpoints.")
+                completed = True
+    with col_cancel:
+        if st.button("Cancel", key=f"{key_prefix}_alcf_cancel"):
+            st.session_state[_PENDING_CLIENT_KEY] = None
+            st.session_state[_PENDING_URL_KEY] = None
+            st.rerun()
+    return completed

--- a/src/ui/providers.py
+++ b/src/ui/providers.py
@@ -1,0 +1,322 @@
+"""Provider registry and readiness checks for the ChemGraph UI.
+
+One place that knows, for every way ChemGraph can reach an LLM, how to
+tell whether it is usable right now and which models it serves.  Used by
+the Configuration page (provider cards) and the first-run setup on the
+main page.  Streamlit-free and network-free so it can be unit-tested;
+live endpoint probes stay in the pages.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from chemgraph.models.supported_models import (
+    ARGO_DEFAULT_BASE_URL,
+    supported_alcf_models,
+    supported_anthropic_models,
+    supported_argo_models,
+    supported_gemini_models,
+    supported_ollama_models,
+    supported_openai_models,
+    supported_openrouter_models,
+)
+from chemgraph.utils.config_utils import get_argo_user_from_nested_config
+
+from ui import alcf_auth
+
+OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1"
+
+ARGO = "argo"
+OPENAI = "openai"
+ANTHROPIC = "anthropic"
+GOOGLE = "google"
+GROQ = "groq"
+OPENROUTER = "openrouter"
+ALCF = "alcf"
+VLLM = "vllm"
+OLLAMA = "ollama"
+
+
+@dataclass(frozen=True)
+class ProviderInfo:
+    """Static description of one LLM provider."""
+
+    id: str
+    label: str
+    icon: str
+    # How the provider authenticates: "argo" (username), "api_key",
+    # "globus" (ALCF), "endpoint" (custom server), or "none" (local server).
+    auth_kind: str
+    # Environment variable carrying the credential, when applicable.
+    env_var: Optional[str]
+    # Section under config["api"] holding base_url/timeout for this provider.
+    config_section: Optional[str]
+    default_model: str
+    models: tuple
+    help_text: str
+
+
+PROVIDERS: tuple[ProviderInfo, ...] = (
+    ProviderInfo(
+        id=ARGO,
+        label="Argo (Argonne)",
+        icon="\U0001f3db",
+        auth_kind="argo",
+        env_var="ARGO_USER",
+        config_section="argo",
+        default_model="argo:gpt-4o",
+        models=tuple(supported_argo_models),
+        help_text=(
+            "Argonne's internal LLM gateway. Needs only your ANL domain "
+            "username -- no API key -- but works only on the lab network "
+            "or VPN."
+        ),
+    ),
+    ProviderInfo(
+        id=OPENAI,
+        label="OpenAI",
+        icon="\U0001f511",
+        auth_kind="api_key",
+        env_var="OPENAI_API_KEY",
+        config_section="openai",
+        default_model="gpt-4o-mini",
+        models=tuple(supported_openai_models),
+        help_text="Direct OpenAI API access with your own API key.",
+    ),
+    ProviderInfo(
+        id=ANTHROPIC,
+        label="Anthropic",
+        icon="\U0001f511",
+        auth_kind="api_key",
+        env_var="ANTHROPIC_API_KEY",
+        config_section="anthropic",
+        default_model="claude-sonnet-4-20250514",
+        models=tuple(supported_anthropic_models),
+        help_text="Claude models with your own Anthropic API key.",
+    ),
+    ProviderInfo(
+        id=GOOGLE,
+        label="Google Gemini",
+        icon="\U0001f511",
+        auth_kind="api_key",
+        env_var="GEMINI_API_KEY",
+        config_section="google",
+        default_model="gemini-2.5-flash",
+        models=tuple(supported_gemini_models),
+        help_text="Gemini models with your own Google AI Studio key.",
+    ),
+    ProviderInfo(
+        id=GROQ,
+        label="Groq",
+        icon="\U0001f511",
+        auth_kind="api_key",
+        env_var="GROQ_API_KEY",
+        config_section="groq",
+        default_model="groq:llama-3.3-70b-versatile",
+        models=(),
+        help_text=(
+            "Fast open-model inference. Use any model as "
+            "'groq:<model-id>' from console.groq.com/docs/models."
+        ),
+    ),
+    ProviderInfo(
+        id=OPENROUTER,
+        label="OpenRouter",
+        icon="\U0001f511",
+        auth_kind="api_key",
+        env_var="OPENROUTER_API_KEY",
+        config_section="openrouter",
+        default_model="openrouter:deepseek/deepseek-v4-flash",
+        models=tuple(supported_openrouter_models),
+        help_text=(
+            "One key for many hosted models. Any slug from "
+            "openrouter.ai/models works as 'openrouter:<slug>'."
+        ),
+    ),
+    ProviderInfo(
+        id=ALCF,
+        label="ALCF Inference (Globus)",
+        icon="\U0001f310",
+        auth_kind="globus",
+        env_var=alcf_auth.TOKEN_ENV,
+        config_section="alcf",
+        default_model="alcf:meta-llama/Llama-3.3-70B-Instruct",
+        models=tuple(supported_alcf_models),
+        help_text=(
+            "ALCF-hosted open models (Sophia/Minerva/Metis clusters). "
+            "Log in with your Globus account -- requires an active ALCF "
+            "allocation."
+        ),
+    ),
+    ProviderInfo(
+        id=VLLM,
+        label="Custom endpoint (vLLM)",
+        icon="\U0001f5a5",
+        auth_kind="endpoint",
+        env_var="VLLM_API_KEY",
+        config_section="vllm",
+        default_model="custom-model",
+        models=(),
+        help_text=(
+            "Any OpenAI-compatible endpoint and model ID. An API key is "
+            "optional for servers that require one."
+        ),
+    ),
+    ProviderInfo(
+        id=OLLAMA,
+        label="Local (Ollama)",
+        icon="\U0001f4bb",
+        auth_kind="none",
+        env_var=None,
+        config_section="local",
+        default_model="llama3.2",
+        models=tuple(supported_ollama_models),
+        help_text=(
+            "Models served by a local Ollama (or other OpenAI-compatible) "
+            "server. No credentials needed."
+        ),
+    ),
+)
+
+
+@dataclass
+class ProviderStatus:
+    """Readiness of one provider given current config + environment."""
+
+    info: ProviderInfo
+    ready: bool
+    detail: str
+
+
+def get_provider(provider_id: str) -> Optional[ProviderInfo]:
+    """Return the provider description for *provider_id*, if known."""
+    for info in PROVIDERS:
+        if info.id == provider_id:
+            return info
+    return None
+
+
+def provider_status(
+    info: ProviderInfo, config: Dict[str, Any]
+) -> ProviderStatus:
+    """Evaluate whether one provider is usable right now.
+
+    Parameters
+    ----------
+    info : ProviderInfo
+        Provider description.
+    config : dict[str, Any]
+        Nested UI configuration.
+
+    Returns
+    -------
+    ProviderStatus
+        Readiness plus a short human-readable reason.
+    """
+    if info.auth_kind == "argo":
+        user = get_argo_user_from_nested_config(config) or os.environ.get(
+            "ARGO_USER"
+        )
+        if user:
+            return ProviderStatus(
+                info, True, f"Argo user '{user}' (ANL network/VPN required)."
+            )
+        return ProviderStatus(info, False, "Set your ANL username.")
+
+    if info.auth_kind == "api_key":
+        if os.environ.get(info.env_var or ""):
+            return ProviderStatus(info, True, f"${info.env_var} is set.")
+        return ProviderStatus(info, False, f"Set ${info.env_var}.")
+
+    if info.auth_kind == "globus":
+        status = alcf_auth.token_status()
+        ready = status["state"] in ("env", "valid", "refreshable")
+        return ProviderStatus(info, ready, status["detail"])
+
+    if info.auth_kind == "endpoint":
+        section = config.get("api", {}).get(info.config_section or "", {})
+        base_url = section.get("base_url") if isinstance(section, dict) else None
+        if base_url:
+            return ProviderStatus(info, True, f"Endpoint: {base_url}")
+        return ProviderStatus(info, False, "Set the endpoint URL.")
+
+    # Local server: configuration alone cannot prove readiness; the page
+    # adds a live reachability probe.
+    return ProviderStatus(info, True, "Requires a running local server.")
+
+
+def all_provider_statuses(config: Dict[str, Any]) -> list[ProviderStatus]:
+    """Return statuses for every known provider."""
+    return [provider_status(info, config) for info in PROVIDERS]
+
+
+def any_provider_ready(config: Dict[str, Any]) -> bool:
+    """Return whether at least one credentialed provider is usable.
+
+    The local server is excluded: it is always nominally "ready" and
+    would defeat first-run detection.
+    """
+    return any(
+        status.ready
+        for status in all_provider_statuses(config)
+        if status.info.auth_kind != "none"
+    )
+
+
+def align_base_url_for_provider(config: Dict[str, Any], provider_id: str) -> None:
+    """Ensure built-in providers have a default URL in their own section.
+
+    Parameters
+    ----------
+    config : dict[str, Any]
+        Nested UI configuration (mutated in place).
+    provider_id : str
+        Activated provider ID; other providers are left untouched.
+    """
+    if provider_id == ARGO:
+        section = config.setdefault("api", {}).setdefault("argo", {})
+        section.setdefault("base_url", ARGO_DEFAULT_BASE_URL)
+    elif provider_id == OPENAI:
+        section = config.setdefault("api", {}).setdefault("openai", {})
+        section.setdefault("base_url", OPENAI_DEFAULT_BASE_URL)
+
+
+def provider_for_model(model_name: str) -> Optional[ProviderInfo]:
+    """Return the provider that serves *model_name*, if identifiable.
+
+    Mirrors the dispatch order of the model loader: prefixes first, then
+    curated lists. Unknown names use the configured vLLM-compatible endpoint.
+
+    Parameters
+    ----------
+    model_name : str
+        Model identifier.
+
+    Returns
+    -------
+    ProviderInfo or None
+        Matching provider description.
+    """
+    if not model_name:
+        return None
+    prefix_map = {
+        "argo:": ARGO,
+        "groq:": GROQ,
+        "openrouter:": OPENROUTER,
+        "alcf:": ALCF,
+    }
+    for prefix, provider_id in prefix_map.items():
+        if model_name.startswith(prefix):
+            return get_provider(provider_id)
+    if model_name in supported_openai_models:
+        return get_provider(OPENAI)
+    if model_name in supported_anthropic_models:
+        return get_provider(ANTHROPIC)
+    if model_name in supported_gemini_models:
+        return get_provider(GOOGLE)
+    if model_name in supported_ollama_models:
+        return get_provider(OLLAMA)
+    return get_provider(VLLM)

--- a/src/ui/state.py
+++ b/src/ui/state.py
@@ -27,6 +27,7 @@ def init_session_state() -> None:
         "active_workflow": None,
         "ui_log_root": None,
         "current_chat_log_dir": None,
+        "_setup_skipped": False,  # True once first-run setup finished/skipped
         # Session persistence
         "session_store": None,  # SessionStore instance (created lazily)
         "current_session_id": None,  # active session ID (str or None)

--- a/tests/test_ui_providers.py
+++ b/tests/test_ui_providers.py
@@ -1,0 +1,273 @@
+"""Tests for provider readiness detection and ALCF token handling."""
+
+import json
+
+import pytest
+
+from ui import alcf_auth, providers
+
+
+@pytest.fixture()
+def clean_env(monkeypatch, tmp_path):
+    """Remove provider credentials and isolate token caches."""
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GROQ_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ARGO_USER",
+        "ALCF_ACCESS_TOKEN",
+    ):
+        # setenv-then-delenv registers an undo even for vars absent before
+        # the test, so values exported by the code under test (e.g.
+        # ensure_access_token) cannot leak into later tests.
+        monkeypatch.setenv(var, "sentinel")
+        monkeypatch.delenv(var)
+    monkeypatch.setattr(
+        alcf_auth, "CHEMGRAPH_TOKENS_PATH", str(tmp_path / "cg_tokens.json")
+    )
+    monkeypatch.setattr(
+        alcf_auth, "HELPER_TOKENS_PATH", str(tmp_path / "helper_tokens.json")
+    )
+    return tmp_path
+
+
+def _config(argo_user=""):
+    return {
+        "api": {
+            "openai": {"base_url": providers.OPENAI_DEFAULT_BASE_URL},
+            "argo": {
+                "base_url": providers.ARGO_DEFAULT_BASE_URL,
+                "argo_user": argo_user,
+            },
+        }
+    }
+
+
+def test_no_provider_ready_without_credentials(clean_env):
+    assert providers.any_provider_ready(_config()) is False
+
+
+def test_argo_ready_with_config_username(clean_env):
+    config = _config(argo_user="aturing")
+
+    status = providers.provider_status(
+        providers.get_provider(providers.ARGO), config
+    )
+
+    assert status.ready is True
+    assert "aturing" in status.detail
+    assert providers.any_provider_ready(config) is True
+
+
+def test_argo_ready_with_env_username(clean_env, monkeypatch):
+    monkeypatch.setenv("ARGO_USER", "aturing")
+
+    status = providers.provider_status(
+        providers.get_provider(providers.ARGO), _config()
+    )
+
+    assert status.ready is True
+
+
+def test_api_key_provider_ready_from_env(clean_env, monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+    statuses = {
+        s.info.id: s.ready for s in providers.all_provider_statuses(_config())
+    }
+
+    assert statuses[providers.ANTHROPIC] is True
+    assert statuses[providers.OPENAI] is False
+
+
+def test_local_provider_does_not_satisfy_first_run_check(clean_env):
+    statuses = {
+        s.info.id: s.ready for s in providers.all_provider_statuses(_config())
+    }
+
+    assert statuses[providers.OLLAMA] is True  # nominally ready...
+    assert providers.any_provider_ready(_config()) is False  # ...but excluded
+
+
+def test_provider_for_model_maps_prefixes_and_lists():
+    assert providers.provider_for_model("argo:gpt-4o").id == providers.ARGO
+    assert providers.provider_for_model("alcf:foo/Bar").id == providers.ALCF
+    assert providers.provider_for_model("groq:x").id == providers.GROQ
+    assert (
+        providers.provider_for_model("openrouter:a/b").id == providers.OPENROUTER
+    )
+    assert providers.provider_for_model("gpt-4o-mini").id == providers.OPENAI
+    assert (
+        providers.provider_for_model("gemini-2.5-flash").id == providers.GOOGLE
+    )
+    assert providers.provider_for_model("llama3.2").id == providers.OLLAMA
+    # Unknown names use the configured OpenAI-compatible vLLM endpoint.
+    assert providers.provider_for_model("mystery-model").id == providers.VLLM
+
+
+def test_vllm_ready_only_with_endpoint_url(clean_env):
+    info = providers.get_provider(providers.VLLM)
+    config = _config()
+
+    assert providers.provider_status(info, config).ready is False
+
+    config["api"]["vllm"] = {"base_url": "https://vllm.example/v1"}
+    assert providers.provider_status(info, config).ready is True
+
+
+def test_every_provider_default_model_maps_back_to_it():
+    for info in providers.PROVIDERS:
+        mapped = providers.provider_for_model(info.default_model)
+        assert mapped is not None and mapped.id == info.id, info.id
+
+
+# ---------------------------------------------------------------------------
+# ALCF token cache handling
+# ---------------------------------------------------------------------------
+
+
+def test_alcf_status_env_token_wins(clean_env, monkeypatch):
+    monkeypatch.setenv("ALCF_ACCESS_TOKEN", "tok")
+
+    assert alcf_auth.token_status()["state"] == "env"
+    assert alcf_auth.ensure_access_token() == "tok"
+
+
+def test_alcf_status_logged_out_without_caches(clean_env):
+    assert alcf_auth.token_status()["state"] == "logged_out"
+    assert alcf_auth.ensure_access_token(allow_refresh=False) is None
+
+
+def test_alcf_valid_cached_record_is_exported(clean_env, monkeypatch):
+    record = {
+        "access_token": "cached-tok",
+        "refresh_token": "r",
+        "expires_at_seconds": 4102444800,  # far future
+    }
+    alcf_auth.save_token_record(record)
+
+    assert alcf_auth.token_status()["state"] == "valid"
+    assert alcf_auth.ensure_access_token(allow_refresh=False) == "cached-tok"
+    import os
+
+    assert os.environ["ALCF_ACCESS_TOKEN"] == "cached-tok"
+
+
+def test_alcf_expired_record_reports_refreshable(clean_env):
+    alcf_auth.save_token_record(
+        {"access_token": "old", "refresh_token": "r", "expires_at_seconds": 1}
+    )
+
+    assert alcf_auth.token_status()["state"] == "refreshable"
+    assert alcf_auth.ensure_access_token(allow_refresh=False) is None
+
+
+def test_alcf_reads_helper_script_nested_format(clean_env, tmp_path):
+    helper = {
+        "data": {
+            "DEFAULT": {
+                alcf_auth.GATEWAY_CLIENT_ID: {
+                    "access_token": "helper-tok",
+                    "refresh_token": "r",
+                    "expires_at_seconds": 4102444800,
+                }
+            }
+        }
+    }
+    with open(alcf_auth.HELPER_TOKENS_PATH, "w") as f:
+        json.dump(helper, f)
+
+    record, source = alcf_auth.read_token_record()
+
+    assert record["access_token"] == "helper-tok"
+    assert source == alcf_auth.HELPER_TOKENS_PATH
+    assert alcf_auth.token_status()["state"] == "valid"
+
+
+def test_alcf_refresh_uses_refresh_token(clean_env, monkeypatch):
+    alcf_auth.save_token_record(
+        {"access_token": "old", "refresh_token": "r", "expires_at_seconds": 1}
+    )
+    monkeypatch.setattr(
+        alcf_auth,
+        "_refresh_record",
+        lambda record: {
+            "access_token": "fresh",
+            "refresh_token": record["refresh_token"],
+            "expires_at_seconds": 4102444800,
+        },
+    )
+
+    assert alcf_auth.ensure_access_token() == "fresh"
+    # The refreshed record is persisted for next time.
+    record, _ = alcf_auth.read_token_record()
+    assert record["access_token"] == "fresh"
+
+
+def test_alcf_exported_env_token_keeps_expiry_semantics(clean_env, monkeypatch):
+    # Simulate a completed in-UI login whose access token later expired:
+    # the env var holds the same (stale) token the cache holds.
+    alcf_auth.save_token_record(
+        {"access_token": "stale", "refresh_token": "r", "expires_at_seconds": 1}
+    )
+    monkeypatch.setenv("ALCF_ACCESS_TOKEN", "stale")
+
+    # Status must not blindly trust the env copy of our own cached token.
+    assert alcf_auth.token_status()["state"] == "refreshable"
+
+    monkeypatch.setattr(
+        alcf_auth,
+        "_refresh_record",
+        lambda record: {
+            "access_token": "fresh",
+            "refresh_token": "r",
+            "expires_at_seconds": 4102444800,
+        },
+    )
+    assert alcf_auth.ensure_access_token() == "fresh"
+    import os
+
+    assert os.environ["ALCF_ACCESS_TOKEN"] == "fresh"
+
+
+def test_alcf_external_env_token_is_trusted(clean_env, monkeypatch):
+    monkeypatch.setenv("ALCF_ACCESS_TOKEN", "external")
+    alcf_auth.save_token_record(
+        {"access_token": "cached", "refresh_token": "r", "expires_at_seconds": 1}
+    )
+
+    # A token that does not match the cache was supplied by the user.
+    assert alcf_auth.token_status()["state"] == "env"
+    assert alcf_auth.ensure_access_token(allow_refresh=False) == "external"
+
+
+def test_align_base_url_for_provider_keeps_separate_sections():
+    config = {"api": {"openai": {"base_url": "https://api.openai.com/v1"}}}
+
+    providers.align_base_url_for_provider(config, providers.ARGO)
+    assert config["api"]["argo"]["base_url"] == providers.ARGO_DEFAULT_BASE_URL
+    assert config["api"]["openai"]["base_url"] == providers.OPENAI_DEFAULT_BASE_URL
+
+    providers.align_base_url_for_provider(config, providers.OPENAI)
+    assert config["api"]["openai"]["base_url"] == providers.OPENAI_DEFAULT_BASE_URL
+
+    # Other providers leave both sections alone.
+    providers.align_base_url_for_provider(config, providers.ANTHROPIC)
+    assert config["api"]["argo"]["base_url"] == providers.ARGO_DEFAULT_BASE_URL
+    assert config["api"]["openai"]["base_url"] == providers.OPENAI_DEFAULT_BASE_URL
+
+
+def test_alcf_logout_clears_cache_and_env(clean_env, monkeypatch):
+    monkeypatch.setenv("ALCF_ACCESS_TOKEN", "tok")
+    alcf_auth.save_token_record(
+        {"access_token": "tok", "expires_at_seconds": 4102444800}
+    )
+
+    alcf_auth.logout()
+
+    import os
+
+    assert "ALCF_ACCESS_TOKEN" not in os.environ
+    assert alcf_auth.read_token_record() == (None, None)


### PR DESCRIPTION
Stacked on #209.

## Problem

Initial setup was the biggest onboarding hurdle:

- Argo settings hid inside the **"OpenAI"** API tab (`argo_user` text field) — nothing told an ANL user that Argo is username-only.
- ALCF users had to find `inference_auth_token.py`, run it in a shell, and paste a token into a password field.
- Groq and OpenRouter existed in routing/config but had no UI at all.
- With nothing configured, the first thing a new user saw was a raw "Failed to initialize agent" error.

## Changes

**Providers tab (Configuration page)** — one status card per provider (Argo, OpenAI, Anthropic, Google, Groq, OpenRouter, ALCF, local Ollama): ✅/○ readiness badge with a reason, credential input, endpoint settings, a model picker, and one-click **Use** activation. The local card probes the server live.

**In-UI Globus login for ALCF** (`ui/alcf_auth.py`) — same Native App client, scope, and session policy as ALCF's official `inference_auth_token.py`: click *Log in with Globus*, paste the code, done. Tokens are cached under `~/.chemgraph/` (chmod 600) with silent refresh-token renewal; caches written by the official helper script are picked up too, so CLI-authenticated users never see a login prompt.

**First-run setup (main page)** — when no credentialed provider is usable and the chat is empty, a four-tab wizard offers: Argo (just an ANL username), your own API key, ALCF via Globus, or a local Ollama server. Completing a tab persists the provider's default model to `config.toml` and drops straight into the chat. Skippable.

**Mismatch banner** — selecting a model whose provider isn't configured now explains what's missing instead of failing agent initialization bare.

`ui/providers.py` (registry + readiness checks) is Streamlit-free; chemistry settings moved to their own Configuration tab.

## Tests

New `tests/test_ui_providers.py`: readiness detection from env/config, model→provider mapping (every provider's default model maps back to it), ALCF token cache states (env/valid/refreshable/logged-out), helper-script nested format, refresh path, logout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
