### PR TITLE
feat(ui): attach files to chat messages

### DIFF
--- a/docs/streamlit_web_interface.md
+++ b/docs/streamlit_web_interface.md
@@ -72,6 +72,13 @@ API credentials entered in the UI should be treated as secrets. Prefer
 environment variables for shared deployments, avoid placing tokens in a
 committed TOML file, and protect network access to the Streamlit server.
 
+## Attachments
+
+Attach structure or data files (XYZ, PDB, CIF, JSON, CSV, ...) with the
+paperclip in the chat box and refer to them in your message ("optimize the
+attached structure"). Files are saved into the exchange's artifact
+directory and the agent receives their exact paths.
+
 ## Sessions and artifacts
 
 The UI maintains chat state and exposes prior sessions through its session

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -40,6 +40,7 @@ from ui.endpoint import check_local_model_endpoint
 from ui.file_utils import (
     extract_log_dir_from_messages,
     find_latest_xyz_file_in_dir,
+    persist_uploads,
 )
 from ui.message_utils import (
     extract_messages_from_result,
@@ -291,8 +292,10 @@ def render() -> None:
         (
             "Type your response..."
             if is_interrupt
-            else "Ask a computational chemistry question..."
+            else "Ask a computational chemistry question (attach structure "
+            "or data files with the paperclip)..."
         ),
+        accept_file="multiple",
     )
 
     # Check for example query submitted via button click
@@ -301,11 +304,28 @@ def render() -> None:
         prompt = example_query
 
     if prompt:
-        if is_interrupt:
-            _handle_human_response(prompt, thread_id)
+        # With accept_file, chat_input returns an object with .text/.files;
+        # example-query buttons still submit a plain string.
+        if isinstance(prompt, str):
+            prompt_text, prompt_files = prompt, []
+        else:
+            prompt_text = prompt.text or ""
+            prompt_files = list(prompt.files or [])
+
+        if prompt_files and not prompt_text.strip():
+            st.warning(
+                "Please include a message describing what to do with the "
+                "attached file(s), then send again."
+            )
+        elif is_interrupt:
+            _handle_human_response(prompt_text, thread_id, prompt_files)
         else:
             _handle_query_submission(
-                prompt, thread_id, endpoint_status, selected_base_url
+                prompt_text,
+                thread_id,
+                endpoint_status,
+                selected_base_url,
+                prompt_files,
             )
 
 
@@ -456,6 +476,40 @@ def _finish_first_run_setup(config: dict, info) -> None:
 # ---------------------------------------------------------------------------
 # Internal renderers
 # ---------------------------------------------------------------------------
+
+
+def _attachment_note(paths: list[str]) -> str:
+    """Return the prompt suffix telling the agent where attachments live.
+
+    Parameters
+    ----------
+    paths : list[str]
+        Absolute paths of the saved attachments.
+
+    Returns
+    -------
+    str
+        Note to append to the agent query (empty when no attachments).
+    """
+    if not paths:
+        return ""
+    lines = "\n".join(f"- {path}" for path in paths)
+    return (
+        "\n\n[The user attached the following file(s). "
+        "Read them from these exact paths:\n" + lines + "\n]"
+    )
+
+
+def _render_attachment_chips(names) -> None:
+    """Show compact attachment indicators under a user message.
+
+    Parameters
+    ----------
+    names : list[str] or None
+        Display names of the attached files.
+    """
+    if names:
+        st.caption("\U0001f4ce " + " · ".join(names))
 
 
 def _render_markdown_with_math(text: str) -> None:
@@ -893,6 +947,7 @@ def _render_single_exchange(idx: int, entry: dict, thread_id: int) -> None:
     # User message
     with st.chat_message("user"):
         st.markdown(entry["query"])
+        _render_attachment_chips(entry.get("attachments"))
 
     # Interrupt exchanges (if any occurred during this query)
     for exch in entry.get("interrupt_exchanges", []):
@@ -1836,6 +1891,7 @@ def _clear_interrupt_state() -> None:
     st.session_state.pending_interrupt_log_dir = None
     st.session_state.pending_interrupt_turn_dir = None
     st.session_state.pending_interrupt_artifact_snapshot = None
+    st.session_state.pending_interrupt_attachments = None
     st.session_state.interrupt_count = 0
     st.session_state.interrupt_exchanges = []
 
@@ -2040,6 +2096,7 @@ def _handle_query_submission(
     thread_id: int,
     endpoint_status: dict,
     selected_base_url: Optional[str],
+    attachments: Optional[list] = None,
 ) -> None:
     """Handle a submitted user query and stream the workflow response.
 
@@ -2053,6 +2110,8 @@ def _handle_query_submission(
         Local endpoint status dictionary.
     selected_base_url : str, optional
         Model endpoint URL used in error messages.
+    attachments : list, optional
+        Uploaded files from the chat input.
     """
     if not endpoint_status["ok"]:
         msg = (
@@ -2099,14 +2158,22 @@ def _handle_query_submission(
     # to exactly this exchange.
     artifact_snapshot = artifact_utils.snapshot_mtimes(agent.log_dir)
 
+    # Save attachments into the turn directory (after the snapshot, so
+    # they are recorded as this exchange's files) and hand the agent
+    # their exact paths.
+    attachment_paths = persist_uploads(attachments, turn_dir or agent.log_dir)
+    attachment_names = [Path(p).name for p in attachment_paths]
+    agent_query = trimmed_query + _attachment_note(attachment_paths)
+
     # Show the user's message immediately
     with st.chat_message("user"):
         st.markdown(trimmed_query)
+        _render_attachment_chips(attachment_names)
 
     # Stream agent response with live tool-call display
     with st.chat_message("assistant"):
         msg_q: queue.Queue = queue.Queue()
-        inputs = {"messages": trimmed_query}
+        inputs = {"messages": agent_query}
 
         stream_thread = threading.Thread(
             target=_stream_workflow,
@@ -2145,7 +2212,10 @@ def _handle_query_submission(
                 agent.log_dir, artifact_snapshot
             )
             artifact_utils.append_manifest_entry(
-                agent.log_dir, trimmed_query, run_artifacts
+                agent.log_dir,
+                trimmed_query,
+                run_artifacts,
+                attachments=attachment_names,
             )
             st.session_state.last_run_result = result
             st.session_state.conversation_history.append(
@@ -2155,6 +2225,7 @@ def _handle_query_submission(
                     "thread_id": thread_id,
                     "log_dir": agent.log_dir,
                     "artifacts": run_artifacts,
+                    "attachments": attachment_names,
                 }
             )
             _save_exchange_to_store(trimmed_query, result)
@@ -2178,6 +2249,7 @@ def _handle_query_submission(
             )
             st.session_state.pending_interrupt_log_dir = agent.log_dir
             st.session_state.pending_interrupt_turn_dir = turn_dir
+            st.session_state.pending_interrupt_attachments = attachment_names
             st.session_state.interrupt_count = 1
             st.session_state.interrupt_exchanges = []
             st.rerun()
@@ -2188,7 +2260,9 @@ def _handle_query_submission(
             st.error(f"Processing error: {event_data}")
 
 
-def _handle_human_response(answer: str, thread_id: int) -> None:
+def _handle_human_response(
+    answer: str, thread_id: int, attachments: Optional[list] = None
+) -> None:
     """Resume the agent workflow with the human's answer.
 
     Parameters
@@ -2197,6 +2271,8 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
         Human response to the pending interrupt question.
     thread_id : int
         Current LangGraph thread ID.
+    attachments : list, optional
+        Uploaded files from the chat input.
     """
     from langgraph.types import Command
 
@@ -2217,6 +2293,15 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
 
     MAX_INTERRUPTS = 10
 
+    # Attachments sent with the reply land in the run's turn directory
+    # (after the submission-time snapshot, so the manifest records them).
+    reply_paths = persist_uploads(attachments, resume_dir)
+    reply_names = [Path(p).name for p in reply_paths]
+    if reply_names:
+        st.session_state.pending_interrupt_attachments = (
+            st.session_state.get("pending_interrupt_attachments") or []
+        ) + reply_names
+
     # Record this exchange
     st.session_state.interrupt_exchanges.append(
         {"question": current_question, "answer": answer}
@@ -2225,11 +2310,12 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
     # Show the user's reply immediately
     with st.chat_message("user"):
         st.markdown(answer)
+        _render_attachment_chips(reply_names)
 
     # Stream resumed agent response
     with st.chat_message("assistant"):
         msg_q: queue.Queue = queue.Queue()
-        resume_cmd = Command(resume=answer)
+        resume_cmd = Command(resume=answer + _attachment_note(reply_paths))
 
         stream_thread = threading.Thread(
             target=_stream_workflow,
@@ -2268,8 +2354,14 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
                 run_log_dir,
                 st.session_state.get("pending_interrupt_artifact_snapshot") or {},
             )
+            all_attachments = (
+                st.session_state.get("pending_interrupt_attachments") or []
+            )
             artifact_utils.append_manifest_entry(
-                run_log_dir, original_query, run_artifacts
+                run_log_dir,
+                original_query,
+                run_artifacts,
+                attachments=all_attachments,
             )
 
             exchanges = list(st.session_state.interrupt_exchanges)
@@ -2282,6 +2374,7 @@ def _handle_human_response(answer: str, thread_id: int) -> None:
                     "log_dir": run_log_dir,
                     "interrupt_exchanges": exchanges,
                     "artifacts": run_artifacts,
+                    "attachments": all_attachments,
                 }
             )
             _save_exchange_to_store(original_query, final_result)

--- a/src/ui/artifacts.py
+++ b/src/ui/artifacts.py
@@ -139,7 +139,10 @@ def classify_artifacts(files: list[str]) -> dict[str, list[str]]:
 
 
 def append_manifest_entry(
-    log_dir: Optional[str], query: str, files: list[str]
+    log_dir: Optional[str],
+    query: str,
+    files: list[str],
+    attachments: Optional[list[str]] = None,
 ) -> None:
     """Append one exchange's artifact list to the log-dir manifest.
 
@@ -154,11 +157,16 @@ def append_manifest_entry(
         User query that produced the artifacts.
     files : list[str]
         Relative artifact paths for the exchange.
+    attachments : list[str], optional
+        Display names of files the user attached to the query.
     """
     if not log_dir:
         return
     entries = load_manifest(log_dir)
-    entries.append({"query": query, "files": list(files)})
+    record: dict = {"query": query, "files": list(files)}
+    if attachments:
+        record["attachments"] = list(attachments)
+    entries.append(record)
     try:
         os.makedirs(log_dir, exist_ok=True)
         manifest_path = Path(log_dir) / MANIFEST_FILENAME
@@ -219,3 +227,5 @@ def attach_artifacts_to_history(history: list[dict], log_dir: Optional[str]) -> 
         if entry.get("query") != record.get("query"):
             break
         entry["artifacts"] = list(record.get("files", []))
+        if record.get("attachments"):
+            entry["attachments"] = list(record["attachments"])

--- a/src/ui/file_utils.py
+++ b/src/ui/file_utils.py
@@ -41,6 +41,47 @@ def find_latest_xyz_file_in_dir(directory: str) -> Optional[str]:
     return latest_path
 
 
+def persist_uploads(uploaded_files, directory: Optional[str]) -> list[str]:
+    """Save chat attachments into a run directory.
+
+    Names are reduced to a safe basename (no path components) and
+    deduplicated against the batch and existing files, so an upload can
+    never overwrite an artifact the run already produced.
+
+    Parameters
+    ----------
+    uploaded_files : sequence
+        Streamlit ``UploadedFile`` objects (anything with ``name`` and
+        ``getvalue()``).
+    directory : str, optional
+        Destination directory (the exchange's artifact dir).
+
+    Returns
+    -------
+    list[str]
+        Absolute paths of the saved files, in input order.
+    """
+    if not uploaded_files or not directory:
+        return []
+    os.makedirs(directory, exist_ok=True)
+    saved: list[str] = []
+    for uploaded in uploaded_files:
+        name = Path(str(getattr(uploaded, "name", "") or "attachment")).name
+        if not name or name in (".", ".."):
+            name = "attachment"
+        candidate = name
+        counter = 1
+        while os.path.exists(os.path.join(directory, candidate)):
+            base = Path(name)
+            candidate = f"{base.stem}_{counter}{base.suffix}"
+            counter += 1
+        path = os.path.abspath(os.path.join(directory, candidate))
+        with open(path, "wb") as f:
+            f.write(uploaded.getvalue())
+        saved.append(path)
+    return saved
+
+
 _WINDOWS_DRIVE_RE = re.compile(r"[A-Za-z]:[\\/]")
 
 

--- a/src/ui/state.py
+++ b/src/ui/state.py
@@ -43,6 +43,7 @@ def init_session_state() -> None:
         "pending_interrupt_log_dir": None,  # str: log dir active when query started
         "pending_interrupt_turn_dir": None,  # str: per-query artifact dir of the run
         "pending_interrupt_artifact_snapshot": None,  # dict: log-dir snapshot at query start
+        "pending_interrupt_attachments": None,  # list[str]: attachment names of the run
         "interrupt_count": 0,  # int: safety counter for sequential interrupts
         "interrupt_exchanges": [],  # list of {"question": str, "answer": str}
     }

--- a/tests/test_ui_attachments.py
+++ b/tests/test_ui_attachments.py
@@ -1,0 +1,88 @@
+"""Tests for chat file attachments (upload persistence and prompt notes)."""
+
+import io
+
+from ui import artifacts
+from ui._pages import main_interface as main_ui
+from ui.file_utils import persist_uploads
+
+
+class _FakeUpload(io.BytesIO):
+    def __init__(self, name, data: bytes):
+        super().__init__(data)
+        self.name = name
+
+
+def test_persist_uploads_writes_files_and_returns_paths(tmp_path):
+    uploads = [
+        _FakeUpload("water.xyz", b"3\nwater\nO 0 0 0\nH 0 0 1\nH 0 1 0\n"),
+        _FakeUpload("data.csv", b"a,b\n1,2\n"),
+    ]
+
+    paths = persist_uploads(uploads, str(tmp_path))
+
+    assert [p.split("/")[-1] for p in paths] == ["water.xyz", "data.csv"]
+    assert (tmp_path / "water.xyz").read_bytes().startswith(b"3\nwater")
+    assert (tmp_path / "data.csv").read_text() == "a,b\n1,2\n"
+
+
+def test_persist_uploads_sanitizes_traversal_names(tmp_path):
+    uploads = [_FakeUpload("../../etc/evil.xyz", b"x")]
+
+    paths = persist_uploads(uploads, str(tmp_path))
+
+    assert paths == [str(tmp_path / "evil.xyz")]
+    assert (tmp_path / "evil.xyz").exists()
+    assert not (tmp_path.parent / "etc").exists()
+
+
+def test_persist_uploads_never_overwrites_existing_files(tmp_path):
+    (tmp_path / "water.xyz").write_text("run output - do not clobber")
+    uploads = [
+        _FakeUpload("water.xyz", b"upload one"),
+        _FakeUpload("water.xyz", b"upload two"),
+    ]
+
+    paths = persist_uploads(uploads, str(tmp_path))
+
+    assert (tmp_path / "water.xyz").read_text() == "run output - do not clobber"
+    assert [p.split("/")[-1] for p in paths] == ["water_1.xyz", "water_2.xyz"]
+    assert (tmp_path / "water_1.xyz").read_bytes() == b"upload one"
+    assert (tmp_path / "water_2.xyz").read_bytes() == b"upload two"
+
+
+def test_persist_uploads_handles_empty_inputs(tmp_path):
+    assert persist_uploads([], str(tmp_path)) == []
+    assert persist_uploads(None, str(tmp_path)) == []
+    assert persist_uploads([_FakeUpload("a.xyz", b"x")], None) == []
+
+
+def test_attachment_note_lists_exact_paths():
+    assert main_ui._attachment_note([]) == ""
+
+    note = main_ui._attachment_note(["/run/turn_001/water.xyz", "/run/d.csv"])
+
+    assert "attached the following file(s)" in note
+    assert "- /run/turn_001/water.xyz" in note
+    assert "- /run/d.csv" in note
+    assert "exact paths" in note
+
+
+def test_manifest_round_trips_attachment_names(tmp_path):
+    artifacts.append_manifest_entry(
+        str(tmp_path),
+        "optimize the attached structure",
+        ["turn_001/water_opt.traj"],
+        attachments=["water.xyz"],
+    )
+    artifacts.append_manifest_entry(str(tmp_path), "plain query", ["a.json"])
+
+    history = [
+        {"query": "optimize the attached structure"},
+        {"query": "plain query"},
+    ]
+    artifacts.attach_artifacts_to_history(history, str(tmp_path))
+
+    assert history[0]["attachments"] == ["water.xyz"]
+    assert history[0]["artifacts"] == ["turn_001/water_opt.traj"]
+    assert "attachments" not in history[1]


### PR DESCRIPTION
The chat input now accepts attachments (paperclip, multiple files, any
format ase.io or the tools can read). Uploads are saved into the
exchange's turn directory -- recorded in the per-exchange manifest,
never clobbering run outputs (name deduplication), sanitized to safe
basenames -- and the agent receives their exact paths appended to the
query, so 'optimize the attached structure' just works. The chat shows
compact attachment chips on the user message, restored when a stored
session is loaded. Replies to human-in-the-loop questions accept
attachments too. File-only submissions prompt for an instruction.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
