### PR TITLE
feat(ui): modern navigation, responsive viewers, and a chemgraph ui command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,15 @@ cg_logs/
 notebooks/iri_*_results.json
 notebooks/iri_*_first_turn.json
 notebooks/iri_*_dataset.json
+
+# Agent/UI generated artifacts (written to the launch dir by older versions)
+ir_spectrum*.png
+frequencies*.csv
+*_report.html
+report.html
+output.json
+output.xyz
+molecule.xyz
+optimized_*.xyz
+*_structure.xyz
+ui_artifacts.json

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,9 @@
+# Streamlit configuration for running the ChemGraph UI from the repo root.
+# Only the accent color is set so the user's light/dark preference is kept.
+# `chemgraph ui` applies the same accent from anywhere via CLI flags.
+
+[theme]
+primaryColor = "#0E8A8C"
+
+[browser]
+gatherUsageStats = false

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ cd ChemGraph
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install -e .
-streamlit run src/ui/app.py
+chemgraph ui
 ```
 
 Open `http://localhost:8501`. For an image-based setup, use the Docker command

--- a/docs/streamlit_web_interface.md
+++ b/docs/streamlit_web_interface.md
@@ -14,10 +14,12 @@ cd ChemGraph
 python -m venv .venv
 source .venv/bin/activate
 python -m pip install -e .
-streamlit run src/ui/app.py
+chemgraph ui
 ```
 
-Open `http://localhost:8501`.
+Open `http://localhost:8501`. `chemgraph ui` works from any directory
+(`--address`, `--port`, and `--headless` are supported); from the repo root
+you can also run `streamlit run src/ui/app.py` directly.
 
 ## Run with Docker
 

--- a/environment.yml
+++ b/environment.yml
@@ -35,8 +35,7 @@ dependencies:
     - mace-torch==0.3.13
     - globus-sdk
     - streamlit==1.48.1
