### PR TITLE
Centralize endpoint configuration and authentication

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -40,9 +40,15 @@ max_requests_per_minute = 60
 default_profile = "standard"
 
 [api.openai]
-base_url = "https://apps.inside.anl.gov/argoapi/api/v1/resource/chat/"
+base_url = "https://api.openai.com/v1"
 timeout = 30
+
+[api.argo]
+base_url = "https://apps.inside.anl.gov/argoapi/v1"
 argo_user = ""
+
+[api.vllm]
+base_url = ""
 
 [api.groq]
 base_url = "https://api.groq.com/openai/v1"

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -46,7 +46,15 @@ TOML provider sections configure endpoints and an optional Argo username:
 ```toml
 [api.openai]
 base_url = "https://api.openai.com/v1"
+
+[api.argo]
+base_url = "https://apps.inside.anl.gov/argoapi/v1"
 argo_user = ""
+
+[api.vllm]
+# Set this for custom OpenAI-compatible model IDs. An explicit empty value
+# disables the one-release [api.openai] custom-endpoint fallback.
+base_url = ""
 
 [api.anthropic]
 base_url = "https://api.anthropic.com"
@@ -63,6 +71,17 @@ base_url = "http://localhost:11434"
 
 The selected model determines which section is consulted. See
 [Models and authentication](models.md).
+
+Base URLs resolve in this order: an explicit CLI/Python argument, the selected
+endpoint's canonical section, a supported legacy section, its environment
+variable, and finally its built-in default. For one release, `argo:` and custom
+model routes can read a legacy `[api.openai].base_url` when their canonical
+section is absent; ChemGraph logs migration guidance whenever it does so.
+
+`[api.argo].argo_user` is the canonical Argo identity setting. The historical
+`[api.openai].argo_user` spelling remains supported for one release with a
+warning. Keep API keys and access tokens in endpoint-specific environment
+variables rather than TOML.
 
 ## MCP connection
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -11,9 +11,11 @@ to see the identifiers registered by your installed version.
 | Anthropic | `claude-...` | `ANTHROPIC_API_KEY` |
 | Google Gemini | `gemini-...` | `GEMINI_API_KEY` |
 | Groq | `groq:<model-id>` | `GROQ_API_KEY` |
+| OpenRouter | `openrouter:<model-id>` | `OPENROUTER_API_KEY` |
 | Argo | `argo:<model-id>` | `ARGO_USER` or `argo_user` in config |
 | ALCF endpoints | Listed by `chemgraph models` | `ALCF_ACCESS_TOKEN` |
 | Ollama | Curated local ID such as `llama3.2` | Running Ollama server; no key |
+| vLLM/custom | Custom ID plus a configured base URL | `VLLM_API_KEY` or placeholder |
 | Codex | `codex:<model-id>` | Experimental subscription setup |
 
 Only set credentials for providers you use. Do not commit secrets to
@@ -75,7 +77,10 @@ Local models vary substantially in tool-calling reliability. See
 
 ## Configuration file
 
-Non-secret endpoint settings and `argo_user` can be placed in `config.toml`.
+Non-secret endpoint settings and `[api.argo].argo_user` can be placed in
+`config.toml`. Use `[api.vllm].base_url` for an otherwise unknown custom model;
+leaving that canonical value empty prevents the direct OpenAI URL from becoming
+an accidental custom-model fallback.
 Choose the CLI model with `--model`; Streamlit reads its model default from the
 configuration file. Environment variables remain the recommended place for tokens.
 See [Configuration](configuration_with_toml.md) for supported sections and

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -90,7 +90,6 @@ def check_api_keys(
     model_name: str,
     *,
     base_url: str | None = None,
-    api_key: str | None = None,
 ) -> tuple[bool, str]:
     """Check if required API keys are available for *model_name*.
 
@@ -111,7 +110,7 @@ def check_api_keys(
         return False, str(exc)
 
     policy = spec.credential
-    if api_key or not policy.required:
+    if not policy.required:
         return True, ""
     if policy.env_var and os.getenv(policy.env_var):
         return True, ""
@@ -272,12 +271,6 @@ def initialize_agent(
     api_key_available, error_msg = check_api_keys(model_name, base_url=base_url)
     if not api_key_available:
         console.print(f"[red]{error_msg}[/red]")
-        console.print(
-            "[dim]Tip: Set environment variables in your shell or .env file[/dim]"
-        )
-        console.print(
-            "[dim]  Example: export OPENAI_API_KEY='your_api_key_here'[/dim]"
-        )
         return None
 
     with Progress(

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -24,15 +24,12 @@ from chemgraph.cli.checkpoint_runtime import (
     DEFAULT_CHECKPOINT_DB,
     CheckpointRuntime,
 )
-from chemgraph.models.supported_models import (
-    MODELS_WITH_REASONING_EFFORT,
-    supported_alcf_models,
-    supported_anthropic_models,
-    supported_gemini_models,
-    supported_ollama_models,
-    supported_openai_models,
-    supported_argo_models,
+from chemgraph.models.endpoints import (
+    ModelRequest,
+    missing_credential_help,
 )
+from chemgraph.models.endpoints.registry import select_endpoint
+from chemgraph.models.supported_models import MODELS_WITH_REASONING_EFFORT
 from chemgraph.utils.async_utils import run_async_callable
 
 from chemgraph.cli.formatting import (
@@ -89,7 +86,12 @@ def resolve_workflow(name: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-def check_api_keys(model_name: str) -> tuple[bool, str]:
+def check_api_keys(
+    model_name: str,
+    *,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> tuple[bool, str]:
     """Check if required API keys are available for *model_name*.
 
     Parameters
@@ -103,88 +105,17 @@ def check_api_keys(model_name: str) -> tuple[bool, str]:
         ``(is_available, error_message)``. The message is empty when the
         required credentials are available or not required.
     """
-    model_lower = model_name.lower()
+    try:
+        spec = select_endpoint(ModelRequest(model=model_name, base_url=base_url))
+    except ValueError as exc:
+        return False, str(exc)
 
-    # Codex subscription models reuse the user's ChatGPT-backed Codex login.
-    # They must never fall through to OpenAI Platform API-key validation.
-    if model_name.startswith("codex:"):
+    policy = spec.credential
+    if api_key or not policy.required:
         return True, ""
-
-    # OpenRouter models. Checked before the OpenAI branch below, whose
-    # ``"o1"/"o3"/"o4" in model_lower`` test is a substring match that would
-    # otherwise claim slugs like ``openrouter:openai/o3``, and before the
-    # local-model branch, which would claim ``openrouter:meta-llama/...``.
-    if model_name.startswith("openrouter:"):
-        if not os.getenv("OPENROUTER_API_KEY"):
-            return (
-                False,
-                "OpenRouter API key not found. Set the OPENROUTER_API_KEY "
-                "environment variable. Get a key at https://openrouter.ai/keys",
-            )
+    if policy.env_var and os.getenv(policy.env_var):
         return True, ""
-
-    # OpenAI models (including GPT family, o-series, and Argo OpenAI)
-    if (
-        model_name in supported_openai_models
-        or model_name in supported_argo_models
-        or model_lower.startswith("gpt")
-        or any(prefix in model_lower for prefix in ["o1", "o3", "o4"])
-    ):
-        # Argo models use a different auth mechanism; skip key check.
-        if model_name in supported_argo_models:
-            pass
-        elif not os.getenv("OPENAI_API_KEY"):
-            return (
-                False,
-                "OpenAI API key not found. Set the OPENAI_API_KEY environment variable.",
-            )
-
-    # Anthropic models
-    elif "claude" in model_lower or model_name in supported_anthropic_models:
-        if not os.getenv("ANTHROPIC_API_KEY"):
-            return (
-                False,
-                "Anthropic API key not found. Set the ANTHROPIC_API_KEY environment variable.",
-            )
-
-    # Google models
-    elif "gemini" in model_lower or model_name in supported_gemini_models:
-        if not os.getenv("GEMINI_API_KEY"):
-            return (
-                False,
-                "Gemini API key not found. Set the GEMINI_API_KEY environment variable.",
-            )
-
-    # GROQ models (groq: prefix)
-    elif model_name.startswith("groq:"):
-        if not os.getenv("GROQ_API_KEY"):
-            return (
-                False,
-                "GROQ API key not found. Set the GROQ_API_KEY environment variable.",
-            )
-
-    # ALCF models (Globus OAuth access token)
-    elif model_name in supported_alcf_models:
-        if not os.getenv("ALCF_ACCESS_TOKEN"):
-            return (
-                False,
-                "ALCF access token not found. To authenticate with ALCF:\n"
-                "  1. pip install globus_sdk\n"
-                "  2. wget https://raw.githubusercontent.com/argonne-lcf/"
-                "inference-endpoints/refs/heads/main/inference_auth_token.py\n"
-                "  3. python inference_auth_token.py authenticate\n"
-                "  4. export ALCF_ACCESS_TOKEN=$(python inference_auth_token.py get_access_token)\n"
-                "\n"
-                "  See: https://docs.alcf.anl.gov/services/inference-endpoints/#api-access",
-            )
-
-    # Local models (no API key needed)
-    elif model_name in supported_ollama_models or any(
-        local in model_lower for local in ["llama", "qwen", "ollama"]
-    ):
-        pass
-
-    return True, ""
+    return False, missing_credential_help(policy)
 
 
 # ---------------------------------------------------------------------------
@@ -338,7 +269,7 @@ def initialize_agent(
             console.print(f"  MCP Tools: {len(tools)} loaded")
 
     # Check API keys before attempting initialization
-    api_key_available, error_msg = check_api_keys(model_name)
+    api_key_available, error_msg = check_api_keys(model_name, base_url=base_url)
     if not api_key_available:
         console.print(f"[red]{error_msg}[/red]")
         console.print(
@@ -348,11 +279,6 @@ def initialize_agent(
             "[dim]  Example: export OPENAI_API_KEY='your_api_key_here'[/dim]"
         )
         return None
-
-    # Resolve API key for providers that need one passed explicitly.
-    api_key: Optional[str] = None
-    if model_name in supported_alcf_models:
-        api_key = os.getenv("ALCF_ACCESS_TOKEN")
 
     with Progress(
         SpinnerColumn(),
@@ -376,7 +302,6 @@ def initialize_agent(
                 model_name=model_name,
                 workflow_type=workflow_type,
                 base_url=base_url,
-                api_key=api_key,
                 argo_user=argo_user,
                 generate_report=generate_report,
                 return_option=return_option,

--- a/src/chemgraph/cli/formatting.py
+++ b/src/chemgraph/cli/formatting.py
@@ -17,7 +17,7 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
 
-from chemgraph.models.supported_models import all_supported_models
+from chemgraph.models.endpoints.registry import CATALOG_ENDPOINTS, catalog_entries
 
 # Shared console instance for the CLI package.
 console = Console()
@@ -54,34 +54,13 @@ def list_models() -> None:
     table.add_column("Provider", style="green")
     table.add_column("Type", style="yellow")
 
-    # Categorize models by provider
-    model_info = {
-        # Prefix-routed providers first: the lookup below breaks on the first
-        # substring match, so "openrouter:openai/gpt-oss-120b" would otherwise
-        # be claimed by the "openai" / "gpt" / "llama" keys.
-        "openrouter:": {"provider": "OpenRouter", "type": "Cloud"},
-        "openai": {"provider": "OpenAI", "type": "Cloud"},
-        "gpt": {"provider": "OpenAI", "type": "Cloud"},
-        "claude": {"provider": "Anthropic", "type": "Cloud"},
-        "gemini": {"provider": "Google", "type": "Cloud"},
-        "llama": {"provider": "Meta", "type": "Local/Cloud"},
-        "qwen": {"provider": "Alibaba", "type": "Local/Cloud"},
-        "ollama": {"provider": "Ollama", "type": "Local"},
-        "groq": {"provider": "GROQ", "type": "Cloud"},
-        "argo:": {"provider": "Argo (ANL)", "type": "Cloud"},
-    }
-
-    for model in all_supported_models:
-        provider = "Unknown"
-        model_type = "Unknown"
-
-        for key, info in model_info.items():
-            if key.lower() in model.lower():
-                provider = info["provider"]
-                model_type = info["type"]
-                break
-
-        table.add_row(model, provider, model_type)
+    entries = catalog_entries()
+    for model, spec in entries:
+        table.add_row(
+            model,
+            spec.display_name or spec.name,
+            spec.model_type,
+        )
 
     table.add_row(
         "codex:<model-id>",
@@ -91,7 +70,7 @@ def list_models() -> None:
 
     console.print(table)
     console.print(
-        f"\n[bold green]Curated models available: {len(all_supported_models)}[/bold green]"
+        f"\n[bold green]Curated models available: {len(entries)}[/bold green]"
     )
 
 
@@ -109,43 +88,21 @@ def check_api_keys_status() -> None:
     table.add_column("Status", style="white", width=15)
     table.add_column("Example Models", style="dim", width=30)
 
-    api_keys = [
-        {
-            "provider": "OpenAI",
-            "env_var": "OPENAI_API_KEY",
-            "examples": "gpt-4o, gpt-4o-mini, o1",
-        },
-        {
-            "provider": "Anthropic",
-            "env_var": "ANTHROPIC_API_KEY",
-            "examples": "claude-3-5-sonnet, claude-3-opus",
-        },
-        {
-            "provider": "Google",
-            "env_var": "GEMINI_API_KEY",
-            "examples": "gemini-pro, gemini-2.5-pro",
-        },
-        {
-            "provider": "GROQ",
-            "env_var": "GROQ_API_KEY",
-            "examples": "groq:llama-3.3-70b-versatile",
-        },
-        {
-            "provider": "OpenRouter",
-            "env_var": "OPENROUTER_API_KEY",
-            "examples": "openrouter:moonshotai/kimi-k3",
-        },
-        {
-            "provider": "ALCF",
-            "env_var": "ALCF_ACCESS_TOKEN",
-            "examples": "Llama-3.1-405B, Qwen3-32B",
-        },
-        {
-            "provider": "Local/Ollama",
-            "env_var": "Not Required",
-            "examples": "llama3.2, qwen2.5",
-        },
-    ]
+    api_keys = []
+    seen: set[tuple[str, str | None]] = set()
+    for spec in CATALOG_ENDPOINTS:
+        policy = spec.credential
+        identity = (spec.display_name or spec.name, policy.env_var)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        api_keys.append(
+            {
+                "provider": identity[0],
+                "env_var": policy.env_var or "Not Required",
+                "examples": ", ".join(spec.curated_models[:2]) or "Prefix-routed",
+            }
+        )
 
     for key_info in api_keys:
         if key_info["env_var"] == "Not Required":

--- a/src/chemgraph/cli/formatting.py
+++ b/src/chemgraph/cli/formatting.py
@@ -92,13 +92,13 @@ def check_api_keys_status() -> None:
     seen: set[tuple[str, str | None]] = set()
     for spec in CATALOG_ENDPOINTS:
         policy = spec.credential
-        identity = (spec.display_name or spec.name, policy.env_var)
+        identity = (spec.config_section or spec.name, policy.env_var)
         if identity in seen:
             continue
         seen.add(identity)
         api_keys.append(
             {
-                "provider": identity[0],
+                "provider": spec.display_name or spec.name,
                 "env_var": policy.env_var or "Not Required",
                 "examples": ", ".join(spec.curated_models[:2]) or "Prefix-routed",
             }

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 import toml
 
-from chemgraph.models.supported_models import all_supported_models
+from chemgraph.models.endpoints.registry import match_endpoint
 from chemgraph.utils.config_utils import (
     flatten_config,
     get_argo_user_from_flat_config,
@@ -559,7 +559,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         console.print(
             "[yellow]Using experimental Codex subscription support.[/yellow]"
         )
-    elif args.model not in all_supported_models:
+    elif match_endpoint(args.model) is None:
         console.print(
             f"[yellow]Using custom model ID: {args.model} (not in curated list)[/yellow]"
         )

--- a/src/chemgraph/models/endpoints/__init__.py
+++ b/src/chemgraph/models/endpoints/__init__.py
@@ -10,6 +10,8 @@ from chemgraph.models.endpoints.base import (
     ModelRequest,
     PreparedModel,
     is_local_http_endpoint,
+    missing_credential_help,
+    normalize_openai_base_url,
     resolve_api_key,
 )
 
@@ -19,5 +21,7 @@ __all__ = [
     "ModelRequest",
     "PreparedModel",
     "is_local_http_endpoint",
+    "missing_credential_help",
+    "normalize_openai_base_url",
     "resolve_api_key",
 ]

--- a/src/chemgraph/models/endpoints/alcf.py
+++ b/src/chemgraph/models/endpoints/alcf.py
@@ -70,6 +70,19 @@ def _resolve_base_url(model_name: str, base_url: str | None) -> str:
     return ALCF_DEFAULT_BASE_URL
 
 
+def resolve_base_url(model_name: str, base_url: str | None) -> str:
+    """Resolve the explicit or serving-cluster ALCF URL."""
+    return _resolve_base_url(model_name, base_url)
+
+
+def config_url_applies(model_name: str) -> bool:
+    """Return whether [api.alcf] may override the Sophia route for a model."""
+    return (
+        model_name not in supported_alcf_minerva_models
+        and model_name not in supported_alcf_metis_models
+    )
+
+
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a curated ``alcf:`` model, selecting its cluster endpoint."""
     requested_model_name = request.model
@@ -82,7 +95,7 @@ def prepare(request: ModelRequest) -> PreparedModel:
 
     api_key = resolve_api_key(ALCF_CREDENTIAL, request.api_key)
 
-    base_url = _resolve_base_url(requested_model_name, request.base_url)
+    base_url = resolve_base_url(requested_model_name, request.base_url)
     wire_model = _normalize_alcf_model(requested_model_name)
 
     client_kwargs = dict(model=wire_model, base_url=base_url, api_key=api_key)
@@ -104,4 +117,10 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=openai_compatible.build,
     credential=ALCF_CREDENTIAL,
+    config_section="alcf",
+    base_url_resolver=resolve_base_url,
+    config_url_applies=config_url_applies,
+    curated_models=tuple(supported_alcf_models),
+    accepted_prefix=ALCF_MODEL_PREFIX,
+    display_name="ALCF",
 )

--- a/src/chemgraph/models/endpoints/anthropic_direct.py
+++ b/src/chemgraph/models/endpoints/anthropic_direct.py
@@ -28,6 +28,11 @@ ANTHROPIC_CREDENTIAL = CredentialPolicy(
 )
 
 
+def resolve_base_url(_model: str, base_url: str | None) -> str | None:
+    """Return an optional Anthropic API URL unchanged."""
+    return base_url
+
+
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a curated Anthropic model."""
     model_name = request.model
@@ -61,4 +66,8 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=anthropic_native.build,
     credential=ANTHROPIC_CREDENTIAL,
+    config_section="anthropic",
+    base_url_resolver=resolve_base_url,
+    curated_models=tuple(supported_anthropic_models),
+    display_name="Anthropic",
 )

--- a/src/chemgraph/models/endpoints/argo.py
+++ b/src/chemgraph/models/endpoints/argo.py
@@ -15,6 +15,7 @@ from chemgraph.models.endpoints.base import (
     ModelRequest,
     PreparedModel,
     is_local_http_endpoint,
+    normalize_openai_base_url,
 )
 from chemgraph.models.endpoints.openai_direct import (
     assemble_client_kwargs,
@@ -27,7 +28,6 @@ from chemgraph.models.supported_models import (
     MODELS_WITHOUT_TEMPERATURE,
     supported_argo_models,
 )
-from chemgraph.utils.config_utils import normalize_openai_base_url
 from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
@@ -89,7 +89,7 @@ ARGO_LOCAL_OPENAI_MODEL_MAP = {
 }
 
 # Argo expects the Argonne username in the client library's API-key field.
-ARGO_CREDENTIAL = CredentialPolicy(env_var="OPENAI_API_KEY", required=False)
+ARGO_CREDENTIAL = CredentialPolicy(required=False)
 
 
 def _normalize_argo_model(model_name: str, base_url: str | None) -> str:
@@ -184,6 +184,16 @@ def _normalize_argo_anthropic_base_url(base_url: str | None) -> str:
     return normalized
 
 
+def resolve_openai_base_url(_model: str, base_url: str | None) -> str:
+    """Resolve the normalized OpenAI-compatible Argo API URL."""
+    return normalize_openai_base_url(base_url) or ARGO_DEFAULT_BASE_URL
+
+
+def resolve_anthropic_base_url(_model: str, base_url: str | None) -> str:
+    """Resolve the Anthropic-native Argo API root."""
+    return _normalize_argo_anthropic_base_url(base_url)
+
+
 def is_argo_anthropic_model(model: str) -> bool:
     """Return whether an Argo model should use Anthropic Messages."""
     return model.startswith("argo:claude-")
@@ -197,13 +207,11 @@ def is_argo_openai_model(model: str) -> bool:
 def prepare_openai(request: ModelRequest) -> PreparedModel:
     """Prepare a non-Claude ``argo:`` model for OpenAI-compatible transport."""
     requested_model_name = request.model
-    base_url = normalize_openai_base_url(request.base_url)
+    base_url = resolve_openai_base_url(requested_model_name, request.base_url)
 
     validate_reasoning_effort(requested_model_name, request.reasoning_effort)
 
-    # Apply default Argo base URL for argo: models when none is specified.
-    if not base_url:
-        base_url = ARGO_DEFAULT_BASE_URL
+    if request.base_url is None:
         logger.info("Using default Argo base URL: %s", base_url)
 
     api_key = _resolve_argo_api_key(request)
@@ -257,7 +265,7 @@ def prepare_anthropic(request: ModelRequest) -> PreparedModel:
             f"Supported models are: {supported_argo_models}."
         )
 
-    base_url = _normalize_argo_anthropic_base_url(request.base_url)
+    base_url = resolve_anthropic_base_url(requested_model_name, request.base_url)
     api_key = _resolve_argo_api_key(request)
     wire_model = _normalize_argo_model(requested_model_name, base_url)
 
@@ -288,6 +296,13 @@ ANTHROPIC_SPEC = EndpointSpec(
     prepare=prepare_anthropic,
     protocol_build=anthropic_native.build,
     credential=ARGO_CREDENTIAL,
+    config_section="argo",
+    legacy_config_sections=("openai",),
+    base_url_resolver=resolve_anthropic_base_url,
+    curated_models=tuple(supported_argo_models),
+    accepted_prefix=ARGO_PREFIX,
+    display_name="Argo (ANL)",
+    supports_structured_output=False,
 )
 
 OPENAI_SPEC = EndpointSpec(
@@ -297,6 +312,13 @@ OPENAI_SPEC = EndpointSpec(
     prepare=prepare_openai,
     protocol_build=openai_compatible.build,
     credential=ARGO_CREDENTIAL,
+    config_section="argo",
+    legacy_config_sections=("openai",),
+    base_url_resolver=resolve_openai_base_url,
+    curated_models=tuple(supported_argo_models),
+    accepted_prefix=ARGO_PREFIX,
+    display_name="Argo (ANL)",
+    supports_structured_output=False,
 )
 
 # Backward compatibility for ``load_openai_model``, whose documented return

--- a/src/chemgraph/models/endpoints/base.py
+++ b/src/chemgraph/models/endpoints/base.py
@@ -16,8 +16,9 @@ Everything in this module is internal. The public model-loading surface remains
 from __future__ import annotations
 
 import os
+import re
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from getpass import getpass
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlparse
@@ -95,10 +96,47 @@ class EndpointSpec:
     prepare: Callable[[ModelRequest], PreparedModel]
     protocol_build: Callable[[dict[str, Any]], "BaseChatModel"]
     credential: CredentialPolicy = field(default_factory=CredentialPolicy)
+    config_section: str | None = None
+    legacy_config_sections: tuple[str, ...] = ()
+    base_url_resolver: Callable[[str, str | None], str | None] | None = None
+    config_url_applies: Callable[[str], bool] = field(
+        default=lambda _model: True,
+        repr=False,
+        compare=False,
+    )
+    curated_models: tuple[str, ...] = ()
+    accepted_prefix: str | None = None
+    display_name: str | None = None
+    model_type: str = "Cloud"
+    supports_structured_output: bool = True
+
+    def resolve_base_url(
+        self,
+        model: str,
+        base_url: str | None,
+        *,
+        from_config: bool = False,
+    ) -> str | None:
+        """Resolve a URL using this endpoint's normalization and defaults."""
+        if from_config and not self.config_url_applies(model):
+            base_url = None
+        if self.base_url_resolver is None:
+            return base_url
+        return self.base_url_resolver(model, base_url)
+
+    def prepare_request(self, request: ModelRequest) -> PreparedModel:
+        """Prepare a request and attach capabilities declared by the spec."""
+        prepared = self.prepare(request)
+        if prepared.supports_structured_output != self.supports_structured_output:
+            prepared = replace(
+                prepared,
+                supports_structured_output=self.supports_structured_output,
+            )
+        return prepared
 
     def build(self, request: ModelRequest) -> "BaseChatModel":
         """Prepare the request and construct the client."""
-        prepared = self.prepare(request)
+        prepared = self.prepare_request(request)
         return self.protocol_build(prepared.client_kwargs)
 
 
@@ -117,6 +155,21 @@ def is_local_http_endpoint(base_url: str | None) -> bool:
         "::1",
         "0.0.0.0",
     }
+
+
+def normalize_openai_base_url(base_url: str | None) -> str | None:
+    """Normalize legacy Argo resource URLs to OpenAI-compatible roots."""
+    if not base_url:
+        return base_url
+    if (
+        "apps-dev.inside.anl.gov/argoapi" in base_url
+        or "apps.inside.anl.gov/argoapi" in base_url
+    ):
+        base_url = re.sub(r"/api/v1/resource/(chat|embed)/?$", "/v1", base_url)
+        base_url = re.sub(r"/docs/?$", "", base_url)
+        base_url = re.sub(r"/api/v1/?$", "/v1", base_url)
+        base_url = base_url.rstrip("/")
+    return base_url
 
 
 def resolve_api_key(
@@ -167,3 +220,8 @@ def _default_missing_help(policy: CredentialPolicy) -> str:
             f"API key not found. Set the {policy.env_var} environment variable."
         )
     return "API key not found."
+
+
+def missing_credential_help(policy: CredentialPolicy) -> str:
+    """Return endpoint-provided or generic missing-credential guidance."""
+    return policy.missing_key_help or _default_missing_help(policy)

--- a/src/chemgraph/models/endpoints/codex.py
+++ b/src/chemgraph/models/endpoints/codex.py
@@ -40,4 +40,7 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=codex_native.build,
     credential=CODEX_CREDENTIAL,
+    accepted_prefix="codex:",
+    display_name="Codex / ChatGPT",
+    model_type="Experimental",
 )

--- a/src/chemgraph/models/endpoints/configuration.py
+++ b/src/chemgraph/models/endpoints/configuration.py
@@ -1,0 +1,141 @@
+"""Resolve endpoint configuration without constructing model clients."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from chemgraph.models.endpoints import EndpointSpec, ModelRequest
+from chemgraph.models.endpoints import vllm as vllm_ep
+from chemgraph.models.endpoints.registry import match_endpoint, select_endpoint
+from chemgraph.utils.logging_config import setup_logger
+
+logger = setup_logger(__name__)
+
+
+def _section(api: Mapping[str, Any], name: str | None) -> Mapping[str, Any]:
+    if not name:
+        return {}
+    value = api.get(name)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value.strip() or None
+    return str(value).strip() or None
+
+
+def resolve_base_url_for_spec(
+    spec: EndpointSpec,
+    model: str,
+    api: Mapping[str, Any],
+    *,
+    explicit: str | None = None,
+    warn_legacy: bool = True,
+) -> str | None:
+    """Resolve explicit, canonical, legacy, environment, and default URL values."""
+    if explicit:
+        return spec.resolve_base_url(model, explicit)
+
+    canonical = spec.config_section
+    if canonical and canonical in api:
+        configured = _text(_section(api, canonical).get("base_url"))
+        return spec.resolve_base_url(model, configured, from_config=True)
+
+    for legacy in spec.legacy_config_sections:
+        configured = _text(_section(api, legacy).get("base_url"))
+        if configured:
+            if warn_legacy:
+                logger.warning(
+                    "Using legacy [api.%s] base_url for endpoint '%s'; move it to "
+                    "[api.%s].base_url.",
+                    legacy,
+                    spec.name,
+                    canonical,
+                )
+            return spec.resolve_base_url(model, configured, from_config=True)
+
+    return spec.resolve_base_url(model, None, from_config=True)
+
+
+def select_endpoint_for_config(
+    model: str,
+    api: Mapping[str, Any],
+    *,
+    explicit_base_url: str | None = None,
+) -> EndpointSpec:
+    """Select the model endpoint, consulting vLLM config only as a fallback."""
+    spec = match_endpoint(model)
+    if spec is not None:
+        return spec
+
+    base_url = resolve_base_url_for_spec(
+        vllm_ep.SPEC,
+        model,
+        api,
+        explicit=explicit_base_url,
+        warn_legacy=False,
+    )
+    return select_endpoint(ModelRequest(model=model, base_url=base_url))
+
+
+def resolve_base_url_for_model(
+    model: str,
+    api: Mapping[str, Any],
+    *,
+    explicit: str | None = None,
+) -> str | None:
+    """Select an endpoint and resolve its effective configured base URL."""
+    try:
+        spec = select_endpoint_for_config(
+            model,
+            api,
+            explicit_base_url=explicit,
+        )
+    except ValueError:
+        return explicit
+    return resolve_base_url_for_spec(spec, model, api, explicit=explicit)
+
+
+def endpoint_api_key(
+    spec: EndpointSpec,
+    api: Mapping[str, Any],
+) -> str | None:
+    """Read an API key only from the selected endpoint's canonical section."""
+    return _text(_section(api, spec.config_section).get("api_key"))
+
+
+def resolve_argo_user(
+    api: Mapping[str, Any],
+    *,
+    explicit: Any = None,
+) -> str | None:
+    """Resolve canonical and one-release legacy Argo user settings."""
+    value = _text(explicit)
+    if value:
+        return value
+
+    canonical = _section(api, "argo")
+    value = _text(canonical.get("argo_user"))
+    if value:
+        return value
+
+    value = _text(canonical.get("user"))
+    if value:
+        logger.warning(
+            "Using compatibility [api.argo].user; rename it to "
+            "[api.argo].argo_user."
+        )
+        return value
+
+    value = _text(_section(api, "openai").get("argo_user"))
+    if value:
+        logger.warning(
+            "Using legacy [api.openai].argo_user; move it to "
+            "[api.argo].argo_user."
+        )
+        return value
+    return None

--- a/src/chemgraph/models/endpoints/configuration.py
+++ b/src/chemgraph/models/endpoints/configuration.py
@@ -20,6 +20,11 @@ def _section(api: Mapping[str, Any], name: str | None) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
 
 
+def has_config_section(api: Mapping[str, Any], name: str | None) -> bool:
+    """Return whether an endpoint section is a valid mapping."""
+    return bool(name and isinstance(api.get(name), Mapping))
+
+
 def _text(value: Any) -> str | None:
     if value is None:
         return None
@@ -41,9 +46,17 @@ def resolve_base_url_for_spec(
         return spec.resolve_base_url(model, explicit)
 
     canonical = spec.config_section
-    if canonical and canonical in api:
+    if has_config_section(api, canonical):
         configured = _text(_section(api, canonical).get("base_url"))
         return spec.resolve_base_url(model, configured, from_config=True)
+
+    if canonical and canonical in api:
+        logger.warning(
+            "Ignoring malformed [api.%s] section for endpoint '%s'; "
+            "expected a table/mapping.",
+            canonical,
+            spec.name,
+        )
 
     for legacy in spec.legacy_config_sections:
         configured = _text(_section(api, legacy).get("base_url"))

--- a/src/chemgraph/models/endpoints/google_direct.py
+++ b/src/chemgraph/models/endpoints/google_direct.py
@@ -28,6 +28,11 @@ GOOGLE_CREDENTIAL = CredentialPolicy(
 )
 
 
+def resolve_base_url(_model: str, base_url: str | None) -> str | None:
+    """Return an optional Google API URL unchanged."""
+    return base_url
+
+
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a curated Gemini model."""
     model_name = request.model
@@ -61,4 +66,8 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=google_native.build,
     credential=GOOGLE_CREDENTIAL,
+    config_section="google",
+    base_url_resolver=resolve_base_url,
+    curated_models=tuple(supported_gemini_models),
+    display_name="Google",
 )

--- a/src/chemgraph/models/endpoints/groq.py
+++ b/src/chemgraph/models/endpoints/groq.py
@@ -28,6 +28,11 @@ GROQ_CREDENTIAL = CredentialPolicy(
 )
 
 
+def resolve_base_url(_model: str, base_url: str | None) -> str | None:
+    """Return an optional Groq-compatible API URL unchanged."""
+    return base_url
+
+
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a ``groq:`` model. Key handling stays inside the loader."""
     client_kwargs = dict(
@@ -54,4 +59,8 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=groq_native.build,
     credential=GROQ_CREDENTIAL,
+    config_section="groq",
+    base_url_resolver=resolve_base_url,
+    accepted_prefix=GROQ_PREFIX,
+    display_name="GROQ",
 )

--- a/src/chemgraph/models/endpoints/ollama.py
+++ b/src/chemgraph/models/endpoints/ollama.py
@@ -21,6 +21,11 @@ PROTOCOL = "ollama"
 OLLAMA_CREDENTIAL = CredentialPolicy(required=False)
 
 
+def resolve_base_url(_model: str, base_url: str | None) -> str | None:
+    """Return an optional local Ollama URL unchanged."""
+    return base_url
+
+
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a curated Ollama model."""
     client_kwargs = dict(
@@ -42,4 +47,9 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=ollama_native.build,
     credential=OLLAMA_CREDENTIAL,
+    config_section="local",
+    base_url_resolver=resolve_base_url,
+    curated_models=tuple(supported_ollama_models),
+    display_name="Ollama",
+    model_type="Local",
 )

--- a/src/chemgraph/models/endpoints/openai_direct.py
+++ b/src/chemgraph/models/endpoints/openai_direct.py
@@ -16,6 +16,7 @@ from chemgraph.models.endpoints.base import (
     EndpointSpec,
     ModelRequest,
     PreparedModel,
+    normalize_openai_base_url,
     resolve_api_key,
 )
 from chemgraph.models.protocols import openai_compatible
@@ -25,7 +26,6 @@ from chemgraph.models.supported_models import (
     SUPPORTED_REASONING_EFFORTS,
     supported_openai_models,
 )
-from chemgraph.utils.config_utils import normalize_openai_base_url
 from chemgraph.utils.logging_config import setup_logger
 
 logger = setup_logger(__name__)
@@ -38,6 +38,11 @@ OPENAI_CREDENTIAL = CredentialPolicy(
     interactive_prompt=True,
     missing_key_help="OPENAI_API_KEY not set. Please provide an OpenAI API key.",
 )
+
+
+def resolve_base_url(_model: str, base_url: str | None) -> str | None:
+    """Normalize an optional direct OpenAI-compatible endpoint URL."""
+    return normalize_openai_base_url(base_url)
 
 
 def validate_reasoning_effort(requested_model_name: str, reasoning_effort: str | None) -> None:
@@ -118,7 +123,7 @@ def assemble_client_kwargs(
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare a direct (unprefixed, curated) OpenAI model."""
     requested_model_name = request.model
-    base_url = normalize_openai_base_url(request.base_url)
+    base_url = resolve_base_url(requested_model_name, request.base_url)
 
     validate_reasoning_effort(requested_model_name, request.reasoning_effort)
 
@@ -155,4 +160,8 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=openai_compatible.build,
     credential=OPENAI_CREDENTIAL,
+    config_section="openai",
+    base_url_resolver=resolve_base_url,
+    curated_models=tuple(supported_openai_models),
+    display_name="OpenAI",
 )

--- a/src/chemgraph/models/endpoints/openrouter.py
+++ b/src/chemgraph/models/endpoints/openrouter.py
@@ -18,6 +18,7 @@ from chemgraph.models.protocols import openai_compatible
 from chemgraph.models.supported_models import (
     MODELS_WITHOUT_TEMPERATURE,
     OPENROUTER_DEFAULT_BASE_URL,
+    supported_openrouter_models,
 )
 from chemgraph.utils.logging_config import setup_logger
 
@@ -49,6 +50,11 @@ OPENROUTER_CREDENTIAL = CredentialPolicy(
 )
 
 
+def resolve_base_url(_model: str, base_url: str | None) -> str:
+    """Resolve an explicit or default OpenRouter API URL."""
+    return base_url or OPENROUTER_DEFAULT_BASE_URL
+
+
 def prepare(request: ModelRequest) -> PreparedModel:
     """Prepare an ``openrouter:`` model. The slug is sent verbatim."""
     # Keep the prefixed name -- it is what the quirk sets are keyed on.
@@ -61,7 +67,7 @@ def prepare(request: ModelRequest) -> PreparedModel:
     client_kwargs = dict(
         model=model_name,
         api_key=api_key,
-        base_url=request.base_url or OPENROUTER_DEFAULT_BASE_URL,
+        base_url=resolve_base_url(requested_model_name, request.base_url),
         max_tokens=OPENROUTER_DEFAULT_MAX_TOKENS,
     )
     # top_p / frequency_penalty / presence_penalty are deliberately not sent:
@@ -86,4 +92,9 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=openai_compatible.build,
     credential=OPENROUTER_CREDENTIAL,
+    config_section="openrouter",
+    base_url_resolver=resolve_base_url,
+    curated_models=tuple(supported_openrouter_models),
+    accepted_prefix=OPENROUTER_PREFIX,
+    display_name="OpenRouter",
 )

--- a/src/chemgraph/models/endpoints/registry.py
+++ b/src/chemgraph/models/endpoints/registry.py
@@ -61,7 +61,9 @@ def select_endpoint(request: ModelRequest) -> EndpointSpec:
     raise ValueError(
         f"Model '{request.model}' not found in any supported model list. "
         "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
-        "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama."
+        "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama. "
+        "For a custom OpenAI-compatible model, provide a base URL or configure "
+        "[api.vllm].base_url."
     )
 
 

--- a/src/chemgraph/models/endpoints/registry.py
+++ b/src/chemgraph/models/endpoints/registry.py
@@ -1,0 +1,92 @@
+"""Ordered endpoint registry and side-effect-free model selection helpers."""
+
+from __future__ import annotations
+
+from chemgraph.models.endpoints import EndpointSpec, ModelRequest
+from chemgraph.models.endpoints import alcf as alcf_ep
+from chemgraph.models.endpoints import anthropic_direct as anthropic_ep
+from chemgraph.models.endpoints import argo as argo_ep
+from chemgraph.models.endpoints import codex as codex_ep
+from chemgraph.models.endpoints import google_direct as google_ep
+from chemgraph.models.endpoints import groq as groq_ep
+from chemgraph.models.endpoints import ollama as ollama_ep
+from chemgraph.models.endpoints import openai_direct as openai_ep
+from chemgraph.models.endpoints import openrouter as openrouter_ep
+from chemgraph.models.endpoints import vllm as vllm_ep
+
+# Prefix routes precede catalog matches. vLLM remains a configured last resort.
+ENDPOINT_REGISTRY = (
+    codex_ep.SPEC,
+    openrouter_ep.SPEC,
+    argo_ep.ANTHROPIC_SPEC,
+    argo_ep.OPENAI_SPEC,
+    alcf_ep.SPEC,
+    openai_ep.SPEC,
+    anthropic_ep.SPEC,
+    google_ep.SPEC,
+    ollama_ep.SPEC,
+    groq_ep.SPEC,
+)
+
+# Preserve the historical discovery order independently of dispatch order.
+CATALOG_ENDPOINTS = (
+    openai_ep.SPEC,
+    ollama_ep.SPEC,
+    alcf_ep.SPEC,
+    anthropic_ep.SPEC,
+    argo_ep.OPENAI_SPEC,
+    google_ep.SPEC,
+    groq_ep.SPEC,
+    openrouter_ep.SPEC,
+)
+
+
+def match_endpoint(model: str) -> EndpointSpec | None:
+    """Return the first model-matched endpoint, excluding the vLLM fallback."""
+    for spec in ENDPOINT_REGISTRY:
+        if spec.matches(model):
+            return spec
+    return None
+
+
+def select_endpoint(request: ModelRequest) -> EndpointSpec:
+    """Select a model endpoint without preparing credentials or a client."""
+    spec = match_endpoint(request.model)
+    if spec is not None:
+        return spec
+
+    if vllm_ep.can_handle(request):
+        return vllm_ep.SPEC
+
+    raise ValueError(
+        f"Model '{request.model}' not found in any supported model list. "
+        "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
+        "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama."
+    )
+
+
+def catalog_entries() -> list[tuple[str, EndpointSpec]]:
+    """Return deduplicated curated model/spec pairs in display order."""
+    entries: list[tuple[str, EndpointSpec]] = []
+    seen: set[str] = set()
+    for spec in CATALOG_ENDPOINTS:
+        for model in spec.curated_models:
+            if model not in seen:
+                seen.add(model)
+                entries.append((model, spec))
+    return entries
+
+
+def catalog_models() -> list[str]:
+    """Return the curated model catalog in compatibility display order."""
+    return [model for model, _spec in catalog_entries()]
+
+
+def config_sections() -> tuple[str, ...]:
+    """Return all canonical and legacy endpoint configuration section names."""
+    sections: list[str] = []
+    for spec in (*ENDPOINT_REGISTRY, vllm_ep.SPEC):
+        for name in (spec.config_section, *spec.legacy_config_sections):
+            if name and name not in sections:
+                sections.append(name)
+    return tuple(sections)

--- a/src/chemgraph/models/endpoints/vllm.py
+++ b/src/chemgraph/models/endpoints/vllm.py
@@ -5,9 +5,8 @@ Consolidates the two ad-hoc fallbacks that previously lived in
 ``_custom_openai_compatible_kwargs``). Selected only for an otherwise unknown
 model when a base URL is available.
 
-PR 1 preserves the current env-first precedence (``VLLM_BASE_URL`` /
-``OPENAI_API_KEY`` win over explicit arguments). The richer ``[api.vllm]``
-precedence and deprecation warnings are introduced in PR 3.
+Configuration and credential precedence is owned here so every caller observes
+the same explicit/canonical/environment/legacy behavior.
 """
 
 from __future__ import annotations
@@ -39,14 +38,29 @@ VLLM_CREDENTIAL = CredentialPolicy(
 )
 
 
+def resolve_configured_base_url(_model: str, base_url: str | None) -> str | None:
+    """Resolve explicit/configured URL before the vLLM environment variable."""
+    return base_url or os.getenv("VLLM_BASE_URL") or None
+
+
 def resolve_base_url(request: ModelRequest) -> str | None:
-    """Resolve the custom endpoint URL (env-first, matching current behavior)."""
-    return os.getenv("VLLM_BASE_URL", request.base_url or "") or None
+    """Resolve an explicit/configured URL before the vLLM environment value."""
+    return resolve_configured_base_url(request.model, request.base_url)
 
 
 def resolve_api_key(request: ModelRequest) -> str:
-    """Resolve the key: OPENAI_API_KEY (deprecated) -> explicit -> dummy."""
-    return os.getenv("OPENAI_API_KEY", request.api_key or DUMMY_KEY)
+    """Resolve explicit, vLLM, deprecated OpenAI, then placeholder credentials."""
+    if request.api_key:
+        return request.api_key
+    if api_key := os.getenv("VLLM_API_KEY"):
+        return api_key
+    if api_key := os.getenv("OPENAI_API_KEY"):
+        logger.warning(
+            "Using deprecated OPENAI_API_KEY for a vLLM/custom endpoint; "
+            "set VLLM_API_KEY instead."
+        )
+        return api_key
+    return DUMMY_KEY
 
 
 def prepare(request: ModelRequest) -> PreparedModel:
@@ -98,4 +112,8 @@ SPEC = EndpointSpec(
     prepare=prepare,
     protocol_build=openai_compatible.build,
     credential=VLLM_CREDENTIAL,
+    config_section="vllm",
+    legacy_config_sections=("openai",),
+    base_url_resolver=resolve_configured_base_url,
+    display_name="vLLM / Custom",
 )

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -15,37 +15,8 @@ from __future__ import annotations
 from typing import Optional
 
 from chemgraph.models.endpoints import ModelRequest, PreparedModel
-from chemgraph.models.endpoints import alcf as alcf_ep
-from chemgraph.models.endpoints import anthropic_direct as anthropic_ep
-from chemgraph.models.endpoints import argo as argo_ep
-from chemgraph.models.endpoints import codex as codex_ep
-from chemgraph.models.endpoints import google_direct as google_ep
-from chemgraph.models.endpoints import groq as groq_ep
-from chemgraph.models.endpoints import ollama as ollama_ep
-from chemgraph.models.endpoints import openai_direct as openai_ep
-from chemgraph.models.endpoints import openrouter as openrouter_ep
-from chemgraph.models.endpoints import vllm as vllm_ep
+from chemgraph.models.endpoints.registry import select_endpoint
 from chemgraph.models.settings import LLMSettings
-
-# Ordered endpoint registry. Resolution preserves the historical dispatch order:
-# codex -> openrouter -> Argo Anthropic -> Argo OpenAI -> curated ALCF ->
-# direct OpenAI -> direct Anthropic -> direct Gemini -> Ollama -> groq. Prefix
-# routes (``matches`` on a prefix) run before catalog checks, so names such as
-# ``openrouter:openai/o3`` cannot be misclassified. The vLLM/custom fallback is
-# *not* in this list; it is selected only via ``vllm.can_handle`` as a last
-# resort.
-_ENDPOINT_REGISTRY = (
-    codex_ep.SPEC,
-    openrouter_ep.SPEC,
-    argo_ep.ANTHROPIC_SPEC,
-    argo_ep.OPENAI_SPEC,
-    alcf_ep.SPEC,
-    openai_ep.SPEC,
-    anthropic_ep.SPEC,
-    google_ep.SPEC,
-    ollama_ep.SPEC,
-    groq_ep.SPEC,
-)
 
 
 def _build_request(
@@ -69,7 +40,7 @@ def _build_request(
         argo_user = settings.argo_user
         if settings.temperature is not None:
             temperature = settings.temperature
-        settings_reasoning = getattr(settings, "reasoning_effort", None)
+        settings_reasoning = settings.reasoning_effort
         if settings_reasoning is not None:
             reasoning_effort = settings_reasoning
 
@@ -88,23 +59,8 @@ def _build_request(
 
 
 def _select_endpoint(request: ModelRequest):
-    """Return the first endpoint spec whose ``matches`` accepts the model.
-
-    Falls back to the vLLM/custom endpoint only when a custom base URL is
-    available. Raises ``ValueError`` for an otherwise unknown model.
-    """
-    for spec in _ENDPOINT_REGISTRY:
-        if spec.matches(request.model):
-            return spec
-
-    if vllm_ep.can_handle(request):
-        return vllm_ep.SPEC
-
-    raise ValueError(
-        f"Model '{request.model}' not found in any supported model list. "
-        "Use a model from: OpenAI, Anthropic, Gemini, groq:<model>, "
-        "openrouter:<model>, codex:<model>, argo:<model>, ALCF, or Ollama."
-    )
+    """Backward-compatible alias for the shared endpoint selector."""
+    return select_endpoint(request)
 
 
 def load_chat_model_prepared(
@@ -134,7 +90,7 @@ def load_chat_model_prepared(
         settings,
     )
     spec = _select_endpoint(request)
-    prepared = spec.prepare(request)
+    prepared = spec.prepare_request(request)
     client = spec.protocol_build(prepared.client_kwargs)
     return client, prepared
 

--- a/src/chemgraph/models/settings.py
+++ b/src/chemgraph/models/settings.py
@@ -6,6 +6,14 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+from chemgraph.models.endpoints.configuration import (
+    endpoint_api_key,
+    resolve_argo_user,
+    resolve_base_url_for_spec,
+    select_endpoint_for_config,
+)
+from chemgraph.models.endpoints.registry import match_endpoint
+
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -21,6 +29,7 @@ class LLMSettings:
     api_key: str | None = None
     argo_user: str | None = None
     provider: str | None = None
+    reasoning_effort: str | None = None
     timeout_s: float | None = None
     temperature: float | None = None
     max_tokens: int | None = None
@@ -40,12 +49,14 @@ class LLMSettings:
         max_retries: int | None = None,
         retry_delay_s: float | None = None,
         user: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> None:
         object.__setattr__(self, "model", model)
         object.__setattr__(self, "base_url", base_url)
         object.__setattr__(self, "api_key", api_key)
         object.__setattr__(self, "argo_user", argo_user or user)
         object.__setattr__(self, "provider", provider)
+        object.__setattr__(self, "reasoning_effort", reasoning_effort)
         object.__setattr__(self, "timeout_s", timeout_s)
         object.__setattr__(self, "temperature", temperature)
         object.__setattr__(self, "max_tokens", max_tokens)
@@ -96,8 +107,9 @@ def _from_mapping(data: Mapping[str, Any]) -> LLMSettings:
         model=str(model),
         base_url=_str_or_none(data.get("base_url")),
         api_key=_str_or_none(api_key),
-        argo_user=_str_or_none(data.get("user") or data.get("argo_user")),
+        argo_user=_str_or_none(data.get("argo_user") or data.get("user")),
         provider=_str_or_none(provider),
+        reasoning_effort=_str_or_none(data.get("reasoning_effort")),
         timeout_s=_float_or_none(data.get("timeout_s")),
         temperature=_float_or_none(data.get("temperature")),
         max_tokens=_int_or_none(data.get("max_tokens")),
@@ -108,41 +120,59 @@ def _from_mapping(data: Mapping[str, Any]) -> LLMSettings:
 
 def _extract_endpoint_from_cli_toml(raw: Mapping[str, Any]) -> dict[str, Any]:
     """Pull LLM endpoint fields out of the CLI's nested TOML structure."""
-    general = raw.get("general") or {}
-    api = raw.get("api") or {}
+    general_value = raw.get("general") or {}
+    api_value = raw.get("api") or {}
+    general = general_value if isinstance(general_value, Mapping) else {}
+    api = api_value if isinstance(api_value, Mapping) else {}
     model = general.get("model")
-    argo_user = general.get("argo_user") or (api.get("argo") or {}).get("user")
+    provider = general.get("provider") or raw.get("provider")
+    explicit_base_url = _str_or_none(
+        general.get("base_url") or raw.get("base_url")
+    )
+    explicit_api_key = _str_or_none(general.get("api_key") or raw.get("api_key"))
 
-    base_url = None
+    spec = None
     if isinstance(model, str):
-        if model.startswith("argo:"):
-            base_url = (api.get("argo") or {}).get("base_url")
-        elif model.startswith("openrouter:"):
-            base_url = (api.get("openrouter") or {}).get("base_url")
-        else:
-            for section_name in ("openai", "anthropic", "gemini", "alcf", "ollama"):
-                section = api.get(section_name) or {}
-                if section.get("base_url"):
-                    base_url = section["base_url"]
-                    break
+        try:
+            spec = select_endpoint_for_config(
+                model,
+                api,
+                explicit_base_url=explicit_base_url,
+            )
+        except ValueError:
+            pass
+
+    base_url = explicit_base_url
+    api_key = explicit_api_key
+    if spec is not None and isinstance(model, str):
+        base_url = resolve_base_url_for_spec(
+            spec,
+            model,
+            api,
+            explicit=explicit_base_url,
+        )
+        api_key = explicit_api_key or endpoint_api_key(spec, api)
 
     return {
         "model": model,
         "base_url": base_url,
-        "argo_user": argo_user,
-        "api_key": (api.get(_provider_section_for(model)) or {}).get("api_key"),
+        "argo_user": resolve_argo_user(
+            api,
+            explicit=general.get("argo_user") or general.get("user"),
+        ),
+        "api_key": api_key,
+        "provider": provider,
+        "reasoning_effort": general.get("reasoning_effort"),
     }
 
 
 def _provider_section_for(model: Any) -> str:
+    """Return the canonical config section for a model identifier."""
     if isinstance(model, str):
-        if model.startswith("argo:"):
-            return "argo"
-        if model.startswith("groq:"):
-            return "groq"
-        if model.startswith("openrouter:"):
-            return "openrouter"
-    return "openai"
+        spec = match_endpoint(model)
+        if spec is not None and spec.config_section:
+            return spec.config_section
+    return "vllm"
 
 
 def _str_or_none(value: Any) -> str | None:

--- a/src/chemgraph/utils/config_utils.py
+++ b/src/chemgraph/utils/config_utils.py
@@ -8,6 +8,7 @@ from chemgraph.models.endpoints import (
     normalize_openai_base_url as _normalize_openai_base_url,
 )
 from chemgraph.models.endpoints.configuration import (
+    has_config_section,
     resolve_argo_user,
     resolve_base_url_for_model,
 )
@@ -15,6 +16,7 @@ from chemgraph.models.endpoints.registry import (
     catalog_entries,
     catalog_models,
     config_sections,
+    match_endpoint,
 )
 
 
@@ -128,7 +130,8 @@ def get_model_options_for_nested_config(config: Dict[str, Any]) -> list[str]:
     """Return model options for UI selection.
 
     Always show all curated models so users can switch providers from the UI.
-    If Argo endpoint is configured, prioritize Argo model IDs at the top.
+    Prioritize Argo when it is selected or a legacy Argo configuration signals
+    that intent.
 
     Parameters
     ----------
@@ -150,15 +153,26 @@ def get_model_options_for_nested_config(config: Dict[str, Any]) -> list[str]:
     if not isinstance(api, dict):
         return models
 
-    argo = api.get("argo")
-    canonical_url = argo.get("base_url") if isinstance(argo, dict) else None
+    general = config.get("general", {})
+    selected_model = general.get("model") if isinstance(general, dict) else None
+    selected_spec = (
+        match_endpoint(selected_model) if isinstance(selected_model, str) else None
+    )
+    selected_argo = bool(
+        selected_spec and selected_spec.config_section == "argo"
+    )
+
     openai = api.get("openai")
     legacy_url = openai.get("base_url") if isinstance(openai, dict) else None
-    legacy_argo = "argo" not in api and legacy_url and "argoapi" in legacy_url
+    legacy_argo = bool(
+        not has_config_section(api, "argo")
+        and legacy_url
+        and "argoapi" in legacy_url
+    )
     if legacy_argo and argo_models:
         resolve_base_url_for_model(argo_models[0], api)
 
-    if canonical_url or legacy_argo:
+    if selected_argo or legacy_argo:
         remaining = [model for model in models if model not in argo_models]
         return argo_models + remaining
     return models

--- a/src/chemgraph/utils/config_utils.py
+++ b/src/chemgraph/utils/config_utils.py
@@ -2,25 +2,25 @@
 
 from __future__ import annotations
 
-import re
 from typing import Any, Dict, Optional
 
-from chemgraph.models.supported_models import (
-    ALCF_DEFAULT_BASE_URL,
-    ALCF_METIS_BASE_URL,
-    ALCF_MINERVA_BASE_URL,
-    ARGO_DEFAULT_BASE_URL,
-    OPENROUTER_DEFAULT_BASE_URL,
-    all_supported_models,
-    supported_alcf_metis_models,
-    supported_alcf_minerva_models,
-    supported_alcf_models,
-    supported_anthropic_models,
-    supported_argo_models,
-    supported_gemini_models,
-    supported_ollama_models,
-    supported_openai_models,
+from chemgraph.models.endpoints import (
+    normalize_openai_base_url as _normalize_openai_base_url,
 )
+from chemgraph.models.endpoints.configuration import (
+    resolve_argo_user,
+    resolve_base_url_for_model,
+)
+from chemgraph.models.endpoints.registry import (
+    catalog_entries,
+    catalog_models,
+    config_sections,
+)
+
+
+def normalize_openai_base_url(base_url: Optional[str]) -> Optional[str]:
+    """Backward-compatible wrapper for endpoint URL normalization."""
+    return _normalize_openai_base_url(base_url)
 
 
 def flatten_config(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -47,6 +47,8 @@ def flatten_config(config: Dict[str, Any]) -> Dict[str, Any]:
                 if isinstance(value, dict):
                     for subkey, subvalue in value.items():
                         flattened[f"{section}_{key}_{subkey}"] = subvalue
+                    if section == "api" and key == "vllm" and "base_url" not in value:
+                        flattened["api_vllm_base_url"] = ""
                 else:
                     flattened[f"{section}_{key}"] = value
 
@@ -65,30 +67,19 @@ def flatten_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return flattened
 
 
-def normalize_openai_base_url(base_url: Optional[str]) -> Optional[str]:
-    """Normalize Argo-style URLs to OpenAI-compatible /v1 URLs.
-
-    Parameters
-    ----------
-    base_url : str, optional
-        Provider base URL.
-
-    Returns
-    -------
-    str or None
-        Normalized URL, or ``None`` when no URL was provided.
-    """
-    if not base_url:
-        return base_url
-    if (
-        "apps-dev.inside.anl.gov/argoapi" in base_url
-        or "apps.inside.anl.gov/argoapi" in base_url
-    ):
-        base_url = re.sub(r"/api/v1/resource/(chat|embed)/?$", "/v1", base_url)
-        base_url = re.sub(r"/docs/?$", "", base_url)
-        base_url = re.sub(r"/api/v1/?$", "/v1", base_url)
-        base_url = base_url.rstrip("/")
-    return base_url
+def _api_from_flat_config(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Reconstruct endpoint sections while preserving explicit empty values."""
+    api: Dict[str, Dict[str, Any]] = {}
+    for section in config_sections():
+        prefix = f"api_{section}_"
+        values = {
+            key.removeprefix(prefix): value
+            for key, value in config.items()
+            if key.startswith(prefix)
+        }
+        if values:
+            api[section] = values
+    return api
 
 
 def get_base_url_for_model_from_nested_config(
@@ -108,35 +99,9 @@ def get_base_url_for_model_from_nested_config(
     str or None
         Matching provider base URL, or ``None`` when not configured.
     """
-    api = config.get("api", {})
-
-    if model_name in supported_argo_models:
-        return normalize_openai_base_url(
-            api.get("openai", {}).get("base_url") or ARGO_DEFAULT_BASE_URL
-        )
-    # Prefix-routed, and matched before any list lookup: the fallthrough at the
-    # end of this function returns [api.openai].base_url, so an uncurated
-    # openrouter: slug would otherwise be sent to whatever OpenAI-compatible
-    # endpoint is configured there (the Argo gateway, by default).
-    if model_name.startswith("openrouter:"):
-        return api.get("openrouter", {}).get("base_url") or OPENROUTER_DEFAULT_BASE_URL
-    if model_name in supported_openai_models:
-        return normalize_openai_base_url(api.get("openai", {}).get("base_url"))
-    # Minerva and Metis have their own endpoints, and [api.alcf] base_url
-    # describes the Sophia default, so it must not be applied to them.
-    if model_name in supported_alcf_minerva_models:
-        return ALCF_MINERVA_BASE_URL
-    if model_name in supported_alcf_metis_models:
-        return ALCF_METIS_BASE_URL
-    if model_name in supported_alcf_models:
-        return api.get("alcf", {}).get("base_url") or ALCF_DEFAULT_BASE_URL
-    if model_name in supported_anthropic_models:
-        return api.get("anthropic", {}).get("base_url")
-    if model_name in supported_gemini_models:
-        return api.get("google", {}).get("base_url")
-    if model_name in supported_ollama_models:
-        return api.get("local", {}).get("base_url")
-    return normalize_openai_base_url(api.get("openai", {}).get("base_url"))
+    api_value = config.get("api", {})
+    api = api_value if isinstance(api_value, dict) else {}
+    return resolve_base_url_for_model(model_name, api)
 
 
 def get_base_url_for_model_from_flat_config(
@@ -156,29 +121,7 @@ def get_base_url_for_model_from_flat_config(
     str or None
         Matching provider base URL, or ``None`` when not configured.
     """
-    if model_name in supported_argo_models:
-        return normalize_openai_base_url(
-            config.get("api_openai_base_url") or ARGO_DEFAULT_BASE_URL
-        )
-    # See the note in get_base_url_for_model_from_nested_config.
-    if model_name.startswith("openrouter:"):
-        return config.get("api_openrouter_base_url") or OPENROUTER_DEFAULT_BASE_URL
-    if model_name in supported_openai_models:
-        return normalize_openai_base_url(config.get("api_openai_base_url"))
-    # See the note in get_base_url_for_model_from_nested_config.
-    if model_name in supported_alcf_minerva_models:
-        return ALCF_MINERVA_BASE_URL
-    if model_name in supported_alcf_metis_models:
-        return ALCF_METIS_BASE_URL
-    if model_name in supported_alcf_models:
-        return config.get("api_alcf_base_url") or ALCF_DEFAULT_BASE_URL
-    if model_name in supported_anthropic_models:
-        return config.get("api_anthropic_base_url")
-    if model_name in supported_gemini_models:
-        return config.get("api_google_base_url")
-    if model_name in supported_ollama_models:
-        return config.get("api_local_base_url")
-    return normalize_openai_base_url(config.get("api_openai_base_url"))
+    return resolve_base_url_for_model(model_name, _api_from_flat_config(config))
 
 
 def get_model_options_for_nested_config(config: Dict[str, Any]) -> list[str]:
@@ -197,11 +140,28 @@ def get_model_options_for_nested_config(config: Dict[str, Any]) -> list[str]:
     list[str]
         Model identifiers for UI selection.
     """
-    base_url = config.get("api", {}).get("openai", {}).get("base_url")
-    if base_url and "argoapi" in base_url:
-        remaining = [m for m in all_supported_models if m not in supported_argo_models]
-        return supported_argo_models + remaining
-    return all_supported_models
+    models = catalog_models()
+    argo_models = [
+        model
+        for model, spec in catalog_entries()
+        if spec.config_section == "argo"
+    ]
+    api = config.get("api", {})
+    if not isinstance(api, dict):
+        return models
+
+    argo = api.get("argo")
+    canonical_url = argo.get("base_url") if isinstance(argo, dict) else None
+    openai = api.get("openai")
+    legacy_url = openai.get("base_url") if isinstance(openai, dict) else None
+    legacy_argo = "argo" not in api and legacy_url and "argoapi" in legacy_url
+    if legacy_argo and argo_models:
+        resolve_base_url_for_model(argo_models[0], api)
+
+    if canonical_url or legacy_argo:
+        remaining = [model for model in models if model not in argo_models]
+        return argo_models + remaining
+    return models
 
 
 def get_argo_user_from_nested_config(config: Dict[str, Any]) -> Optional[str]:
@@ -217,10 +177,8 @@ def get_argo_user_from_nested_config(config: Dict[str, Any]) -> Optional[str]:
     str or None
         Configured Argo username, or ``None``.
     """
-    value = config.get("api", {}).get("openai", {}).get("argo_user")
-    if isinstance(value, str):
-        value = value.strip()
-    return value or None
+    api = config.get("api", {})
+    return resolve_argo_user(api if isinstance(api, dict) else {})
 
 
 def get_argo_user_from_flat_config(config: Dict[str, Any]) -> Optional[str]:
@@ -236,7 +194,4 @@ def get_argo_user_from_flat_config(config: Dict[str, Any]) -> Optional[str]:
     str or None
         Configured Argo username, or ``None``.
     """
-    value = config.get("api_openai_argo_user")
-    if isinstance(value, str):
-        value = value.strip()
-    return value or None
+    return resolve_argo_user(_api_from_flat_config(config))

--- a/src/ui/_pages/configuration.py
+++ b/src/ui/_pages/configuration.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import streamlit as st
 import toml
 
+from chemgraph.models.supported_models import ARGO_DEFAULT_BASE_URL
 from ui.config import get_default_config, load_config, save_config
 
 # ---------------------------------------------------------------------------
@@ -379,19 +380,15 @@ def _render_api_settings(config: dict) -> None:
             st.rerun()
 
     st.markdown("---")
-    api_tabs = st.tabs(["OpenAI", "Anthropic", "Google", "ALCF", "Local"])
+    api_tabs = st.tabs(
+        ["OpenAI", "Argo", "vLLM", "Anthropic", "Google", "ALCF", "Local"]
+    )
 
     with api_tabs[0]:
         config["api"]["openai"]["base_url"] = st.text_input(
             "Base URL",
             value=config["api"]["openai"]["base_url"],
             key="config_openai_url",
-        )
-        config["api"]["openai"]["argo_user"] = st.text_input(
-            "Argo User (optional)",
-            value=config["api"]["openai"].get("argo_user", ""),
-            key="config_openai_argo_user",
-            help="ANL domain username for Argo requests. If blank, ChemGraph falls back to ARGO_USER env var.",
         )
         config["api"]["openai"]["timeout"] = st.number_input(
             "Timeout (seconds)",
@@ -402,6 +399,42 @@ def _render_api_settings(config: dict) -> None:
         )
 
     with api_tabs[1]:
+        legacy_openai = config["api"].get("openai", {})
+        argo_section = config["api"].setdefault("argo", {})
+        legacy_url = legacy_openai.get("base_url", "")
+        legacy_user = legacy_openai.get("argo_user", "")
+        argo_section["base_url"] = st.text_input(
+            "Base URL",
+            value=argo_section.get("base_url")
+            or (legacy_url if "argoapi" in legacy_url else ARGO_DEFAULT_BASE_URL),
+            key="config_argo_url",
+        )
+        argo_section["argo_user"] = st.text_input(
+            "Argo User (optional)",
+            value=argo_section.get("argo_user")
+            or argo_section.get("user")
+            or legacy_user,
+            key="config_argo_user",
+            help=(
+                "ANL domain username for Argo requests. If blank, ChemGraph "
+                "falls back to ARGO_USER."
+            ),
+        )
+
+    with api_tabs[2]:
+        vllm_section = config["api"].get("vllm", {})
+        vllm_base_url = st.text_input(
+            "Base URL (optional)",
+            value=vllm_section.get("base_url", ""),
+            key="config_vllm_url",
+            help=(
+                "Endpoint for unknown/custom OpenAI-compatible model IDs. "
+                "Leave empty to disable config-based fallback."
+            ),
+        )
+        _update_vllm_config(config["api"], vllm_base_url)
+
+    with api_tabs[3]:
         config["api"]["anthropic"]["base_url"] = st.text_input(
             "Base URL",
             value=config["api"]["anthropic"]["base_url"],
@@ -415,7 +448,7 @@ def _render_api_settings(config: dict) -> None:
             key="config_anthropic_timeout",
         )
 
-    with api_tabs[2]:
+    with api_tabs[4]:
         config["api"]["google"]["base_url"] = st.text_input(
             "Base URL",
             value=config["api"]["google"]["base_url"],
@@ -429,7 +462,7 @@ def _render_api_settings(config: dict) -> None:
             key="config_google_timeout",
         )
 
-    with api_tabs[3]:
+    with api_tabs[5]:
         alcf_section = config["api"].setdefault("alcf", {})
         alcf_section["base_url"] = st.text_input(
             "Base URL",
@@ -452,7 +485,7 @@ def _render_api_settings(config: dict) -> None:
             "in the API Keys section above, or export `ALCF_ACCESS_TOKEN` in your shell."
         )
 
-    with api_tabs[4]:
+    with api_tabs[6]:
         config["api"]["local"]["base_url"] = st.text_input(
             "Base URL",
             value=config["api"]["local"]["base_url"],
@@ -465,6 +498,12 @@ def _render_api_settings(config: dict) -> None:
             value=config["api"]["local"]["timeout"],
             key="config_local_timeout",
         )
+
+
+def _update_vllm_config(api: dict, base_url: str) -> None:
+    """Preserve an absent legacy vLLM section until a URL is supplied."""
+    if "vllm" in api or base_url.strip():
+        api.setdefault("vllm", {})["base_url"] = base_url
 
 
 def _render_raw_toml(config: dict) -> None:

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -18,7 +18,8 @@ from ase.io import read as ase_read
 from chemgraph.agent.llm_agent import HumanInputRequired
 from chemgraph.memory.store import SessionStore
 from chemgraph.memory.durable import delete_durable_session
-from chemgraph.models.supported_models import supported_argo_models
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints.registry import select_endpoint
 from chemgraph.schemas.ase_input import (
     get_available_calculator_names,
     get_default_calculator_name,
@@ -120,9 +121,11 @@ def _ensure_chat_log_dir() -> str:
 
 
 def _resolve_structured_output_for_model(
-    model_name: str, structured_output: bool
+    model_name: str,
+    structured_output: bool,
+    base_url: Optional[str] = None,
 ) -> tuple[bool, Optional[str]]:
-    """Disable structured output for Argo models, including quick overrides.
+    """Apply the selected endpoint's structured-output capability.
 
     Parameters
     ----------
@@ -136,10 +139,16 @@ def _resolve_structured_output_for_model(
     tuple[bool, str | None]
         Effective structured-output setting and optional warning message.
     """
-    if model_name in supported_argo_models and structured_output:
+    try:
+        spec = select_endpoint(ModelRequest(model=model_name, base_url=base_url))
+    except ValueError:
+        return structured_output, None
+
+    if not spec.supports_structured_output and structured_output:
         return (
             False,
-            "Structured output is disabled for Argo models to avoid JSON parsing errors.",
+            "Structured output is disabled for this model endpoint to avoid "
+            "JSON parsing errors.",
         )
     return structured_output, None
 
@@ -178,8 +187,11 @@ def render() -> None:
     _render_available_calculators_sidebar()
     _render_chat_controls()
 
+    selected_base_url = _get_base_url_for_model(selected_model, config)
     structured_output, ui_notice = _resolve_structured_output_for_model(
-        selected_model, structured_output
+        selected_model,
+        structured_output,
+        selected_base_url,
     )
     st.session_state.ui_notice = ui_notice
     st.session_state.active_model = selected_model
@@ -187,7 +199,6 @@ def render() -> None:
     if ui_notice:
         st.info(ui_notice)
 
-    selected_base_url = _get_base_url_for_model(selected_model, config)
     endpoint_status = check_local_model_endpoint(selected_base_url)
 
     # ----- Session management sidebar -----

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -48,6 +48,8 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
                         # Merge missing keys from default
                         for key, value in default_config[section].items():
                             if key not in config[section]:
+                                if section == "api" and key in {"argo", "vllm"}:
+                                    continue
                                 config[section][key] = value
                             elif isinstance(config[section][key], dict) and isinstance(
                                 value, dict
@@ -111,8 +113,12 @@ def get_default_config() -> Dict[str, Any]:
             "openai": {
                 "base_url": "https://api.openai.com/v1",
                 "timeout": 30,
+            },
+            "argo": {
+                "base_url": "https://apps.inside.anl.gov/argoapi/v1",
                 "argo_user": "",
             },
+            "vllm": {"base_url": ""},
             "anthropic": {"base_url": "https://api.anthropic.com", "timeout": 30},
             "google": {
                 "base_url": "https://generativelanguage.googleapis.com/v1beta",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -264,6 +264,25 @@ def test_flat_config_argo_legacy_fallback_warns(caplog, _propagate_logs):
     assert any("legacy [api.openai]" in r.message for r in caplog.records)
 
 
+def test_malformed_argo_section_uses_warned_legacy_fallback(
+    caplog, _propagate_logs
+):
+    raw = {
+        "general": {"model": "argo:gpt-4o"},
+        "api": {
+            "argo": None,
+            "openai": {"base_url": "https://legacy.example/argo/v1"},
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        resolved = _extract_endpoint_from_cli_toml(raw)
+
+    assert resolved["base_url"] == "https://legacy.example/argo/v1"
+    assert any("malformed [api.argo]" in r.message for r in caplog.records)
+    assert any("legacy [api.openai]" in r.message for r in caplog.records)
+
+
 def test_empty_vllm_section_suppresses_openai_fallback(monkeypatch):
     monkeypatch.delenv("VLLM_BASE_URL", raising=False)
     raw = {
@@ -366,6 +385,26 @@ def test_absent_vllm_section_uses_warned_legacy_fallback(
     assert any("legacy [api.openai]" in r.message for r in caplog.records)
 
 
+def test_malformed_vllm_section_uses_legacy_fallback(
+    monkeypatch, caplog, _propagate_logs
+):
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {
+            "vllm": None,
+            "openai": {"base_url": "https://legacy.example/v1"},
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        resolved = _extract_endpoint_from_cli_toml(raw)
+
+    assert resolved["base_url"] == "https://legacy.example/v1"
+    assert any("malformed [api.vllm]" in r.message for r in caplog.records)
+    assert any("legacy [api.openai]" in r.message for r in caplog.records)
+
+
 def test_ui_loader_preserves_absent_canonical_sections(tmp_path):
     from chemgraph.utils.config_utils import (
         get_base_url_for_model_from_nested_config as nested,
@@ -447,6 +486,58 @@ def test_check_api_keys_custom_model_uses_resolved_vllm_policy(_clear_keys):
     ) == (True, "")
 
 
+def test_check_api_keys_unknown_model_requires_custom_endpoint(_clear_keys):
+    from chemgraph.cli.commands import check_api_keys
+
+    ok, message = check_api_keys("custom-model")
+
+    assert ok is False
+    assert "base URL" in message
+    assert "[api.vllm].base_url" in message
+
+
+def test_api_key_status_keeps_distinct_keyless_providers(monkeypatch):
+    from io import StringIO
+    from types import SimpleNamespace
+
+    from rich.console import Console
+
+    from chemgraph.cli import formatting
+
+    output = StringIO()
+    monkeypatch.setattr(
+        formatting,
+        "console",
+        Console(file=output, color_system=None, width=160),
+    )
+    monkeypatch.setattr(
+        formatting,
+        "CATALOG_ENDPOINTS",
+        (
+            SimpleNamespace(
+                name="keyless_a",
+                display_name="Keyless",
+                config_section="keyless_a",
+                credential=SimpleNamespace(env_var=None),
+                curated_models=("keyless-a-model",),
+            ),
+            SimpleNamespace(
+                name="keyless_b",
+                display_name="Keyless",
+                config_section="keyless_b",
+                credential=SimpleNamespace(env_var=None),
+                curated_models=("keyless-b-model",),
+            ),
+        ),
+    )
+
+    formatting.check_api_keys_status()
+
+    rendered = output.getvalue()
+    assert "keyless-a-model" in rendered
+    assert "keyless-b-model" in rendered
+
+
 def test_vllm_api_key_precedence(monkeypatch):
     from chemgraph.models.endpoints import ModelRequest
     from chemgraph.models.endpoints.vllm import resolve_api_key
@@ -526,14 +617,28 @@ def test_argo_user_compatibility_alias_still_works():
 # ---------------------------------------------------------------------------
 
 
-def test_model_options_prioritize_argo_from_canonical_section():
+def test_model_options_prioritize_selected_argo_model():
     from chemgraph.utils.config_utils import get_model_options_for_nested_config
     from chemgraph.models.supported_models import supported_argo_models
 
-    cfg = {"api": {"argo": {"base_url": "https://apps.inside.anl.gov/argoapi/v1"}}}
+    cfg = {
+        "general": {"model": "argo:gpt-4o"},
+        "api": {
+            "argo": {"base_url": "https://apps.inside.anl.gov/argoapi/v1"}
+        },
+    }
     assert (
         get_model_options_for_nested_config(cfg)[0] == supported_argo_models[0]
     )
+
+
+def test_model_options_do_not_prioritize_unselected_default_argo():
+    from chemgraph.models.supported_models import supported_argo_models
+    from chemgraph.utils.config_utils import get_model_options_for_nested_config
+    from ui.config import get_default_config
+
+    options = get_model_options_for_nested_config(get_default_config())
+    assert options[0] not in supported_argo_models
 
 
 def test_model_options_prioritize_argo_from_legacy_openai():
@@ -550,6 +655,25 @@ def test_model_options_prioritize_argo_from_legacy_openai():
     assert (
         get_model_options_for_nested_config(cfg)[0] == supported_argo_models[0]
     )
+
+
+def test_model_options_use_legacy_argo_when_canonical_is_malformed():
+    from chemgraph.models.supported_models import supported_argo_models
+    from chemgraph.utils.config_utils import get_model_options_for_nested_config
+
+    cfg = {
+        "general": {"model": "gpt-4o-mini"},
+        "api": {
+            "argo": None,
+            "openai": {
+                "base_url": (
+                    "https://apps.inside.anl.gov/argoapi/"
+                    "api/v1/resource/chat/"
+                )
+            },
+        },
+    }
+    assert get_model_options_for_nested_config(cfg)[0] == supported_argo_models[0]
 
 
 def test_model_options_no_argo_when_openai_is_direct():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,592 @@
+"""PR 3 regression tests for configuration + auth cleanup (issue #201).
+
+These lock in the behaviors PR 3 introduced on top of the endpoint registry:
+
+- ``LLMSettings`` carries ``reasoning_effort`` and round-trips it through
+  ``load_lm_settings`` / mappings.
+- The CLI TOML section resolver reads each endpoint's own ``[api.<section>]``
+  for both ``base_url`` and ``api_key`` -- Anthropic/Gemini/ALCF keys are no
+  longer sourced from ``[api.openai]`` (the bug this PR fixes).
+- The Argo OpenAI/Anthropic split resolves to distinct config sections.
+- The legacy ``[api.openai]`` base-URL fallback still works for argo/vllm and
+  emits a migration warning.
+- ``config_utils`` URL ladders and ``check_api_keys`` resolve through endpoint
+  metadata rather than per-provider branches.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from chemgraph.models.settings import (
+    LLMSettings,
+    _extract_endpoint_from_cli_toml,
+    load_lm_settings,
+)
+from chemgraph.models.supported_models import (
+    ALCF_METIS_BASE_URL,
+    ALCF_MINERVA_BASE_URL,
+    supported_anthropic_models,
+    supported_alcf_metis_models,
+    supported_alcf_minerva_models,
+    supported_gemini_models,
+)
+
+ANTHROPIC_MODEL = supported_anthropic_models[0]
+GEMINI_MODEL = supported_gemini_models[0]
+MINERVA_MODEL = supported_alcf_minerva_models[0]
+METIS_MODEL = supported_alcf_metis_models[0]
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort field
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_effort_roundtrips_through_llm_settings():
+    settings = LLMSettings(model="gpt-4o", reasoning_effort="high")
+    assert settings.reasoning_effort == "high"
+
+
+def test_reasoning_effort_roundtrips_through_load_lm_settings():
+    settings = load_lm_settings({"model": "gpt-4o", "reasoning_effort": "medium"})
+    assert settings.reasoning_effort == "medium"
+
+
+def test_reasoning_effort_defaults_to_none():
+    assert load_lm_settings({"model": "gpt-4o"}).reasoning_effort is None
+
+
+def test_reasoning_effort_addition_preserves_existing_positional_arguments():
+    settings = LLMSettings(
+        "gpt-4o",
+        "https://example/v1",
+        "key",
+        "argo-user",
+        None,
+        30,
+        0.1,
+        1024,
+        2,
+        0.5,
+        "academy-user",
+    )
+    assert settings.timeout_s == 30
+    assert settings.user == "argo-user"
+    assert settings.reasoning_effort is None
+
+
+def test_reasoning_effort_roundtrips_through_toml(tmp_path):
+    """A [general].reasoning_effort in a TOML file must survive loading."""
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        '[general]\nmodel = "argo:gpt-4o"\nreasoning_effort = "high"\n'
+    )
+    assert load_lm_settings(str(cfg)).reasoning_effort == "high"
+
+
+# ---------------------------------------------------------------------------
+# Section-resolution bug fix: keys come from the endpoint's own section
+# ---------------------------------------------------------------------------
+
+
+def _cli_toml(model: str) -> dict:
+    return {
+        "general": {"model": model},
+        "api": {
+            "openai": {
+                "base_url": "https://argo/openai",
+                "api_key": "OPENAI_KEY",
+            },
+            "anthropic": {
+                "base_url": "https://api.anthropic.com",
+                "api_key": "ANTHROPIC_KEY",
+            },
+            "google": {
+                "base_url": "https://generativelanguage.googleapis.com/v1beta",
+                "api_key": "GEMINI_KEY",
+            },
+        },
+    }
+
+
+def test_anthropic_key_not_sourced_from_openai_section():
+    """Regression: Anthropic keys used to default to [api.openai]."""
+    resolved = _extract_endpoint_from_cli_toml(_cli_toml(ANTHROPIC_MODEL))
+    assert resolved["api_key"] == "ANTHROPIC_KEY"
+    assert resolved["base_url"] == "https://api.anthropic.com"
+
+
+def test_gemini_key_not_sourced_from_openai_section():
+    resolved = _extract_endpoint_from_cli_toml(_cli_toml(GEMINI_MODEL))
+    assert resolved["api_key"] == "GEMINI_KEY"
+    assert resolved["base_url"] == "https://generativelanguage.googleapis.com/v1beta"
+
+
+def test_openai_model_still_reads_openai_section():
+    resolved = _extract_endpoint_from_cli_toml(_cli_toml("gpt-4o"))
+    assert resolved["api_key"] == "OPENAI_KEY"
+
+
+@pytest.mark.parametrize(
+    ("model", "expected_url"),
+    [(MINERVA_MODEL, ALCF_MINERVA_BASE_URL), (METIS_MODEL, ALCF_METIS_BASE_URL)],
+)
+def test_alcf_config_does_not_override_model_cluster(model, expected_url):
+    raw = {
+        "general": {"model": model},
+        "api": {
+            "alcf": {
+                "base_url": "https://sophia.example/v1",
+                "api_key": "ALCF_KEY",
+            }
+        },
+    }
+    resolved = _extract_endpoint_from_cli_toml(raw)
+    assert resolved["base_url"] == expected_url
+    assert resolved["api_key"] == "ALCF_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Argo OpenAI / Anthropic split resolves to distinct sections
+# ---------------------------------------------------------------------------
+
+
+def _argo_toml(model: str) -> dict:
+    return {
+        "general": {"model": model},
+        "api": {
+            "argo": {
+                "base_url": "https://argo/v1",
+                "api_key": "ARGO_KEY",
+                "argo_user": "alice",
+            },
+        },
+    }
+
+
+def test_argo_openai_model_reads_argo_section():
+    resolved = _extract_endpoint_from_cli_toml(_argo_toml("argo:gpt-4o"))
+    assert resolved["base_url"] == "https://argo/v1"
+    assert resolved["api_key"] == "ARGO_KEY"
+
+
+def test_argo_claude_model_reads_shared_argo_section():
+    resolved = _extract_endpoint_from_cli_toml(_argo_toml("argo:claude-opus-5"))
+    assert resolved["base_url"] == "https://argo"
+    assert resolved["api_key"] == "ARGO_KEY"
+
+
+# ---------------------------------------------------------------------------
+# Legacy [api.openai] base-URL fallback for argo / vllm (one release, warns)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _propagate_logs(monkeypatch):
+    """ChemGraph loggers set propagate=False; re-enable so caplog sees them."""
+    for name in (
+        "chemgraph.models.endpoints.configuration",
+        "chemgraph.models.endpoints.vllm",
+    ):
+        monkeypatch.setattr(logging.getLogger(name), "propagate", True)
+
+
+def test_argo_falls_back_to_legacy_openai_base_url_with_warning(caplog, _propagate_logs):
+    raw = {
+        "general": {"model": "argo:gpt-4o"},
+        "api": {"openai": {"base_url": "https://legacy/argo"}},
+    }
+    with caplog.at_level(logging.WARNING):
+        resolved = _extract_endpoint_from_cli_toml(raw)
+    assert resolved["base_url"] == "https://legacy/argo"
+    assert any("legacy [api.openai]" in r.message for r in caplog.records)
+
+
+def test_argo_user_falls_back_through_sections():
+    raw = {
+        "general": {"model": "argo:gpt-4o"},
+        "api": {"openai": {"argo_user": "legacy_user"}},
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["argo_user"] == "legacy_user"
+
+    raw["api"]["argo"] = {"argo_user": "canonical_user"}
+    assert _extract_endpoint_from_cli_toml(raw)["argo_user"] == "canonical_user"
+
+
+def test_argo_canonical_section_beats_legacy_section():
+    raw = {
+        "general": {"model": "argo:gpt-4o"},
+        "api": {
+            "argo": {"base_url": "https://canonical/argo/v1"},
+            "openai": {"base_url": "https://legacy/argo/v1"},
+        },
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["base_url"] == (
+        "https://canonical/argo/v1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# config_utils URL ladders resolve through endpoint metadata
+# ---------------------------------------------------------------------------
+
+
+def test_nested_config_routes_shared_argo_section():
+    from chemgraph.utils.config_utils import (
+        get_base_url_for_model_from_nested_config as nested,
+    )
+
+    cfg = {"api": {"argo": {"base_url": "https://argo/v1"}}}
+    assert nested("argo:gpt-4o", cfg) == "https://argo/v1"
+    assert nested("argo:claude-opus-5", cfg) == "https://argo"
+
+
+def test_nested_config_anthropic_reads_own_section():
+    from chemgraph.utils.config_utils import (
+        get_base_url_for_model_from_nested_config as nested,
+    )
+
+    cfg = {"api": {"anthropic": {"base_url": "https://api.anthropic.com"}}}
+    assert nested(ANTHROPIC_MODEL, cfg) == "https://api.anthropic.com"
+
+
+def test_flat_config_argo_legacy_fallback_warns(caplog, _propagate_logs):
+    from chemgraph.utils.config_utils import (
+        get_base_url_for_model_from_flat_config as flat,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        url = flat("argo:gpt-4o", {"api_openai_base_url": "https://legacy/argo/v1"})
+    assert url == "https://legacy/argo/v1"
+    assert any("legacy [api.openai]" in r.message for r in caplog.records)
+
+
+def test_empty_vllm_section_suppresses_openai_fallback(monkeypatch):
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {
+            "openai": {"base_url": "https://api.openai.com/v1"},
+            "vllm": {"base_url": ""},
+        },
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["base_url"] is None
+
+
+def test_empty_vllm_section_still_allows_environment(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "https://env.example/v1")
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {
+            "openai": {"base_url": "https://api.openai.com/v1"},
+            "vllm": {"base_url": ""},
+        },
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["base_url"] == (
+        "https://env.example/v1"
+    )
+
+
+def test_vllm_canonical_url_beats_legacy_and_environment(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "https://env.example/v1")
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {
+            "openai": {"base_url": "https://legacy.example/v1"},
+            "vllm": {"base_url": "https://canonical.example/v1"},
+        },
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["base_url"] == (
+        "https://canonical.example/v1"
+    )
+
+
+def test_vllm_key_never_comes_from_openai_config_section(monkeypatch):
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {
+            "openai": {"api_key": "OPENAI_CONFIG_KEY"},
+            "vllm": {
+                "base_url": "https://canonical.example/v1",
+                "api_key": "VLLM_CONFIG_KEY",
+            },
+        },
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["api_key"] == "VLLM_CONFIG_KEY"
+
+    del raw["api"]["vllm"]["api_key"]
+    assert _extract_endpoint_from_cli_toml(raw)["api_key"] is None
+
+
+def test_vllm_legacy_url_beats_environment(monkeypatch):
+    monkeypatch.setenv("VLLM_BASE_URL", "https://env.example/v1")
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {"openai": {"base_url": "https://legacy.example/v1"}},
+    }
+    assert _extract_endpoint_from_cli_toml(raw)["base_url"] == (
+        "https://legacy.example/v1"
+    )
+
+
+def test_flattened_empty_vllm_section_preserves_canonical_presence(monkeypatch):
+    from chemgraph.utils.config_utils import (
+        flatten_config,
+        get_base_url_for_model_from_flat_config as flat,
+    )
+
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    config = flatten_config(
+        {
+            "api": {
+                "openai": {"base_url": "https://api.openai.com/v1"},
+                "vllm": {},
+            }
+        }
+    )
+    assert config["api_vllm_base_url"] == ""
+    assert flat("custom-model", config) is None
+
+
+def test_absent_vllm_section_uses_warned_legacy_fallback(
+    monkeypatch, caplog, _propagate_logs
+):
+    monkeypatch.delenv("VLLM_BASE_URL", raising=False)
+    raw = {
+        "general": {"model": "custom-model"},
+        "api": {"openai": {"base_url": "https://legacy.example/v1"}},
+    }
+    with caplog.at_level(logging.WARNING):
+        resolved = _extract_endpoint_from_cli_toml(raw)
+    assert resolved["base_url"] == "https://legacy.example/v1"
+    assert any("legacy [api.openai]" in r.message for r in caplog.records)
+
+
+def test_ui_loader_preserves_absent_canonical_sections(tmp_path):
+    from chemgraph.utils.config_utils import (
+        get_base_url_for_model_from_nested_config as nested,
+    )
+    from ui.config import load_config
+
+    cfg = tmp_path / "legacy.toml"
+    cfg.write_text(
+        '[general]\nmodel = "custom-model"\n'
+        '[api.openai]\nbase_url = "https://legacy.example/v1"\n'
+    )
+    loaded = load_config(str(cfg))
+    assert "argo" not in loaded["api"]
+    assert "vllm" not in loaded["api"]
+    assert nested("custom-model", loaded) == "https://legacy.example/v1"
+
+
+def test_ui_editor_does_not_materialize_empty_vllm_section():
+    from ui._pages.configuration import _update_vllm_config
+
+    api = {"openai": {"base_url": "https://legacy.example/v1"}}
+    _update_vllm_config(api, "")
+    assert "vllm" not in api
+
+    _update_vllm_config(api, "https://canonical.example/v1")
+    assert api["vllm"]["base_url"] == "https://canonical.example/v1"
+
+
+# ---------------------------------------------------------------------------
+# check_api_keys resolves through endpoint CredentialPolicy
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _clear_keys(monkeypatch):
+    for var in (
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GROQ_API_KEY",
+        "ALCF_ACCESS_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_check_api_keys_missing_anthropic(_clear_keys):
+    from chemgraph.cli.commands import check_api_keys
+
+    ok, message = check_api_keys(ANTHROPIC_MODEL)
+    assert ok is False
+    assert "ANTHROPIC_API_KEY" in message
+
+
+def test_check_api_keys_present_anthropic(_clear_keys, monkeypatch):
+    from chemgraph.cli.commands import check_api_keys
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "x")
+    assert check_api_keys(ANTHROPIC_MODEL) == (True, "")
+
+
+def test_check_api_keys_argo_needs_no_key(_clear_keys):
+    from chemgraph.cli.commands import check_api_keys
+
+    assert check_api_keys("argo:gpt-4o") == (True, "")
+
+
+def test_check_api_keys_codex_needs_no_key(_clear_keys):
+    from chemgraph.cli.commands import check_api_keys
+
+    assert check_api_keys("codex:gpt-5") == (True, "")
+
+
+def test_check_api_keys_custom_model_uses_resolved_vllm_policy(_clear_keys):
+    from chemgraph.cli.commands import check_api_keys
+
+    assert check_api_keys(
+        "custom-model",
+        base_url="https://vllm.example/v1",
+    ) == (True, "")
+
+
+def test_vllm_api_key_precedence(monkeypatch):
+    from chemgraph.models.endpoints import ModelRequest
+    from chemgraph.models.endpoints.vllm import resolve_api_key
+
+    monkeypatch.setenv("VLLM_API_KEY", "vllm-env")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-env")
+    assert resolve_api_key(
+        ModelRequest(model="custom", api_key="explicit")
+    ) == "explicit"
+    assert resolve_api_key(ModelRequest(model="custom")) == "vllm-env"
+
+
+def test_vllm_openai_key_fallback_warns(monkeypatch, caplog, _propagate_logs):
+    from chemgraph.models.endpoints import ModelRequest
+    from chemgraph.models.endpoints.vllm import resolve_api_key
+
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-env")
+    with caplog.at_level(logging.WARNING):
+        assert resolve_api_key(ModelRequest(model="custom")) == "openai-env"
+    assert any("deprecated OPENAI_API_KEY" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# config_utils Argo-user helpers read the canonical [api.argo].user (#4)
+# ---------------------------------------------------------------------------
+
+
+def test_argo_user_nested_reads_canonical_section():
+    from chemgraph.utils.config_utils import get_argo_user_from_nested_config
+
+    cfg = {"api": {"argo": {"argo_user": "alice"}}}
+    assert get_argo_user_from_nested_config(cfg) == "alice"
+
+
+def test_argo_user_nested_legacy_fallback():
+    from chemgraph.utils.config_utils import get_argo_user_from_nested_config
+
+    cfg = {"api": {"openai": {"argo_user": "bob"}}}
+    assert get_argo_user_from_nested_config(cfg) == "bob"
+
+
+def test_argo_user_nested_canonical_beats_legacy():
+    from chemgraph.utils.config_utils import get_argo_user_from_nested_config
+
+    cfg = {
+        "api": {
+            "argo": {"argo_user": "alice"},
+            "openai": {"argo_user": "bob"},
+        }
+    }
+    assert get_argo_user_from_nested_config(cfg) == "alice"
+
+
+def test_argo_user_flat_reads_canonical_key():
+    from chemgraph.utils.config_utils import get_argo_user_from_flat_config
+
+    assert (
+        get_argo_user_from_flat_config({"api_argo_argo_user": "alice"})
+        == "alice"
+    )
+    assert (
+        get_argo_user_from_flat_config({"api_openai_argo_user": "bob"}) == "bob"
+    )
+
+
+def test_argo_user_compatibility_alias_still_works():
+    from chemgraph.utils.config_utils import get_argo_user_from_nested_config
+
+    assert get_argo_user_from_nested_config(
+        {"api": {"argo": {"user": "alice"}}}
+    ) == "alice"
+
+
+# ---------------------------------------------------------------------------
+# UI model options prioritize Argo based on [api.argo] configuration (#4)
+# ---------------------------------------------------------------------------
+
+
+def test_model_options_prioritize_argo_from_canonical_section():
+    from chemgraph.utils.config_utils import get_model_options_for_nested_config
+    from chemgraph.models.supported_models import supported_argo_models
+
+    cfg = {"api": {"argo": {"base_url": "https://apps.inside.anl.gov/argoapi/v1"}}}
+    assert (
+        get_model_options_for_nested_config(cfg)[0] == supported_argo_models[0]
+    )
+
+
+def test_model_options_prioritize_argo_from_legacy_openai():
+    from chemgraph.utils.config_utils import get_model_options_for_nested_config
+    from chemgraph.models.supported_models import supported_argo_models
+
+    cfg = {
+        "api": {
+            "openai": {
+                "base_url": "https://apps.inside.anl.gov/argoapi/api/v1/resource/chat/"
+            }
+        }
+    }
+    assert (
+        get_model_options_for_nested_config(cfg)[0] == supported_argo_models[0]
+    )
+
+
+def test_model_options_no_argo_when_openai_is_direct():
+    from chemgraph.utils.config_utils import get_model_options_for_nested_config
+    from chemgraph.models.supported_models import supported_argo_models
+
+    cfg = {"api": {"openai": {"base_url": "https://api.openai.com/v1"}}}
+    assert (
+        get_model_options_for_nested_config(cfg)[0] not in supported_argo_models
+    )
+
+
+# ---------------------------------------------------------------------------
+# Direct OpenAI vs Argo route to distinct base URLs (#2)
+# ---------------------------------------------------------------------------
+
+
+def test_direct_openai_and_argo_resolve_distinct_urls():
+    from chemgraph.utils.config_utils import (
+        get_base_url_for_model_from_nested_config as nested,
+    )
+
+    cfg = {
+        "api": {
+            "openai": {"base_url": "https://api.openai.com/v1"},
+            "argo": {"base_url": "https://apps.inside.anl.gov/argoapi/v1"},
+        }
+    }
+    assert nested("gpt-4o", cfg) == "https://api.openai.com/v1"
+    assert nested("argo:gpt-4o", cfg) == "https://apps.inside.anl.gov/argoapi/v1"
+
+
+def test_repository_config_has_canonical_argo_and_vllm_sections():
+    import tomllib
+    from pathlib import Path
+
+    config = tomllib.loads(Path("config.toml").read_text())
+    assert config["api"]["openai"]["base_url"] == "https://api.openai.com/v1"
+    assert "argo" in config["api"]
+    assert "vllm" in config["api"]

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -1,6 +1,7 @@
 from contextlib import nullcontext
 import os
 
+from chemgraph.models.supported_models import supported_argo_models
 from ui._pages import main_interface as main_ui
 from ui.message_utils import extract_molecular_structure, normalize_latex_delimiters
 
@@ -98,7 +99,7 @@ class _FakeStreamlitRich(_FakeStreamlit):
 
 
 def test_argo_structured_output_is_disabled_after_model_selection():
-    argo_model = next(iter(main_ui.supported_argo_models))
+    argo_model = next(iter(supported_argo_models))
 
     structured, notice = main_ui._resolve_structured_output_for_model(
         argo_model, True


### PR DESCRIPTION
## Summary

- Centralize endpoint selection, URL resolution, credentials, model catalogs, and capabilities in endpoint metadata.
- Fix TOML resolution so models read only their selected endpoint section, and add `reasoning_effort` to `LLMSettings`.
- Add canonical `[api.argo]` and `[api.vllm]` sections with warned one-release fallbacks.
- Migrate CLI and UI provider logic to the shared metadata and preserve legacy vLLM configuration behavior.

## Related issues

Part of #201.

## Compatibility

Legacy `[api.openai]` Argo/custom endpoint settings and `api_openai_argo_user` remain supported for one release with migration warnings. An explicit empty `[api.vllm].base_url` disables the legacy custom-endpoint fallback.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs
- [x] Chore / refactor / CI

## How was this tested?

- `ruff check .` from a clean detached worktree
- `.cg_fix_ase/bin/python -m pytest tests/ -k "not tblite" -q --deselect=tests/test_logging_config.py::test_configure_logging_stops_root_duplication_and_keeps_child_file_log`
- `git diff --check`

The full non-live suite passed with 585 tests; the documented unrelated logging regression was deselected.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added/updated tests for the change
- [x] Updated docs for the user-facing configuration changes