### PR TITLE
feat(ui): interactive IR spectra and optimization convergence plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ molecule.xyz
 optimized_*.xyz
 *_structure.xyz
 ui_artifacts.json
+*_opt.traj

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ dependencies:
     - globus-sdk
     - streamlit==1.48.1
     - py3Dmol
+    - plotly
     - langsmith==0.10.10
     - mcp==1.28.1
     - fastmcp==3.4.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "globus_sdk",
     "streamlit==1.48.1",
     "py3Dmol",
+    "plotly",
     "langsmith==0.10.10",
     "rich==14.1.0",
     "toml==0.10.2",
@@ -80,6 +81,7 @@ uma = [
 ui = [
     "streamlit",
     "py3Dmol",
+    "plotly",
 ]
 parsl = [
     "parsl",

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -71,6 +71,23 @@ def _resolve_path(path: str) -> str:
     return path
 
 
+def _write_ir_peaks_csv(path: str, rows) -> None:
+    """Write per-mode IR peaks as ``mode,frequency_cm1,intensity`` rows.
+
+    Parameters
+    ----------
+    path : str
+        Destination CSV path (already resolved).
+    rows : sequence of tuple
+        ``(mode_index, frequency_text, intensity)`` per vibrational mode;
+        imaginary frequencies carry an ``i`` suffix like frequencies CSVs.
+    """
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("mode,frequency_cm1,intensity\n")
+        for mode_index, freq_text, intensity in rows:
+            f.write(f"{mode_index},{freq_text},{float(intensity):.8g}\n")
+
+
 def _write_ir_spectrum_csv(path: str, frequencies, intensities) -> None:
     """Write a broadened IR spectrum as ``frequency_cm1,intensity`` rows.
 
@@ -794,10 +811,31 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                         ir_csv_path, freq_intensity[0], freq_intensity[1]
                     )
 
+                    # Per-mode peak data (frequency + IR intensity), so the
+                    # UI can re-broaden the spectrum and link peaks to the
+                    # normal-mode trajectories written above.
+                    ir_energies = ir.get_energies()
+                    peak_rows = []
+                    for mode_index in mode_indices:
+                        e = ir_energies[mode_index]
+                        is_imag = abs(e.imag) > 1e-8
+                        e_val = e.imag if is_imag else e.real
+                        freq_text = f"{e_val / units.invcm:.4f}" + (
+                            "i" if is_imag else ""
+                        )
+                        peak_rows.append(
+                            (mode_index, freq_text, float(ir.intensities[mode_index]))
+                        )
+                    ir_peaks_path = _resolve_path(f"ir_peaks_{mol_stem}.csv")
+                    _write_ir_peaks_csv(ir_peaks_path, peak_rows)
+
                     logger.info("IR spectrum plot saved to %s", ir_plot_path)
                     ir_data["IR Plot"] = f"Saved to {os.path.abspath(ir_plot_path)}"
                     ir_data["IR spectrum data"] = (
                         f"Saved to {os.path.abspath(ir_csv_path)}"
+                    )
+                    ir_data["IR peak data"] = (
+                        f"Saved to {os.path.abspath(ir_peaks_path)}"
                     )
                     ir_data["Normal mode data"] = (
                         f"Normal modes saved as individual .traj files with prefix {mol_stem}_"

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -71,6 +71,24 @@ def _resolve_path(path: str) -> str:
     return path
 
 
+def _write_ir_spectrum_csv(path: str, frequencies, intensities) -> None:
+    """Write a broadened IR spectrum as ``frequency_cm1,intensity`` rows.
+
+    Parameters
+    ----------
+    path : str
+        Destination CSV path (already resolved).
+    frequencies : sequence
+        Spectrum frequencies in cm^-1.
+    intensities : sequence
+        Absorption intensities matching *frequencies*.
+    """
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("frequency_cm1,intensity\n")
+        for freq_value, intensity in zip(frequencies, intensities):
+            f.write(f"{float(freq_value):.4f},{float(intensity):.8g}\n")
+
+
 def _resolve_existing_path(path: str) -> str:
     """Resolve a path to read that a sibling tool may have written to the log dir.
 
@@ -623,8 +641,21 @@ def run_ase_core(params: ASEInputSchema) -> dict:
 
         logger.info("Running optimization with %s (fmax=%s, steps=%s)", optimizer, fmax, steps)
         optimization_steps = 0
+        opt_traj_path: Optional[str] = None
         if len(atoms) > 1:
-            dyn = optimizer_class(atoms)
+            traj_stem = (
+                Path(input_structure_file).stem if input_structure_file else "mol"
+            )
+            # Keep the trajectory next to the results file so all run
+            # artifacts land in the same directory.
+            traj_name = f"{traj_stem}_opt.traj"
+            if output_results_file:
+                opt_traj_path = str(
+                    Path(output_results_file).with_name(traj_name)
+                )
+            else:
+                opt_traj_path = _resolve_path(traj_name)
+            dyn = optimizer_class(atoms, trajectory=opt_traj_path)
             converged = dyn.run(fmax=fmax, steps=steps)
             optimization_steps = dyn.nsteps
         else:
@@ -756,8 +787,18 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     fig.savefig(ir_plot_path, format="png", dpi=300)
                     plt.close(fig)
 
+                    # Also save the spectrum data so the UI can plot it
+                    # interactively instead of showing the static image.
+                    ir_csv_path = _resolve_path(f"ir_spectrum_{mol_stem}.csv")
+                    _write_ir_spectrum_csv(
+                        ir_csv_path, freq_intensity[0], freq_intensity[1]
+                    )
+
                     logger.info("IR spectrum plot saved to %s", ir_plot_path)
                     ir_data["IR Plot"] = f"Saved to {os.path.abspath(ir_plot_path)}"
+                    ir_data["IR spectrum data"] = (
+                        f"Saved to {os.path.abspath(ir_csv_path)}"
+                    )
                     ir_data["Normal mode data"] = (
                         f"Normal modes saved as individual .traj files with prefix {mol_stem}_"
                     )
@@ -850,13 +891,16 @@ def run_ase_core(params: ASEInputSchema) -> dict:
                     "Geometry optimization completed without convergence after "
                     f"{optimization_steps} steps. Results saved to {abs_output}"
                 )
-            return {
+            result = {
                 "status": "success",
                 "message": message,
                 **energy_metadata,
                 "single_point_energy": potential_energy,
                 "unit": "eV",
             }
+            if opt_traj_path and os.path.exists(opt_traj_path):
+                result["trajectory_file"] = os.path.abspath(opt_traj_path)
+            return result
         elif driver == "vib":
             return {
                 "status": "success",

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -935,6 +935,12 @@ def _render_single_exchange(idx: int, entry: dict, thread_id: int) -> None:
         if html_filename:
             _render_html_report(idx, html_filename, messages, entry)
 
+        # Optimization convergence (needs the recorded trajectory artifact)
+        if artifact_kinds is not None and artifact_kinds.get(
+            artifact_utils.TRAJECTORIES
+        ):
+            _render_optimization_section(idx, entry, artifact_kinds)
+
         # IR spectrum: prefer the exchange's recorded artifacts; fall back to
         # keyword sniffing only for legacy entries without a manifest.
         if artifact_kinds is not None:
@@ -1363,24 +1369,29 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
         return
 
     # vib/thermo runs record frequencies but no spectrum -- label honestly.
+    has_spectrum_data = bool(
+        artifact_kinds and artifact_kinds.get(artifact_utils.IR_SPECTRA)
+    )
     label = (
         "\U0001f50d IR Spectrum"
-        if ir_path or artifact_kinds is None
+        if ir_path or has_spectrum_data or artifact_kinds is None
         else "\U0001f50d Vibrational Modes"
     )
     with st.expander(label, expanded=True):
         col1, col2 = st.columns(2, border=True)
 
         with col1:
-            if ir_path and os.path.exists(ir_path):
-                st.image(ir_path)
-            elif artifact_kinds is not None:
-                st.caption(
-                    "This run computed vibrational modes; no IR spectrum "
-                    "was requested."
-                )
-            else:
-                st.warning("IR spectrum plot not found.")
+            if not _render_interactive_ir_spectrum(idx, artifact_kinds, log_dir):
+                # Runs without spectrum data only produced the static image.
+                if ir_path and os.path.exists(ir_path):
+                    st.image(ir_path)
+                elif artifact_kinds is not None:
+                    st.caption(
+                        "This run computed vibrational modes; no IR spectrum "
+                        "was requested."
+                    )
+                else:
+                    st.warning("IR spectrum plot not found.")
 
         with col2:
             if not freq_path or not os.path.exists(freq_path):
@@ -1448,6 +1459,103 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
                 view = visualize_trajectory(traj)
                 view.zoomTo()
                 render_py3dmol(view)
+
+
+def _render_interactive_ir_spectrum(
+    idx: int, artifact_kinds: Optional[dict], log_dir: Optional[str]
+) -> bool:
+    """Render the exchange's IR spectrum as an interactive chart.
+
+    Parameters
+    ----------
+    idx : int
+        One-based exchange index.
+    artifact_kinds : dict or None
+        Classified artifacts for the exchange.
+    log_dir : str, optional
+        Run artifact directory.
+
+    Returns
+    -------
+    bool
+        ``True`` when the interactive chart was rendered.
+    """
+    if not artifact_kinds:
+        return False
+    spectra = artifact_kinds.get(artifact_utils.IR_SPECTRA, [])
+    if not spectra:
+        return False
+    try:
+        from ui import plots as ui_plots
+    except ImportError:
+        return False
+
+    csv_path = _resolve_artifact_path(spectra[-1], log_dir)
+    data = ui_plots.load_ir_spectrum_csv(csv_path)
+    if data is None:
+        return False
+    frequencies, intensities = data
+    st.plotly_chart(
+        ui_plots.ir_spectrum_figure(frequencies, intensities),
+        use_container_width=True,
+        key=f"ir_chart_{idx}",
+    )
+    return True
+
+
+def _render_optimization_section(
+    idx: int, entry: dict, artifact_kinds: dict
+) -> None:
+    """Render convergence chart and animation for an optimization run.
+
+    Parameters
+    ----------
+    idx : int
+        One-based exchange index.
+    entry : dict
+        Conversation-history entry.
+    artifact_kinds : dict
+        Classified artifacts for the exchange.
+    """
+    try:
+        from ui import plots as ui_plots
+    except ImportError:
+        return
+
+    traj_rel = artifact_kinds[artifact_utils.TRAJECTORIES][-1]
+    traj_path = _resolve_artifact_path(traj_rel, entry.get("log_dir"))
+    if not os.path.exists(traj_path):
+        return
+    data = ui_plots.read_optimization_trajectory(traj_path)
+    if data is None:
+        return
+    energies, fmax_values = data
+    if len(energies) < 2:
+        return
+
+    with st.expander(
+        f"\U0001f4c9 Optimization ({len(energies)} steps)", expanded=False
+    ):
+        col_chart, col_anim = st.columns(2, border=True)
+        with col_chart:
+            st.plotly_chart(
+                ui_plots.convergence_figure(energies, fmax_values),
+                use_container_width=True,
+                key=f"convergence_{idx}",
+            )
+        with col_anim:
+            if PY3DMOL_AVAILABLE:
+                try:
+                    from ase.io.trajectory import Trajectory
+
+                    view = visualize_trajectory(Trajectory(traj_path))
+                    view.zoomTo()
+                    render_py3dmol(view)
+                    st.caption("Optimization path animation")
+                except Exception as exc:
+                    st.warning(f"Could not animate trajectory: {exc}")
+            else:
+                st.info("Install py3Dmol to animate the optimization path.")
 
 
 def _render_verbose_info(idx: int, messages: list, entry: dict) -> None:

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -63,6 +63,7 @@ from ui.visualization import (
     PY3DMOL_AVAILABLE,
     display_molecular_structure,
     render_py3dmol,
+    trajectory_to_xyz_frames,
     visualize_trajectory,
 )
 
@@ -1335,6 +1336,168 @@ def _trajectory_mode_index(filename: str, fallback: int) -> int:
         return fallback
 
 
+@st.cache_data(show_spinner=False)
+def _cached_mode_frames(traj_path: str, mtime: float) -> Optional[str]:
+    """Load a normal-mode trajectory as multi-model XYZ text (cached).
+
+    Parameters
+    ----------
+    traj_path : str
+        Path to the mode's ``.traj`` file.
+    mtime : float
+        File modification time; part of the cache key so rewritten
+        files re-load.
+
+    Returns
+    -------
+    str or None
+        XYZ frame text, or ``None`` when the file cannot be read.
+    """
+    try:
+        from ase.io.trajectory import Trajectory
+
+        with Trajectory(traj_path) as traj:
+            return trajectory_to_xyz_frames(traj)
+    except Exception:
+        return None
+
+
+def _render_ir_explorer_panel(
+    idx: int,
+    peaks_path: Optional[str],
+    freq_path: Optional[str],
+    log_dir: Optional[str],
+) -> bool:
+    """Render the linked viewer + spectrum explorer for an IR run.
+
+    Needs the per-mode peak data (``ir_peaks_*.csv``); returns ``False``
+    so the caller falls back to the static layout when it is missing.
+
+    Parameters
+    ----------
+    idx : int
+        One-based exchange index.
+    peaks_path : str, optional
+        Resolved ``ir_peaks_*.csv`` path.
+    freq_path : str, optional
+        Resolved ``frequencies_*.csv`` path (maps modes to trajectories).
+    log_dir : str, optional
+        Run artifact directory.
+
+    Returns
+    -------
+    bool
+        ``True`` when the explorer was rendered.
+    """
+    if not peaks_path or not os.path.exists(peaks_path):
+        return False
+    if not freq_path or not os.path.exists(freq_path):
+        return False
+    try:
+        from ui import plots as ui_plots
+        from ui.ir_explorer import render_ir_explorer
+    except ImportError:
+        return False
+
+    peak_records = ui_plots.load_ir_peaks_csv(peaks_path)
+    if not peak_records:
+        return False
+    real_peaks = [
+        p
+        for p in peak_records
+        if not p["imaginary"] and p["frequency"] is not None
+    ]
+    if not real_peaks:
+        return False
+
+    # Map mode index -> trajectory filename via the frequencies table.
+    traj_names: dict[int, str] = {}
+    try:
+        df = pd.read_csv(freq_path, index_col=False, names=["filename", "frequency"])
+        for row_idx, row in df.iterrows():
+            name = str(row["filename"])
+            traj_names[_trajectory_mode_index(name, row_idx)] = name
+    except Exception:
+        pass
+
+    # ----- Controls: mode dropdown + Gaussian width slider -----
+    col_mode, col_width = st.columns([3, 2], vertical_alignment="bottom")
+    with col_mode:
+        option_labels: dict[str, int] = {}
+        for p in peak_records:
+            suffix = "i" if p["imaginary"] else ""
+            freq_value = p["frequency"] if p["frequency"] is not None else 0.0
+            option_label = (
+                f"Mode {p['mode']}: {freq_value:.2f}{suffix} cm⁻¹"
+            )
+            option_labels[option_label] = p["mode"]
+        selected_label = st.selectbox(
+            "Normal mode",
+            list(option_labels.keys()),
+            index=0,
+            key=f"ir_frequency_select_{idx}",
+        )
+        selected_mode = option_labels[selected_label]
+    with col_width:
+        width = st.slider(
+            "Peak width (FWHM, cm⁻¹)",
+            min_value=1,
+            max_value=100,
+            value=8,
+            key=f"ir_width_{idx}",
+        )
+
+    curve_x, curve_y = ui_plots.gaussian_broadened_spectrum(
+        [p["frequency"] for p in real_peaks],
+        [p["intensity"] for p in real_peaks],
+        float(width),
+    )
+
+    import numpy as np
+
+    traj_base = str(Path(freq_path).parent)
+    peaks_payload = []
+    for p in peak_records:
+        frames = None
+        traj_name = traj_names.get(p["mode"])
+        if traj_name:
+            traj_path = _resolve_artifact_path(traj_name, traj_base)
+            if os.path.exists(traj_path):
+                frames = _cached_mode_frames(
+                    traj_path, os.path.getmtime(traj_path)
+                )
+        freq_value = p["frequency"] if p["frequency"] is not None else 0.0
+        marker_y = (
+            float(np.interp(freq_value, curve_x, curve_y))
+            if not p["imaginary"]
+            else 0.0
+        )
+        peaks_payload.append(
+            {
+                "mode": p["mode"],
+                "freq": freq_value,
+                "intensity": p["intensity"],
+                "imaginary": p["imaginary"],
+                "y": marker_y,
+                "frames": frames,
+            }
+        )
+
+    render_ir_explorer(curve_x, curve_y, peaks_payload, selected_mode)
+    selected_record = next(
+        (p for p in peak_records if p["mode"] == selected_mode), None
+    )
+    if selected_record is not None and selected_record["imaginary"]:
+        st.caption(
+            "The selected mode is imaginary and not part of the spectrum."
+        )
+    st.caption(
+        "Hover a peak to preview its normal mode; the dropdown selection "
+        "stays highlighted."
+    )
+    return True
+
+
 def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
     """Render IR spectrum plot, frequency table, and trajectory viewer.
 
@@ -1349,16 +1512,20 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
     """
     log_dir = _artifact_log_dir(messages, entry)
     artifact_kinds = _entry_artifact_kinds(entry)
+    peaks_path = None
     if artifact_kinds is not None:
         # Use exactly the files this exchange produced.
         ir_files = artifact_kinds.get(artifact_utils.IR_PLOTS, [])
         freq_files = artifact_kinds.get(artifact_utils.FREQUENCY_TABLES, [])
+        peaks_files = artifact_kinds.get(artifact_utils.IR_PEAKS, [])
         ir_path = (
             _resolve_artifact_path(ir_files[-1], log_dir) if ir_files else None
         )
         freq_path = (
             _resolve_artifact_path(freq_files[-1], log_dir) if freq_files else None
         )
+        if peaks_files:
+            peaks_path = _resolve_artifact_path(peaks_files[-1], log_dir)
     else:
         # Legacy entries: newest match in the entry's own log directory.
         ir_path = _latest_artifact_path(log_dir, "ir_spectrum*.png")
@@ -1378,6 +1545,11 @@ def _render_ir_spectrum(idx: int, messages: list, entry: dict) -> None:
         else "\U0001f50d Vibrational Modes"
     )
     with st.expander(label, expanded=True):
+        # Runs with per-mode peak data get the linked explorer: hover a
+        # peak to see its mode animate, re-broaden with the width slider.
+        if _render_ir_explorer_panel(idx, peaks_path, freq_path, log_dir):
+            return
+
         col1, col2 = st.columns(2, border=True)
 
         with col1:

--- a/src/ui/artifacts.py
+++ b/src/ui/artifacts.py
@@ -28,8 +28,10 @@ MANIFEST_FILENAME = "ui_artifacts.json"
 # Classification buckets, in the order the UI renders them.
 STRUCTURES = "structures"
 IR_PLOTS = "ir_plots"
+IR_SPECTRA = "ir_spectra"
 FREQUENCY_TABLES = "frequency_tables"
 MODE_TRAJECTORIES = "mode_trajectories"
+TRAJECTORIES = "trajectories"
 REPORTS = "reports"
 IMAGES = "images"
 DATA = "data"
@@ -114,10 +116,14 @@ def classify_artifacts(files: list[str]) -> dict[str, list[str]]:
             _add(STRUCTURES, rel)
         elif name.endswith(".png") and name.startswith("ir_spectrum"):
             _add(IR_PLOTS, rel)
+        elif name.endswith(".csv") and name.startswith("ir_spectrum"):
+            _add(IR_SPECTRA, rel)
         elif name.endswith(".csv") and name.startswith("frequencies"):
             _add(FREQUENCY_TABLES, rel)
         elif fnmatch.fnmatch(name, "*_vib.*.traj"):
             _add(MODE_TRAJECTORIES, rel)
+        elif name.endswith(".traj"):
+            _add(TRAJECTORIES, rel)
         elif name.endswith((".html", ".htm")):
             _add(REPORTS, rel)
         elif name.endswith(".png"):

--- a/src/ui/artifacts.py
+++ b/src/ui/artifacts.py
@@ -29,6 +29,7 @@ MANIFEST_FILENAME = "ui_artifacts.json"
 STRUCTURES = "structures"
 IR_PLOTS = "ir_plots"
 IR_SPECTRA = "ir_spectra"
+IR_PEAKS = "ir_peaks"
 FREQUENCY_TABLES = "frequency_tables"
 MODE_TRAJECTORIES = "mode_trajectories"
 TRAJECTORIES = "trajectories"
@@ -118,6 +119,8 @@ def classify_artifacts(files: list[str]) -> dict[str, list[str]]:
             _add(IR_PLOTS, rel)
         elif name.endswith(".csv") and name.startswith("ir_spectrum"):
             _add(IR_SPECTRA, rel)
+        elif name.endswith(".csv") and name.startswith("ir_peaks"):
+            _add(IR_PEAKS, rel)
         elif name.endswith(".csv") and name.startswith("frequencies"):
             _add(FREQUENCY_TABLES, rel)
         elif fnmatch.fnmatch(name, "*_vib.*.traj"):

--- a/src/ui/ir_explorer.py
+++ b/src/ui/ir_explorer.py
@@ -1,0 +1,202 @@
+"""Combined 3D-viewer + IR-spectrum component with hover linking.
+
+Streamlit widgets cannot forward hover events to Python, so linking
+"hover a peak" to "animate that normal mode" requires both panels in one
+HTML component: a 3Dmol.js viewer (left) and a Plotly.js spectrum
+(right) wired together in JavaScript. Hovering a peak highlights it and
+plays its mode; leaving reverts to the mode chosen in the Streamlit
+dropdown, which is drawn with a persistent highlight.
+
+``build_ir_explorer_html`` is pure (unit-testable); ``render_ir_explorer``
+is the thin Streamlit wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import streamlit as st
+
+# Same CDN builds the rest of the app already relies on (py3Dmol embeds
+# 3dmol from jsdelivr; st.plotly_chart bundles its own plotly).
+_3DMOL_JS = "https://cdn.jsdelivr.net/npm/3dmol@2.5.5/build/3Dmol-min.js"
+_PLOTLY_JS = "https://cdn.plot.ly/plotly-2.35.2.min.js"
+
+_TEMPLATE = """<!DOCTYPE html>
+<html><head>
+<meta charset="utf-8"/>
+<script src="__3DMOL_JS__"></script>
+<script src="__PLOTLY_JS__"></script>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%;
+               font-family: "Source Sans Pro", sans-serif; }
+  #wrap { display: flex; gap: 10px; height: __HEIGHT__px; }
+  #viewerbox { flex: 0 0 42%; position: relative;
+               border: 1px solid rgba(128,128,128,.35);
+               border-radius: 8px; overflow: hidden; background: white; }
+  #viewer { width: 100%; height: 100%; position: relative; }
+  #modelabel { position: absolute; left: 8px; top: 6px; z-index: 5;
+               font-size: 13px; color: #444;
+               background: rgba(255,255,255,.8);
+               padding: 2px 8px; border-radius: 6px; }
+  #spectrum { flex: 1; min-width: 0; }
+</style></head>
+<body>
+<div id="wrap">
+  <div id="viewerbox"><div id="viewer"></div><div id="modelabel"></div></div>
+  <div id="spectrum"></div>
+</div>
+<script>
+const DATA = __PAYLOAD__;
+const ACCENT = "#0E9594";
+const AXIS_INK = "#8a8f98";
+const peaks = DATA.peaks;
+
+// ---------------- 3D viewer ----------------
+// WebGL can be unavailable (remote desktops, headless browsers, old
+// GPUs); the spectrum must keep working, so the viewer fails soft.
+let viewer = null;
+try {
+  viewer = $3Dmol.createViewer("viewer", {backgroundColor: "white"});
+} catch (e) {
+  document.getElementById("modelabel").textContent =
+      "3D viewer unavailable (WebGL required)";
+}
+let activeMode = null;
+function showMode(mode) {
+  if (mode === activeMode) return;
+  activeMode = mode;
+  const p = peaks.find(q => q.mode === mode);
+  const label = document.getElementById("modelabel");
+  if (p) {
+    label.textContent = "Mode " + p.mode + " \\u2014 " +
+        p.freq.toFixed(1) + (p.imaginary ? "i" : "") + " cm\\u207b\\u00b9";
+  }
+  if (!viewer) return;
+  try {
+    viewer.removeAllModels();
+    if (!p) { label.textContent = ""; viewer.render(); return; }
+    if (!p.frames) { viewer.render(); return; }
+    viewer.addModelsAsFrames(p.frames, "xyz");
+    viewer.setStyle({}, {stick: {radius: 0.12}, sphere: {scale: 0.25}});
+    viewer.zoomTo();
+    viewer.animate({loop: "backAndForth", interval: 60});
+    viewer.render();
+  } catch (e) {
+    label.textContent = "3D viewer unavailable (WebGL required)";
+    viewer = null;
+  }
+}
+
+// ---------------- spectrum ----------------
+const real = peaks.filter(p => !p.imaginary);
+const baseSize = real.map(p => p.mode === DATA.selected_mode ? 13 : 9);
+const baseLine = real.map(p => p.mode === DATA.selected_mode ? 2.5 : 1.4);
+const traces = [
+  {x: DATA.curve.x, y: DATA.curve.y, mode: "lines", hoverinfo: "skip",
+   line: {color: ACCENT, width: 2}},
+  {x: real.map(p => p.freq), y: real.map(p => p.y), mode: "markers",
+   marker: {size: baseSize.slice(), color: "rgba(14,149,148,.25)",
+            line: {color: ACCENT, width: baseLine.slice()}},
+   customdata: real.map(p => [p.mode, p.intensity]),
+   hovertemplate: "mode %{customdata[0]}<br>%{x:.1f} cm\\u207b\\u00b9" +
+                  "<br>I = %{customdata[1]:.3g}<extra></extra>"}
+];
+const selected = real.find(p => p.mode === DATA.selected_mode);
+const layout = {
+  xaxis: {title: {text: "Wavenumber (cm\\u207b\\u00b9)"},
+          autorange: "reversed", color: AXIS_INK,
+          gridcolor: "rgba(128,128,128,.25)", zeroline: false},
+  yaxis: {title: {text: "Intensity ((D/\\u00c5)\\u00b2 amu\\u207b\\u00b9)"},
+          color: AXIS_INK, gridcolor: "rgba(128,128,128,.25)",
+          zeroline: false},
+  paper_bgcolor: "rgba(0,0,0,0)", plot_bgcolor: "rgba(0,0,0,0)",
+  showlegend: false, hovermode: "closest",
+  margin: {l: 60, r: 10, t: 10, b: 45},
+  shapes: selected ? [{type: "line", x0: selected.freq, x1: selected.freq,
+                       y0: 0, y1: 1, yref: "paper",
+                       line: {color: ACCENT, width: 1, dash: "dot"}}] : []
+};
+const spec = document.getElementById("spectrum");
+Plotly.newPlot(spec, traces, layout, {responsive: true, displayModeBar: false});
+
+function setHighlight(hoverIdx) {
+  const sizes = baseSize.slice();
+  const widths = baseLine.slice();
+  if (hoverIdx !== null) { sizes[hoverIdx] = 17; widths[hoverIdx] = 3; }
+  Plotly.restyle(spec, {"marker.size": [sizes],
+                        "marker.line.width": [widths]}, [1]);
+}
+spec.on("plotly_hover", ev => {
+  const pt = ev.points && ev.points.find(p => p.curveNumber === 1);
+  if (!pt) return;
+  setHighlight(pt.pointIndex);
+  showMode(real[pt.pointIndex].mode);
+});
+spec.on("plotly_unhover", () => {
+  setHighlight(null);
+  showMode(DATA.selected_mode);
+});
+
+showMode(DATA.selected_mode);
+</script>
+</body></html>
+"""
+
+
+def build_ir_explorer_html(
+    curve_x: list[float],
+    curve_y: list[float],
+    peaks: list[dict],
+    selected_mode: Optional[int],
+    height: int = 430,
+) -> str:
+    """Build the self-contained HTML for the IR explorer.
+
+    Parameters
+    ----------
+    curve_x : list[float]
+        Broadened-spectrum grid (cm^-1).
+    curve_y : list[float]
+        Broadened-spectrum intensities.
+    peaks : list[dict]
+        Per-mode records: ``mode`` (int), ``freq`` (float), ``intensity``
+        (float), ``y`` (marker height on the curve), ``imaginary`` (bool),
+        and ``frames`` (multi-model XYZ text or ``None``).
+    selected_mode : int, optional
+        Mode chosen in the dropdown; drawn with a persistent highlight
+        and shown in the viewer when nothing is hovered.
+    height : int, optional
+        Component height in pixels.
+
+    Returns
+    -------
+    str
+        Complete HTML document.
+    """
+    payload = json.dumps(
+        {
+            "curve": {"x": curve_x, "y": curve_y},
+            "peaks": peaks,
+            "selected_mode": selected_mode,
+        }
+    ).replace("</", "<\\/")
+    return (
+        _TEMPLATE.replace("__3DMOL_JS__", _3DMOL_JS)
+        .replace("__PLOTLY_JS__", _PLOTLY_JS)
+        .replace("__HEIGHT__", str(height))
+        .replace("__PAYLOAD__", payload)
+    )
+
+
+def render_ir_explorer(
+    curve_x: list[float],
+    curve_y: list[float],
+    peaks: list[dict],
+    selected_mode: Optional[int],
+    height: int = 430,
+) -> None:
+    """Render the combined viewer + spectrum component."""
+    html = build_ir_explorer_html(curve_x, curve_y, peaks, selected_mode, height)
+    st.components.v1.html(html, height=height + 12, scrolling=False)

--- a/src/ui/ir_explorer.py
+++ b/src/ui/ir_explorer.py
@@ -75,6 +75,10 @@ function showMode(mode) {
   }
   if (!viewer) return;
   try {
+    // Cancel the running animation loop first: animate() starts a new
+    // timer without stopping the old one, and stacked timers make the
+    // vibration play faster after every hover.
+    viewer.stopAnimate();
     viewer.removeAllModels();
     if (!p) { label.textContent = ""; viewer.render(); return; }
     if (!p.frames) { viewer.render(); return; }
@@ -140,6 +144,12 @@ spec.on("plotly_unhover", () => {
 });
 
 showMode(DATA.selected_mode);
+
+// Debug handle for automated checks (e.g. animation-timer counting).
+window.__cg_debug = {
+  timers: () => (viewer && viewer.animationTimers) ? viewer.animationTimers.size : -1,
+  mode: () => activeMode
+};
 </script>
 </body></html>
 """