-    - stmol==0.0.9
-    - ipython-genutils==0.2.0
+    - py3Dmol
     - langsmith==0.10.10
     - mcp==1.28.1
     - fastmcp==3.4.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ dependencies = [
     "mace-torch",
     "globus_sdk",
     "streamlit==1.48.1",
-    "stmol==0.0.9",
-    "ipython-genutils==0.2.0",
+    "py3Dmol",
     "langsmith==0.10.10",
     "rich==14.1.0",
     "toml==0.10.2",
@@ -80,8 +79,7 @@ uma = [
 ]
 ui = [
     "streamlit",
-    "stmol",
-    "ipython-genutils",
+    "py3Dmol",
 ]
 parsl = [
     "parsl",

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -276,6 +276,30 @@ Examples:
     # ---- "models" subcommand ---------------------------------------------
     subparsers.add_parser("models", help="List all available LLM models.")
 
+    # ---- "ui" subcommand ---------------------------------------------------
+    ui_parser = subparsers.add_parser(
+        "ui",
+        help="Launch the ChemGraph web UI (Streamlit).",
+    )
+    ui_parser.add_argument(
+        "--address",
+        default="localhost",
+        help="Bind address (default: localhost).",
+    )
+    ui_parser.add_argument(
+        "--port", type=int, default=8501, help="Port (default: 8501)."
+    )
+    ui_parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Do not open a browser window.",
+    )
+    ui_parser.add_argument(
+        "ui_args",
+        nargs=argparse.REMAINDER,
+        help="Extra arguments forwarded to 'streamlit run'.",
+    )
+
     # ---- "dashboard" subcommands ----------------------------------------
     dashboard_parser = subparsers.add_parser(
         "dashboard",
@@ -744,6 +768,25 @@ def main() -> None:
 
     elif args.command == "models":
         list_models()
+
+    elif args.command == "ui":
+        # Lazy import: the ui package needs streamlit, which is optional.
+        try:
+            from ui.streamlit_launcher import launch
+        except ImportError as exc:
+            console.print(
+                f"[red]The web UI needs streamlit: {exc}. "
+                "Install with: pip install 'chemgraph[ui]'[/red]"
+            )
+            raise SystemExit(1)
+        raise SystemExit(
+            launch(
+                address=args.address,
+                port=args.port,
+                headless=args.headless,
+                extra_args=_strip_remainder_separator(args.ui_args),
+            )
+        )
 
     elif args.command == "dashboard":
         _run_module_main(

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -60,8 +60,9 @@ from ui.session_utils import (
 )
 from ui.state import init_session_state
 from ui.visualization import (
-    STMOL_AVAILABLE,
+    PY3DMOL_AVAILABLE,
     display_molecular_structure,
+    render_py3dmol,
     visualize_trajectory,
 )
 
@@ -870,8 +871,14 @@ def _render_conversation_history(thread_id: int) -> None:
         _render_single_exchange(idx, entry, thread_id)
 
 
+@st.fragment
 def _render_single_exchange(idx: int, entry: dict, thread_id: int) -> None:
     """Render one user-query / agent-response exchange.
+
+    Runs as a fragment so widget interactions inside an exchange (viewer
+    style, vibrational-mode selection) rerun only that exchange instead
+    of the whole app -- with long chats this is the difference between
+    an instant update and re-rendering every viewer on the page.
 
     Parameters
     ----------
@@ -1429,16 +1436,18 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
             traj_path = _resolve_artifact_path(traj_file, traj_base)
             if not os.path.exists(traj_path):
                 st.warning(f"Trajectory file '{traj_file}' not found.")
-            elif not STMOL_AVAILABLE:
-                st.info("3D viewer not available; install stmol to animate trajectories.")
+            elif not PY3DMOL_AVAILABLE:
+                st.info(
+                    "3D viewer not available; install py3Dmol to animate "
+                    "trajectories."
+                )
             else:
-                import stmol
                 from ase.io.trajectory import Trajectory
 
                 traj = Trajectory(traj_path)
                 view = visualize_trajectory(traj)
                 view.zoomTo()
-                stmol.showmol(view, height=400, width=500)
+                render_py3dmol(view)
 
 
 def _render_verbose_info(idx: int, messages: list, entry: dict) -> None:

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -1,10 +1,11 @@
 """ChemGraph Streamlit application entry point.
 
-Run with:  ``streamlit run src/ui/app.py``
+Run with:  ``streamlit run src/ui/app.py``  (or ``chemgraph ui``)
 
 This thin module handles page configuration (which **must** be the first
-Streamlit call), sidebar navigation, and page dispatch.  All page content
-lives in :mod:`ui.pages`.
+Streamlit call) and navigation via ``st.navigation``, which gives each
+page its own URL and a native sidebar entry.  All page content lives in
+:mod:`ui._pages`.
 """
 
 import sys
@@ -22,7 +23,7 @@ from chemgraph import __version__ as chemgraph_version  # noqa: E402
 
 from ui.branding import ICON_IMAGES, LOGO_IMAGES, first_existing_asset  # noqa: E402
 from ui.system_info import render_sidebar_host_and_build_info  # noqa: E402
-from ui.visualization import warn_stmol_unavailable  # noqa: E402
+from ui.visualization import warn_viewer_unavailable  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Page configuration -- MUST be the first Streamlit call
@@ -40,11 +41,46 @@ st.set_page_config(
     initial_sidebar_state="expanded",
 )
 
-# One-time stmol availability warning
-warn_stmol_unavailable()
+# One-time 3D viewer availability warning
+warn_viewer_unavailable()
+
 
 # ---------------------------------------------------------------------------
-# Sidebar navigation
+# Pages
+# ---------------------------------------------------------------------------
+
+
+def _chat_page() -> None:
+    """Render the chat page."""
+    from ui._pages import main_interface
+
+    main_interface.render()
+
+
+def _configuration_page() -> None:
+    """Render the configuration page."""
+    from ui._pages import configuration
+
+    configuration.render()
+
+
+def _about_page() -> None:
+    """Render the about page."""
+    from ui._pages import about
+
+    about.render()
+
+
+navigation = st.navigation(
+    [
+        st.Page(_chat_page, title="Chat", icon="\U0001f9ea", default=True),
+        st.Page(_configuration_page, title="Configuration", icon="⚙️"),
+        st.Page(_about_page, title="About", icon="\U0001f4d6"),
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# Sidebar chrome shared by all pages
 # ---------------------------------------------------------------------------
 logo_image = first_existing_asset(LOGO_IMAGES)
 icon_image = first_existing_asset(ICON_IMAGES)
@@ -53,30 +89,6 @@ if logo_image:
 else:
     st.sidebar.title("\U0001f9ea ChemGraph")
 
-page = st.sidebar.radio(
-    "Navigate",
-    ["\U0001f3e0 Main Interface", "\u2699\ufe0f Configuration", "\U0001f4d6 About ChemGraph"],
-    index=0,
-    key="page_navigation",
-)
 render_sidebar_host_and_build_info()
 
-# ---------------------------------------------------------------------------
-# Page dispatch
-# ---------------------------------------------------------------------------
-if page == "\U0001f4d6 About ChemGraph":
-    from ui._pages import about
-
-    about.render()
-    st.stop()
-
-elif page == "\u2699\ufe0f Configuration":
-    from ui._pages import configuration
-
-    configuration.render()
-    st.stop()
-
-else:
-    from ui._pages import main_interface
-
-    main_interface.render()
+navigation.run()

--- a/src/ui/streamlit_launcher.py
+++ b/src/ui/streamlit_launcher.py
@@ -1,0 +1,105 @@
+"""Launcher for the ChemGraph web UI.
+
+Used by ``chemgraph ui`` (and installable as a standalone entry point)
+so users can start the Streamlit app without knowing where the package
+is installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+# Brand accent applied on top of the user's light/dark base theme.
+PRIMARY_COLOR = "#0E8A8C"
+
+
+def app_path() -> str:
+    """Return the absolute path of the Streamlit app module."""
+    import ui
+
+    return str(Path(ui.__file__).resolve().parent / "app.py")
+
+
+def launch(
+    address: str = "localhost",
+    port: int = 8501,
+    headless: bool = False,
+    extra_args: Sequence[str] = (),
+) -> int:
+    """Run ``streamlit run`` for the ChemGraph UI and wait for it.
+
+    Parameters
+    ----------
+    address : str, optional
+        Bind address for the Streamlit server.
+    port : int, optional
+        Server port.
+    headless : bool, optional
+        Do not open a browser (for servers/containers).
+    extra_args : Sequence[str], optional
+        Additional arguments passed through to ``streamlit run``.
+
+    Returns
+    -------
+    int
+        The Streamlit process exit code.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        app_path(),
+        "--server.address",
+        address,
+        "--server.port",
+        str(port),
+        "--browser.gatherUsageStats",
+        "false",
+        "--theme.primaryColor",
+        PRIMARY_COLOR,
+    ]
+    if headless:
+        cmd += ["--server.headless", "true"]
+    cmd += list(extra_args)
+    try:
+        return subprocess.call(cmd)
+    except KeyboardInterrupt:
+        return 0
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """Console entry point."""
+    parser = argparse.ArgumentParser(
+        prog="chemgraph ui",
+        description="Launch the ChemGraph web UI (Streamlit).",
+    )
+    parser.add_argument(
+        "--address",
+        default="localhost",
+        help="Bind address (default: localhost).",
+    )
+    parser.add_argument(
+        "--port", type=int, default=8501, help="Port (default: 8501)."
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Do not open a browser window.",
+    )
+    parser.add_argument(
+        "streamlit_args",
+        nargs=argparse.REMAINDER,
+        help="Extra arguments passed to 'streamlit run' (prefix with --).",
+    )
+    args = parser.parse_args(argv)
+    extra = [a for a in args.streamlit_args if a != "--"]
+    raise SystemExit(launch(args.address, args.port, args.headless, extra))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ui/visualization.py
+++ b/src/ui/visualization.py
@@ -11,15 +11,35 @@ from ase.data import chemical_symbols
 from chemgraph.tools.ase_core import create_ase_atoms, create_xyz_string
 
 # ---------------------------------------------------------------------------
-# Optional stmol / py3Dmol availability
+# Optional py3Dmol availability
 # ---------------------------------------------------------------------------
 
 try:
-    import stmol
+    import py3Dmol
 
-    STMOL_AVAILABLE = True
+    PY3DMOL_AVAILABLE = True
 except ImportError:
-    STMOL_AVAILABLE = False
+    py3Dmol = None
+    PY3DMOL_AVAILABLE = False
+
+# Default viewer height in pixels; width always follows the container.
+VIEWER_HEIGHT = 420
+
+
+def render_py3dmol(view, height: int = VIEWER_HEIGHT) -> None:
+    """Embed a py3Dmol view at full container width.
+
+    Replaces the unmaintained ``stmol`` shim: py3Dmol renders itself to
+    a self-contained HTML snippet that Streamlit can embed directly.
+
+    Parameters
+    ----------
+    view : py3Dmol.view
+        Configured viewer.
+    height : int, optional
+        Component height in pixels.
+    """
+    st.components.v1.html(view._make_html(), height=height + 8, scrolling=False)
 
 
 # ---------------------------------------------------------------------------
@@ -50,14 +70,14 @@ def _stable_key(prefix: str, title: str) -> str:
     return f"{prefix}_{slug}"
 
 
-def warn_stmol_unavailable() -> None:
-    """Display a one-time warning when stmol is not installed."""
-    if STMOL_AVAILABLE or st.session_state.get("_stmol_warning_shown"):
+def warn_viewer_unavailable() -> None:
+    """Display a one-time warning when py3Dmol is not installed."""
+    if PY3DMOL_AVAILABLE or st.session_state.get("_viewer_warning_shown"):
         return
 
-    st.session_state["_stmol_warning_shown"] = True
-    st.warning("**stmol** not available -- falling back to text/table view.")
-    st.info("To enable 3D visualization, install with: `pip install stmol`")
+    st.session_state["_viewer_warning_shown"] = True
+    st.warning("**py3Dmol** not available -- falling back to text/table view.")
+    st.info("To enable 3D visualization, install with: `pip install py3Dmol`")
 
 
 def create_ase_atoms_with_streamlit_error(atomic_numbers, positions):
@@ -114,7 +134,7 @@ def display_molecular_structure(atomic_numbers, positions, title="Structure") ->
 
         # 3-D panel --------------------------------------------------------
         with col1:
-            if STMOL_AVAILABLE:
+            if PY3DMOL_AVAILABLE:
                 style_options = ["ball_and_stick", "stick", "sphere", "wireframe"]
                 selected_style = st.selectbox(
                     "Visualization Style",
@@ -123,9 +143,7 @@ def display_molecular_structure(atomic_numbers, positions, title="Structure") ->
                 )
 
                 try:
-                    import py3Dmol
-
-                    view = py3Dmol.view(width=500, height=400)
+                    view = py3Dmol.view(width="100%", height=VIEWER_HEIGHT)
                     view.addModel(xyz_string, "xyz")
 
                     if selected_style == "ball_and_stick":
@@ -140,7 +158,7 @@ def display_molecular_structure(atomic_numbers, positions, title="Structure") ->
                         view.setStyle({"stick": {}, "sphere": {"scale": 0.3}})
 
                     view.zoomTo()
-                    stmol.showmol(view, height=400, width=500)
+                    render_py3dmol(view)
 
                 except Exception as viz_error:
                     st.error(f"3D visualization error: {viz_error}")
@@ -175,8 +193,6 @@ def visualize_trajectory(traj):
     py3Dmol.view
         Configured animated viewer.
     """
-    import py3Dmol
-
     xyz_frames = []
     for i, atoms in enumerate(traj):
         symbols = atoms.get_chemical_symbols()
@@ -188,7 +204,7 @@ def visualize_trajectory(traj):
         xyz_frames.append("\n".join(lines))
     xyz_str = "\n".join(xyz_frames)
 
-    view = py3Dmol.view(width=500, height=400)
+    view = py3Dmol.view(width="100%", height=VIEWER_HEIGHT)
     view.addModelsAsFrames(xyz_str, "xyz")
 
     view.setViewStyle({"style": "outline", "width": 0.05})

--- a/tests/test_ui_apptest.py
+++ b/tests/test_ui_apptest.py
@@ -1,0 +1,84 @@
+"""End-to-end smoke tests for the Streamlit app using st.testing.
+
+These run the real app script (navigation, first-run setup, chat page)
+in-process without a browser. Provider credentials and config paths are
+isolated so results do not depend on the developer's environment.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_APP_PATH = str(Path(__file__).resolve().parents[1] / "src" / "ui" / "app.py")
+
+_CREDENTIAL_VARS = (
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+    "GROQ_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ARGO_USER",
+    "ALCF_ACCESS_TOKEN",
+    "CHEMGRAPH_LOG_DIR",
+)
+
+
+@pytest.fixture()
+def isolated_app(monkeypatch, tmp_path):
+    """Return an AppTest for the app with credentials/config isolated."""
+    from streamlit.testing.v1 import AppTest
+
+    for var in _CREDENTIAL_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    import ui.alcf_auth as alcf_auth
+    import ui.config as ui_config
+
+    monkeypatch.setattr(
+        ui_config, "_DEFAULT_CONFIG_PATH", str(tmp_path / "config.toml")
+    )
+    monkeypatch.setattr(
+        alcf_auth, "CHEMGRAPH_TOKENS_PATH", str(tmp_path / "tokens.json")
+    )
+    monkeypatch.setattr(
+        alcf_auth, "HELPER_TOKENS_PATH", str(tmp_path / "helper.json")
+    )
+    return AppTest.from_file(_APP_PATH, default_timeout=60)
+
+
+def test_first_run_setup_renders_without_credentials(isolated_app):
+    at = isolated_app.run()
+
+    assert not at.exception
+    assert any("Welcome" in info.value for info in at.info)
+    labels = [b.label for b in at.button]
+    assert "Use Argo" in labels
+    assert "Skip setup for now" in labels
+
+
+def test_argo_setup_persists_username_and_enters_chat(isolated_app, tmp_path):
+    at = isolated_app.run()
+
+    at.text_input(key="setup_argo_user").set_value("aturing")
+    at.run()
+    at.button(key="setup_argo_go").click()
+    at.run()
+
+    assert not at.exception
+    config = at.session_state["config"]
+    assert config["api"]["argo"]["argo_user"] == "aturing"
+    assert config["general"]["model"].startswith("argo:")
+    # The wizard is gone; the chat input is available.
+    assert len(at.chat_input) == 1
+    # And the choice was persisted to disk.
+    assert (tmp_path / "config.toml").exists()
+
+
+def test_chat_page_renders_with_provider_key(isolated_app, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    at = isolated_app.run()
+
+    assert not at.exception
+    # No wizard; chat input is present immediately.
+    assert not any("Welcome" in info.value for info in at.info)
+    assert len(at.chat_input) == 1

--- a/tests/test_ui_launcher.py
+++ b/tests/test_ui_launcher.py
@@ -1,0 +1,54 @@
+"""Tests for the web-UI launcher and its CLI wiring."""
+
+import sys
+
+from ui import streamlit_launcher
+
+
+def test_app_path_points_at_real_file():
+    path = streamlit_launcher.app_path()
+    assert path.endswith("app.py")
+    import os
+
+    assert os.path.exists(path)
+
+
+def test_launch_builds_streamlit_command(monkeypatch):
+    captured = {}
+
+    def fake_call(cmd):
+        captured["cmd"] = cmd
+        return 0
+
+    monkeypatch.setattr(streamlit_launcher.subprocess, "call", fake_call)
+
+    code = streamlit_launcher.launch(
+        address="0.0.0.0",
+        port=9000,
+        headless=True,
+        extra_args=["--server.enableCORS", "false"],
+    )
+
+    assert code == 0
+    cmd = captured["cmd"]
+    assert cmd[:4] == [sys.executable, "-m", "streamlit", "run"]
+    assert cmd[4] == streamlit_launcher.app_path()
+    assert cmd[cmd.index("--server.address") + 1] == "0.0.0.0"
+    assert cmd[cmd.index("--server.port") + 1] == "9000"
+    assert cmd[cmd.index("--server.headless") + 1] == "true"
+    assert cmd[-2:] == ["--server.enableCORS", "false"]
+
+
+def test_cli_ui_subcommand_dispatches_to_launcher(monkeypatch):
+    import importlib
+
+    # chemgraph.cli.__init__ re-exports main() under the submodule's name,
+    # so plain attribute imports would return the function.
+    cli_main = importlib.import_module("chemgraph.cli.main")
+
+    parser = cli_main.create_argument_parser()
+    args = parser.parse_args(["ui", "--port", "9001", "--headless"])
+
+    assert args.command == "ui"
+    assert args.port == 9001
+    assert args.headless is True


### PR DESCRIPTION
Stacked on #210.

## Changes

**Navigation** — replaced the sidebar radio + manual dispatch with `st.navigation`/`st.Page`: native sidebar entries and a URL per page.

**Responsiveness**
- Each chat exchange renders as a `st.fragment`: changing a viewer style or vibrational mode reruns only that exchange instead of re-rendering every viewer on the page.
- 3D viewers size to their container (`width="100%"`) instead of a fixed 500×400 px.

**Viewer stack** — removed the unmaintained `stmol` shim (2022, dragged in `ipython-genutils`); py3Dmol is embedded directly via its own HTML and is now a declared dependency instead of a transitive one.

**Launch UX** — new `chemgraph ui` subcommand (`--address/--port/--headless`, extra args forwarded to `streamlit run`) so the app starts from any directory; the previously-dead `streamlit_launcher.py` is now the wired-up implementation. A repo-root `.streamlit/config.toml` sets only the brand accent (`#0E8A8C`) so the user's light/dark preference is preserved; `chemgraph ui` applies the same accent via CLI flags. Docs updated.

**Hygiene** — `.gitignore` patterns for artifacts older versions wrote to the launch directory (`ir_spectrum*.png`, `frequencies*.csv`, `*_report.html`, `molecule.xyz`, …) so they can't be committed by accident again.

## Tests

- New `tests/test_ui_apptest.py` — Streamlit **AppTest end-to-end** smoke tests: navigation boots without exceptions, the first-run wizard renders when no provider is configured, completing the Argo path persists config and lands in a working chat, and a provider key skips the wizard.
- New `tests/test_ui_launcher.py` — launcher command construction and CLI parser wiring.
- Verified live: headless `streamlit run` boots clean, page health-checks OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