--- a/src/ui/plots.py
+++ b/src/ui/plots.py
@@ -55,6 +55,97 @@ def load_ir_spectrum_csv(
     return frequencies, intensities
 
 
+def load_ir_peaks_csv(
+    path: str,
+) -> Optional[list[dict]]:
+    """Read a ``mode,frequency_cm1,intensity`` CSV written by the IR driver.
+
+    Parameters
+    ----------
+    path : str
+        Peaks CSV path.
+
+    Returns
+    -------
+    list[dict] or None
+        One record per mode: ``{"mode": int, "frequency": float | None,
+        "intensity": float, "imaginary": bool}``; ``frequency`` is the
+        magnitude and ``None`` marks unparsable rows. ``None`` is returned
+        when the file is missing or holds no modes.
+    """
+    peaks: list[dict] = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for row in csv.reader(f):
+                if len(row) < 3:
+                    continue
+                try:
+                    mode = int(row[0])
+                    intensity = float(row[2])
+                except ValueError:
+                    continue  # header or junk line
+                freq_text = row[1].strip()
+                imaginary = freq_text.endswith("i")
+                try:
+                    frequency = float(freq_text.rstrip("i"))
+                except ValueError:
+                    frequency = None
+                peaks.append(
+                    {
+                        "mode": mode,
+                        "frequency": frequency,
+                        "intensity": intensity,
+                        "imaginary": imaginary,
+                    }
+                )
+    except OSError:
+        return None
+    return peaks or None
+
+
+def gaussian_broadened_spectrum(
+    frequencies: list[float],
+    intensities: list[float],
+    width: float,
+    npts: int = 1200,
+) -> tuple[list[float], list[float]]:
+    """Fold peaks into a Gaussian-broadened spectrum, matching ASE.
+
+    Follows :meth:`ase.vibrations.Vibrations.fold` with
+    ``normalize=False``: each peak is an unnormalized Gaussian of height
+    ``intensity`` whose full width at half maximum is *width*.
+
+    Parameters
+    ----------
+    frequencies : list[float]
+        Peak positions in cm^-1 (real modes only).
+    intensities : list[float]
+        Peak intensities, same length as *frequencies*.
+    width : float
+        FWHM of the Gaussians in cm^-1.
+    npts : int, optional
+        Number of grid points.
+
+    Returns
+    -------
+    tuple[list[float], list[float]]
+        Grid and folded spectrum.
+    """
+    import numpy as np
+
+    freqs = np.asarray(frequencies, dtype=float)
+    intens = np.asarray(intensities, dtype=float)
+    start = max(0.0, float(freqs.min()) - max(200.0, 3.0 * width))
+    end = float(freqs.max()) + max(200.0, 3.0 * width)
+    sigma = width / 2.0 / np.sqrt(2.0 * np.log(2.0))
+    grid = np.linspace(start, end, npts)
+    spectrum = (
+        intens[None, :]
+        * np.exp(-((freqs[None, :] - grid[:, None]) ** 2) / 2.0 / sigma**2)
+    ).sum(axis=1)
+    return grid.tolist(), spectrum.tolist()
+
+
 def ir_spectrum_figure(
     frequencies: list[float], intensities: list[float]
 ) -> go.Figure:

--- a/src/ui/plots.py
+++ b/src/ui/plots.py
@@ -1,0 +1,227 @@
+"""Interactive Plotly figures for ChemGraph artifacts.
+
+Data-reading helpers are Streamlit-free so they can be unit-tested; the
+figures are rendered by the pages with ``st.plotly_chart``, whose
+built-in Streamlit theme adapts fonts and surfaces to light/dark mode.
+"""
+
+from __future__ import annotations
+
+import csv
+from typing import Optional
+
+import plotly.graph_objects as go
+
+# Single-series data-mark color, validated for chroma (>= 0.1) and
+# contrast (>= 3:1) against both the light and dark Streamlit surfaces.
+LINE_COLOR = "#0E9594"
+
+_GRID_STYLE = {"showgrid": True, "gridwidth": 1, "zeroline": False}
+
+
+def load_ir_spectrum_csv(
+    path: str,
+) -> Optional[tuple[list[float], list[float]]]:
+    """Read a ``frequency_cm1,intensity`` CSV written by the IR driver.
+
+    Parameters
+    ----------
+    path : str
+        Spectrum CSV path.
+
+    Returns
+    -------
+    tuple[list[float], list[float]] or None
+        ``(frequencies, intensities)``, or ``None`` when the file is
+        missing/empty/malformed.
+    """
+    frequencies: list[float] = []
+    intensities: list[float] = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for row in csv.reader(f):
+                if len(row) < 2:
+                    continue
+                try:
+                    freq, intensity = float(row[0]), float(row[1])
+                except ValueError:
+                    continue  # header or junk line
+                frequencies.append(freq)
+                intensities.append(intensity)
+    except OSError:
+        return None
+    if not frequencies:
+        return None
+    return frequencies, intensities
+
+
+def ir_spectrum_figure(
+    frequencies: list[float], intensities: list[float]
+) -> go.Figure:
+    """Build an interactive IR spectrum figure.
+
+    Follows IR convention: wavenumber decreases left to right.
+
+    Parameters
+    ----------
+    frequencies : list[float]
+        Spectrum frequencies in cm^-1.
+    intensities : list[float]
+        Absorption intensities.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Configured single-series line figure.
+    """
+    fig = go.Figure(
+        go.Scatter(
+            x=frequencies,
+            y=intensities,
+            mode="lines",
+            line={"color": LINE_COLOR, "width": 2},
+            name="IR spectrum",
+            hovertemplate=(
+                "%{x:.0f} cm⁻¹<br>intensity %{y:.3g}<extra></extra>"
+            ),
+        )
+    )
+    fig.update_layout(
+        xaxis={
+            "title": {"text": "Wavenumber (cm⁻¹)"},
+            "autorange": "reversed",
+            **_GRID_STYLE,
+        },
+        yaxis={
+            "title": {"text": "Intensity ((D/Å)² amu⁻¹)"},
+            **_GRID_STYLE,
+        },
+        showlegend=False,
+        hovermode="x",
+        margin={"l": 10, "r": 10, "t": 10, "b": 10},
+        height=380,
+    )
+    return fig
+
+
+def read_optimization_trajectory(
+    path: str,
+) -> Optional[tuple[list[float], list[Optional[float]]]]:
+    """Extract per-step energies and max forces from an ASE trajectory.
+
+    Parameters
+    ----------
+    path : str
+        ASE ``.traj`` file written by the optimizer.
+
+    Returns
+    -------
+    tuple or None
+        ``(energies_eV, fmax_eV_per_A)`` per optimization step; force
+        entries are ``None`` for frames without stored forces. ``None``
+        when the file cannot be read or holds no energies.
+    """
+    try:
+        from ase.io.trajectory import Trajectory
+
+        energies: list[float] = []
+        fmax_values: list[Optional[float]] = []
+        with Trajectory(path) as traj:
+            for atoms in traj:
+                energies.append(float(atoms.get_potential_energy()))
+                try:
+                    forces = atoms.get_forces()
+                    fmax_values.append(
+                        float((forces**2).sum(axis=1).max() ** 0.5)
+                    )
+                except Exception:
+                    fmax_values.append(None)
+    except Exception:
+        return None
+    if not energies:
+        return None
+    return energies, fmax_values
+
+
+def convergence_figure(
+    energies: list[float], fmax_values: Optional[list[Optional[float]]] = None
+) -> go.Figure:
+    """Build an optimization-convergence figure.
+
+    Energy and max force are different measures, so they get their own
+    stacked panels sharing the step axis (never a dual axis).
+
+    Parameters
+    ----------
+    energies : list[float]
+        Potential energy per optimization step (eV).
+    fmax_values : list[float | None], optional
+        Max force per step (eV/Å); the force panel is added only when at
+        least one value is present.
+
+    Returns
+    -------
+    plotly.graph_objects.Figure
+        Configured convergence figure.
+    """
+    from plotly.subplots import make_subplots
+
+    steps = list(range(len(energies)))
+    have_forces = bool(fmax_values) and any(
+        v is not None for v in fmax_values
+    )
+    rows = 2 if have_forces else 1
+    fig = make_subplots(
+        rows=rows,
+        cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.08,
+    )
+    fig.add_trace(
+        go.Scatter(
+            x=steps,
+            y=energies,
+            mode="lines+markers",
+            line={"color": LINE_COLOR, "width": 2},
+            marker={"size": 8},
+            name="Energy",
+            hovertemplate="step %{x}<br>%{y:.6f} eV<extra></extra>",
+        ),
+        row=1,
+        col=1,
+    )
+    fig.update_yaxes(
+        title={"text": "Energy (eV)"}, row=1, col=1, **_GRID_STYLE
+    )
+    if have_forces:
+        fig.add_trace(
+            go.Scatter(
+                x=steps,
+                y=[v for v in fmax_values],
+                mode="lines+markers",
+                line={"color": LINE_COLOR, "width": 2},
+                marker={"size": 8},
+                name="Max force",
+                hovertemplate="step %{x}<br>%{y:.4f} eV/Å<extra></extra>",
+            ),
+            row=2,
+            col=1,
+        )
+        fig.update_yaxes(
+            title={"text": "Max force (eV/Å)"},
+            type="log",
+            dtick=1,  # one tick per decade; SI-style log ticks are ambiguous
+            row=2,
+            col=1,
+            **_GRID_STYLE,
+        )
+        fig.update_xaxes(title={"text": "Step"}, row=2, col=1, **_GRID_STYLE)
+    else:
+        fig.update_xaxes(title={"text": "Step"}, row=1, col=1, **_GRID_STYLE)
+    fig.update_layout(
+        showlegend=False,
+        hovermode="x",
+        margin={"l": 10, "r": 10, "t": 10, "b": 10},
+        height=420 if have_forces else 300,
+    )
+    return fig

--- a/src/ui/visualization.py
+++ b/src/ui/visualization.py
@@ -180,6 +180,41 @@ def display_molecular_structure(atomic_numbers, positions, title="Structure") ->
     return False
 
 
+def trajectory_to_xyz_frames(traj, max_frames: int = 40) -> str:
+    """Serialize trajectory frames to multi-model XYZ text.
+
+    The format is what 3Dmol.js consumes via ``addModelsAsFrames`` --
+    both the Streamlit-side viewer and the combined IR explorer embed it.
+
+    Parameters
+    ----------
+    traj : Iterable[ase.Atoms]
+        Trajectory frames.
+    max_frames : int, optional
+        Downsample evenly to at most this many frames to bound the
+        payload size when many modes are embedded at once.
+
+    Returns
+    -------
+    str
+        Concatenated XYZ blocks, one per frame.
+    """
+    frames = list(traj)
+    if max_frames and len(frames) > max_frames:
+        step = -(-len(frames) // max_frames)  # ceil division
+        frames = frames[::step]
+    xyz_frames = []
+    for i, atoms in enumerate(frames):
+        symbols = atoms.get_chemical_symbols()
+        pos = atoms.get_positions()
+        lines = [str(len(symbols)), f"Frame {i}"]
+        lines += [
+            f"{s} {x:.6f} {y:.6f} {z:.6f}" for s, (x, y, z) in zip(symbols, pos)
+        ]
+        xyz_frames.append("\n".join(lines))
+    return "\n".join(xyz_frames)
+
+
 def visualize_trajectory(traj):
     """Create an animated py3Dmol view from an ASE trajectory.
 
@@ -193,16 +228,7 @@ def visualize_trajectory(traj):
     py3Dmol.view
         Configured animated viewer.
     """
-    xyz_frames = []
-    for i, atoms in enumerate(traj):
-        symbols = atoms.get_chemical_symbols()
-        pos = atoms.get_positions()
-        lines = [str(len(symbols)), f"Frame {i}"]
-        lines += [
-            f"{s} {x:.6f} {y:.6f} {z:.6f}" for s, (x, y, z) in zip(symbols, pos)
-        ]
-        xyz_frames.append("\n".join(lines))
-    xyz_str = "\n".join(xyz_frames)
+    xyz_str = trajectory_to_xyz_frames(traj)
 
     view = py3Dmol.view(width="100%", height=VIEWER_HEIGHT)
     view.addModelsAsFrames(xyz_str, "xyz")

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -264,7 +264,7 @@ def test_run_ase_core_reports_optimization_completion(
             return -1.234
 
     class _FakeOptimizer:
-        def __init__(self, _atoms):
+        def __init__(self, _atoms, trajectory=None):
             self.nsteps = 0
 
         def run(self, *, fmax, steps):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -216,3 +216,45 @@ def test_run_ase_thermo(thermo_ase_schema):
     assert "entropy" in data['thermochemistry']
     assert "gibbs_free_energy" in data['thermochemistry']
     assert "unit" in data['thermochemistry']
+
+
+def test_run_ase_opt_writes_trajectory_next_to_output(tmp_path):
+    """The optimizer records its path as {stem}_opt.traj beside the output."""
+    import shutil
+
+    input_xyz = tmp_path / "water.xyz"
+    shutil.copy2(TEST_DIR / "water.xyz", input_xyz)
+    schema = ASEInputSchema(
+        input_structure_file=str(input_xyz),
+        output_results_file=str(tmp_path / "water_output.json"),
+        driver="opt",
+        optimizer="bfgs",
+        fmax=0.5,
+        steps=5,
+        calculator={"calculator_type": "emt"},
+    )
+
+    result = run_ase.invoke({"params": schema})
+
+    assert result["status"] == "success"
+    traj_path = Path(result["trajectory_file"])
+    assert traj_path == tmp_path / "water_opt.traj"
+    assert traj_path.exists()
+
+    from ase.io.trajectory import Trajectory
+
+    with Trajectory(str(traj_path)) as traj:
+        energies = [float(a.get_potential_energy()) for a in traj]
+    assert len(energies) >= 1
+
+
+def test_write_ir_spectrum_csv_roundtrip(tmp_path):
+    from chemgraph.tools.ase_core import _write_ir_spectrum_csv
+
+    path = tmp_path / "ir_spectrum_water.csv"
+    _write_ir_spectrum_csv(str(path), [500.0, 1500.25], [0.0, 1.5e-3])
+
+    lines = path.read_text().splitlines()
+    assert lines[0] == "frequency_cm1,intensity"
+    assert lines[1] == "500.0000,0"
+    assert lines[2] == "1500.2500,0.0015"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -258,3 +258,18 @@ def test_write_ir_spectrum_csv_roundtrip(tmp_path):
     assert lines[0] == "frequency_cm1,intensity"
     assert lines[1] == "500.0000,0"
     assert lines[2] == "1500.2500,0.0015"
+
+
+def test_write_ir_peaks_csv_roundtrip(tmp_path):
+    from chemgraph.tools.ase_core import _write_ir_peaks_csv
+
+    path = tmp_path / "ir_peaks_water.csv"
+    _write_ir_peaks_csv(
+        str(path),
+        [(0, "45.1200i", 0.001), (6, "1595.4321", 1.25)],
+    )
+
+    lines = path.read_text().splitlines()
+    assert lines[0] == "mode,frequency_cm1,intensity"
+    assert lines[1] == "0,45.1200i,0.001"
+    assert lines[2] == "6,1595.4321,1.25"

--- a/tests/test_ui_artifacts.py
+++ b/tests/test_ui_artifacts.py
@@ -57,8 +57,10 @@ def test_classify_artifacts_buckets_by_kind():
         [
             "water_opt.xyz",
             "ir_spectrum_methanol.png",
+            "ir_spectrum_methanol.csv",
             "frequencies_methanol.csv",
             "methanol_vib.3.traj",
+            "water_opt.traj",
             "report.html",
             "convergence.png",
             "output.json",
@@ -68,8 +70,10 @@ def test_classify_artifacts_buckets_by_kind():
 
     assert kinds[artifacts.STRUCTURES] == ["water_opt.xyz"]
     assert kinds[artifacts.IR_PLOTS] == ["ir_spectrum_methanol.png"]
+    assert kinds[artifacts.IR_SPECTRA] == ["ir_spectrum_methanol.csv"]
     assert kinds[artifacts.FREQUENCY_TABLES] == ["frequencies_methanol.csv"]
     assert kinds[artifacts.MODE_TRAJECTORIES] == ["methanol_vib.3.traj"]
+    assert kinds[artifacts.TRAJECTORIES] == ["water_opt.traj"]
     assert kinds[artifacts.REPORTS] == ["report.html"]
     assert kinds[artifacts.IMAGES] == ["convergence.png"]
     assert kinds[artifacts.DATA] == ["output.json"]

--- a/tests/test_ui_artifacts.py
+++ b/tests/test_ui_artifacts.py
@@ -58,6 +58,7 @@ def test_classify_artifacts_buckets_by_kind():
             "water_opt.xyz",
             "ir_spectrum_methanol.png",
             "ir_spectrum_methanol.csv",
+            "ir_peaks_methanol.csv",
             "frequencies_methanol.csv",
             "methanol_vib.3.traj",
             "water_opt.traj",
@@ -71,6 +72,7 @@ def test_classify_artifacts_buckets_by_kind():
     assert kinds[artifacts.STRUCTURES] == ["water_opt.xyz"]
     assert kinds[artifacts.IR_PLOTS] == ["ir_spectrum_methanol.png"]
     assert kinds[artifacts.IR_SPECTRA] == ["ir_spectrum_methanol.csv"]
+    assert kinds[artifacts.IR_PEAKS] == ["ir_peaks_methanol.csv"]
     assert kinds[artifacts.FREQUENCY_TABLES] == ["frequencies_methanol.csv"]
     assert kinds[artifacts.MODE_TRAJECTORIES] == ["methanol_vib.3.traj"]
     assert kinds[artifacts.TRAJECTORIES] == ["water_opt.traj"]

--- a/tests/test_ui_ir_explorer.py
+++ b/tests/test_ui_ir_explorer.py
@@ -35,6 +35,17 @@ def test_explorer_html_embeds_payload_and_libraries():
     assert "plotly_hover" in html and "plotly_unhover" in html
 
 
+def test_explorer_stops_previous_animation_before_starting_a_new_one():
+    html = build_ir_explorer_html(
+        [1.0], [1.0], [_peak(0, 1.0, 1.0)], selected_mode=0
+    )
+
+    # animate() stacks timers unless the previous loop is cancelled first;
+    # stacked timers made vibrations speed up on every hover.
+    assert "stopAnimate()" in html
+    assert html.index("viewer.stopAnimate()") < html.index("viewer.animate(")
+
+
 def test_explorer_html_escapes_closing_tags_in_payload():
     html = build_ir_explorer_html(
         curve_x=[1.0],

--- a/tests/test_ui_ir_explorer.py
+++ b/tests/test_ui_ir_explorer.py
@@ -1,0 +1,80 @@
+"""Tests for the combined IR explorer component and frame serialization."""
+
+from ase import Atoms
+
+from ui.ir_explorer import build_ir_explorer_html
+from ui.visualization import trajectory_to_xyz_frames
+
+
+def _peak(mode, freq, intensity, frames="3\nFrame 0\nO 0 0 0\nH 0 0 1\nH 0 1 0"):
+    return {
+        "mode": mode,
+        "freq": freq,
+        "intensity": intensity,
+        "imaginary": False,
+        "y": intensity,
+        "frames": frames,
+    }
+
+
+def test_explorer_html_embeds_payload_and_libraries():
+    html = build_ir_explorer_html(
+        curve_x=[500.0, 1595.0, 4000.0],
+        curve_y=[0.0, 1.3, 0.0],
+        peaks=[_peak(6, 1595.0, 1.3), _peak(7, 3650.0, 0.8)],
+        selected_mode=6,
+        height=400,
+    )
+
+    assert "cdn.jsdelivr.net/npm/3dmol" in html
+    assert "cdn.plot.ly/plotly" in html
+    assert "__HEIGHT__" not in html and "400px" in html
+    assert '"selected_mode": 6' in html
+    assert '"mode": 7' in html
+    assert "Frame 0" in html  # frames text made it into the payload
+    assert "plotly_hover" in html and "plotly_unhover" in html
+
+
+def test_explorer_html_escapes_closing_tags_in_payload():
+    html = build_ir_explorer_html(
+        curve_x=[1.0],
+        curve_y=[1.0],
+        peaks=[_peak(0, 1.0, 1.0, frames="1\n</script>\nH 0 0 0")],
+        selected_mode=0,
+    )
+
+    # A literal "</script>" inside the JSON would terminate the script tag.
+    assert "</script>\\nH" not in html
+    assert "<\\/script>" in html
+
+
+def test_explorer_html_handles_missing_frames_and_selection():
+    peak = _peak(3, 100.0, 0.5, frames=None)
+    html = build_ir_explorer_html([1.0], [0.0], [peak], selected_mode=None)
+
+    assert '"frames": null' in html
+    assert '"selected_mode": null' in html
+
+
+def test_trajectory_to_xyz_frames_serializes_all_frames():
+    frames = [
+        Atoms("H2", positions=[[0, 0, 0], [0, 0, 0.7 + 0.01 * i]])
+        for i in range(5)
+    ]
+
+    text = trajectory_to_xyz_frames(frames)
+
+    blocks = text.split("Frame ")
+    assert len(blocks) == 6  # header split: preamble + 5 frames
+    assert text.startswith("2\nFrame 0\n")
+    assert text.count("\nH ") == 10
+
+
+def test_trajectory_to_xyz_frames_downsamples_evenly():
+    frames = [Atoms("H", positions=[[0, 0, float(i)]]) for i in range(30)]
+
+    text = trajectory_to_xyz_frames(frames, max_frames=10)
+
+    n_frames = text.count("Frame ")
+    assert n_frames <= 10
+    assert "0.000000" in text  # first frame kept

--- a/tests/test_ui_plots.py
+++ b/tests/test_ui_plots.py
@@ -1,0 +1,104 @@
+"""Tests for interactive plot data helpers and figures (ui.plots)."""
+
+from pathlib import Path
+
+import pytest
+from ase import Atoms
+from ase.calculators.emt import EMT
+from ase.io.trajectory import Trajectory
+
+from ui import plots
+
+
+def _write_spectrum_csv(path: Path) -> None:
+    path.write_text(
+        "frequency_cm1,intensity\n500.0,0.0\n1500.5,0.25\n3000.0,1.5\n"
+    )
+
+
+def test_load_ir_spectrum_csv_skips_header_and_junk(tmp_path):
+    csv_path = tmp_path / "ir_spectrum_water.csv"
+    csv_path.write_text(
+        "frequency_cm1,intensity\n"
+        "500.0,0.0\n"
+        "not,a-number\n"
+        "1500.5,0.25\n"
+    )
+
+    freqs, intens = plots.load_ir_spectrum_csv(str(csv_path))
+
+    assert freqs == [500.0, 1500.5]
+    assert intens == [0.0, 0.25]
+
+
+def test_load_ir_spectrum_csv_handles_missing_and_empty(tmp_path):
+    assert plots.load_ir_spectrum_csv(str(tmp_path / "missing.csv")) is None
+    empty = tmp_path / "empty.csv"
+    empty.write_text("frequency_cm1,intensity\n")
+    assert plots.load_ir_spectrum_csv(str(empty)) is None
+
+
+def test_ir_spectrum_figure_follows_ir_convention(tmp_path):
+    csv_path = tmp_path / "ir_spectrum_water.csv"
+    _write_spectrum_csv(csv_path)
+    freqs, intens = plots.load_ir_spectrum_csv(str(csv_path))
+
+    fig = plots.ir_spectrum_figure(freqs, intens)
+
+    assert fig.layout.xaxis.autorange == "reversed"  # wavenumber convention
+    assert fig.layout.showlegend is False  # single series needs no legend
+    trace = fig.data[0]
+    assert list(trace.x) == freqs
+    assert trace.line.color == plots.LINE_COLOR
+
+
+@pytest.fixture()
+def emt_trajectory(tmp_path):
+    """A tiny real optimization trajectory written with EMT."""
+    from ase.optimize import BFGS
+
+    atoms = Atoms(
+        "H2O",
+        positions=[[0, 0, 0], [0, 0, 1.2], [0, 1.2, 0]],
+        calculator=EMT(),
+    )
+    traj_path = tmp_path / "water_opt.traj"
+    BFGS(atoms, trajectory=str(traj_path)).run(fmax=0.5, steps=4)
+    return str(traj_path)
+
+
+def test_read_optimization_trajectory(emt_trajectory):
+    energies, fmax_values = plots.read_optimization_trajectory(emt_trajectory)
+
+    assert len(energies) >= 2
+    assert len(fmax_values) == len(energies)
+    assert all(isinstance(e, float) for e in energies)
+    assert all(v is None or v >= 0 for v in fmax_values)
+
+
+def test_read_optimization_trajectory_missing_file(tmp_path):
+    assert plots.read_optimization_trajectory(str(tmp_path / "no.traj")) is None
+
+
+def test_convergence_figure_uses_stacked_panels(emt_trajectory):
+    energies, fmax_values = plots.read_optimization_trajectory(emt_trajectory)
+
+    fig = plots.convergence_figure(energies, fmax_values)
+
+    assert len(fig.data) == 2  # energy + force panels, never a dual axis
+    assert fig.layout.yaxis2.type == "log"
+    assert fig.layout.showlegend is False
+
+
+def test_convergence_figure_without_forces_is_single_panel():
+    fig = plots.convergence_figure([1.0, 0.5, 0.4], [None, None, None])
+
+    assert len(fig.data) == 1
+
+
+def test_trajectory_reader_roundtrip_matches_ase(emt_trajectory):
+    energies, _ = plots.read_optimization_trajectory(emt_trajectory)
+    with Trajectory(emt_trajectory) as traj:
+        expected = [float(a.get_potential_energy()) for a in traj]
+
+    assert energies == expected

--- a/tests/test_ui_plots.py
+++ b/tests/test_ui_plots.py
@@ -96,6 +96,66 @@ def test_convergence_figure_without_forces_is_single_panel():
     assert len(fig.data) == 1
 
 
+def test_load_ir_peaks_csv_parses_modes_and_imaginary_flags(tmp_path):
+    path = tmp_path / "ir_peaks_water.csv"
+    path.write_text(
+        "mode,frequency_cm1,intensity\n"
+        "0,45.1200i,0.001\n"
+        "6,1595.4321,1.25\n"
+        "not,a,row\n"
+        "7,3650.0000,0.8\n"
+    )
+
+    peaks = plots.load_ir_peaks_csv(str(path))
+
+    assert [p["mode"] for p in peaks] == [0, 6, 7]
+    assert peaks[0]["imaginary"] is True
+    assert peaks[0]["frequency"] == 45.12
+    assert peaks[1] == {
+        "mode": 6,
+        "frequency": 1595.4321,
+        "intensity": 1.25,
+        "imaginary": False,
+    }
+    assert plots.load_ir_peaks_csv(str(tmp_path / "missing.csv")) is None
+
+
+def test_gaussian_broadening_matches_ase_fold_semantics():
+    # ASE fold with normalize=False: each peak is an unnormalized Gaussian
+    # of height == intensity and FWHM == width.
+    freqs = [1000.0, 3000.0]
+    intens = [2.0, 0.5]
+    width = 20.0
+
+    grid, spectrum = plots.gaussian_broadened_spectrum(freqs, intens, width)
+
+    import numpy as np
+
+    grid = np.asarray(grid)
+    spectrum = np.asarray(spectrum)
+    for f, i in zip(freqs, intens):
+        peak_height = spectrum[np.argmin(abs(grid - f))]
+        assert abs(peak_height - i) < 0.01 * i  # height == intensity
+        half = spectrum[np.argmin(abs(grid - (f + width / 2)))]
+        assert abs(half - i / 2) < 0.05 * i  # FWHM == width
+    # The grid covers both peaks with margin.
+    assert grid[0] < freqs[0] and grid[-1] > freqs[-1]
+
+
+def test_gaussian_broadening_width_smooths_valleys():
+    freqs = [1000.0, 1100.0]
+    intens = [1.0, 1.0]
+
+    import numpy as np
+
+    def valley(width):
+        grid, spec = plots.gaussian_broadened_spectrum(freqs, intens, width)
+        grid = np.asarray(grid)
+        return np.asarray(spec)[np.argmin(abs(grid - 1050.0))]
+
+    assert valley(5) < valley(30) < valley(80)  # wider peaks fill the gap
+
+
 def test_trajectory_reader_roundtrip_matches_ase(emt_trajectory):
     energies, _ = plots.read_optimization_trajectory(emt_trajectory)
     with Trajectory(emt_trajectory) as traj:


### PR DESCRIPTION
Stacked on #211.

## Problem

The IR spectrum was a static matplotlib PNG (no zoom/hover, fixed DPI), and geometry optimizations left no visual trace in the UI at all — the spectrum data and the optimization path were computed and thrown away.

## Changes

**Backend (`ase_core`)**
- The IR driver saves the broadened spectrum it already computes as `ir_spectrum_<mol>.csv` next to the PNG and reports the path in the result.
- Optimizers record their path as `<mol>_opt.traj` beside the results file; the opt result includes `trajectory_file` when written.

**UI**
- IR panels render an **interactive Plotly spectrum** from the CSV — zoom, hover readouts, IR wavenumber convention (axis reversed) — with the PNG kept for legacy runs.
- New per-exchange **Optimization panel**: energy and log-scale max-force convergence as stacked panels (shared step axis), next to a 3D animation of the optimization path.
- Both new artifact types flow through the per-exchange manifest, so history re-renders stay attributed to the right run.
- Chart color `#0E9594` validated for chroma and ≥3:1 contrast against both light and dark surfaces; `st.plotly_chart`'s Streamlit theme adapts fonts/backgrounds to the app theme. `plotly` added as a dependency.

Rendered previews were checked visually (reversed wavenumber axis, decade ticks on the log force axis, marker/line specs).

## Tests

- `tests/test_ui_plots.py`: CSV loader tolerance, IR-convention figure assertions, trajectory reader round-trip against ASE using a real (EMT) mini-optimization, stacked-panel layout.
- `tests/test_tools.py`: EMT opt writes `<stem>_opt.traj` next to the output file and reports it; IR CSV writer round-trip.
- Existing MCP fake-optimizer test double updated to accept the `trajectory` kwarg (matching the real ASE interface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
