### PR TITLE
Add reusable Deep Agent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Useful run options include:
 | `-r`, `--report` | Allow generation of an HTML report |
 | `--human-supervised` | Allow supported workflows to pause for input |
 | `--deepagent-workspace PATH` | Set the workspace for `deep_agent` or the optional main-agent worker |
+| `--deepagent-skill PATH` | Add an explicit backend-relative Agent Skills directory; repeat to layer sources |
 | `--output-file` | Save the CLI response to a file |
 | `-v` / `-vv` | Enable INFO / DEBUG diagnostics |
 
@@ -160,8 +161,13 @@ subagent:
 ```bash
 chemgraph run --interactive --workflow deep_agent --deepagent-workspace .
 chemgraph run --interactive --workflow main_agent --deepagent \
-  --deepagent-workspace .
+  --deepagent-workspace . \
+  --deepagent-skill /workspace/.agents/skills/
 ```
+
+Skill directories are never discovered automatically. Each source contains
+one directory per skill with a `SKILL.md`; when names collide, the source from
+the later `--deepagent-skill` occurrence wins.
 
 Headless workspace mutation is disabled unless the command includes an
 explicit workspace and `--deepagent-dangerously-skip-approvals`. Use that mode

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Useful run options include:
 | `-s`, `--structured` | Request structured final output |
 | `-r`, `--report` | Allow generation of an HTML report |
 | `--human-supervised` | Allow supported workflows to pause for input |
+| `--deepagent-workspace PATH` | Set the workspace for `deep_agent` or the optional main-agent worker |
 | `--output-file` | Save the CLI response to a file |
 | `-v` / `-vv` | Enable INFO / DEBUG diagnostics |
 
@@ -151,6 +152,20 @@ chemgraph run --interactive --workflow main_agent --resume <session-id>
 See the [CLI guide](https://argonne-lcf.github.io/ChemGraph/cli/) for session
 semantics, interactive commands, MCP connections, tracing, and the
 development-only workspace Deep Agent.
+
+Call the workspace Deep Agent directly in an approval-driven interactive
+session, or attach the same workflow to `main_agent` as the `deepagent`
+subagent:
+
+```bash
+chemgraph run --interactive --workflow deep_agent --deepagent-workspace .
+chemgraph run --interactive --workflow main_agent --deepagent \
+  --deepagent-workspace .
+```
+
+Headless workspace mutation is disabled unless the command includes an
+explicit workspace and `--deepagent-dangerously-skip-approvals`. Use that mode
+only in a disposable, isolated checkout.
 
 ### Use the Python API
 
@@ -233,6 +248,7 @@ stdio client configuration and the experimental HPC servers.
 | --- | --- | --- |
 | `single_agent` | General molecule lookup, ASE calculations, and reports | Default and recommended first workflow |
 | `main_agent` | Long-lived supervisor with delegated chemistry work | Interactive mode; use `MainAgentSession` in Python |
+| `deep_agent` | Repository exploration, coding, and workspace tasks (`deepagent` is an alias) | Interactive approvals by default; broad local shell access |
 | `multi_agent` | Planner/executor decomposition and parallel subtasks | More model calls and orchestration overhead |
 | `python_relp` | LLM-directed Python and arithmetic (`python_repl` is an alias) | Executes Python in the ChemGraph process; use only with trusted prompts |
 | `molecular_docking` | Ligand/receptor docking with AutoDock Vina | `docking` extra plus Vina from conda-forge |
@@ -349,6 +365,8 @@ chemgraph run -vv -q "What is the SMILES string for water?"
   install it only if the requested workflow needs it.
 - A first MACE or local-embedding run may pause while model weights download.
 - `main_agent` requires `--interactive`.
+- Headless `deep_agent` requires an explicit workspace and the unsafe
+  skip-approvals flag.
 - The Streamlit source command must be run from a repository checkout.
 - A stale installed package can shadow a checkout; activate the intended
   environment and use an editable install.

--- a/config.toml
+++ b/config.toml
@@ -8,6 +8,7 @@ thread = 1
 recursion_limit = 20
 human_supervised = false
 # Development-only: add a workspace Deep Agent to interactive main_agent.
+# To call it directly, set workflow = "deep_agent" instead.
 enable_deepagent = false
 # deepagent_workspace = "."
 # Durable main-agent checkpoint database.

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,8 @@ human_supervised = false
 # To call it directly, set workflow = "deep_agent" instead.
 enable_deepagent = false
 # deepagent_workspace = "."
+# Ordered backend-relative Agent Skills directories (later entries win).
+# deepagent_skills = ["/workspace/.agents/skills/"]
 # Durable main-agent checkpoint database.
 # checkpoint_db = "~/.chemgraph/checkpoints.db"
 verbose = false

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -79,8 +79,47 @@ state by a subagent. It does not grant access to the host filesystem or to
 files written under `CHEMGRAPH_LOG_DIR`.
 
 The development workspace Deep Agent can execute broad filesystem and shell
-actions. Enable it only in a disposable, trusted workspace after reviewing the
-CLI warning.
+actions. Call it directly with action reviews:
+
+```bash
+chemgraph run --interactive --workflow deep_agent \
+  --deepagent-workspace /path/to/disposable-checkout
+```
+
+Or add the same graph to the supervisor as the `deepagent` subagent:
+
+```bash
+chemgraph run --interactive --workflow main_agent --deepagent \
+  --deepagent-workspace /path/to/disposable-checkout
+```
+
+The direct interactive workflow keeps one process-local thread until the model
+or workflow changes. It is not restored across CLI processes. Shell and file
+mutations use structured approve/reject prompts.
+
+The selected directory is mounted for file tools at `/workspace`. Thus,
+`--deepagent-workspace test/` makes `/workspace/example.py` refer to
+`test/example.py`, not `test/workspace/example.py`. Shell execution uses the
+absolute host-path mapping supplied to the model. Existing files under a
+previously created `test/workspace/` directory are not migrated.
+
+Deep Agent run logs use the normal ChemGraph locations rather than the selected
+workspace. The default is `cg_logs/session_*` for state JSON plus the configured
+session database. Pending approval state and the final resumed state are both
+recorded.
+
+For automation, headless execution must opt out of those prompts explicitly:
+
+```bash
+chemgraph run --workflow deep_agent \
+  --deepagent-workspace /path/to/disposable-checkout \
+  --deepagent-dangerously-skip-approvals \
+  --query "Run the repository tests and summarize failures."
+```
+
+The unsafe flag is accepted only for non-interactive `deep_agent`, is not read
+from TOML, and requires an explicit workspace. The backend's shell is not
+confined to the workspace, so use a disposable, isolated environment.
 
 ## Saved sessions
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,6 +86,12 @@ chemgraph run --interactive --workflow deep_agent \
   --deepagent-workspace /path/to/disposable-checkout
 ```
 
+Interactive Deep Agent startup uses the current directory when
+`--deepagent-workspace` is omitted. Before enabling it, the confirmation panel
+shows the resolved workspace and explains that shell commands can access the
+host beyond that directory. Declining leaves the capability disabled. Headless
+runs still require an explicit workspace and the approval-skip flag.
+
 Or add the same graph to the supervisor as the `deepagent` subagent:
 
 ```bash

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -90,7 +90,8 @@ Or add the same graph to the supervisor as the `deepagent` subagent:
 
 ```bash
 chemgraph run --interactive --workflow main_agent --deepagent \
-  --deepagent-workspace /path/to/disposable-checkout
+  --deepagent-workspace /path/to/disposable-checkout \
+  --deepagent-skill /workspace/.agents/skills/
 ```
 
 The direct interactive workflow keeps one process-local thread until the model
@@ -103,6 +104,20 @@ The selected directory is mounted for file tools at `/workspace`. Thus,
 absolute host-path mapping supplied to the model. Existing files under a
 previously created `test/workspace/` directory are not migrated.
 
+Skills are opt-in. Repeat `--deepagent-skill PATH` to provide ordered,
+backend-relative source directories; the later source wins when two sources
+contain the same skill name. For the virtual CLI workspace, a conventional
+project source can be selected explicitly as
+`/workspace/.agents/skills/`. ChemGraph does not scan project or user
+directories automatically.
+
+Each source must contain one directory per skill, and each skill directory
+must contain a `SKILL.md` with `name` and `description` YAML frontmatter.
+Metadata is cached in the checkpoint for the life of the thread, so restart or
+reinitialize the workflow after changing the available skill set. Reading a
+skill does not require an action review, while executing a bundled script or
+mutating its files continues to use the normal Deep Agent approval policy.
+
 Deep Agent run logs use the normal ChemGraph locations rather than the selected
 workspace. The default is `cg_logs/session_*` for state JSON plus the configured
 session database. Pending approval state and the final resumed state are both
@@ -113,6 +128,7 @@ For automation, headless execution must opt out of those prompts explicitly:
 ```bash
 chemgraph run --workflow deep_agent \
   --deepagent-workspace /path/to/disposable-checkout \
+  --deepagent-skill /workspace/.agents/skills/ \
   --deepagent-dangerously-skip-approvals \
   --query "Run the repository tests and summarize failures."
 ```

--- a/docs/codex_subscription.md
+++ b/docs/codex_subscription.md
@@ -64,9 +64,24 @@ agent = ChemGraph(
 )
 ```
 
+The same model adapter can drive the workspace harness:
+
+```bash
+chemgraph run --interactive \
+  --model "codex:<codex-model-id>" \
+  --workflow deep_agent \
+  --deepagent-workspace /path/to/disposable-checkout
+```
+
+This measures the model inside ChemGraph's Deep Agent prompt, tools, approval
+policy, and checkpoint loop. It is not a native Codex runtime comparison. For
+comparisons with Codex or Claude Code, use identical starting checkouts and
+tasks, record the runtime and safety mode, and score resulting patches and
+tests independently.
+
 ## Limitations
 
-- Only `single_agent` and `main_agent` are supported.
+- Only `single_agent`, `main_agent`, and `deep_agent` are supported.
 - `main_agent` must be interactive and can restore its supervisor checkpoint;
   individual Codex calls still start fresh read-only threads.
 - The integration pins `openai-codex==0.144.4`; check the installed ChemGraph

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -113,9 +113,15 @@ checkpoint_db = "~/.chemgraph/checkpoints.db"
 enable_deepagent = false
 ```
 
-`main_agent` still requires interactive CLI mode. Deep Agent is a
-development-only capability with broad local access; leave it disabled unless
-you understand the security boundary.
+`main_agent` still requires interactive CLI mode. `enable_deepagent` controls
+only its optional `deepagent` subagent. To call the graph directly, select
+`workflow = "deep_agent"`; `deepagent_workspace` applies to either entry point.
+Deep Agent is a development-only capability with broad local access, so leave
+it disabled unless you understand the security boundary.
+
+The headless-only `--deepagent-dangerously-skip-approvals` switch is
+intentionally not configurable through TOML. It must be typed explicitly for
+each run together with `--deepagent-workspace`.
 
 ## Evaluation profiles
 

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -111,6 +111,7 @@ definitions. See [MCP servers](mcp_servers.md).
 workflow = "main_agent"
 checkpoint_db = "~/.chemgraph/checkpoints.db"
 enable_deepagent = false
+# deepagent_skills = ["/workspace/.agents/skills/"]
 ```
 
 `main_agent` still requires interactive CLI mode. `enable_deepagent` controls
@@ -122,6 +123,13 @@ it disabled unless you understand the security boundary.
 The headless-only `--deepagent-dangerously-skip-approvals` switch is
 intentionally not configurable through TOML. It must be typed explicitly for
 each run together with `--deepagent-workspace`.
+
+`deepagent_skills` is an ordered list of backend-relative source directories.
+It applies to a direct `deep_agent` or to an enabled `main_agent` worker. Later
+sources override earlier sources with the same skill name. A repeated
+`--deepagent-skill` CLI option replaces the TOML list for that run; explicitly
+disabling the worker with `--no-deepagent` also clears its configured skills.
+No skill directories are loaded when the list is omitted.
 
 ## Evaluation profiles
 

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -89,6 +89,10 @@ agent = ChemGraph(
         root_dir="/path/to/checkout",
         virtual_mode=True,
     ),
+    deepagent_skills=[
+        "/workspace/shared-skills/",
+        "/workspace/.agents/skills/",
+    ],
 )
 result = await agent.run(
     "Review the test failures.",
@@ -102,10 +106,21 @@ tool path `/workspace/src/example.py` maps directly to
 also supplies that host path for shell commands. Custom backends, existing
 composite backends, and non-virtual local backends are passed through unchanged.
 
+`deepagent_skills` contains ordered POSIX paths interpreted by that same
+backend. ChemGraph passes them to Deep Agents without scanning any implicit
+user or project locations. Each source contains skill directories with a
+required `SKILL.md`; later sources override earlier sources with the same
+skill name. With `StateBackend`, callers invoking the graph directly must seed
+the corresponding files in graph state before the skills can load.
+
 The default approval policy interrupts before shell commands and file
 mutations. Without a `human_input_handler`, `run()` raises
 `HumanInputRequired`; its `payload` retains the structured Deep Agents action
-requests and must be resumed with matching structured decisions. Setting
+requests and must be resumed with matching structured decisions. Its
+`interrupts` tuple retains every pending request and its LangGraph interrupt
+ID; callers must resume concurrent requests with an exact mapping from those
+IDs to responses. `question` and `payload` continue to describe the first
+request for compatibility. Setting
 `deepagent_auto_approve=True` removes this boundary and should be limited to an
 externally isolated, explicitly trusted workspace.
 
@@ -116,7 +131,12 @@ from chemgraph.graphs.deep_agent import construct_deep_agent_graph
 from chemgraph.registry import AgentRegistry
 
 standalone_graph = construct_deep_agent_graph(model, backend=backend)
-worker = AgentRegistry().as_subagent("deepagent", llm=model, backend=backend)
+worker = AgentRegistry().as_subagent(
+    "deepagent",
+    llm=model,
+    backend=backend,
+    skills=["/workspace/.agents/skills/"],
+)
 ```
 
 `as_subagent()` compiles the graph with `checkpointer=None` so it inherits its

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -120,7 +120,10 @@ requests and must be resumed with matching structured decisions. Its
 `interrupts` tuple retains every pending request and its LangGraph interrupt
 ID; callers must resume concurrent requests with an exact mapping from those
 IDs to responses. `question` and `payload` continue to describe the first
-request for compatibility. Setting
+request for compatibility. A configured handler may use the legacy
+`handler(question)` signature or `handler(question, payload)` when it needs the
+raw structured request; both synchronous and asynchronous handlers are
+supported. Setting
 `deepagent_auto_approve=True` removes this boundary and should be limited to an
 externally isolated, explicitly trusted workspace.
 

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -73,6 +73,56 @@ For CLI use, the equivalent is:
 chemgraph run --interactive --workflow main_agent
 ```
 
+## Workspace Deep Agent
+
+The workspace workflow is separately callable through `ChemGraph.run()`:
+
+```python
+from deepagents.backends import LocalShellBackend
+
+from chemgraph.agent.llm_agent import ChemGraph
+
+agent = ChemGraph(
+    model_name="claude-sonnet-4-20250514",
+    workflow_type="deep_agent",
+    deepagent_backend=LocalShellBackend(
+        root_dir="/path/to/checkout",
+        virtual_mode=True,
+    ),
+)
+result = await agent.run(
+    "Review the test failures.",
+    config={"configurable": {"thread_id": "workspace-review"}},
+)
+```
+
+A virtual `LocalShellBackend` is exposed to the agent at `/workspace`, so file
+tool path `/workspace/src/example.py` maps directly to
+`/path/to/checkout/src/example.py`. The generated Deep Agents system context
+also supplies that host path for shell commands. Custom backends, existing
+composite backends, and non-virtual local backends are passed through unchanged.
+
+The default approval policy interrupts before shell commands and file
+mutations. Without a `human_input_handler`, `run()` raises
+`HumanInputRequired`; its `payload` retains the structured Deep Agents action
+requests and must be resumed with matching structured decisions. Setting
+`deepagent_auto_approve=True` removes this boundary and should be limited to an
+externally isolated, explicitly trusted workspace.
+
+The same constructor can be composed as a worker:
+
+```python
+from chemgraph.graphs.deep_agent import construct_deep_agent_graph
+from chemgraph.registry import AgentRegistry
+
+standalone_graph = construct_deep_agent_graph(model, backend=backend)
+worker = AgentRegistry().as_subagent("deepagent", llm=model, backend=backend)
+```
+
+`as_subagent()` compiles the graph with `checkpointer=None` so it inherits its
+parent checkpoint. `construct_main_agent_graph(enable_deepagent=True, ...)`
+uses this same workflow under the stable subagent name `deepagent`.
+
 ## Custom tools
 
 `ChemGraph` can be extended with compatible LangChain tools. Keep tools narrow,

--- a/docs/python_api.md
+++ b/docs/python_api.md
@@ -78,6 +78,8 @@ chemgraph run --interactive --workflow main_agent
 The workspace workflow is separately callable through `ChemGraph.run()`:
 
 ```python
+import os
+
 from deepagents.backends import LocalShellBackend
 
 from chemgraph.agent.llm_agent import ChemGraph
@@ -88,6 +90,12 @@ agent = ChemGraph(
     deepagent_backend=LocalShellBackend(
         root_dir="/path/to/checkout",
         virtual_mode=True,
+        env={
+            name: os.environ[name]
+            for name in ("PATH", "PYTHONPATH", "VIRTUAL_ENV", "CONDA_PREFIX", "TMPDIR")
+            if name in os.environ
+        },
+        inherit_env=False,
     ),
     deepagent_skills=[
         "/workspace/shared-skills/",
@@ -143,8 +151,15 @@ worker = AgentRegistry().as_subagent(
 ```
 
 `as_subagent()` compiles the graph with `checkpointer=None` so it inherits its
-parent checkpoint. `construct_main_agent_graph(enable_deepagent=True, ...)`
+parent checkpoint. The registry returns the canonical worker name `deep_agent`,
+even when requested through the `deepagent` alias; use `worker["name"]` when
+composing task calls. `construct_main_agent_graph(enable_deepagent=True, ...)`
 uses this same workflow under the stable subagent name `deepagent`.
+
+Caller-owned asynchronous checkpointers, including `AsyncSqliteSaver`, are
+supported by `await agent.run(...)` and `await agent.apersist_run_state(config)`.
+Keep the saver open on the same event loop for the run and any resumes. The
+synchronous state methods remain available for synchronous checkpointers.
 
 ## Custom tools
 

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -65,10 +65,10 @@ print(registry.names())
 worker = registry.build("single_agent", llm=model)
 ```
 
-The registered workers are `single_agent`, `multi_agent`, `python_relp`,
+The registered workers are `single_agent`, `deep_agent`, `multi_agent`, `python_relp`,
 `graspa`, `mock_agent`, `graspa_mcp`, `rag_agent`, `single_agent_xanes`,
-`molecular_docking`, and `single_agent_iri`. Existing `python_repl`,
-`graspa_agent`, and `iri` spellings are supported as aliases.
+`molecular_docking`, and `single_agent_iri`. Existing `deepagent`,
+`python_repl`, `graspa_agent`, and `iri` spellings are supported as aliases.
 
 Standalone workers keep their existing default in-memory checkpointer. When a
 worker is handed to an orchestration graph, use `as_subagent()` or
@@ -83,6 +83,10 @@ workers = registry.as_subagents(
 
 main_graph = construct_main_agent_graph(model, subagents=workers)
 ```
+
+The built-in `deep_agent` entry is the same workspace graph used by
+`main_agent`'s optional `deepagent` worker. Supply its backend through worker
+options when local filesystem or shell access is intended.
 
 `as_subagents()` validates names, availability, constructor loading, and
 constructor options for the whole requested set before invoking any constructor.

--- a/docs/registries.md
+++ b/docs/registries.md
@@ -86,7 +86,9 @@ main_graph = construct_main_agent_graph(model, subagents=workers)
 
 The built-in `deep_agent` entry is the same workspace graph used by
 `main_agent`'s optional `deepagent` worker. Supply its backend through worker
-options when local filesystem or shell access is intended.
+options when local filesystem or shell access is intended. Explicit Agent
+Skills sources can be supplied alongside it with
+`skills=["/workspace/.agents/skills/"]`; source order is preserved.
 
 `as_subagents()` validates names, availability, constructor loading, and
 constructor options for the whole requested set before invoking any constructor.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -7,6 +7,7 @@ Python. `single_agent` is the recommended first choice.
 | --- | --- | --- |
 | `single_agent` | One general chemistry agent with local tools | Default; CLI and Python |
 | `main_agent` | Durable supervisor with checkpointed subagents | Interactive CLI or `MainAgentSession` only |
+| `deep_agent` | Repository exploration, coding, and workspace tasks | CLI and Python; alias `deepagent`; broad local shell access |
 | `multi_agent` | Routes tasks among specialized agents | More model calls and orchestration overhead |
 | `python_relp` | Chemistry agent with Python REPL capability | Executes Python in the current process; alias `python_repl` |
 | `graspa` | gRASPA-oriented agent | Site-specific executable/configuration; alias `graspa_agent` |
@@ -40,6 +41,54 @@ chemgraph run --interactive --workflow main_agent
 In Python, construct `MainAgentSession`; `ChemGraph.run()` rejects this workflow.
 See [Python API](python_api.md).
 
+## Deep Agent
+
+`deep_agent` is one reusable workspace workflow with two entry points. It can
+run directly through `ChemGraph(workflow_type="deep_agent")`, or it can be
+registered under `main_agent` as the `deepagent` subagent. Both paths use
+`construct_deep_agent_graph`, so the prompt, backend, tools, recursion limit,
+and approval policy have one implementation.
+
+```bash
+# Direct, process-local interactive thread with action reviews.
+chemgraph run --interactive --workflow deep_agent --deepagent-workspace .
+
+# The same worker delegated by the durable supervisor.
+chemgraph run --interactive --workflow main_agent --deepagent \
+  --deepagent-workspace .
+```
+
+The standalone interactive workflow keeps one thread while that CLI process is
+open; it does not provide cross-process restoration in this first version.
+File mutations and shell commands require structured approve/reject decisions.
+Headless execution is rejected unless both an explicit workspace and
+`--deepagent-dangerously-skip-approvals` are supplied.
+
+With the CLI's virtual local backend, `/workspace` is the project root exposed
+to the Deep Agent. For example, `--deepagent-workspace test/` maps
+`/workspace/script.py` to `test/script.py` on the host. Deep Agents also tells
+the model the corresponding absolute host path to use with shell commands.
+Older files created under `test/workspace/` are not moved automatically.
+
+Run state and session records remain standard ChemGraph artifacts. By default,
+state snapshots are written under the process's `cg_logs/session_*` directory
+and session messages go to the configured ChemGraph session store; neither is
+placed inside the selected Deep Agent workspace. Approval-interrupted direct
+runs save both the pending checkpoint and the completed state after resumption.
+
+!!! danger "Host shell access"
+    The local backend can modify files under its workspace and its shell is not
+    confined to that directory. Use only trusted prompts and disposable,
+    isolated workspaces. The skip-approvals flag removes the action-review
+    boundary for that run.
+
+For comparisons with Claude Code or native Codex, keep the task set, starting
+checkout, time budget, and scoring fixed, and record which runtime performed
+each run. Selecting a `codex:` model here evaluates that model through
+ChemGraph's Deep Agent harness; it does not reproduce the native Codex product
+runtime. `deep_agent` is intentionally not included in the chemistry-focused
+`chemgraph eval` workflow matrix.
+
 ## Multi-agent
 
 `multi_agent` delegates among specialized graphs. It is useful when a request
@@ -67,7 +116,8 @@ scientific engine, credentials, site configuration, or server. Consult
 ## Interface compatibility
 
 The Streamlit interface exposes a subset of workflows. The CLI is the broadest
-discovery surface, but `main_agent` is interactive-only and some specialized
-workflows depend on local resources. Run `chemgraph --help` and
+discovery surface, but `main_agent` is interactive-only, `deep_agent` has an
+explicit local-access safety boundary, and some specialized workflows depend
+on local resources. Run `chemgraph --help` and
 `chemgraph models` against the installed release instead of assuming every
 workflow is available in every environment.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -55,7 +55,8 @@ chemgraph run --interactive --workflow deep_agent --deepagent-workspace .
 
 # The same worker delegated by the durable supervisor.
 chemgraph run --interactive --workflow main_agent --deepagent \
-  --deepagent-workspace .
+  --deepagent-workspace . \
+  --deepagent-skill /workspace/.agents/skills/
 ```
 
 The standalone interactive workflow keeps one thread while that CLI process is
@@ -63,6 +64,13 @@ open; it does not provide cross-process restoration in this first version.
 File mutations and shell commands require structured approve/reject decisions.
 Headless execution is rejected unless both an explicit workspace and
 `--deepagent-dangerously-skip-approvals` are supplied.
+
+Agent Skills are loaded only from explicitly supplied backend-relative source
+directories. Repeat `--deepagent-skill` to layer sources; the later source wins
+for duplicate skill names. The equivalent Python options are `skills=` on
+`construct_deep_agent_graph` and `deepagent_skills=` on `ChemGraph` or
+`construct_main_agent_graph`. Skill metadata uses progressive disclosure and
+is cached for the thread after its first load.
 
 With the CLI's virtual local backend, `/workspace` is the project root exposed
 to the Deep Agent. For example, `--deepagent-workspace test/` maps

--- a/src/chemgraph/agent/interrupts.py
+++ b/src/chemgraph/agent/interrupts.py
@@ -1,0 +1,65 @@
+"""Shared normalization helpers for resumable LangGraph interrupts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PendingInterrupt:
+    """One pending request for user input."""
+
+    id: str
+    payload: Any
+
+
+def normalize_interrupts(values: Any) -> list[PendingInterrupt]:
+    """Convert LangGraph interrupt values into stable application records."""
+    if values is None:
+        return []
+    if not isinstance(values, (list, tuple)):
+        values = [values]
+
+    return [
+        PendingInterrupt(
+            id=str(getattr(item, "id", "") or ""),
+            payload=getattr(item, "value", item),
+        )
+        for item in values
+    ]
+
+
+def deduplicate_interrupts(
+    interrupts: list[PendingInterrupt],
+) -> tuple[PendingInterrupt, ...]:
+    """Deduplicate streamed and checkpointed copies of pending interrupts."""
+    unique: list[PendingInterrupt] = []
+    seen: set[str] = set()
+    for item in interrupts:
+        key = item.id or repr(item.payload)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return tuple(unique)
+
+
+def interrupt_question(payload: Any) -> str:
+    """Extract readable question text from an interrupt payload."""
+    if isinstance(payload, dict):
+        return str(
+            payload.get(
+                "question",
+                payload.get("message", payload.get("instruction", payload)),
+            )
+        )
+    return str(payload)
+
+
+__all__ = [
+    "PendingInterrupt",
+    "deduplicate_interrupts",
+    "interrupt_question",
+    "normalize_interrupts",
+]

--- a/src/chemgraph/agent/interrupts.py
+++ b/src/chemgraph/agent/interrupts.py
@@ -23,7 +23,11 @@ def normalize_interrupts(values: Any) -> list[PendingInterrupt]:
 
     return [
         PendingInterrupt(
-            id=str(getattr(item, "id", "") or ""),
+            id=(
+                str(getattr(item, "id", "") or "")
+                if getattr(item, "id", "") != "placeholder-id"
+                else ""
+            ),
             payload=getattr(item, "value", item),
         )
         for item in values
@@ -37,12 +41,39 @@ def deduplicate_interrupts(
     unique: list[PendingInterrupt] = []
     seen: set[str] = set()
     for item in interrupts:
-        key = item.id or repr(item.payload)
-        if key in seen:
+        if item.id and item.id in seen:
             continue
-        seen.add(key)
+        if item.id:
+            seen.add(item.id)
         unique.append(item)
     return tuple(unique)
+
+
+def collect_pending_interrupts(
+    streamed: list[PendingInterrupt], snapshot: Any = None, *, fallback: bool = False,
+) -> tuple[PendingInterrupt, ...]:
+    """Prefer checkpoint requests over streamed copies of the same pause.
+
+    Anonymous requests cannot be matched by payload: distinct actions may have
+    identical payloads. Use one authoritative collection instead.
+    """
+    checkpointed = normalize_interrupts(getattr(snapshot, "interrupts", ()))
+    if not checkpointed:
+        for task in getattr(snapshot, "tasks", ()):
+            checkpointed.extend(normalize_interrupts(getattr(task, "interrupts", ())))
+    pending = deduplicate_interrupts(checkpointed or streamed)
+    if fallback and not pending:
+        return (PendingInterrupt(id="", payload={"question": "The workflow needs your input."}),)
+    return pending
+
+
+def is_tool_review(payload: Any) -> bool:
+    """Return whether an interrupt contains structured action reviews."""
+    return (
+        isinstance(payload, dict)
+        and isinstance(payload.get("action_requests"), list)
+        and isinstance(payload.get("review_configs"), list)
+    )
 
 
 def interrupt_question(payload: Any) -> str:
@@ -59,7 +90,9 @@ def interrupt_question(payload: Any) -> str:
 
 __all__ = [
     "PendingInterrupt",
+    "collect_pending_interrupts",
     "deduplicate_interrupts",
     "interrupt_question",
+    "is_tool_review",
     "normalize_interrupts",
 ]

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -12,7 +12,8 @@ import uuid
 from chemgraph.agent.events import EventCallback, _AstreamEventCallback
 from chemgraph.agent.interrupts import (
     PendingInterrupt,
-    deduplicate_interrupts,
+    collect_pending_interrupts,
+    is_tool_review,
     interrupt_question,
     normalize_interrupts,
 )
@@ -256,7 +257,6 @@ class ChemGraph:
         reasoning_effort: Optional[str] = None,
         checkpointer: BaseCheckpointSaver | None = None,
     ):
-        normalized_deepagent_skills = normalize_skill_sources(deepagent_skills)
         if enable_deepagent and workflow_type != "main_agent":
             raise ValueError(
                 "enable_deepagent is supported only for the main_agent workflow."
@@ -268,7 +268,7 @@ class ChemGraph:
                 "deepagent_backend requires enable_deepagent=True or "
                 "workflow_type='deep_agent'."
             )
-        if normalized_deepagent_skills and not (
+        if deepagent_skills and not (
             enable_deepagent or workflow_type == "deep_agent"
         ):
             raise ValueError(
@@ -297,6 +297,7 @@ class ChemGraph:
                 "Experimental codex: models currently support only the "
                 "single_agent, main_agent, and deep_agent workflows."
             )
+        normalized_deepagent_skills = normalize_skill_sources(deepagent_skills)
         reasoning_effort = _resolve_reasoning_effort(model_name, reasoning_effort)
 
         # Always generate a unique identifier for this instance
@@ -711,6 +712,17 @@ class ChemGraph:
         dict or str
             Dictionary of metadata if successful, or "Error" if failed.
         """
+        if config is None:
+            config = {"configurable": {"thread_id": "1"}}
+        try:
+            state = self.get_state(config=config)
+        except Exception as exc:
+            print("Error with write_state: ", str(exc))
+            return "Error"
+        return self._write_state_snapshot(state, config, file_path, file_name)
+
+    def _write_state_snapshot(self, state, config, file_path=None, file_name=None):
+        """Serialize an already retrieved checkpoint for either runner."""
         import json
         import subprocess
 
@@ -730,7 +742,6 @@ class ChemGraph:
                     file_name = f"state_thread_{thread_id}_{self.uuid}_{timestamp}.json"
                 file_path = os.path.join(log_dir, file_name)
 
-            state = self.get_state(config=config)
             serialized_state = serialize_state(state)
 
             try:
@@ -940,6 +951,35 @@ class ChemGraph:
             "Use 'last_message' or 'state'."
         )
 
+    async def apersist_run_state(self, config: dict) -> dict | None:
+        """Retrieve and log a checkpoint without calling a sync saver API."""
+        try:
+            state = await self.aget_state(config)
+        except Exception:
+            logger.warning("Could not log workflow checkpoint.", exc_info=True)
+            return None
+        self._write_state_snapshot(state, config)
+        return state
+
+    async def afinalize_completed_run(
+        self, last_state: dict, config: dict, query: str,
+    ) -> Any:
+        """Persist a completed async run and return the configured result."""
+        self._save_messages_to_store(
+            last_state, query, thread_id=str(config["configurable"]["thread_id"])
+        )
+        state = await self.apersist_run_state(config)
+        if self.return_option == "last_message":
+            return last_state["messages"][-1]
+        if self.return_option == "state":
+            if state is None:
+                state = await self.aget_state(config)
+            return serialize_state(state)
+        raise ValueError(
+            f"Unsupported return_option: {self.return_option}. "
+            "Use 'last_message' or 'state'."
+        )
+
     def load_previous_context(
         self,
         session_id: str,
@@ -1081,6 +1121,7 @@ class ChemGraph:
             prev_msgs: list = []
             last_st = None
             found_interrupts: list[PendingInterrupt] = []
+            bare_interrupt = False
             try:
                 async for s in self.workflow.astream(
                     stream_input, stream_mode="values", config=cfg
@@ -1106,35 +1147,17 @@ class ChemGraph:
                 if interrupts:
                     found_interrupts.extend(normalize_interrupts(interrupts))
                 else:
-                    found_interrupts.append(
-                        PendingInterrupt(
-                            id="",
-                            payload={
-                                "question": "The workflow needs your input."
-                            },
-                        )
-                    )
+                    bare_interrupt = True
 
-            # Double-check the checkpoint for pending interrupts that
-            # the stream may not have surfaced explicitly.
             try:
-                snapshot = self.workflow.get_state(cfg)
-                if snapshot:
-                    found_interrupts.extend(
-                        normalize_interrupts(
-                            getattr(snapshot, "interrupts", ())
-                        )
-                    )
-                    for task in getattr(snapshot, "tasks", ()):
-                        found_interrupts.extend(
-                            normalize_interrupts(
-                                getattr(task, "interrupts", ())
-                            )
-                        )
+                snapshot = await self.workflow.aget_state(cfg)
             except Exception:
                 snapshot = None
+                logger.debug("Could not inspect workflow checkpoint.", exc_info=True)
 
-            pending_interrupts = deduplicate_interrupts(found_interrupts)
+            pending_interrupts = collect_pending_interrupts(
+                found_interrupts, snapshot, fallback=bare_interrupt,
+            )
             if pending_interrupts:
                 logger.info("Graph interrupted: %s", pending_interrupts)
                 # Refresh state from checkpoint for consistency.
@@ -1199,7 +1222,9 @@ class ChemGraph:
             max_interrupts = 10  # safety guard against infinite interrupt loops
             interrupt_count = 0
             while pending_interrupts:
-                interrupt_count += len(pending_interrupts)
+                interrupt_count += sum(
+                    not is_tool_review(pending.payload) for pending in pending_interrupts
+                )
                 if interrupt_count > max_interrupts:
                     logger.error(
                         "Exceeded maximum number of human interrupts (%d); "
@@ -1269,12 +1294,12 @@ class ChemGraph:
                 },
             )
 
-            return self.finalize_completed_run(last_state, config, query)
+            return await self.afinalize_completed_run(last_state, config, query)
 
         except HumanInputRequired:
             # No human_input_handler configured — propagate so the
             # caller (CLI / UI) can prompt the user and resume.
-            self.persist_run_state(config)
+            await self.apersist_run_state(config)
             raise
         except Exception as e:
             event(

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -48,6 +48,10 @@ from langgraph.checkpoint.base import BaseCheckpointSaver
 
 from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.graphs.main_agent import construct_main_agent_graph
+from chemgraph.graphs.deep_agent import (
+    DEFAULT_DEEPAGENT_PROMPT,
+    construct_deep_agent_graph,
+)
 from chemgraph.agent.turn import serialize_state
 
 
@@ -83,6 +87,7 @@ class PromptConfig:
     override the fields relevant to the active ``workflow_type``:
 
     - ``system``/``formatter``/``report``: single_agent, main_agent, mock_agent.
+    - ``deepagent``: deep_agent and the optional main_agent workspace worker.
     - ``planner``/``executor``/``aggregator``/``formatter_multi``: multi_agent.
     """
 
@@ -93,6 +98,7 @@ class PromptConfig:
     executor: str = default_executor_prompt
     aggregator: str = default_aggregator_prompt
     formatter_multi: str = default_formatter_multi_prompt
+    deepagent: str = DEFAULT_DEEPAGENT_PROMPT
 
 
 def _resolve_reasoning_effort(
@@ -129,12 +135,13 @@ class ChemGraph:
     model_name : str, optional
         Name of the language model to use, by default "gpt-4o-mini".
         Experimental ChatGPT subscription-backed Codex models use the
-        ``codex:<model-id>`` prefix and support ``single_agent`` and
-        ``main_agent``.
+        ``codex:<model-id>`` prefix and support ``single_agent``,
+        ``main_agent``, and ``deep_agent``.
     workflow_type : str, optional
         Type of workflow to use. Options:
         - "single_agent"
         - "main_agent" (drive with ``MainAgentSession``, not ``run``)
+        - "deep_agent"
         - "multi_agent"
         - "python_relp"
         - "graspa_agent"
@@ -166,11 +173,13 @@ class ChemGraph:
         Maximum number of LLM retry attempts when an agent
         fails to parse its output, by default 1
     human_input_handler : callable, optional
-        A callback ``f(question: str) -> str`` invoked when the graph
+        A callback ``f(question: str) -> Any`` invoked when the graph
         pauses for human input (via ``interrupt()``).  Receives the
-        question text and must return the human's answer as a string.
-        If ``None`` (default), interrupts will propagate as
-        ``GraphInterrupt`` exceptions.  The handler may also be an
+        question text and returns the resume value. Deep Agent action reviews
+        require a structured decision mapping rather than a string.
+        If ``None`` (default), interrupts propagate as
+        ``HumanInputRequired`` exceptions whose ``payload`` retains the raw
+        interrupt value. The handler may also be an
         ``async`` callable.
     human_supervised : bool, optional
         Whether to include the ``ask_human`` tool so the agent can
@@ -186,6 +195,11 @@ class ChemGraph:
     deepagent_backend : BackendProtocol, optional
         Backend used by the workspace Deep Agent. When omitted, its files are
         stored in checkpointed agent state.
+    deepagent_auto_approve : bool, optional
+        Disable Deep Agent tool-review interrupts for a standalone
+        ``deep_agent`` workflow. This permits unreviewed file mutations and
+        command execution and should be used only in an isolated, explicitly
+        trusted workspace, by default False.
     on_event : callable, optional
         Callback invoked with dashboard workflow events, by default None.
 
@@ -217,11 +231,12 @@ class ChemGraph:
         memory_db_path: Optional[str] = None,
         log_dir: Optional[str] = None,
         max_retries: int = 1,
-        human_input_handler: Optional[Callable[[str], str]] = None,
+        human_input_handler: Optional[Callable[[str], Any]] = None,
         human_supervised: bool = False,
         terminal_tool_names: Collection[str] = (),
         enable_deepagent: bool = False,
         deepagent_backend: Any | None = None,
+        deepagent_auto_approve: bool = False,
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
         checkpointer: BaseCheckpointSaver | None = None,
@@ -230,17 +245,34 @@ class ChemGraph:
             raise ValueError(
                 "enable_deepagent is supported only for the main_agent workflow."
             )
-        if deepagent_backend is not None and not enable_deepagent:
-            raise ValueError("deepagent_backend requires enable_deepagent=True.")
-        if checkpointer is not None and workflow_type != "main_agent":
-            raise ValueError("checkpointer is supported only for the main_agent workflow.")
+        if deepagent_backend is not None and not (
+            enable_deepagent or workflow_type == "deep_agent"
+        ):
+            raise ValueError(
+                "deepagent_backend requires enable_deepagent=True or "
+                "workflow_type='deep_agent'."
+            )
+        if deepagent_auto_approve and workflow_type != "deep_agent":
+            raise ValueError(
+                "deepagent_auto_approve is supported only for the deep_agent "
+                "workflow."
+            )
+        if checkpointer is not None and workflow_type not in {
+            "main_agent",
+            "deep_agent",
+        }:
+            raise ValueError(
+                "checkpointer is supported only for the main_agent and "
+                "deep_agent workflows."
+            )
         if model_name.startswith("codex:") and workflow_type not in {
             "single_agent",
             "main_agent",
+            "deep_agent",
         }:
             raise ValueError(
                 "Experimental codex: models currently support only the "
-                "single_agent and main_agent workflows."
+                "single_agent, main_agent, and deep_agent workflows."
             )
         reasoning_effort = _resolve_reasoning_effort(model_name, reasoning_effort)
 
@@ -310,6 +342,7 @@ class ChemGraph:
         self.executor_prompt = prompts.executor
         self.aggregator_prompt = prompts.aggregator
         self.formatter_multi_prompt = prompts.formatter_multi
+        self.deepagent_prompt = prompts.deepagent
         self.tools = tools
         self.data_tools = data_tools
         self.max_retries = max_retries
@@ -318,6 +351,7 @@ class ChemGraph:
         self.terminal_tool_names = tuple(terminal_tool_names)
         self.enable_deepagent = enable_deepagent
         self.deepagent_backend = deepagent_backend
+        self.deepagent_auto_approve = deepagent_auto_approve
         self.checkpointer = checkpointer
         self.on_event = on_event
 
@@ -398,6 +432,11 @@ class ChemGraph:
             "formatter_prompt": self.formatter_prompt,
             "report_prompt": self.report_prompt,
         }
+        if (
+            self.enable_deepagent
+            and self.deepagent_prompt != DEFAULT_DEEPAGENT_PROMPT
+        ):
+            topology_payload["deepagent_prompt"] = self.deepagent_prompt
         topology_fingerprint = hashlib.sha256(
             json.dumps(topology_payload, sort_keys=True, default=str).encode("utf-8")
         ).hexdigest()
@@ -432,6 +471,7 @@ class ChemGraph:
         self.workflow_map = {
             "single_agent": {"constructor": construct_single_agent_graph},
             "main_agent": {"constructor": construct_main_agent_graph},
+            "deep_agent": {"constructor": construct_deep_agent_graph},
             "multi_agent": {"constructor": construct_multi_agent_graph},
             "python_relp": {"constructor": construct_relp_graph},
             "graspa": {"constructor": construct_graspa_graph},
@@ -477,12 +517,28 @@ class ChemGraph:
                 enable_deepagent=self.enable_deepagent,
                 deepagent_backend=self.deepagent_backend,
                 deepagent_recursion_limit=self.recursion_limit,
+                deepagent_system_prompt=self.deepagent_prompt,
                 checkpointer=self.checkpointer,
                 subagent_recorder=(
                     SubagentRunRecorder(self.session_store)
                     if self.session_store is not None
                     else None
                 ),
+            )
+        elif self.workflow_type == "deep_agent":
+            deepagent_options: dict[str, Any] = {}
+            if self.checkpointer is not None:
+                deepagent_options["checkpointer"] = self.checkpointer
+            if self.deepagent_auto_approve:
+                deepagent_options["interrupt_on"] = None
+            self.workflow = self.workflow_map[workflow_type]["constructor"](
+                llm,
+                tools=self.tools,
+                system_prompt=self.deepagent_prompt,
+                backend=self.deepagent_backend,
+                recursion_limit=self.recursion_limit,
+                name="deepagent",
+                **deepagent_options,
             )
         elif self.workflow_type == "multi_agent":
             self.workflow = self.workflow_map[workflow_type]["constructor"](
@@ -632,7 +688,9 @@ class ChemGraph:
         try:
             if config is None:
                 config = {"configurable": {"thread_id": "1"}}
-            timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            timestamp = datetime.datetime.now().strftime(
+                "%Y-%m-%d_%H-%M-%S_%f"
+            )
             thread_id = config["configurable"]["thread_id"]
             if not file_path:
                 log_dir = getattr(self, "log_dir", None) or os.environ.get(
@@ -680,6 +738,9 @@ class ChemGraph:
                         "formatter_prompt": self.formatter_prompt,
                     }
                 )
+
+            elif self.workflow_type == "deep_agent":
+                output_data.update({"system_prompt": self.deepagent_prompt})
 
             elif self.workflow_type == "graspa_mcp":
                 output_data.update(
@@ -823,6 +884,33 @@ class ChemGraph:
         except Exception as e:
             logger.warning(f"Failed to save messages to session store: {e}")
 
+    def _persist_run_state(self, config: dict) -> None:
+        """Write the current checkpoint state to the configured log directory."""
+        log_dir = self.log_dir or "cg_logs"
+        os.makedirs(log_dir, exist_ok=True)
+        self.write_state(config=config)
+
+    def _finalize_completed_run(
+        self,
+        last_state: dict,
+        config: dict,
+        query: str,
+    ) -> Any:
+        """Persist a completed run and return the configured result shape."""
+        self._save_messages_to_store(
+            last_state, query, thread_id=str(config["configurable"]["thread_id"])
+        )
+        self._persist_run_state(config)
+
+        if self.return_option == "last_message":
+            return last_state["messages"][-1]
+        if self.return_option == "state":
+            return serialize_state(self.get_state(config=config))
+        raise ValueError(
+            f"Unsupported return_option: {self.return_option}. "
+            "Use 'last_message' or 'state'."
+        )
+
     def load_previous_context(
         self,
         session_id: str,
@@ -850,7 +938,12 @@ class ChemGraph:
             return ""
         return self.session_store.build_context_summary(session_id)
 
-    async def _call_human_input_handler(self, question: str) -> str:
+    async def _call_human_input_handler(
+        self,
+        question: str,
+        *,
+        payload: Any = None,
+    ) -> Any:
         """Invoke the human_input_handler, supporting both sync and async callables.
 
         Raises :class:`HumanInputRequired` when no handler is configured,
@@ -859,7 +952,7 @@ class ChemGraph:
         """
         handler = self.human_input_handler
         if handler is None:
-            raise HumanInputRequired(question)
+            raise HumanInputRequired(question, payload=payload)
         if asyncio.iscoroutinefunction(handler):
             return await handler(question)
         return handler(question)
@@ -915,24 +1008,6 @@ class ChemGraph:
             cfg.setdefault("configurable", {}).setdefault("thread_id", "1")
             cfg["recursion_limit"] = self.recursion_limit
             return cfg
-
-        def _save_state_and_select_return(last_state, cfg):
-            log_dir = self.log_dir
-            if not log_dir:
-                log_dir = "cg_logs"
-
-            os.makedirs(log_dir, exist_ok=True)
-            log_path = None
-            self.write_state(config=cfg, file_path=log_path)
-
-            if self.return_option == "last_message":
-                return last_state["messages"][-1]
-            elif self.return_option == "state":
-                return serialize_state(self.get_state(config=cfg))
-            else:
-                raise ValueError(
-                    f"Unsupported return_option: {self.return_option}. Use 'last_message' or 'state'."
-                )
 
         async def _stream_until_interrupt(stream_input, cfg):
             """Stream the workflow until completion or an interrupt.
@@ -1089,7 +1164,10 @@ class ChemGraph:
                     question = str(interrupt_value)
 
                 logger.info("Requesting human input: %s", question)
-                human_answer = await self._call_human_input_handler(question)
+                human_answer = await self._call_human_input_handler(
+                    question,
+                    payload=interrupt_value,
+                )
                 logger.info("Human responded: %s", human_answer)
 
                 # Resume the graph from the checkpoint with the human's answer.
@@ -1100,9 +1178,6 @@ class ChemGraph:
 
             if last_state is None:
                 raise RuntimeError("Workflow produced no states.")
-
-            # Save messages to persistent session store
-            self._save_messages_to_store(last_state, query, thread_id=thread_id)
 
             messages = _state_messages(last_state)
             executed_tools = _executed_tool_names(messages)
@@ -1122,11 +1197,12 @@ class ChemGraph:
                 },
             )
 
-            return _save_state_and_select_return(last_state, config)
+            return self._finalize_completed_run(last_state, config, query)
 
         except HumanInputRequired:
             # No human_input_handler configured — propagate so the
             # caller (CLI / UI) can prompt the user and resume.
+            self._persist_run_state(config)
             raise
         except Exception as e:
             event(
@@ -1142,6 +1218,7 @@ class ChemGraph:
             logger.error(f"Error running workflow {self.workflow_type}: {e}")
             raise
 
+
 class HumanInputRequired(Exception):
     """Raised when the graph needs human input but no handler is configured.
 
@@ -1150,6 +1227,7 @@ class HumanInputRequired(Exception):
     ``Command(resume=answer)``.
     """
 
-    def __init__(self, question: str):
+    def __init__(self, question: str, *, payload: Any = None):
         self.question = question
+        self.payload = question if payload is None else payload
         super().__init__(question)

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -6,10 +6,16 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 import time
-from typing import Any, Callable, Collection, List, Optional
+from typing import Any, Callable, Collection, List, Optional, Sequence
 import uuid
 
 from chemgraph.agent.events import EventCallback, _AstreamEventCallback
+from chemgraph.agent.interrupts import (
+    PendingInterrupt,
+    deduplicate_interrupts,
+    interrupt_question,
+    normalize_interrupts,
+)
 from chemgraph.memory.store import SessionStore
 from chemgraph import __version__
 from chemgraph.memory.schemas import (
@@ -50,6 +56,7 @@ from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.graphs.main_agent import construct_main_agent_graph
 from chemgraph.graphs.deep_agent import (
     DEFAULT_DEEPAGENT_PROMPT,
+    _normalize_skill_sources,
     construct_deep_agent_graph,
 )
 from chemgraph.agent.turn import serialize_state
@@ -195,6 +202,9 @@ class ChemGraph:
     deepagent_backend : BackendProtocol, optional
         Backend used by the workspace Deep Agent. When omitted, its files are
         stored in checkpointed agent state.
+    deepagent_skills : sequence of str, optional
+        Ordered backend-relative directories containing Agent Skills. Later
+        sources override earlier sources with the same skill name.
     deepagent_auto_approve : bool, optional
         Disable Deep Agent tool-review interrupts for a standalone
         ``deep_agent`` workflow. This permits unreviewed file mutations and
@@ -236,11 +246,13 @@ class ChemGraph:
         terminal_tool_names: Collection[str] = (),
         enable_deepagent: bool = False,
         deepagent_backend: Any | None = None,
+        deepagent_skills: Sequence[str] | None = None,
         deepagent_auto_approve: bool = False,
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
         checkpointer: BaseCheckpointSaver | None = None,
     ):
+        normalized_deepagent_skills = _normalize_skill_sources(deepagent_skills)
         if enable_deepagent and workflow_type != "main_agent":
             raise ValueError(
                 "enable_deepagent is supported only for the main_agent workflow."
@@ -250,6 +262,13 @@ class ChemGraph:
         ):
             raise ValueError(
                 "deepagent_backend requires enable_deepagent=True or "
+                "workflow_type='deep_agent'."
+            )
+        if normalized_deepagent_skills and not (
+            enable_deepagent or workflow_type == "deep_agent"
+        ):
+            raise ValueError(
+                "deepagent_skills requires enable_deepagent=True or "
                 "workflow_type='deep_agent'."
             )
         if deepagent_auto_approve and workflow_type != "deep_agent":
@@ -351,6 +370,7 @@ class ChemGraph:
         self.terminal_tool_names = tuple(terminal_tool_names)
         self.enable_deepagent = enable_deepagent
         self.deepagent_backend = deepagent_backend
+        self.deepagent_skills = normalized_deepagent_skills
         self.deepagent_auto_approve = deepagent_auto_approve
         self.checkpointer = checkpointer
         self.on_event = on_event
@@ -427,6 +447,9 @@ class ChemGraph:
             "terminal_tool_names": self.terminal_tool_names,
             "enable_deepagent": self.enable_deepagent,
             "workspace": str(workspace) if workspace is not None else None,
+            "deepagent_skills": (
+                self.deepagent_skills if self.enable_deepagent else ()
+            ),
             "tool_signatures": tool_signatures,
             "system_prompt": self.system_prompt,
             "formatter_prompt": self.formatter_prompt,
@@ -454,6 +477,7 @@ class ChemGraph:
                 deepagent_workspace=(
                     str(Path(workspace).resolve()) if workspace is not None else None
                 ),
+                deepagent_skills=self.deepagent_skills,
                 subagent_names=(
                     ("chemgraph", "deepagent")
                     if self.enable_deepagent
@@ -516,6 +540,7 @@ class ChemGraph:
                 subagent_terminal_tool_names=self.terminal_tool_names,
                 enable_deepagent=self.enable_deepagent,
                 deepagent_backend=self.deepagent_backend,
+                deepagent_skills=self.deepagent_skills,
                 deepagent_recursion_limit=self.recursion_limit,
                 deepagent_system_prompt=self.deepagent_prompt,
                 checkpointer=self.checkpointer,
@@ -534,6 +559,7 @@ class ChemGraph:
             self.workflow = self.workflow_map[workflow_type]["constructor"](
                 llm,
                 tools=self.tools,
+                skills=self.deepagent_skills,
                 system_prompt=self.deepagent_prompt,
                 backend=self.deepagent_backend,
                 recursion_limit=self.recursion_limit,
@@ -943,6 +969,7 @@ class ChemGraph:
         question: str,
         *,
         payload: Any = None,
+        interrupts: Sequence[PendingInterrupt] = (),
     ) -> Any:
         """Invoke the human_input_handler, supporting both sync and async callables.
 
@@ -952,7 +979,11 @@ class ChemGraph:
         """
         handler = self.human_input_handler
         if handler is None:
-            raise HumanInputRequired(question, payload=payload)
+            raise HumanInputRequired(
+                question,
+                payload=payload,
+                interrupts=interrupts,
+            )
         if asyncio.iscoroutinefunction(handler):
             return await handler(question)
         return handler(question)
@@ -1012,9 +1043,8 @@ class ChemGraph:
         async def _stream_until_interrupt(stream_input, cfg):
             """Stream the workflow until completion or an interrupt.
 
-            Returns ``(last_state, interrupt_value)`` where
-            ``interrupt_value`` is ``None`` when the graph completed
-            normally.
+            Returns ``(last_state, pending_interrupts)``. The interrupt tuple
+            is empty when the graph completed normally.
 
             LangGraph's ``astream(stream_mode="values")`` does **not**
             raise ``GraphInterrupt``.  Instead the stream emits a state
@@ -1027,22 +1057,16 @@ class ChemGraph:
             """
             prev_msgs: list = []
             last_st = None
-            interrupt_val = None
+            found_interrupts: list[PendingInterrupt] = []
             try:
                 async for s in self.workflow.astream(
                     stream_input, stream_mode="values", config=cfg
                 ):
                     # Detect inline interrupt marker emitted by astream.
                     if "__interrupt__" in s:
-                        int_data = s["__interrupt__"]
-                        if isinstance(int_data, (list, tuple)) and int_data:
-                            interrupt_val = int_data[0].value
-                        elif hasattr(int_data, "value"):
-                            interrupt_val = int_data.value
-                        else:
-                            interrupt_val = {
-                                "question": "The workflow needs your input."
-                            }
+                        found_interrupts.extend(
+                            normalize_interrupts(s["__interrupt__"])
+                        )
 
                     if "messages" in s and s["messages"] != prev_msgs:
                         new_message = s["messages"][-1]
@@ -1057,37 +1081,44 @@ class ChemGraph:
                 # Fallback: some LangGraph versions may still raise.
                 interrupts = gi.args[0] if gi.args else []
                 if interrupts:
-                    interrupt_val = interrupts[0].value
+                    found_interrupts.extend(normalize_interrupts(interrupts))
                 else:
-                    interrupt_val = {
-                        "question": "The workflow needs your input."
-                    }
+                    found_interrupts.append(
+                        PendingInterrupt(
+                            id="",
+                            payload={
+                                "question": "The workflow needs your input."
+                            },
+                        )
+                    )
 
             # Double-check the checkpoint for pending interrupts that
             # the stream may not have surfaced explicitly.
-            if interrupt_val is None:
-                try:
-                    snapshot = self.workflow.get_state(cfg)
-                    if snapshot and snapshot.tasks:
-                        for t in snapshot.tasks:
-                            t_interrupts = getattr(t, "interrupts", None)
-                            if t_interrupts:
-                                interrupt_val = t_interrupts[0].value
-                                break
-                except Exception:
-                    pass
+            try:
+                snapshot = self.workflow.get_state(cfg)
+                if snapshot:
+                    found_interrupts.extend(
+                        normalize_interrupts(
+                            getattr(snapshot, "interrupts", ())
+                        )
+                    )
+                    for task in getattr(snapshot, "tasks", ()):
+                        found_interrupts.extend(
+                            normalize_interrupts(
+                                getattr(task, "interrupts", ())
+                            )
+                        )
+            except Exception:
+                snapshot = None
 
-            if interrupt_val is not None:
-                logger.info("Graph interrupted: %s", interrupt_val)
+            pending_interrupts = deduplicate_interrupts(found_interrupts)
+            if pending_interrupts:
+                logger.info("Graph interrupted: %s", pending_interrupts)
                 # Refresh state from checkpoint for consistency.
-                try:
-                    snapshot = self.workflow.get_state(cfg)
-                    if snapshot:
-                        last_st = snapshot.values
-                except Exception:
-                    pass
+                if snapshot:
+                    last_st = snapshot.values
 
-            return last_st, interrupt_val
+            return last_st, pending_interrupts
 
         logger.debug("run called with config=%s", config)
         config = _validate_config(config)
@@ -1132,7 +1163,10 @@ class ChemGraph:
         )
 
         try:
-            last_state, interrupt_value = await _stream_until_interrupt(inputs, config)
+            last_state, pending_interrupts = await _stream_until_interrupt(
+                inputs,
+                config,
+            )
 
             # --- Human-in-the-loop resume loop ---
             # When the graph pauses with an interrupt, ask the human and
@@ -1141,8 +1175,8 @@ class ChemGraph:
             # the first answer).
             max_interrupts = 10  # safety guard against infinite interrupt loops
             interrupt_count = 0
-            while interrupt_value is not None:
-                interrupt_count += 1
+            while pending_interrupts:
+                interrupt_count += len(pending_interrupts)
                 if interrupt_count > max_interrupts:
                     logger.error(
                         "Exceeded maximum number of human interrupts (%d); "
@@ -1154,25 +1188,40 @@ class ChemGraph:
                         f"human interrupts."
                     )
 
-                # Extract the question text from the interrupt value.
-                if isinstance(interrupt_value, dict):
-                    question = interrupt_value.get(
-                        "question",
-                        interrupt_value.get("message", str(interrupt_value)),
+                if len(pending_interrupts) > 1 and any(
+                    not pending.id for pending in pending_interrupts
+                ):
+                    raise RuntimeError(
+                        "Multiple pending interrupts require stable IDs."
                     )
-                else:
-                    question = str(interrupt_value)
 
-                logger.info("Requesting human input: %s", question)
-                human_answer = await self._call_human_input_handler(
-                    question,
-                    payload=interrupt_value,
-                )
-                logger.info("Human responded: %s", human_answer)
+                answers: list[Any] = []
+                for pending in pending_interrupts:
+                    question = interrupt_question(pending.payload)
+                    logger.info("Requesting human input: %s", question)
+                    answer = await self._call_human_input_handler(
+                        question,
+                        payload=pending.payload,
+                        interrupts=pending_interrupts,
+                    )
+                    logger.info("Human responded: %s", answer)
+                    answers.append(answer)
+
+                if len(pending_interrupts) == 1:
+                    resume_value = answers[0]
+                else:
+                    resume_value = {
+                        pending.id: answer
+                        for pending, answer in zip(
+                            pending_interrupts,
+                            answers,
+                            strict=True,
+                        )
+                    }
 
                 # Resume the graph from the checkpoint with the human's answer.
-                resume_cmd = Command(resume=human_answer)
-                last_state, interrupt_value = await _stream_until_interrupt(
+                resume_cmd = Command(resume=resume_value)
+                last_state, pending_interrupts = await _stream_until_interrupt(
                     resume_cmd, config
                 )
 
@@ -1222,12 +1271,21 @@ class ChemGraph:
 class HumanInputRequired(Exception):
     """Raised when the graph needs human input but no handler is configured.
 
-    Carries the question text so that external callers (CLI, UI) can
-    present it to the user and resume the graph with
-    ``Command(resume=answer)``.
+    ``question`` and ``payload`` describe the first request for compatibility.
+    ``interrupts`` retains every pending request so concurrent pauses can be
+    resumed with an interrupt-ID mapping.
     """
 
-    def __init__(self, question: str, *, payload: Any = None):
+    def __init__(
+        self,
+        question: str,
+        *,
+        payload: Any = None,
+        interrupts: Sequence[PendingInterrupt] = (),
+    ):
         self.question = question
         self.payload = question if payload is None else payload
+        self.interrupts = tuple(interrupts) or (
+            PendingInterrupt(id="", payload=self.payload),
+        )
         super().__init__(question)

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -1,6 +1,6 @@
-import asyncio
 import datetime
 import hashlib
+import inspect
 import json
 import os
 from dataclasses import dataclass
@@ -56,8 +56,8 @@ from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.graphs.main_agent import construct_main_agent_graph
 from chemgraph.graphs.deep_agent import (
     DEFAULT_DEEPAGENT_PROMPT,
-    _normalize_skill_sources,
     construct_deep_agent_graph,
+    normalize_skill_sources,
 )
 from chemgraph.agent.turn import serialize_state
 
@@ -83,6 +83,8 @@ from chemgraph.prompt.xanes_prompt import (
 import logging
 
 logger = logging.getLogger(__name__)
+
+HumanInputHandler = Callable[[str], Any] | Callable[[str, Any], Any]
 
 
 @dataclass
@@ -180,10 +182,12 @@ class ChemGraph:
         Maximum number of LLM retry attempts when an agent
         fails to parse its output, by default 1
     human_input_handler : callable, optional
-        A callback ``f(question: str) -> Any`` invoked when the graph
-        pauses for human input (via ``interrupt()``).  Receives the
-        question text and returns the resume value. Deep Agent action reviews
-        require a structured decision mapping rather than a string.
+        A callback ``f(question: str) -> Any`` or
+        ``f(question: str, payload: Any) -> Any`` invoked when the graph
+        pauses for human input (via ``interrupt()``). The optional second
+        argument receives the raw interrupt payload. Deep Agent action reviews
+        require the callback to return a structured decision mapping rather
+        than a string.
         If ``None`` (default), interrupts propagate as
         ``HumanInputRequired`` exceptions whose ``payload`` retains the raw
         interrupt value. The handler may also be an
@@ -241,7 +245,7 @@ class ChemGraph:
         memory_db_path: Optional[str] = None,
         log_dir: Optional[str] = None,
         max_retries: int = 1,
-        human_input_handler: Optional[Callable[[str], Any]] = None,
+        human_input_handler: Optional[HumanInputHandler] = None,
         human_supervised: bool = False,
         terminal_tool_names: Collection[str] = (),
         enable_deepagent: bool = False,
@@ -252,7 +256,7 @@ class ChemGraph:
         reasoning_effort: Optional[str] = None,
         checkpointer: BaseCheckpointSaver | None = None,
     ):
-        normalized_deepagent_skills = _normalize_skill_sources(deepagent_skills)
+        normalized_deepagent_skills = normalize_skill_sources(deepagent_skills)
         if enable_deepagent and workflow_type != "main_agent":
             raise ValueError(
                 "enable_deepagent is supported only for the main_agent workflow."
@@ -447,9 +451,6 @@ class ChemGraph:
             "terminal_tool_names": self.terminal_tool_names,
             "enable_deepagent": self.enable_deepagent,
             "workspace": str(workspace) if workspace is not None else None,
-            "deepagent_skills": (
-                self.deepagent_skills if self.enable_deepagent else ()
-            ),
             "tool_signatures": tool_signatures,
             "system_prompt": self.system_prompt,
             "formatter_prompt": self.formatter_prompt,
@@ -460,6 +461,8 @@ class ChemGraph:
             and self.deepagent_prompt != DEFAULT_DEEPAGENT_PROMPT
         ):
             topology_payload["deepagent_prompt"] = self.deepagent_prompt
+        if self.enable_deepagent and self.deepagent_skills:
+            topology_payload["deepagent_skills"] = self.deepagent_skills
         topology_fingerprint = hashlib.sha256(
             json.dumps(topology_payload, sort_keys=True, default=str).encode("utf-8")
         ).hexdigest()
@@ -910,13 +913,13 @@ class ChemGraph:
         except Exception as e:
             logger.warning(f"Failed to save messages to session store: {e}")
 
-    def _persist_run_state(self, config: dict) -> None:
+    def persist_run_state(self, config: dict) -> None:
         """Write the current checkpoint state to the configured log directory."""
         log_dir = self.log_dir or "cg_logs"
         os.makedirs(log_dir, exist_ok=True)
         self.write_state(config=config)
 
-    def _finalize_completed_run(
+    def finalize_completed_run(
         self,
         last_state: dict,
         config: dict,
@@ -926,7 +929,7 @@ class ChemGraph:
         self._save_messages_to_store(
             last_state, query, thread_id=str(config["configurable"]["thread_id"])
         )
-        self._persist_run_state(config)
+        self.persist_run_state(config)
 
         if self.return_option == "last_message":
             return last_state["messages"][-1]
@@ -984,9 +987,29 @@ class ChemGraph:
                 payload=payload,
                 interrupts=interrupts,
             )
-        if asyncio.iscoroutinefunction(handler):
-            return await handler(question)
-        return handler(question)
+        args: tuple[Any, ...] = (question,)
+        kwargs: dict[str, Any] = {}
+        try:
+            signature = inspect.signature(handler)
+        except (TypeError, ValueError):
+            pass
+        else:
+            try:
+                signature.bind(question, payload)
+            except TypeError:
+                try:
+                    signature.bind(question, payload=payload)
+                except TypeError:
+                    pass
+                else:
+                    kwargs["payload"] = payload
+            else:
+                args = (question, payload)
+
+        result = handler(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
 
     async def run(self, query: str, config=None, resume_from: Optional[str] = None):
         """
@@ -996,9 +1019,9 @@ class ChemGraph:
 
         When the graph pauses for human input (via ``interrupt()``), the
         ``human_input_handler`` callback is invoked to obtain the user's
-        response, and the graph is automatically resumed.  If no handler
-        is configured, the ``GraphInterrupt`` exception propagates to the
-        caller.
+        response, and the graph is automatically resumed. If no handler
+        is configured, a ``HumanInputRequired`` exception propagates to the
+        caller with the raw interrupt payload.
 
         Parameters
         ----------
@@ -1246,12 +1269,12 @@ class ChemGraph:
                 },
             )
 
-            return self._finalize_completed_run(last_state, config, query)
+            return self.finalize_completed_run(last_state, config, query)
 
         except HumanInputRequired:
             # No human_input_handler configured — propagate so the
             # caller (CLI / UI) can prompt the user and resume.
-            self._persist_run_state(config)
+            self.persist_run_state(config)
             raise
         except Exception as e:
             event(

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -13,6 +13,11 @@ from langgraph.errors import GraphInterrupt
 from langgraph.types import Command
 
 from chemgraph.agent.events import EventCallback, _AstreamEventCallback
+from chemgraph.agent.interrupts import (
+    PendingInterrupt,
+    deduplicate_interrupts,
+    normalize_interrupts,
+)
 from chemgraph.agent.turn import serialize_state
 from chemgraph.graphs.main_agent import latest_assistant_text
 from chemgraph.memory.schemas import MainAgentGraphConfig, MainAgentSessionMetadata
@@ -38,14 +43,6 @@ class IncompatibleCheckpointError(MainAgentRestoreError):
 
 
 @dataclass(frozen=True)
-class PendingInterrupt:
-    """One pending request for user input."""
-
-    id: str
-    payload: Any
-
-
-@dataclass(frozen=True)
 class MainAgentTurnResult:
     """Result returned when a supervisor turn completes or pauses."""
 
@@ -54,35 +51,6 @@ class MainAgentTurnResult:
     assistant_response: str
     interrupts: tuple[PendingInterrupt, ...]
     state: dict[str, Any]
-
-
-def _pending_interrupts(values: Any) -> list[PendingInterrupt]:
-    if values is None:
-        return []
-    if not isinstance(values, (list, tuple)):
-        values = [values]
-
-    return [
-        PendingInterrupt(
-            id=str(getattr(item, "id", "") or ""),
-            payload=getattr(item, "value", item),
-        )
-        for item in values
-    ]
-
-
-def _deduplicate_interrupts(
-    interrupts: list[PendingInterrupt],
-) -> tuple[PendingInterrupt, ...]:
-    unique: list[PendingInterrupt] = []
-    seen: set[str] = set()
-    for item in interrupts:
-        key = item.id or repr(item.payload)
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(item)
-    return tuple(unique)
 
 
 class MainAgentSession:
@@ -276,18 +244,23 @@ class MainAgentSession:
                 config=self.config,
             ):
                 last_state = state
-                found.extend(_pending_interrupts(state.get("__interrupt__")))
+                found.extend(normalize_interrupts(state.get("__interrupt__")))
         except GraphInterrupt as exc:
             raw_interrupts = exc.args[0] if exc.args else []
-            found.extend(_pending_interrupts(raw_interrupts))
+            found.extend(normalize_interrupts(raw_interrupts))
 
         snapshot = await self.workflow.aget_state(self.config)
         state_values = snapshot.values if snapshot else (last_state or {})
         if snapshot:
+            found.extend(
+                normalize_interrupts(getattr(snapshot, "interrupts", ()))
+            )
             for task in snapshot.tasks:
-                found.extend(_pending_interrupts(getattr(task, "interrupts", ())))
+                found.extend(
+                    normalize_interrupts(getattr(task, "interrupts", ()))
+                )
 
-        pending = _deduplicate_interrupts(found)
+        pending = deduplicate_interrupts(found)
         self._pending = pending
         result = MainAgentTurnResult(
             thread_id=self.thread_id,
@@ -366,12 +339,12 @@ class MainAgentSession:
             )
 
     def _result_from_snapshot(self, snapshot: Any) -> MainAgentTurnResult:
-        found = list(_pending_interrupts(getattr(snapshot, "interrupts", ())))
+        found = list(normalize_interrupts(getattr(snapshot, "interrupts", ())))
         failed = bool(getattr(snapshot, "next", ()))
         for task in snapshot.tasks:
-            found.extend(_pending_interrupts(getattr(task, "interrupts", ())))
+            found.extend(normalize_interrupts(getattr(task, "interrupts", ())))
             failed = failed or bool(getattr(task, "error", None))
-        pending = _deduplicate_interrupts(found)
+        pending = deduplicate_interrupts(found)
         status: SessionStatus
         if pending:
             status = "waiting_for_user"

--- a/src/chemgraph/agent/main_session.py
+++ b/src/chemgraph/agent/main_session.py
@@ -15,7 +15,7 @@ from langgraph.types import Command
 from chemgraph.agent.events import EventCallback, _AstreamEventCallback
 from chemgraph.agent.interrupts import (
     PendingInterrupt,
-    deduplicate_interrupts,
+    collect_pending_interrupts,
     normalize_interrupts,
 )
 from chemgraph.agent.turn import serialize_state
@@ -251,16 +251,7 @@ class MainAgentSession:
 
         snapshot = await self.workflow.aget_state(self.config)
         state_values = snapshot.values if snapshot else (last_state or {})
-        if snapshot:
-            found.extend(
-                normalize_interrupts(getattr(snapshot, "interrupts", ()))
-            )
-            for task in snapshot.tasks:
-                found.extend(
-                    normalize_interrupts(getattr(task, "interrupts", ()))
-                )
-
-        pending = deduplicate_interrupts(found)
+        pending = collect_pending_interrupts(found, snapshot)
         self._pending = pending
         result = MainAgentTurnResult(
             thread_id=self.thread_id,
@@ -339,12 +330,10 @@ class MainAgentSession:
             )
 
     def _result_from_snapshot(self, snapshot: Any) -> MainAgentTurnResult:
-        found = list(normalize_interrupts(getattr(snapshot, "interrupts", ())))
         failed = bool(getattr(snapshot, "next", ()))
         for task in snapshot.tasks:
-            found.extend(normalize_interrupts(getattr(task, "interrupts", ())))
             failed = failed or bool(getattr(task, "error", None))
-        pending = deduplicate_interrupts(found)
+        pending = collect_pending_interrupts([], snapshot)
         status: SessionStatus
         if pending:
             status = "waiting_for_user"

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -46,6 +46,7 @@ from chemgraph.cli.formatting import (
 ALL_WORKFLOW_TYPES = [
     "single_agent",
     "main_agent",
+    "deep_agent",
     "multi_agent",
     "python_relp",
     "graspa",
@@ -59,6 +60,7 @@ ALL_WORKFLOW_TYPES = [
 
 # Common aliases so users can type the "obvious" name.
 WORKFLOW_ALIASES: Dict[str, str] = {
+    "deepagent": "deep_agent",
     "python_repl": "python_relp",
     "graspa_agent": "graspa",
     "iri": "single_agent_iri",
@@ -133,7 +135,11 @@ _DEEPAGENT_ENV_ALLOWLIST = (
 )
 
 
-def _create_experimental_deepagent_backend(workspace: str | None):
+def _create_experimental_deepagent_backend(
+    workspace: str | None,
+    *,
+    require_confirmation: bool = True,
+):
     """Create the explicitly approved development-only host-shell backend."""
     from deepagents.backends import LocalShellBackend
 
@@ -145,13 +151,17 @@ def _create_experimental_deepagent_backend(workspace: str | None):
         Panel(
             "The experimental Deep Agent can read and modify files under "
             f"{root} and can run arbitrary shell commands on this host. The "
-            "shell is not confined to that directory. Every shell command and "
-            "file mutation will require approval.",
+            "shell is not confined to that directory. "
+            + (
+                "Every shell command and file mutation will require approval."
+                if require_confirmation
+                else "Tool approvals are disabled for this run."
+            ),
             title="[bold red]Experimental host-shell access[/bold red]",
             style="red",
         )
     )
-    if not Confirm.ask(
+    if require_confirmation and not Confirm.ask(
         "Enable this development-only capability?",
         default=False,
     ):
@@ -185,6 +195,7 @@ def initialize_agent(
     on_event: Optional[Any] = None,
     enable_deepagent: bool = False,
     deepagent_workspace: str | None = None,
+    deepagent_auto_approve: bool = False,
     checkpointer: Any | None = None,
     reasoning_effort: str | None = None,
     max_retries: int = 1,
@@ -224,6 +235,9 @@ def initialize_agent(
         Enable the development-only workspace worker for ``main_agent``.
     deepagent_workspace : str, optional
         Root directory exposed to the development-only local backend.
+    deepagent_auto_approve : bool, optional
+        Disable tool-review interrupts for standalone ``deep_agent``. This is
+        intended only for explicitly trusted, isolated headless runs.
 
     Returns
     -------
@@ -237,14 +251,27 @@ def initialize_agent(
         raise ValueError(
             "The experimental Deep Agent is available only with main_agent."
         )
-    if deepagent_workspace is not None and not enable_deepagent:
-        raise ValueError("--deepagent-workspace requires --deepagent.")
+    uses_deepagent = enable_deepagent or workflow_type == "deep_agent"
+    if deepagent_workspace is not None and not uses_deepagent:
+        raise ValueError(
+            "deepagent_workspace requires enable_deepagent=True or the "
+            "deep_agent workflow."
+        )
+    if deepagent_auto_approve and workflow_type != "deep_agent":
+        raise ValueError(
+            "deepagent_auto_approve is available only for the deep_agent workflow."
+        )
+    if deepagent_auto_approve and not deepagent_workspace:
+        raise ValueError(
+            "deepagent_auto_approve requires an explicit deepagent_workspace."
+        )
 
     deepagent_backend = None
-    if enable_deepagent:
+    if uses_deepagent:
         try:
             deepagent_backend = _create_experimental_deepagent_backend(
-                deepagent_workspace
+                deepagent_workspace,
+                require_confirmation=not deepagent_auto_approve,
             )
         except (RuntimeError, ValueError) as exc:
             console.print(f"[red]{escape(str(exc))}[/red]")
@@ -259,7 +286,7 @@ def initialize_agent(
         console.print(f"  Generate Report: {generate_report}")
         console.print(f"  Human Supervised: {human_supervised}")
         console.print(f"  Recursion Limit: {recursion_limit}")
-        console.print(f"  Deep Agent: {enable_deepagent}")
+        console.print(f"  Deep Agent: {uses_deepagent}")
         if base_url:
             console.print(f"  Base URL: {base_url}")
         if argo_user:
@@ -305,6 +332,7 @@ def initialize_agent(
                 on_event=on_event,
                 enable_deepagent=enable_deepagent,
                 deepagent_backend=deepagent_backend,
+                deepagent_auto_approve=deepagent_auto_approve,
                 checkpointer=checkpointer,
                 reasoning_effort=reasoning_effort,
                 max_retries=max_retries,
@@ -439,7 +467,7 @@ def run_query(
         except HumanInputRequired as hir:
             progress.update(task, description="[yellow]Agent needs your input")
             time.sleep(0.2)
-            question = hir.question
+            interrupt_payload = hir.payload
         except Exception as e:
             progress.update(task, description="[red]Query failed!")
             console.print(f"[red]Error processing query: {e}[/red]")
@@ -448,7 +476,7 @@ def run_query(
     # --- Interrupt-resume loop ---
     # The spinner's `with` block has exited, so the terminal is free
     # for interactive user input.
-    while question is not None:
+    while interrupt_payload is not None:
         interrupt_count += 1
         if interrupt_count > max_interrupts:
             console.print(
@@ -456,14 +484,7 @@ def run_query(
             )
             return None
 
-        console.print(
-            Panel(
-                question,
-                title="[bold yellow]Agent needs your input[/bold yellow]",
-                style="yellow",
-            )
-        )
-        human_answer = Prompt.ask("[bold cyan]Your response[/bold cyan]")
+        human_answer = _prompt_for_interrupt(interrupt_payload)
 
         # Resume the graph, streaming messages so tool-call parameters
         # are printed just like the initial invocation.
@@ -480,11 +501,20 @@ def run_query(
             """
             prev_msgs: list = []
             last_st = None
+            next_interrupt = None
             async for s in agent.workflow.astream(
                 Command(resume=human_answer),
                 stream_mode="values",
                 config=resume_config,
             ):
+                if "__interrupt__" in s:
+                    interrupt_data = s["__interrupt__"]
+                    if isinstance(interrupt_data, (list, tuple)) and interrupt_data:
+                        next_interrupt = getattr(
+                            interrupt_data[0], "value", interrupt_data[0]
+                        )
+                    elif hasattr(interrupt_data, "value"):
+                        next_interrupt = interrupt_data.value
                 if "messages" in s and s["messages"] != prev_msgs:
                     new_message = s["messages"][-1]
                     try:
@@ -493,6 +523,23 @@ def run_query(
                         pass
                     prev_msgs = s["messages"]
                 last_st = s
+            if next_interrupt is None:
+                try:
+                    snapshot = agent.workflow.get_state(resume_config)
+                    for pending_task in getattr(snapshot, "tasks", ()):
+                        interrupts = getattr(pending_task, "interrupts", ())
+                        if interrupts:
+                            next_interrupt = getattr(
+                                interrupts[0], "value", interrupts[0]
+                            )
+                            break
+                except Exception:
+                    pass
+            if next_interrupt is not None:
+                raise HumanInputRequired(
+                    _interrupt_question(next_interrupt),
+                    payload=next_interrupt,
+                )
             return last_st
 
         try:
@@ -502,15 +549,14 @@ def run_query(
                 console.print("[red]Resume produced no output.[/red]")
                 return None
 
-            if agent.return_option == "last_message":
-                return result["messages"][-1] if result else None
-            elif agent.return_option == "state":
-                from chemgraph.agent.llm_agent import serialize_state
-
-                return serialize_state(agent.get_state(config=config))
-            return result
+            return agent._finalize_completed_run(
+                result,
+                resume_config,
+                query,
+            )
         except HumanInputRequired as hir:
-            question = hir.question
+            agent._persist_run_state(resume_config)
+            interrupt_payload = hir.payload
         except Exception as e:
             console.print(f"[red]Error processing query: {e}[/red]")
             return None
@@ -1009,6 +1055,7 @@ def interactive_mode(
     tools: Optional[list] = None,
     enable_deepagent: bool = False,
     deepagent_workspace: str | None = None,
+    deepagent_auto_approve: bool = False,
     checkpoint_db: str | None = None,
     resume_session: str | None = None,
 ) -> None:
@@ -1047,6 +1094,9 @@ def interactive_mode(
         selected workflow is ``main_agent``.
     deepagent_workspace : str, optional
         Local workspace used by the experimental host-shell backend.
+    deepagent_auto_approve : bool, optional
+        Disable action approvals for a standalone Deep Agent. The CLI rejects
+        this option in interactive mode.
     """
     console.print(create_banner())
     console.print("[bold green]Welcome to ChemGraph Interactive Mode![/bold green]")
@@ -1142,8 +1192,12 @@ def interactive_mode(
         enable_deepagent=enable_deepagent and workflow == "main_agent",
         deepagent_workspace=(
             deepagent_workspace
-            if enable_deepagent and workflow == "main_agent"
+            if workflow == "deep_agent"
+            or (enable_deepagent and workflow == "main_agent")
             else None
+        ),
+        deepagent_auto_approve=(
+            deepagent_auto_approve and workflow == "deep_agent"
         ),
         checkpointer=checkpoint_saver,
         reasoning_effort=reasoning_effort,
@@ -1164,6 +1218,7 @@ def interactive_mode(
         if workflow == "main_agent"
         else None
     )
+    standalone_thread_id = _next_thread_id() if workflow == "deep_agent" else None
 
     if restored_thread_id and main_session is not None:
         result = restore_main_agent_session(
@@ -1265,7 +1320,7 @@ Example queries:
                 console.print(f"Workflow: {workflow}")
                 console.print(
                     "Deep Agent: "
-                    f"{'enabled' if enable_deepagent and workflow == 'main_agent' else 'disabled'}"
+                    f"{'enabled' if workflow == 'deep_agent' or (enable_deepagent and workflow == 'main_agent') else 'disabled'}"
                 )
                 if main_session is not None:
                     console.print(f"Thread ID: {main_session.thread_id}")
@@ -1413,11 +1468,15 @@ Example queries:
                     "[bold cyan]Enter query to continue with[/bold cyan]"
                 )
                 if resume_query.strip():
+                    run_options = {}
+                    if standalone_thread_id is not None:
+                        run_options["thread_id"] = standalone_thread_id
                     result = run_query(
                         agent,
                         resume_query,
                         verbose=verbose,
                         resume_from=argument,
+                        **run_options,
                     )
                     if result:
                         format_response(result, verbose=verbose)
@@ -1468,8 +1527,12 @@ Example queries:
                     enable_deepagent=enable_deepagent and workflow == "main_agent",
                     deepagent_workspace=(
                         deepagent_workspace
-                        if enable_deepagent and workflow == "main_agent"
+                        if workflow == "deep_agent"
+                        or (enable_deepagent and workflow == "main_agent")
                         else None
+                    ),
+                    deepagent_auto_approve=(
+                        deepagent_auto_approve and workflow == "deep_agent"
                     ),
                     checkpointer=(checkpoint_saver if workflow == "main_agent" else None),
                     reasoning_effort=new_reasoning_effort,
@@ -1492,6 +1555,9 @@ Example queries:
                         )
                         if workflow == "main_agent"
                         else None
+                    )
+                    standalone_thread_id = (
+                        _next_thread_id() if workflow == "deep_agent" else None
                     )
                     console.print(f"[green]Model changed to: {model}[/green]")
                 continue
@@ -1536,8 +1602,12 @@ Example queries:
                         ),
                         deepagent_workspace=(
                             deepagent_workspace
-                            if enable_deepagent and new_workflow == "main_agent"
+                            if new_workflow == "deep_agent"
+                            or (enable_deepagent and new_workflow == "main_agent")
                             else None
+                        ),
+                        deepagent_auto_approve=(
+                            deepagent_auto_approve and new_workflow == "deep_agent"
                         ),
                         checkpointer=(
                             checkpoint_saver if new_workflow == "main_agent" else None
@@ -1555,6 +1625,11 @@ Example queries:
                                 checkpoint_db=checkpoint_db or DEFAULT_CHECKPOINT_DB,
                             )
                             if workflow == "main_agent"
+                            else None
+                        )
+                        standalone_thread_id = (
+                            _next_thread_id()
+                            if workflow == "deep_agent"
                             else None
                         )
                         console.print(
@@ -1582,8 +1657,17 @@ Example queries:
                         checkpoint_runtime=checkpoint_runtime,
                     )
             else:
-                # Existing workflows use a fresh thread for each query.
-                result = run_query(agent, query, verbose=verbose)
+                # Deep Agent keeps process-local context for this REPL; other
+                # standalone workflows use a fresh thread for each query.
+                run_options = {}
+                if standalone_thread_id is not None:
+                    run_options["thread_id"] = standalone_thread_id
+                result = run_query(
+                    agent,
+                    query,
+                    verbose=verbose,
+                    **run_options,
+                )
             if result:
                 format_response(result, verbose=verbose)
                 if main_session is not None:

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -10,7 +10,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 from rich.panel import Panel
 from rich.markup import escape
@@ -18,6 +18,12 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
+from chemgraph.agent.interrupts import (
+    deduplicate_interrupts,
+    interrupt_question as _interrupt_question,
+    normalize_interrupts,
+)
+from chemgraph.graphs.deep_agent import _normalize_skill_sources
 from chemgraph.memory.store import SessionStore
 from chemgraph.memory.durable import delete_durable_session
 from chemgraph.cli.checkpoint_runtime import (
@@ -195,6 +201,7 @@ def initialize_agent(
     on_event: Optional[Any] = None,
     enable_deepagent: bool = False,
     deepagent_workspace: str | None = None,
+    deepagent_skills: Sequence[str] | None = None,
     deepagent_auto_approve: bool = False,
     checkpointer: Any | None = None,
     reasoning_effort: str | None = None,
@@ -235,6 +242,8 @@ def initialize_agent(
         Enable the development-only workspace worker for ``main_agent``.
     deepagent_workspace : str, optional
         Root directory exposed to the development-only local backend.
+    deepagent_skills : sequence of str, optional
+        Ordered backend-relative Agent Skills directories.
     deepagent_auto_approve : bool, optional
         Disable tool-review interrupts for standalone ``deep_agent``. This is
         intended only for explicitly trusted, isolated headless runs.
@@ -247,6 +256,7 @@ def initialize_agent(
     """
     # Resolve workflow alias before initializing.
     workflow_type = resolve_workflow(workflow_type)
+    deepagent_skills = _normalize_skill_sources(deepagent_skills)
     if enable_deepagent and workflow_type != "main_agent":
         raise ValueError(
             "The experimental Deep Agent is available only with main_agent."
@@ -255,6 +265,11 @@ def initialize_agent(
     if deepagent_workspace is not None and not uses_deepagent:
         raise ValueError(
             "deepagent_workspace requires enable_deepagent=True or the "
+            "deep_agent workflow."
+        )
+    if deepagent_skills and not uses_deepagent:
+        raise ValueError(
+            "deepagent_skills requires enable_deepagent=True or the "
             "deep_agent workflow."
         )
     if deepagent_auto_approve and workflow_type != "deep_agent":
@@ -287,6 +302,8 @@ def initialize_agent(
         console.print(f"  Human Supervised: {human_supervised}")
         console.print(f"  Recursion Limit: {recursion_limit}")
         console.print(f"  Deep Agent: {uses_deepagent}")
+        if deepagent_skills:
+            console.print(f"  Deep Agent Skills: {len(deepagent_skills)} source(s)")
         if base_url:
             console.print(f"  Base URL: {base_url}")
         if argo_user:
@@ -332,6 +349,7 @@ def initialize_agent(
                 on_event=on_event,
                 enable_deepagent=enable_deepagent,
                 deepagent_backend=deepagent_backend,
+                deepagent_skills=deepagent_skills,
                 deepagent_auto_approve=deepagent_auto_approve,
                 checkpointer=checkpointer,
                 reasoning_effort=reasoning_effort,
@@ -467,7 +485,7 @@ def run_query(
         except HumanInputRequired as hir:
             progress.update(task, description="[yellow]Agent needs your input")
             time.sleep(0.2)
-            interrupt_payload = hir.payload
+            pending_interrupts = hir.interrupts
         except Exception as e:
             progress.update(task, description="[red]Query failed!")
             console.print(f"[red]Error processing query: {e}[/red]")
@@ -476,15 +494,37 @@ def run_query(
     # --- Interrupt-resume loop ---
     # The spinner's `with` block has exited, so the terminal is free
     # for interactive user input.
-    while interrupt_payload is not None:
-        interrupt_count += 1
+    while pending_interrupts:
+        interrupt_count += len(pending_interrupts)
         if interrupt_count > max_interrupts:
             console.print(
                 "[red]Exceeded maximum number of human interrupts. Aborting.[/red]"
             )
             return None
 
-        human_answer = _prompt_for_interrupt(interrupt_payload)
+        if len(pending_interrupts) > 1:
+            if any(not pending.id for pending in pending_interrupts):
+                console.print(
+                    "[red]Multiple pending interrupts do not expose stable "
+                    "IDs and cannot be resumed safely.[/red]"
+                )
+                return None
+
+        answers = [
+            _prompt_for_interrupt(pending.payload)
+            for pending in pending_interrupts
+        ]
+        if len(pending_interrupts) == 1:
+            human_answer = answers[0]
+        else:
+            human_answer = {
+                pending.id: answer
+                for pending, answer in zip(
+                    pending_interrupts,
+                    answers,
+                    strict=True,
+                )
+            }
 
         # Resume the graph, streaming messages so tool-call parameters
         # are printed just like the initial invocation.
@@ -501,20 +541,16 @@ def run_query(
             """
             prev_msgs: list = []
             last_st = None
-            next_interrupt = None
+            found_interrupts = []
             async for s in agent.workflow.astream(
                 Command(resume=human_answer),
                 stream_mode="values",
                 config=resume_config,
             ):
                 if "__interrupt__" in s:
-                    interrupt_data = s["__interrupt__"]
-                    if isinstance(interrupt_data, (list, tuple)) and interrupt_data:
-                        next_interrupt = getattr(
-                            interrupt_data[0], "value", interrupt_data[0]
-                        )
-                    elif hasattr(interrupt_data, "value"):
-                        next_interrupt = interrupt_data.value
+                    found_interrupts.extend(
+                        normalize_interrupts(s["__interrupt__"])
+                    )
                 if "messages" in s and s["messages"] != prev_msgs:
                     new_message = s["messages"][-1]
                     try:
@@ -523,22 +559,27 @@ def run_query(
                         pass
                     prev_msgs = s["messages"]
                 last_st = s
-            if next_interrupt is None:
-                try:
-                    snapshot = agent.workflow.get_state(resume_config)
-                    for pending_task in getattr(snapshot, "tasks", ()):
-                        interrupts = getattr(pending_task, "interrupts", ())
-                        if interrupts:
-                            next_interrupt = getattr(
-                                interrupts[0], "value", interrupts[0]
-                            )
-                            break
-                except Exception:
-                    pass
-            if next_interrupt is not None:
+            try:
+                snapshot = agent.workflow.get_state(resume_config)
+                found_interrupts.extend(
+                    normalize_interrupts(
+                        getattr(snapshot, "interrupts", ())
+                    )
+                )
+                for pending_task in getattr(snapshot, "tasks", ()):
+                    found_interrupts.extend(
+                        normalize_interrupts(
+                            getattr(pending_task, "interrupts", ())
+                        )
+                    )
+            except Exception:
+                pass
+            next_interrupts = deduplicate_interrupts(found_interrupts)
+            if next_interrupts:
                 raise HumanInputRequired(
-                    _interrupt_question(next_interrupt),
-                    payload=next_interrupt,
+                    _interrupt_question(next_interrupts[0].payload),
+                    payload=next_interrupts[0].payload,
+                    interrupts=next_interrupts,
                 )
             return last_st
 
@@ -556,7 +597,7 @@ def run_query(
             )
         except HumanInputRequired as hir:
             agent._persist_run_state(resume_config)
-            interrupt_payload = hir.payload
+            pending_interrupts = hir.interrupts
         except Exception as e:
             console.print(f"[red]Error processing query: {e}[/red]")
             return None
@@ -601,18 +642,6 @@ def _render_main_agent_event(event: str, payload: dict[str, Any]) -> None:
         f"[dim]→[/dim] [bold]{escape(str(tool_name))}[/bold]"
         f"({escape(str(arguments))})"
     )
-
-
-def _interrupt_question(payload: Any) -> str:
-    """Extract readable question text from an interrupt payload."""
-    if isinstance(payload, dict):
-        return str(
-            payload.get(
-                "question",
-                payload.get("message", payload.get("instruction", payload)),
-            )
-        )
-    return str(payload)
 
 
 def _is_tool_review(payload: Any) -> bool:
@@ -1055,6 +1084,7 @@ def interactive_mode(
     tools: Optional[list] = None,
     enable_deepagent: bool = False,
     deepagent_workspace: str | None = None,
+    deepagent_skills: Sequence[str] | None = None,
     deepagent_auto_approve: bool = False,
     checkpoint_db: str | None = None,
     resume_session: str | None = None,
@@ -1094,6 +1124,8 @@ def interactive_mode(
         selected workflow is ``main_agent``.
     deepagent_workspace : str, optional
         Local workspace used by the experimental host-shell backend.
+    deepagent_skills : sequence of str, optional
+        Ordered backend-relative Agent Skills directories.
     deepagent_auto_approve : bool, optional
         Disable action approvals for a standalone Deep Agent. The CLI rejects
         this option in interactive mode.
@@ -1150,6 +1182,7 @@ def interactive_mode(
         human_supervised = stored_graph_config.human_supervised
         enable_deepagent = stored_graph_config.enable_deepagent
         deepagent_workspace = stored_graph_config.deepagent_workspace
+        deepagent_skills = stored_graph_config.deepagent_skills
         reasoning_effort = stored_graph_config.reasoning_effort
         max_retries = stored_graph_config.max_retries
         terminal_tool_names = stored_graph_config.terminal_tool_names
@@ -1192,6 +1225,12 @@ def interactive_mode(
         enable_deepagent=enable_deepagent and workflow == "main_agent",
         deepagent_workspace=(
             deepagent_workspace
+            if workflow == "deep_agent"
+            or (enable_deepagent and workflow == "main_agent")
+            else None
+        ),
+        deepagent_skills=(
+            deepagent_skills
             if workflow == "deep_agent"
             or (enable_deepagent and workflow == "main_agent")
             else None
@@ -1391,6 +1430,7 @@ Example queries:
                             tools=tools,
                             enable_deepagent=target_config.enable_deepagent,
                             deepagent_workspace=target_config.deepagent_workspace,
+                            deepagent_skills=target_config.deepagent_skills,
                             checkpointer=candidate_saver,
                             reasoning_effort=target_config.reasoning_effort,
                             max_retries=target_config.max_retries,
@@ -1439,6 +1479,7 @@ Example queries:
                     terminal_tool_names = target_config.terminal_tool_names
                     enable_deepagent = target_config.enable_deepagent
                     deepagent_workspace = target_config.deepagent_workspace
+                    deepagent_skills = target_config.deepagent_skills
                     if (
                         previous_db is not None
                         and os.path.abspath(os.path.expanduser(previous_db))
@@ -1531,6 +1572,12 @@ Example queries:
                         or (enable_deepagent and workflow == "main_agent")
                         else None
                     ),
+                    deepagent_skills=(
+                        deepagent_skills
+                        if workflow == "deep_agent"
+                        or (enable_deepagent and workflow == "main_agent")
+                        else None
+                    ),
                     deepagent_auto_approve=(
                         deepagent_auto_approve and workflow == "deep_agent"
                     ),
@@ -1602,6 +1649,12 @@ Example queries:
                         ),
                         deepagent_workspace=(
                             deepagent_workspace
+                            if new_workflow == "deep_agent"
+                            or (enable_deepagent and new_workflow == "main_agent")
+                            else None
+                        ),
+                        deepagent_skills=(
+                            deepagent_skills
                             if new_workflow == "deep_agent"
                             or (enable_deepagent and new_workflow == "main_agent")
                             else None

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -23,7 +23,7 @@ from chemgraph.agent.interrupts import (
     interrupt_question as _interrupt_question,
     normalize_interrupts,
 )
-from chemgraph.graphs.deep_agent import _normalize_skill_sources
+from chemgraph.graphs.deep_agent import normalize_skill_sources
 from chemgraph.memory.store import SessionStore
 from chemgraph.memory.durable import delete_durable_session
 from chemgraph.cli.checkpoint_runtime import (
@@ -256,7 +256,7 @@ def initialize_agent(
     """
     # Resolve workflow alias before initializing.
     workflow_type = resolve_workflow(workflow_type)
-    deepagent_skills = _normalize_skill_sources(deepagent_skills)
+    deepagent_skills = normalize_skill_sources(deepagent_skills)
     if enable_deepagent and workflow_type != "main_agent":
         raise ValueError(
             "The experimental Deep Agent is available only with main_agent."
@@ -590,13 +590,13 @@ def run_query(
                 console.print("[red]Resume produced no output.[/red]")
                 return None
 
-            return agent._finalize_completed_run(
+            return agent.finalize_completed_run(
                 result,
                 resume_config,
                 query,
             )
         except HumanInputRequired as hir:
-            agent._persist_run_state(resume_config)
+            agent.persist_run_state(resume_config)
             pending_interrupts = hir.interrupts
         except Exception as e:
             console.print(f"[red]Error processing query: {e}[/red]")

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -19,7 +19,8 @@ from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
 from chemgraph.agent.interrupts import (
-    deduplicate_interrupts,
+    collect_pending_interrupts,
+    is_tool_review as _is_tool_review,
     interrupt_question as _interrupt_question,
     normalize_interrupts,
 )
@@ -256,30 +257,35 @@ def initialize_agent(
     """
     # Resolve workflow alias before initializing.
     workflow_type = resolve_workflow(workflow_type)
-    deepagent_skills = normalize_skill_sources(deepagent_skills)
-    if enable_deepagent and workflow_type != "main_agent":
-        raise ValueError(
-            "The experimental Deep Agent is available only with main_agent."
-        )
-    uses_deepagent = enable_deepagent or workflow_type == "deep_agent"
-    if deepagent_workspace is not None and not uses_deepagent:
-        raise ValueError(
-            "deepagent_workspace requires enable_deepagent=True or the "
-            "deep_agent workflow."
-        )
-    if deepagent_skills and not uses_deepagent:
-        raise ValueError(
-            "deepagent_skills requires enable_deepagent=True or the "
-            "deep_agent workflow."
-        )
-    if deepagent_auto_approve and workflow_type != "deep_agent":
-        raise ValueError(
-            "deepagent_auto_approve is available only for the deep_agent workflow."
-        )
-    if deepagent_auto_approve and not deepagent_workspace:
-        raise ValueError(
-            "deepagent_auto_approve requires an explicit deepagent_workspace."
-        )
+    try:
+        if enable_deepagent and workflow_type != "main_agent":
+            raise ValueError(
+                "The experimental Deep Agent is available only with main_agent."
+            )
+        uses_deepagent = enable_deepagent or workflow_type == "deep_agent"
+        if deepagent_workspace is not None and not uses_deepagent:
+            raise ValueError(
+                "deepagent_workspace requires enable_deepagent=True or the "
+                "deep_agent workflow."
+            )
+        if deepagent_skills and not uses_deepagent:
+            raise ValueError(
+                "deepagent_skills requires enable_deepagent=True or the "
+                "deep_agent workflow."
+            )
+        if deepagent_auto_approve and workflow_type != "deep_agent":
+            raise ValueError(
+                "deepagent_auto_approve is available only for the deep_agent workflow."
+            )
+        if deepagent_auto_approve and not deepagent_workspace:
+            raise ValueError(
+                "deepagent_auto_approve requires an explicit deepagent_workspace."
+            )
+
+        deepagent_skills = normalize_skill_sources(deepagent_skills)
+    except (TypeError, ValueError) as exc:
+        console.print(f"[red]{escape(str(exc))}[/red]")
+        return None
 
     deepagent_backend = None
     if uses_deepagent:
@@ -451,6 +457,7 @@ def run_query(
     Any
         Agent result, resumed graph result, or ``None`` on failure.
     """
+    from langgraph.errors import GraphInterrupt
     from langgraph.types import Command
     from chemgraph.agent.llm_agent import HumanInputRequired
 
@@ -495,7 +502,9 @@ def run_query(
     # The spinner's `with` block has exited, so the terminal is free
     # for interactive user input.
     while pending_interrupts:
-        interrupt_count += len(pending_interrupts)
+        interrupt_count += sum(
+            not _is_tool_review(pending.payload) for pending in pending_interrupts
+        )
         if interrupt_count > max_interrupts:
             console.print(
                 "[red]Exceeded maximum number of human interrupts. Aborting.[/red]"
@@ -510,21 +519,26 @@ def run_query(
                 )
                 return None
 
-        answers = [
-            _prompt_for_interrupt(pending.payload)
-            for pending in pending_interrupts
-        ]
-        if len(pending_interrupts) == 1:
-            human_answer = answers[0]
-        else:
-            human_answer = {
-                pending.id: answer
-                for pending, answer in zip(
-                    pending_interrupts,
-                    answers,
-                    strict=True,
-                )
-            }
+        try:
+            answers = [
+                _prompt_for_interrupt(pending.payload)
+                for pending in pending_interrupts
+            ]
+            if len(pending_interrupts) == 1:
+                human_answer = answers[0]
+            else:
+                human_answer = {
+                    pending.id: answer
+                    for pending, answer in zip(
+                        pending_interrupts,
+                        answers,
+                        strict=True,
+                    )
+                }
+
+        except (TypeError, ValueError) as exc:
+            console.print(f"[red]Error processing query: {escape(str(exc))}[/red]")
+            return None
 
         # Resume the graph, streaming messages so tool-call parameters
         # are printed just like the initial invocation.
@@ -542,46 +556,46 @@ def run_query(
             prev_msgs: list = []
             last_st = None
             found_interrupts = []
-            async for s in agent.workflow.astream(
-                Command(resume=human_answer),
-                stream_mode="values",
-                config=resume_config,
-            ):
-                if "__interrupt__" in s:
-                    found_interrupts.extend(
-                        normalize_interrupts(s["__interrupt__"])
-                    )
-                if "messages" in s and s["messages"] != prev_msgs:
-                    new_message = s["messages"][-1]
-                    try:
-                        new_message.pretty_print()
-                    except Exception:
-                        pass
-                    prev_msgs = s["messages"]
-                last_st = s
+            bare_interrupt = False
             try:
-                snapshot = agent.workflow.get_state(resume_config)
-                found_interrupts.extend(
-                    normalize_interrupts(
-                        getattr(snapshot, "interrupts", ())
-                    )
-                )
-                for pending_task in getattr(snapshot, "tasks", ()):
-                    found_interrupts.extend(
-                        normalize_interrupts(
-                            getattr(pending_task, "interrupts", ())
+                async for s in agent.workflow.astream(
+                    Command(resume=human_answer),
+                    stream_mode="values",
+                    config=resume_config,
+                ):
+                    if "__interrupt__" in s:
+                        found_interrupts.extend(
+                            normalize_interrupts(s["__interrupt__"])
                         )
-                    )
+                    if "messages" in s and s["messages"] != prev_msgs:
+                        new_message = s["messages"][-1]
+                        try:
+                            new_message.pretty_print()
+                        except Exception:
+                            pass
+                        prev_msgs = s["messages"]
+                    last_st = s
+            except GraphInterrupt as exc:
+                raw = exc.args[0] if exc.args else ()
+                found_interrupts.extend(normalize_interrupts(raw))
+                bare_interrupt = not raw
+            try:
+                snapshot = await agent.workflow.aget_state(resume_config)
             except Exception:
-                pass
-            next_interrupts = deduplicate_interrupts(found_interrupts)
+                snapshot = None
+            next_interrupts = collect_pending_interrupts(
+                found_interrupts, snapshot, fallback=bare_interrupt,
+            )
             if next_interrupts:
+                await agent.apersist_run_state(resume_config)
                 raise HumanInputRequired(
                     _interrupt_question(next_interrupts[0].payload),
                     payload=next_interrupts[0].payload,
                     interrupts=next_interrupts,
                 )
-            return last_st
+            if last_st is None:
+                return None
+            return await agent.afinalize_completed_run(last_st, resume_config, query)
 
         try:
             result = run_async_callable(_resume_stream)
@@ -590,13 +604,8 @@ def run_query(
                 console.print("[red]Resume produced no output.[/red]")
                 return None
 
-            return agent.finalize_completed_run(
-                result,
-                resume_config,
-                query,
-            )
+            return result
         except HumanInputRequired as hir:
-            agent.persist_run_state(resume_config)
             pending_interrupts = hir.interrupts
         except Exception as e:
             console.print(f"[red]Error processing query: {e}[/red]")
@@ -641,15 +650,6 @@ def _render_main_agent_event(event: str, payload: dict[str, Any]) -> None:
         f"[dim]Subagent[/dim] [bold cyan]{escape(str(subagent_name))}[/bold cyan] "
         f"[dim]→[/dim] [bold]{escape(str(tool_name))}[/bold]"
         f"({escape(str(arguments))})"
-    )
-
-
-def _is_tool_review(payload: Any) -> bool:
-    """Return whether an interrupt is a Deep Agents tool-review request."""
-    return (
-        isinstance(payload, dict)
-        and isinstance(payload.get("action_requests"), list)
-        and isinstance(payload.get("review_configs"), list)
     )
 
 
@@ -737,23 +737,27 @@ def _run_main_agent_operation(
 
     interrupt_count = 0
     while result.status == "waiting_for_user" and result.interrupts:
-        interrupt_count += len(result.interrupts)
+        interrupt_count += sum(
+            not _is_tool_review(pending.payload) for pending in result.interrupts
+        )
         if interrupt_count > 10:
             console.print(
                 "[red]Exceeded maximum number of nested clarifications.[/red]"
             )
             return None
 
-        answers: Any
-        if len(result.interrupts) == 1:
-            pending = result.interrupts[0]
-            answers = _prompt_for_interrupt(pending.payload)
-        else:
-            answers = {}
-            for pending in result.interrupts:
-                answers[pending.id] = _prompt_for_interrupt(pending.payload)
-
         try:
+            answers: Any
+            if len(result.interrupts) == 1:
+                pending = result.interrupts[0]
+                answers = _prompt_for_interrupt(pending.payload)
+            else:
+                if any(not pending.id for pending in result.interrupts):
+                    raise ValueError("Multiple pending interrupts require stable IDs.")
+                answers = {}
+                for pending in result.interrupts:
+                    answers[pending.id] = _prompt_for_interrupt(pending.payload)
+
             result = (
                 checkpoint_runtime.run(lambda: session.resume(answers))
                 if checkpoint_runtime is not None

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -119,7 +119,10 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         type=str,
         default=None,
         metavar="PATH",
-        help="Workspace root for the experimental local-shell Deep Agent",
+        help=(
+            "Workspace root mounted at /workspace for file tools; shell "
+            "commands are not confined to it"
+        ),
     )
     parser.add_argument(
         "--deepagent-skill",
@@ -136,8 +139,9 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         "--deepagent-dangerously-skip-approvals",
         action="store_true",
         help=(
-            "Allow a headless deep_agent to execute commands and mutate its "
-            "explicit workspace without approval prompts"
+            "Allow a headless deep_agent to execute commands and mutate files "
+            "without approval prompts; its shell is not confined to the "
+            "workspace"
         ),
     )
     parser.add_argument(

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -122,6 +122,17 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         help="Workspace root for the experimental local-shell Deep Agent",
     )
     parser.add_argument(
+        "--deepagent-skill",
+        dest="deepagent_skills",
+        action="append",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Backend-relative Agent Skills directory for the Deep Agent; "
+            "repeat to layer multiple sources"
+        ),
+    )
+    parser.add_argument(
         "--deepagent-dangerously-skip-approvals",
         action="store_true",
         help=(
@@ -409,6 +420,7 @@ def load_config(config_file: str) -> Dict[str, Any]:
                 "human_supervised": False,
                 "enable_deepagent": False,
                 "deepagent_workspace": None,
+                "deepagent_skills": None,
                 "checkpoint_db": None,
                 "verbose": False,
             },
@@ -457,6 +469,7 @@ def _handle_run(args: argparse.Namespace) -> None:
     """
     cli_deepagent = getattr(args, "deepagent", None)
     cli_deepagent_workspace = getattr(args, "deepagent_workspace", None)
+    cli_deepagent_skills = getattr(args, "deepagent_skills", None)
 
     # Handle special commands first
     if getattr(args, "list_models", False):
@@ -520,6 +533,7 @@ def _handle_run(args: argparse.Namespace) -> None:
     args.workflow = resolve_workflow(args.workflow)
     enable_deepagent = bool(getattr(args, "deepagent", False))
     deepagent_workspace = getattr(args, "deepagent_workspace", None)
+    deepagent_skills = getattr(args, "deepagent_skills", None)
     deepagent_auto_approve = bool(
         getattr(args, "deepagent_dangerously_skip_approvals", False)
     )
@@ -537,6 +551,17 @@ def _handle_run(args: argparse.Namespace) -> None:
         else:
             console.print(
                 "[red]--deepagent-workspace requires --deepagent or "
+                "-w deep_agent.[/red]"
+            )
+            sys.exit(2)
+    if deepagent_skills and not (
+        enable_deepagent or args.workflow == "deep_agent"
+    ):
+        if cli_deepagent is False and cli_deepagent_skills is None:
+            deepagent_skills = None
+        else:
+            console.print(
+                "[red]--deepagent-skill requires --deepagent or "
                 "-w deep_agent.[/red]"
             )
             sys.exit(2)
@@ -611,6 +636,7 @@ def _handle_run(args: argparse.Namespace) -> None:
             tools=mcp_tools,
             enable_deepagent=enable_deepagent,
             deepagent_workspace=deepagent_workspace,
+            deepagent_skills=deepagent_skills,
             checkpoint_db=(
                 getattr(args, "checkpoint_db", None) or config.get("checkpoint_db")
             ),
@@ -684,6 +710,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         tools=mcp_tools,
         on_event=trace.on_event if trace else None,
         deepagent_workspace=deepagent_workspace,
+        deepagent_skills=deepagent_skills,
         deepagent_auto_approve=deepagent_auto_approve,
     )
 

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -122,6 +122,14 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         help="Workspace root for the experimental local-shell Deep Agent",
     )
     parser.add_argument(
+        "--deepagent-dangerously-skip-approvals",
+        action="store_true",
+        help=(
+            "Allow a headless deep_agent to execute commands and mutate its "
+            "explicit workspace without approval prompts"
+        ),
+    )
+    parser.add_argument(
         "--recursion-limit",
         type=int,
         default=20,
@@ -512,17 +520,52 @@ def _handle_run(args: argparse.Namespace) -> None:
     args.workflow = resolve_workflow(args.workflow)
     enable_deepagent = bool(getattr(args, "deepagent", False))
     deepagent_workspace = getattr(args, "deepagent_workspace", None)
-    if deepagent_workspace is not None and not enable_deepagent:
+    deepagent_auto_approve = bool(
+        getattr(args, "deepagent_dangerously_skip_approvals", False)
+    )
+    if enable_deepagent and args.workflow != "main_agent":
+        console.print(
+            "[red]--deepagent adds a worker only to the main_agent workflow. "
+            "Use -w deep_agent to call it directly.[/red]"
+        )
+        sys.exit(2)
+    if deepagent_workspace is not None and not (
+        enable_deepagent or args.workflow == "deep_agent"
+    ):
         if cli_deepagent is False and cli_deepagent_workspace is None:
             deepagent_workspace = None
         else:
-            console.print("[red]--deepagent-workspace requires --deepagent.[/red]")
+            console.print(
+                "[red]--deepagent-workspace requires --deepagent or "
+                "-w deep_agent.[/red]"
+            )
             sys.exit(2)
     if enable_deepagent and not getattr(args, "interactive", False):
         console.print(
             "[red]The experimental Deep Agent requires interactive mode.[/red]"
         )
         sys.exit(2)
+    if deepagent_auto_approve and (
+        args.workflow != "deep_agent" or getattr(args, "interactive", False)
+    ):
+        console.print(
+            "[red]--deepagent-dangerously-skip-approvals is supported only "
+            "for non-interactive -w deep_agent runs.[/red]"
+        )
+        sys.exit(2)
+    if args.workflow == "deep_agent" and not getattr(args, "interactive", False):
+        if not deepagent_auto_approve:
+            console.print(
+                "[red]Headless deep_agent runs require "
+                "--deepagent-dangerously-skip-approvals.[/red]"
+            )
+            sys.exit(2)
+        if not deepagent_workspace:
+            console.print(
+                "[red]Headless deep_agent runs require an explicit "
+                "--deepagent-workspace PATH.[/red]"
+            )
+            sys.exit(2)
 
     if args.workflow == "main_agent":
         if not getattr(args, "interactive", False):
@@ -640,6 +683,8 @@ def _handle_run(args: argparse.Namespace) -> None:
         human_supervised=args.human_supervised,
         tools=mcp_tools,
         on_event=trace.on_event if trace else None,
+        deepagent_workspace=deepagent_workspace,
+        deepagent_auto_approve=deepagent_auto_approve,
     )
 
     if not agent:

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -16,6 +16,7 @@ from typing import Any, Dict
 
 import toml
 
+from chemgraph.graphs.deep_agent import normalize_skill_sources
 from chemgraph.models.endpoints.registry import match_endpoint
 from chemgraph.utils.config_utils import (
     flatten_config,
@@ -83,7 +84,7 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
         "--workflow",
         type=str,
         choices=_WORKFLOW_CHOICES,
-        default="single_agent",
+        default=None,
         help="Workflow type (default: single_agent)",
     )
     parser.add_argument(
@@ -534,42 +535,41 @@ def _handle_run(args: argparse.Namespace) -> None:
     argo_user = get_argo_user_from_flat_config(config) if config else None
 
     # Resolve workflow alias (e.g. python_repl -> python_relp)
-    args.workflow = resolve_workflow(args.workflow)
+    args.workflow = resolve_workflow(args.workflow or "single_agent")
     enable_deepagent = bool(getattr(args, "deepagent", False))
     deepagent_workspace = getattr(args, "deepagent_workspace", None)
     deepagent_skills = getattr(args, "deepagent_skills", None)
     deepagent_auto_approve = bool(
         getattr(args, "deepagent_dangerously_skip_approvals", False)
     )
-    if enable_deepagent and args.workflow != "main_agent":
+    interactive = bool(getattr(args, "interactive", False))
+    if cli_deepagent is True and args.workflow != "main_agent":
         console.print(
             "[red]--deepagent adds a worker only to the main_agent workflow. "
             "Use -w deep_agent to call it directly.[/red]"
         )
         sys.exit(2)
-    if deepagent_workspace is not None and not (
-        enable_deepagent or args.workflow == "deep_agent"
-    ):
-        if cli_deepagent is False and cli_deepagent_workspace is None:
+    uses_deepagent = args.workflow == "deep_agent" or (
+        enable_deepagent and args.workflow == "main_agent"
+    )
+    if not uses_deepagent:
+        if cli_deepagent_workspace is not None:
+            console.print("[red]--deepagent-workspace requires --deepagent or -w deep_agent.[/red]")
+            sys.exit(2)
+        if cli_deepagent_skills is not None:
+            console.print("[red]--deepagent-skill requires --deepagent or -w deep_agent.[/red]")
+            sys.exit(2)
+        # Retain saved settings for later REPL workflow switches.
+        if not interactive or cli_deepagent is False:
             deepagent_workspace = None
-        else:
-            console.print(
-                "[red]--deepagent-workspace requires --deepagent or "
-                "-w deep_agent.[/red]"
-            )
-            sys.exit(2)
-    if deepagent_skills and not (
-        enable_deepagent or args.workflow == "deep_agent"
-    ):
-        if cli_deepagent is False and cli_deepagent_skills is None:
             deepagent_skills = None
-        else:
-            console.print(
-                "[red]--deepagent-skill requires --deepagent or "
-                "-w deep_agent.[/red]"
-            )
+    if uses_deepagent and deepagent_skills is not None:
+        try:
+            normalize_skill_sources(deepagent_skills)
+        except (TypeError, ValueError) as exc:
+            console.print(f"[red]Invalid Deep Agent skills: {exc}[/red]")
             sys.exit(2)
-    if enable_deepagent and not getattr(args, "interactive", False):
+    if enable_deepagent and args.workflow == "main_agent" and not interactive:
         console.print(
             "[red]The experimental Deep Agent requires interactive mode.[/red]"
         )

--- a/src/chemgraph/graphs/deep_agent.py
+++ b/src/chemgraph/graphs/deep_agent.py
@@ -1,0 +1,105 @@
+"""Reusable Deep Agent workflow for workspace and coding tasks."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from copy import deepcopy
+from typing import Any
+
+from deepagents import create_deep_agent
+from deepagents.backends import CompositeBackend, LocalShellBackend, StateBackend
+from deepagents.backends.protocol import BackendProtocol
+from langgraph.checkpoint.memory import InMemorySaver
+
+
+DEFAULT_DEEPAGENT_PROMPT = """\
+You are ChemGraph's workspace specialist. Complete repository exploration,
+coding, testing, file analysis, and other multi-step workspace tasks. Use the
+built-in filesystem and execution tools when needed. Treat `/workspace` as the
+project root when that virtual mount is available. The execution tool runs in a
+host shell, so follow any "Shell paths vs. virtual paths" mapping in the system
+instructions when passing file paths to shell commands. Do not perform
+molecular simulations or invent chemistry results; return those tasks to the
+supervisor for delegation to the `chemgraph` specialist.
+
+The calling supervisor sees only your final assistant message. Return a concise,
+self-contained report including important results, changed paths, commands run,
+and any failures or unresolved risks.
+"""
+
+
+DEFAULT_DEEPAGENT_INTERRUPT_ON = {
+    "execute": {"allowed_decisions": ["approve", "reject"]},
+    "write_file": {"allowed_decisions": ["approve", "reject"]},
+    "edit_file": {"allowed_decisions": ["approve", "reject"]},
+    "delete": {"allowed_decisions": ["approve", "reject"]},
+}
+
+
+_DEFAULT_CHECKPOINTER = object()
+_DEFAULT_INTERRUPT_POLICY = object()
+_WORKSPACE_MOUNT = "/workspace/"
+
+
+def _normalize_backend(backend: BackendProtocol) -> BackendProtocol:
+    """Mount a virtual local workspace at the path Deep Agent expects."""
+    if isinstance(backend, LocalShellBackend) and backend.virtual_mode:
+        return CompositeBackend(
+            default=backend,
+            routes={_WORKSPACE_MOUNT: backend},
+        )
+    return backend
+
+
+def construct_deep_agent_graph(
+    llm: Any,
+    *,
+    tools: Sequence[Any] | None = None,
+    system_prompt: str = DEFAULT_DEEPAGENT_PROMPT,
+    backend: BackendProtocol | None = None,
+    interrupt_on: dict[str, Any] | None | object = _DEFAULT_INTERRUPT_POLICY,
+    recursion_limit: int = 50,
+    checkpointer: Any = _DEFAULT_CHECKPOINTER,
+    name: str = "deepagent",
+):
+    """Construct a standalone or parent-checkpointed workspace Deep Agent.
+
+    Standalone construction receives an in-memory checkpointer so approval
+    interrupts can be resumed. Orchestrators should explicitly pass
+    ``checkpointer=None`` so the worker inherits the parent graph's checkpoint.
+    Passing ``interrupt_on=None`` disables approval interrupts and should be
+    reserved for an externally isolated, explicitly trusted execution context.
+    """
+    if recursion_limit <= 0:
+        raise ValueError("recursion_limit must be positive.")
+
+    effective_checkpointer = (
+        InMemorySaver()
+        if checkpointer is _DEFAULT_CHECKPOINTER
+        else checkpointer
+    )
+    effective_interrupt_on = (
+        deepcopy(DEFAULT_DEEPAGENT_INTERRUPT_ON)
+        if interrupt_on is _DEFAULT_INTERRUPT_POLICY
+        else interrupt_on
+    )
+    effective_backend = _normalize_backend(
+        backend if backend is not None else StateBackend()
+    )
+    workflow = create_deep_agent(
+        model=llm,
+        tools=list(tools or []),
+        system_prompt=system_prompt,
+        backend=effective_backend,
+        interrupt_on=effective_interrupt_on,
+        checkpointer=effective_checkpointer,
+        name=name,
+    )
+    return workflow.with_config({"recursion_limit": recursion_limit})
+
+
+__all__ = [
+    "DEFAULT_DEEPAGENT_INTERRUPT_ON",
+    "DEFAULT_DEEPAGENT_PROMPT",
+    "construct_deep_agent_graph",
+]

--- a/src/chemgraph/graphs/deep_agent.py
+++ b/src/chemgraph/graphs/deep_agent.py
@@ -41,6 +41,23 @@ _DEFAULT_INTERRUPT_POLICY = object()
 _WORKSPACE_MOUNT = "/workspace/"
 
 
+def _normalize_skill_sources(skills: Sequence[str] | None) -> tuple[str, ...]:
+    """Validate and freeze ordered backend-relative skill source paths."""
+    if skills is None:
+        return ()
+    if isinstance(skills, (str, bytes)):
+        raise TypeError("skills must be a sequence of path strings, not a string.")
+
+    normalized: list[str] = []
+    for source in skills:
+        if not isinstance(source, str):
+            raise TypeError("Every skill source must be a string.")
+        if not source.strip():
+            raise ValueError("Skill source paths must not be empty.")
+        normalized.append(source)
+    return tuple(normalized)
+
+
 def _normalize_backend(backend: BackendProtocol) -> BackendProtocol:
     """Mount a virtual local workspace at the path Deep Agent expects."""
     if isinstance(backend, LocalShellBackend) and backend.virtual_mode:
@@ -55,6 +72,7 @@ def construct_deep_agent_graph(
     llm: Any,
     *,
     tools: Sequence[Any] | None = None,
+    skills: Sequence[str] | None = None,
     system_prompt: str = DEFAULT_DEEPAGENT_PROMPT,
     backend: BackendProtocol | None = None,
     interrupt_on: dict[str, Any] | None | object = _DEFAULT_INTERRUPT_POLICY,
@@ -67,6 +85,8 @@ def construct_deep_agent_graph(
     Standalone construction receives an in-memory checkpointer so approval
     interrupts can be resumed. Orchestrators should explicitly pass
     ``checkpointer=None`` so the worker inherits the parent graph's checkpoint.
+    ``skills`` contains ordered, backend-relative Agent Skills directories;
+    later sources override earlier sources with the same skill name.
     Passing ``interrupt_on=None`` disables approval interrupts and should be
     reserved for an externally isolated, explicitly trusted execution context.
     """
@@ -86,9 +106,11 @@ def construct_deep_agent_graph(
     effective_backend = _normalize_backend(
         backend if backend is not None else StateBackend()
     )
+    skill_sources = _normalize_skill_sources(skills)
     workflow = create_deep_agent(
         model=llm,
         tools=list(tools or []),
+        skills=list(skill_sources) if skill_sources else None,
         system_prompt=system_prompt,
         backend=effective_backend,
         interrupt_on=effective_interrupt_on,

--- a/src/chemgraph/graphs/deep_agent.py
+++ b/src/chemgraph/graphs/deep_agent.py
@@ -41,7 +41,7 @@ _DEFAULT_INTERRUPT_POLICY = object()
 _WORKSPACE_MOUNT = "/workspace/"
 
 
-def _normalize_skill_sources(skills: Sequence[str] | None) -> tuple[str, ...]:
+def normalize_skill_sources(skills: Sequence[str] | None) -> tuple[str, ...]:
     """Validate and freeze ordered backend-relative skill source paths."""
     if skills is None:
         return ()
@@ -106,7 +106,7 @@ def construct_deep_agent_graph(
     effective_backend = _normalize_backend(
         backend if backend is not None else StateBackend()
     )
-    skill_sources = _normalize_skill_sources(skills)
+    skill_sources = normalize_skill_sources(skills)
     workflow = create_deep_agent(
         model=llm,
         tools=list(tools or []),
@@ -124,4 +124,5 @@ __all__ = [
     "DEFAULT_DEEPAGENT_INTERRUPT_ON",
     "DEFAULT_DEEPAGENT_PROMPT",
     "construct_deep_agent_graph",
+    "normalize_skill_sources",
 ]

--- a/src/chemgraph/graphs/deep_agent.py
+++ b/src/chemgraph/graphs/deep_agent.py
@@ -58,11 +58,40 @@ def normalize_skill_sources(skills: Sequence[str] | None) -> tuple[str, ...]:
     return tuple(normalized)
 
 
+class _WorkspaceShellBackend(StateBackend, LocalShellBackend):
+    """Use checkpoint files at the root while retaining local-shell execution.
+
+    StateBackend precedes LocalShellBackend so file operations never expose a
+    second host-file namespace. The local-shell type also preserves Deep Agents'
+    execution detection and virtual-to-host path guidance.
+    """
+
+    def __init__(self, shell: LocalShellBackend):
+        StateBackend.__init__(self)
+        self.shell = shell
+
+    @property
+    def id(self) -> str:
+        return self.shell.id
+
+    def execute(self, command: str, *, timeout: int | None = None):
+        return self.shell.execute(command, timeout=timeout)
+
+    async def aexecute(self, command: str, *, timeout: int | None = None):
+        return await self.shell.aexecute(command, timeout=timeout)
+
+    async def agrep(self, pattern, path=None, glob=None, *, max_count=None):
+        # FilesystemBackend's async override searches the host directly.
+        return await BackendProtocol.agrep(
+            self, pattern, path, glob, max_count=max_count,
+        )
+
+
 def _normalize_backend(backend: BackendProtocol) -> BackendProtocol:
     """Mount a virtual local workspace at the path Deep Agent expects."""
     if isinstance(backend, LocalShellBackend) and backend.virtual_mode:
         return CompositeBackend(
-            default=backend,
+            default=_WorkspaceShellBackend(backend),
             routes={_WORKSPACE_MOUNT: backend},
         )
     return backend

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from collections.abc import Collection, Sequence
 from typing import Any
 
-from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
 from deepagents.backends.protocol import BackendProtocol
 from deepagents.middleware import FilesystemMiddleware, SubAgentMiddleware
@@ -18,6 +17,10 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.errors import GraphInterrupt
 
 from chemgraph.agent.events import SUBAGENT_METADATA_KEY
+from chemgraph.graphs.deep_agent import (
+    DEFAULT_DEEPAGENT_PROMPT,
+    construct_deep_agent_graph,
+)
 from chemgraph.graphs.single_agent import construct_single_agent_graph
 from chemgraph.memory.subagent_recorder import SubagentRunRecorder
 
@@ -46,27 +49,6 @@ Rules:
 8. Use `read_file` to inspect checkpoint-backed files returned by subagents
    when their contents are needed. This tool cannot access host files.
 """
-
-
-DEFAULT_DEEPAGENT_PROMPT = """\
-You are ChemGraph's workspace specialist. Complete repository exploration,
-coding, testing, file analysis, and other multi-step workspace tasks. Use the
-built-in filesystem and execution tools when needed. Do not perform molecular
-simulations or invent chemistry results; return those tasks to the supervisor
-for delegation to the `chemgraph` specialist.
-
-The calling supervisor sees only your final assistant message. Return a concise,
-self-contained report including important results, changed paths, commands run,
-and any failures or unresolved risks.
-"""
-
-
-_DEEPAGENT_INTERRUPT_ON = {
-    "execute": {"allowed_decisions": ["approve", "reject"]},
-    "write_file": {"allowed_decisions": ["approve", "reject"]},
-    "edit_file": {"allowed_decisions": ["approve", "reject"]},
-    "delete": {"allowed_decisions": ["approve", "reject"]},
-}
 
 
 def latest_assistant_text(messages: list[Any]) -> str:
@@ -225,6 +207,7 @@ def construct_main_agent_graph(
     enable_deepagent: bool = False,
     deepagent_backend: BackendProtocol | None = None,
     deepagent_recursion_limit: int = 50,
+    deepagent_system_prompt: str = DEFAULT_DEEPAGENT_PROMPT,
     system_prompt: str = DEFAULT_MAIN_AGENT_PROMPT,
     checkpointer: Any | None = None,
     subagent_recorder: SubagentRunRecorder | None = None,
@@ -266,19 +249,19 @@ def construct_main_agent_graph(
         registered_subagents = list(subagents)
 
     if enable_deepagent:
-        workspace_agent = create_deep_agent(
-            model=llm,
+        workspace_agent = construct_deep_agent_graph(
+            llm,
             tools=[],
-            system_prompt=DEFAULT_DEEPAGENT_PROMPT,
+            system_prompt=deepagent_system_prompt,
             backend=(
                 deepagent_backend
                 if deepagent_backend is not None
                 else StateBackend()
             ),
-            interrupt_on=_DEEPAGENT_INTERRUPT_ON,
             checkpointer=None,
+            recursion_limit=deepagent_recursion_limit,
             name="deepagent",
-        ).with_config({"recursion_limit": deepagent_recursion_limit})
+        )
         registered_subagents.append(
             {
                 "name": "deepagent",

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -206,6 +206,7 @@ def construct_main_agent_graph(
     subagent_terminal_tool_names: Collection[str] = (),
     enable_deepagent: bool = False,
     deepagent_backend: BackendProtocol | None = None,
+    deepagent_skills: Sequence[str] | None = None,
     deepagent_recursion_limit: int = 50,
     deepagent_system_prompt: str = DEFAULT_DEEPAGENT_PROMPT,
     system_prompt: str = DEFAULT_MAIN_AGENT_PROMPT,
@@ -217,6 +218,8 @@ def construct_main_agent_graph(
         raise ValueError("deepagent_recursion_limit must be positive.")
     if deepagent_backend is not None and not enable_deepagent:
         raise ValueError("deepagent_backend requires enable_deepagent=True.")
+    if deepagent_skills and not enable_deepagent:
+        raise ValueError("deepagent_skills requires enable_deepagent=True.")
 
     if subagents is None:
         worker_kwargs: dict[str, Any] = {
@@ -252,6 +255,7 @@ def construct_main_agent_graph(
         workspace_agent = construct_deep_agent_graph(
             llm,
             tools=[],
+            skills=deepagent_skills,
             system_prompt=deepagent_system_prompt,
             backend=(
                 deepagent_backend

--- a/src/chemgraph/graphs/main_agent.py
+++ b/src/chemgraph/graphs/main_agent.py
@@ -41,10 +41,11 @@ Rules:
 5. When available, use `chemgraph` for molecular construction, simulation,
    calculator use, and other computational chemistry work. Use `deepagent` for
    repository exploration, coding, testing, file analysis, and other long
-   workspace tasks when that specialist is available.
+   workspace tasks when that specialist is available. Registry-composed workers
+   use the name `deep_agent`; use the exact registered name in `task` calls.
 6. Do not launch parallel workspace-mutating tasks. Parallel delegation is
    appropriate only for independent read-only work.
-7. If deepagent is available, do not generate the code or file edits yourself;
+7. If deepagent or deep_agent is available, do not generate the code or file edits yourself;
    delegate those tasks to deepagent.
 8. Use `read_file` to inspect checkpoint-backed files returned by subagents
    when their contents are needed. This tool cannot access host files.

--- a/src/chemgraph/memory/schemas.py
+++ b/src/chemgraph/memory/schemas.py
@@ -50,6 +50,7 @@ class MainAgentGraphConfig(BaseModel):
     terminal_tool_names: tuple[str, ...] = ()
     enable_deepagent: bool = False
     deepagent_workspace: Optional[str] = None
+    deepagent_skills: tuple[str, ...] = ()
     subagent_names: tuple[str, ...] = ("chemgraph",)
     tool_signatures: tuple[str, ...] = ()
     package_version: str = ""

--- a/src/chemgraph/registry/agents.py
+++ b/src/chemgraph/registry/agents.py
@@ -56,6 +56,13 @@ BUILTIN_AGENT_SPECS: tuple[AgentSpec, ...] = (
         tags=frozenset({"general", "chemistry"}),
     ),
     AgentSpec(
+        "deep_agent",
+        "Workspace and coding worker for repository-scale tasks.",
+        "chemgraph.graphs.deep_agent:construct_deep_agent_graph",
+        aliases=("deepagent",),
+        tags=frozenset({"coding", "workspace"}),
+    ),
+    AgentSpec(
         "multi_agent",
         "Planner-executor ChemGraph worker for decomposable chemistry tasks.",
         "chemgraph.graphs.multi_agent:construct_multi_agent_graph",

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -1,4 +1,5 @@
 import pytest
+from langchain_core.messages import AIMessage
 from langgraph.checkpoint.memory import MemorySaver
 
 from chemgraph.cli.commands import ALL_WORKFLOW_TYPES
@@ -10,10 +11,12 @@ from chemgraph.registry import (
     UnknownRegistryEntryError,
 )
 from chemgraph.tools.generic_tools import calculator
+from tests.test_main_agent import _ScriptedChatModel
 
 
 EXPECTED_WORKERS = (
     "single_agent",
+    "deep_agent",
     "multi_agent",
     "python_relp",
     "graspa",
@@ -54,6 +57,7 @@ def test_existing_workflow_aliases_resolve_to_canonical_workers():
     registry = AgentRegistry()
 
     assert registry.resolve_name("python_repl") == "python_relp"
+    assert registry.resolve_name("deepagent") == "deep_agent"
     assert registry.resolve_name("graspa_agent") == "graspa"
     assert registry.resolve_name("iri") == "single_agent_iri"
     assert registry.get_spec("python_repl").name == "python_relp"
@@ -183,7 +187,7 @@ def test_all_workers_build_standalone_with_default_memory_checkpointer():
         kwargs = _graspa_mcp_options() if name == "graspa_mcp" else {}
         graph = registry.build(
             name,
-            llm=object(),
+            llm=_ScriptedChatModel(responses=[AIMessage(content="done")]),
             require_available=False,
             **kwargs,
         )
@@ -194,7 +198,7 @@ def test_all_workers_adapt_to_parent_checkpointed_subagents():
     registry = AgentRegistry()
     workers = registry.as_subagents(
         registry.names(),
-        llm=object(),
+        llm=_ScriptedChatModel(responses=[AIMessage(content="done")]),
         options={"graspa_mcp": _graspa_mcp_options()},
         require_available=False,
     )

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -79,6 +79,9 @@ class _GraphStreamCompatibleWorkflow:
     def get_state(self, config):
         return SimpleNamespace(values=self.last_state)
 
+    async def aget_state(self, config):
+        return self.get_state(config)
+
 
 @pytest.fixture
 def mock_agent_patches():

--- a/tests/test_codex_model.py
+++ b/tests/test_codex_model.py
@@ -278,6 +278,7 @@ def test_shared_loader_routes_codex_prefix(monkeypatch):
     [
         ("single_agent", "construct_single_agent_graph"),
         ("main_agent", "construct_main_agent_graph"),
+        ("deep_agent", "construct_deep_agent_graph"),
     ],
 )
 def test_chemgraph_routes_codex_to_supported_workflow(
@@ -309,7 +310,7 @@ def test_chemgraph_routes_codex_to_supported_workflow(
 
 
 def test_chemgraph_rejects_codex_for_unsupported_workflows():
-    with pytest.raises(ValueError, match="single_agent and main_agent workflows"):
+    with pytest.raises(ValueError, match="single_agent, main_agent, and deep_agent"):
         ChemGraph(model_name="codex:test-model", workflow_type="multi_agent")
 
 

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -1,5 +1,6 @@
 """Tests for the reusable standalone Deep Agent workflow."""
 
+import hashlib
 import json
 import shlex
 import sys
@@ -17,6 +18,7 @@ from chemgraph.agent.llm_agent import ChemGraph, PromptConfig
 from chemgraph.cli import commands
 from chemgraph.graphs.deep_agent import (
     DEFAULT_DEEPAGENT_INTERRUPT_ON,
+    DEFAULT_DEEPAGENT_PROMPT,
     construct_deep_agent_graph,
 )
 from chemgraph.models.endpoints import PreparedModel
@@ -43,6 +45,36 @@ class _RecordingChatModel(_ScriptedChatModel):
             run_manager=run_manager,
             **kwargs,
         )
+
+
+def _legacy_topology_fingerprint(agent: ChemGraph) -> str:
+    """Reproduce the main-agent fingerprint before skill support was added."""
+    workspace = getattr(agent.deepagent_backend, "cwd", None)
+    graph_config = agent.main_agent_metadata.graph_config
+    topology_payload = {
+        "model_name": agent.model_name,
+        "reasoning_effort": agent.reasoning_effort,
+        "recursion_limit": agent.recursion_limit,
+        "structured_output": agent.structured_output,
+        "generate_report": agent.generate_report,
+        "max_retries": agent.max_retries,
+        "human_supervised": agent.human_supervised,
+        "terminal_tool_names": agent.terminal_tool_names,
+        "enable_deepagent": agent.enable_deepagent,
+        "workspace": str(workspace) if workspace is not None else None,
+        "tool_signatures": graph_config.tool_signatures,
+        "system_prompt": agent.system_prompt,
+        "formatter_prompt": agent.formatter_prompt,
+        "report_prompt": agent.report_prompt,
+    }
+    if (
+        agent.enable_deepagent
+        and agent.deepagent_prompt != DEFAULT_DEEPAGENT_PROMPT
+    ):
+        topology_payload["deepagent_prompt"] = agent.deepagent_prompt
+    return hashlib.sha256(
+        json.dumps(topology_payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
 
 
 def test_constructor_builds_safe_standalone_graph(monkeypatch):
@@ -377,6 +409,73 @@ async def test_chemgraph_resumes_all_pending_interrupt_ids(monkeypatch, tmp_path
     }
 
 
+@pytest.mark.asyncio
+async def test_human_input_handler_receives_raw_structured_payload():
+    payload = {
+        "action_requests": [
+            {"name": "execute", "args": {"command": "pytest"}}
+        ],
+        "review_configs": [
+            {
+                "action_name": "execute",
+                "allowed_decisions": ["approve", "reject"],
+            }
+        ],
+    }
+    decision = {"decisions": [{"type": "reject"}]}
+    received = []
+
+    def handler(question, raw_payload):
+        received.append((question, raw_payload))
+        return decision
+
+    agent = object.__new__(ChemGraph)
+    agent.human_input_handler = handler
+
+    result = await agent._call_human_input_handler(
+        "Review the requested action.",
+        payload=payload,
+    )
+
+    assert result is decision
+    assert received == [("Review the requested action.", payload)]
+    assert received[0][1] is payload
+
+
+@pytest.mark.asyncio
+async def test_human_input_handler_awaits_async_callable_object():
+    payload = {"question": "Continue?"}
+
+    class AsyncHandler:
+        async def __call__(self, question, raw_payload):
+            return question, raw_payload
+
+    agent = object.__new__(ChemGraph)
+    agent.human_input_handler = AsyncHandler()
+
+    assert await agent._call_human_input_handler(
+        "Continue?",
+        payload=payload,
+    ) == ("Continue?", payload)
+
+
+@pytest.mark.asyncio
+async def test_human_input_handler_does_not_retry_callback_type_error():
+    calls = []
+
+    def handler(question, payload):
+        calls.append((question, payload))
+        raise TypeError("handler failed")
+
+    agent = object.__new__(ChemGraph)
+    agent.human_input_handler = handler
+
+    with pytest.raises(TypeError, match="handler failed"):
+        await agent._call_human_input_handler("Continue?", payload={"id": 1})
+
+    assert calls == [("Continue?", {"id": 1})]
+
+
 def test_main_agent_metadata_persists_skills_in_topology(monkeypatch, tmp_path):
     monkeypatch.setattr(
         "chemgraph.agent.llm_agent.load_chat_model_prepared",
@@ -394,7 +493,23 @@ def test_main_agent_metadata_persists_skills_in_topology(monkeypatch, tmp_path):
         lambda *_args, **_kwargs: SimpleNamespace(),
     )
 
-    agents = [
+    no_skill_agents = [
+        ChemGraph(
+            workflow_type="main_agent",
+            enable_deepagent=enable_deepagent,
+            enable_memory=False,
+            log_dir=str(tmp_path),
+        )
+        for enable_deepagent in (False, True)
+    ]
+    for agent in no_skill_agents:
+        graph_config = agent.main_agent_metadata.graph_config
+        assert graph_config.deepagent_skills == ()
+        assert graph_config.topology_fingerprint == _legacy_topology_fingerprint(
+            agent
+        )
+
+    skill_agents = [
         ChemGraph(
             workflow_type="main_agent",
             enable_deepagent=True,
@@ -406,7 +521,7 @@ def test_main_agent_metadata_persists_skills_in_topology(monkeypatch, tmp_path):
         for skill in ("/workspace/base/", "/workspace/project/")
     ]
 
-    configs = [agent.main_agent_metadata.graph_config for agent in agents]
+    configs = [agent.main_agent_metadata.graph_config for agent in skill_agents]
     assert configs[0].deepagent_skills == ("/workspace/base/",)
     assert configs[1].deepagent_skills == ("/workspace/project/",)
     assert configs[0].topology_fingerprint != configs[1].topology_fingerprint

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -1,0 +1,365 @@
+"""Tests for the reusable standalone Deep Agent workflow."""
+
+import json
+import shlex
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from deepagents.backends import CompositeBackend, LocalShellBackend, StateBackend
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command
+from pydantic import Field
+
+from chemgraph.agent.llm_agent import ChemGraph, PromptConfig
+from chemgraph.cli import commands
+from chemgraph.graphs.deep_agent import (
+    DEFAULT_DEEPAGENT_INTERRUPT_ON,
+    construct_deep_agent_graph,
+)
+from chemgraph.models.endpoints import PreparedModel
+from tests.test_main_agent import _ScriptedChatModel
+
+
+class _FakeWorkflow:
+    def __init__(self):
+        self.config = None
+
+    def with_config(self, config):
+        self.config = config
+        return self
+
+
+class _RecordingChatModel(_ScriptedChatModel):
+    received_messages: list[Any] = Field(default_factory=list)
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        self.received_messages = list(messages)
+        return super()._generate(
+            messages,
+            stop=stop,
+            run_manager=run_manager,
+            **kwargs,
+        )
+
+
+def test_constructor_builds_safe_standalone_graph(monkeypatch):
+    captured = {}
+    workflow = _FakeWorkflow()
+
+    def fake_create_deep_agent(**kwargs):
+        captured.update(kwargs)
+        return workflow
+
+    monkeypatch.setattr(
+        "chemgraph.graphs.deep_agent.create_deep_agent",
+        fake_create_deep_agent,
+    )
+
+    result = construct_deep_agent_graph(object(), recursion_limit=17)
+
+    assert result is workflow
+    assert captured["tools"] == []
+    assert isinstance(captured["backend"], StateBackend)
+    assert isinstance(captured["checkpointer"], MemorySaver)
+    assert captured["interrupt_on"] == DEFAULT_DEEPAGENT_INTERRUPT_ON
+    assert captured["interrupt_on"] is not DEFAULT_DEEPAGENT_INTERRUPT_ON
+    assert captured["name"] == "deepagent"
+    assert workflow.config == {"recursion_limit": 17}
+
+
+def test_constructor_mounts_virtual_local_backend_at_workspace(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+    workflow = _FakeWorkflow()
+    backend = LocalShellBackend(root_dir=tmp_path, virtual_mode=True, env={})
+
+    monkeypatch.setattr(
+        "chemgraph.graphs.deep_agent.create_deep_agent",
+        lambda **kwargs: captured.update(kwargs) or workflow,
+    )
+
+    construct_deep_agent_graph(object(), backend=backend)
+
+    mounted = captured["backend"]
+    assert isinstance(mounted, CompositeBackend)
+    assert mounted.default is backend
+    assert mounted.routes == {"/workspace/": backend}
+
+    write_result = mounted.write(
+        "/workspace/probe.py",
+        "print('workspace reachable')\n",
+    )
+    assert write_result.error is None
+    assert (tmp_path / "probe.py").is_file()
+    assert not (tmp_path / "workspace" / "probe.py").exists()
+
+    command = (
+        f"{shlex.quote(sys.executable)} "
+        f"{shlex.quote(str(tmp_path / 'probe.py'))}"
+    )
+    execute_result = mounted.execute(command)
+    assert execute_result.exit_code == 0
+    assert execute_result.output == "workspace reachable\n"
+
+
+def test_virtual_workspace_supplies_shell_host_path_to_model(tmp_path):
+    model = _RecordingChatModel(
+        responses=[AIMessage(content="workspace reviewed")]
+    )
+    workflow = construct_deep_agent_graph(
+        model,
+        backend=LocalShellBackend(root_dir=tmp_path, virtual_mode=True, env={}),
+    )
+
+    workflow.invoke(
+        {"messages": [HumanMessage(content="Review the workspace")]},
+        config={"configurable": {"thread_id": "workspace-mapping"}},
+    )
+
+    system_prompt = "\n".join(
+        str(message.content)
+        for message in model.received_messages
+        if message.type == "system"
+    )
+    assert "Shell paths vs. virtual paths" in system_prompt
+    assert "`/workspace/`" in system_prompt
+    assert str(tmp_path.resolve()) in system_prompt
+
+
+def test_constructor_preserves_nonvirtual_local_backend(monkeypatch, tmp_path):
+    captured = {}
+    workflow = _FakeWorkflow()
+    backend = LocalShellBackend(root_dir=tmp_path, virtual_mode=False, env={})
+
+    monkeypatch.setattr(
+        "chemgraph.graphs.deep_agent.create_deep_agent",
+        lambda **kwargs: captured.update(kwargs) or workflow,
+    )
+
+    construct_deep_agent_graph(object(), backend=backend)
+
+    assert captured["backend"] is backend
+
+
+def test_constructor_supports_parent_checkpoint_and_unsafe_execution(monkeypatch):
+    captured = {}
+    workflow = _FakeWorkflow()
+    backend = object()
+
+    monkeypatch.setattr(
+        "chemgraph.graphs.deep_agent.create_deep_agent",
+        lambda **kwargs: captured.update(kwargs) or workflow,
+    )
+
+    construct_deep_agent_graph(
+        object(),
+        backend=backend,
+        checkpointer=None,
+        interrupt_on=None,
+    )
+
+    assert captured["backend"] is backend
+    assert captured["checkpointer"] is None
+    assert captured["interrupt_on"] is None
+
+
+def test_constructor_rejects_nonpositive_recursion_limit():
+    with pytest.raises(ValueError, match="must be positive"):
+        construct_deep_agent_graph(object(), recursion_limit=0)
+
+
+def test_standalone_graph_is_directly_invocable():
+    workflow = construct_deep_agent_graph(
+        _ScriptedChatModel(responses=[AIMessage(content="workspace reviewed")])
+    )
+
+    result = workflow.invoke(
+        {"messages": [HumanMessage(content="Review the workspace")]},
+        config={"configurable": {"thread_id": "direct-deep-agent"}},
+    )
+
+    assert result["messages"][-1].content == "workspace reviewed"
+
+
+def test_chemgraph_routes_standalone_deep_agent_configuration(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+    workflow = SimpleNamespace()
+    backend = object()
+    checkpointer = MemorySaver()
+    tool = object()
+
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        lambda **_kwargs: (
+            "fake-llm",
+            PreparedModel(
+                endpoint_name="test",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        ),
+    )
+
+    def fake_constructor(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return workflow
+
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.construct_deep_agent_graph",
+        fake_constructor,
+    )
+
+    agent = ChemGraph(
+        workflow_type="deep_agent",
+        prompts=PromptConfig(deepagent="custom workspace prompt"),
+        tools=[tool],
+        deepagent_backend=backend,
+        deepagent_auto_approve=True,
+        checkpointer=checkpointer,
+        enable_memory=False,
+        log_dir=str(tmp_path),
+    )
+
+    assert agent.workflow is workflow
+    assert captured["args"] == ("fake-llm",)
+    assert captured["kwargs"] == {
+        "tools": [tool],
+        "system_prompt": "custom workspace prompt",
+        "backend": backend,
+        "recursion_limit": 50,
+        "name": "deepagent",
+        "checkpointer": checkpointer,
+        "interrupt_on": None,
+    }
+
+
+def test_cli_resume_persists_deepagent_logs_and_session(
+    monkeypatch,
+    tmp_path,
+):
+    approval = {
+        "action_requests": [
+            {"name": "write_file", "args": {"file_path": "/workspace/result.txt"}}
+        ],
+        "review_configs": [
+            {
+                "action_name": "write_file",
+                "allowed_decisions": ["approve", "reject"],
+            }
+        ],
+    }
+
+    class ApprovalWorkflow:
+        def __init__(self):
+            self.pending = False
+            self.state = {"messages": []}
+
+        async def astream(self, stream_input, **_kwargs):
+            if isinstance(stream_input, Command):
+                self.pending = False
+                self.state = {
+                    "messages": [
+                        HumanMessage(content="Write the result"),
+                        AIMessage(content="Result written."),
+                    ]
+                }
+                yield self.state
+                return
+
+            self.pending = True
+            self.state = {
+                "messages": [HumanMessage(content="Write the result")]
+            }
+            yield {
+                **self.state,
+                "__interrupt__": [SimpleNamespace(value=approval)],
+            }
+
+        def get_state(self, _config):
+            tasks = (
+                (
+                    SimpleNamespace(
+                        interrupts=(SimpleNamespace(value=approval),)
+                    ),
+                )
+                if self.pending
+                else ()
+            )
+            return SimpleNamespace(values=self.state, tasks=tasks)
+
+    workflow = ApprovalWorkflow()
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        lambda **_kwargs: (
+            "fake-llm",
+            PreparedModel(
+                endpoint_name="test",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.construct_deep_agent_graph",
+        lambda *_args, **_kwargs: workflow,
+    )
+    monkeypatch.setattr(
+        commands,
+        "_prompt_for_interrupt",
+        lambda _payload: {"decisions": [{"type": "approve"}]},
+    )
+
+    log_dir = tmp_path / "cg_logs" / "session"
+    workspace = tmp_path / "test"
+    workspace.mkdir()
+    agent = ChemGraph(
+        workflow_type="deep_agent",
+        deepagent_backend=LocalShellBackend(root_dir=workspace, env={}),
+        memory_db_path=str(tmp_path / "sessions.db"),
+        log_dir=str(log_dir),
+    )
+
+    result = commands.run_query(agent, "Write the result", thread_id=7)
+
+    assert result.content == "Result written."
+    state_logs = sorted(log_dir.glob("state_thread_7_*.json"))
+    assert len(state_logs) == 2
+    saved_states = [json.loads(path.read_text()) for path in state_logs]
+    assert all(saved["thread_id"] == 7 for saved in saved_states)
+    assert "Result written." not in state_logs[0].read_text()
+    assert "Result written." in state_logs[1].read_text()
+    assert not (workspace / "cg_logs").exists()
+
+    session = agent.session_store.get_session(agent.session_id)
+    assert session is not None
+    assert [message.content for message in session.messages] == [
+        "Write the result",
+        "Result written.",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {"workflow_type": "single_agent", "deepagent_backend": object()},
+            "deepagent_backend",
+        ),
+        (
+            {"workflow_type": "main_agent", "deepagent_auto_approve": True},
+            "deepagent_auto_approve",
+        ),
+    ],
+)
+def test_chemgraph_rejects_deepagent_options_for_other_workflows(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        ChemGraph(enable_memory=False, **kwargs)

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -2,7 +2,9 @@
 
 import hashlib
 import json
+import os
 import shlex
+import subprocess
 import sys
 from types import SimpleNamespace
 from typing import Any
@@ -77,6 +79,26 @@ def _legacy_topology_fingerprint(agent: ChemGraph) -> str:
     ).hexdigest()
 
 
+def _message_content_text(message: Any) -> str:
+    """Return text without escaping structured content-block strings."""
+    content = message.content
+    if isinstance(content, list):
+        return "\n".join(
+            block.get("text", str(block))
+            if isinstance(block, dict)
+            else str(block)
+            for block in content
+        )
+    return str(content)
+
+
+def _shell_command(*parts: str) -> str:
+    """Quote a command for the current platform's host shell."""
+    if os.name == "nt":
+        return subprocess.list2cmdline(parts)
+    return shlex.join(parts)
+
+
 def test_constructor_builds_safe_standalone_graph(monkeypatch):
     captured = {}
     workflow = _FakeWorkflow()
@@ -138,7 +160,7 @@ def test_constructor_loads_ordered_workspace_skills(tmp_path):
     )
 
     system_prompt = "\n".join(
-        str(message.content)
+        _message_content_text(message)
         for message in model.received_messages
         if message.type == "system"
     )
@@ -188,9 +210,9 @@ def test_constructor_mounts_virtual_local_backend_at_workspace(
     assert (tmp_path / "probe.py").is_file()
     assert not (tmp_path / "workspace" / "probe.py").exists()
 
-    command = (
-        f"{shlex.quote(sys.executable)} "
-        f"{shlex.quote(str(tmp_path / 'probe.py'))}"
+    command = _shell_command(
+        sys.executable,
+        str(tmp_path / "probe.py"),
     )
     execute_result = mounted.execute(command)
     assert execute_result.exit_code == 0
@@ -212,7 +234,7 @@ def test_virtual_workspace_supplies_shell_host_path_to_model(tmp_path):
     )
 
     system_prompt = "\n".join(
-        str(message.content)
+        _message_content_text(message)
         for message in model.received_messages
         if message.type == "system"
     )

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -62,12 +62,70 @@ def test_constructor_builds_safe_standalone_graph(monkeypatch):
 
     assert result is workflow
     assert captured["tools"] == []
+    assert captured["skills"] is None
     assert isinstance(captured["backend"], StateBackend)
     assert isinstance(captured["checkpointer"], MemorySaver)
     assert captured["interrupt_on"] == DEFAULT_DEEPAGENT_INTERRUPT_ON
     assert captured["interrupt_on"] is not DEFAULT_DEEPAGENT_INTERRUPT_ON
     assert captured["name"] == "deepagent"
     assert workflow.config == {"recursion_limit": 17}
+
+
+def test_constructor_loads_ordered_workspace_skills(tmp_path):
+    base_skill = tmp_path / "base-skills" / "review-workflow"
+    project_skill = tmp_path / "project-skills" / "review-workflow"
+    base_skill.mkdir(parents=True)
+    project_skill.mkdir(parents=True)
+    base_skill.joinpath("SKILL.md").write_text(
+        "---\n"
+        "name: review-workflow\n"
+        "description: Base review workflow.\n"
+        "---\n\n"
+        "# Base Review\n",
+    )
+    project_skill.joinpath("SKILL.md").write_text(
+        "---\n"
+        "name: review-workflow\n"
+        "description: Project-specific review workflow.\n"
+        "---\n\n"
+        "# Project Review\n",
+    )
+    model = _RecordingChatModel(responses=[AIMessage(content="reviewed")])
+    workflow = construct_deep_agent_graph(
+        model,
+        backend=LocalShellBackend(root_dir=tmp_path, virtual_mode=True, env={}),
+        skills=[
+            "/workspace/base-skills/",
+            "/workspace/project-skills/",
+        ],
+    )
+
+    workflow.invoke(
+        {"messages": [HumanMessage(content="Review the project")]},
+        config={"configurable": {"thread_id": "skill-loading"}},
+    )
+
+    system_prompt = "\n".join(
+        str(message.content)
+        for message in model.received_messages
+        if message.type == "system"
+    )
+    assert "Project-specific review workflow." in system_prompt
+    assert "Base review workflow." not in system_prompt
+    assert "/workspace/project-skills/review-workflow/SKILL.md" in system_prompt
+
+
+@pytest.mark.parametrize(
+    ("skills", "error"),
+    [
+        ("/skills/", TypeError),
+        ([""], ValueError),
+        ([object()], TypeError),
+    ],
+)
+def test_constructor_rejects_invalid_skill_sources(skills, error):
+    with pytest.raises(error, match="[Ss]kill"):
+        construct_deep_agent_graph(object(), skills=skills)
 
 
 def test_constructor_mounts_virtual_local_backend_at_workspace(
@@ -223,6 +281,7 @@ def test_chemgraph_routes_standalone_deep_agent_configuration(
         prompts=PromptConfig(deepagent="custom workspace prompt"),
         tools=[tool],
         deepagent_backend=backend,
+        deepagent_skills=["/workspace/base/", "/workspace/project/"],
         deepagent_auto_approve=True,
         checkpointer=checkpointer,
         enable_memory=False,
@@ -233,6 +292,7 @@ def test_chemgraph_routes_standalone_deep_agent_configuration(
     assert captured["args"] == ("fake-llm",)
     assert captured["kwargs"] == {
         "tools": [tool],
+        "skills": ("/workspace/base/", "/workspace/project/"),
         "system_prompt": "custom workspace prompt",
         "backend": backend,
         "recursion_limit": 50,
@@ -240,6 +300,116 @@ def test_chemgraph_routes_standalone_deep_agent_configuration(
         "checkpointer": checkpointer,
         "interrupt_on": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_chemgraph_resumes_all_pending_interrupt_ids(monkeypatch, tmp_path):
+    first = SimpleNamespace(id="first-id", value={"question": "First?"})
+    second = SimpleNamespace(id="second-id", value={"question": "Second?"})
+
+    class MultiInterruptWorkflow:
+        def __init__(self):
+            self.pending = True
+            self.resume_value = None
+            self.state = {"messages": [HumanMessage(content="Continue")]}
+
+        async def astream(self, stream_input, **_kwargs):
+            if isinstance(stream_input, Command):
+                self.resume_value = stream_input.resume
+                self.pending = False
+                self.state = {
+                    "messages": [
+                        HumanMessage(content="Continue"),
+                        AIMessage(content="Completed."),
+                    ]
+                }
+                yield self.state
+                return
+            yield {**self.state, "__interrupt__": [first, second]}
+
+        def get_state(self, _config):
+            tasks = (
+                (SimpleNamespace(interrupts=(first, second)),)
+                if self.pending
+                else ()
+            )
+            return SimpleNamespace(
+                values=self.state,
+                tasks=tasks,
+                interrupts=(),
+            )
+
+    workflow = MultiInterruptWorkflow()
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        lambda **_kwargs: (
+            "fake-llm",
+            PreparedModel(
+                endpoint_name="test",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.construct_deep_agent_graph",
+        lambda *_args, **_kwargs: workflow,
+    )
+    questions = []
+    agent = ChemGraph(
+        workflow_type="deep_agent",
+        human_input_handler=lambda question: questions.append(question)
+        or f"answer-{len(questions)}",
+        enable_memory=False,
+        log_dir=str(tmp_path),
+    )
+
+    result = await agent.run(
+        "Continue",
+        config={"configurable": {"thread_id": "multi-interrupt"}},
+    )
+
+    assert result.content == "Completed."
+    assert questions == ["First?", "Second?"]
+    assert workflow.resume_value == {
+        "first-id": "answer-1",
+        "second-id": "answer-2",
+    }
+
+
+def test_main_agent_metadata_persists_skills_in_topology(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        lambda **_kwargs: (
+            "fake-llm",
+            PreparedModel(
+                endpoint_name="test",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.construct_main_agent_graph",
+        lambda *_args, **_kwargs: SimpleNamespace(),
+    )
+
+    agents = [
+        ChemGraph(
+            workflow_type="main_agent",
+            enable_deepagent=True,
+            deepagent_backend=SimpleNamespace(cwd=tmp_path),
+            deepagent_skills=[skill],
+            enable_memory=False,
+            log_dir=str(tmp_path),
+        )
+        for skill in ("/workspace/base/", "/workspace/project/")
+    ]
+
+    configs = [agent.main_agent_metadata.graph_config for agent in agents]
+    assert configs[0].deepagent_skills == ("/workspace/base/",)
+    assert configs[1].deepagent_skills == ("/workspace/project/",)
+    assert configs[0].topology_fingerprint != configs[1].topology_fingerprint
 
 
 def test_cli_resume_persists_deepagent_logs_and_session(
@@ -357,6 +527,10 @@ def test_cli_resume_persists_deepagent_logs_and_session(
         (
             {"workflow_type": "main_agent", "deepagent_auto_approve": True},
             "deepagent_auto_approve",
+        ),
+        (
+            {"workflow_type": "single_agent", "deepagent_skills": ["/skills/"]},
+            "deepagent_skills",
         ),
     ],
 )

--- a/tests/test_deep_agent.py
+++ b/tests/test_deep_agent.py
@@ -199,7 +199,8 @@ def test_constructor_mounts_virtual_local_backend_at_workspace(
 
     mounted = captured["backend"]
     assert isinstance(mounted, CompositeBackend)
-    assert mounted.default is backend
+    assert isinstance(mounted.default, LocalShellBackend)
+    assert isinstance(mounted.default, StateBackend)
     assert mounted.routes == {"/workspace/": backend}
 
     write_result = mounted.write(
@@ -392,6 +393,9 @@ async def test_chemgraph_resumes_all_pending_interrupt_ids(monkeypatch, tmp_path
                 tasks=tasks,
                 interrupts=(),
             )
+
+        async def aget_state(self, config):
+            return self.get_state(config)
 
     workflow = MultiInterruptWorkflow()
     monkeypatch.setattr(
@@ -602,6 +606,9 @@ def test_cli_resume_persists_deepagent_logs_and_session(
                 else ()
             )
             return SimpleNamespace(values=self.state, tasks=tasks)
+
+        async def aget_state(self, config):
+            return self.get_state(config)
 
     workflow = ApprovalWorkflow()
     monkeypatch.setattr(

--- a/tests/test_deep_agent_cli_review.py
+++ b/tests/test_deep_agent_cli_review.py
@@ -1,0 +1,215 @@
+"""CLI configuration and error-handling regressions for Deep Agent."""
+
+from types import SimpleNamespace
+
+import pytest
+import toml
+from rich.console import Console
+
+from chemgraph.agent.interrupts import PendingInterrupt
+from chemgraph.agent.llm_agent import ChemGraph, HumanInputRequired
+from chemgraph.cli import commands
+from tests.test_main_agent_cli import _FakeMainSession, _turn_result, cli_main
+
+
+@pytest.fixture
+def dispatch(monkeypatch):
+    received = {}
+    monkeypatch.setattr(
+        cli_main, "interactive_mode", lambda **kwargs: received.update(kwargs)
+    )
+    monkeypatch.setattr(
+        cli_main,
+        "initialize_agent",
+        lambda *args, **kwargs: (
+            received.update(workflow=args[1], **kwargs) or SimpleNamespace()
+        ),
+    )
+    monkeypatch.setattr(cli_main, "run_query", lambda *args, **kwargs: "done")
+    monkeypatch.setattr(cli_main, "format_response", lambda *args, **kwargs: None)
+    return received
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+@pytest.mark.parametrize("enabled", [False, True])
+def test_saved_deepagent_settings_do_not_block_other_workflows(
+    tmp_path, dispatch, interactive, enabled
+):
+    path = tmp_path / "config.toml"
+    path.write_text(
+        toml.dumps(
+            {
+                "general": {
+                    "workflow": "single_agent",
+                    "enable_deepagent": enabled,
+                    "deepagent_workspace": str(tmp_path),
+                    "deepagent_skills": ["/workspace/skills/"],
+                }
+            }
+        )
+    )
+    argv = ["run", "--config", str(path), "-q", "test"]
+    if interactive:
+        argv.append("--interactive")
+    cli_main._handle_run(cli_main.create_argument_parser().parse_args(argv))
+    assert dispatch["workflow"] == "single_agent"
+    assert dispatch["deepagent_workspace"] == (str(tmp_path) if interactive else None)
+    assert dispatch["deepagent_skills"] == (
+        ["/workspace/skills/"] if interactive else None
+    )
+    if interactive:
+        assert dispatch["enable_deepagent"] is enabled
+
+
+@pytest.mark.parametrize(
+    "override,expected", [(None, "deep_agent"), ("single_agent", "single_agent")]
+)
+def test_workflow_config_and_explicit_cli_precedence(
+    tmp_path, dispatch, override, expected
+):
+    path = tmp_path / "config.toml"
+    path.write_text(toml.dumps({"general": {"workflow": "deepagent"}}))
+    argv = ["run", "--interactive", "--config", str(path)]
+    if override:
+        argv += ["-w", override]
+    cli_main._handle_run(cli_main.create_argument_parser().parse_args(argv))
+    assert dispatch["workflow"] == expected
+
+
+def test_missing_workflow_defaults_to_single_agent(dispatch):
+    cli_main._handle_run(
+        cli_main.create_argument_parser().parse_args(["run", "--interactive"])
+    )
+    assert dispatch["workflow"] == "single_agent"
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ["--deepagent"],
+        ["--deepagent-workspace", "/tmp"],
+        ["--deepagent-skill", "/skills/"],
+    ],
+)
+def test_explicit_incompatible_deepagent_flags_still_fail(dispatch, flags):
+    args = cli_main.create_argument_parser().parse_args(
+        ["run", "--interactive", "-w", "single_agent", *flags]
+    )
+    with pytest.raises(SystemExit) as exc:
+        cli_main._handle_run(args)
+    assert exc.value.code == 2
+    assert not dispatch
+
+
+@pytest.mark.parametrize("skills", ["/workspace/skills/", [""], [123]])
+def test_malformed_active_skills_are_cli_input_errors(tmp_path, dispatch, skills):
+    path = tmp_path / "config.toml"
+    path.write_text(
+        toml.dumps({"general": {"workflow": "deep_agent", "deepagent_skills": skills}})
+    )
+    args = cli_main.create_argument_parser().parse_args(
+        ["run", "--interactive", "--config", str(path)]
+    )
+    with commands.console.capture() as capture, pytest.raises(SystemExit) as exc:
+        cli_main._handle_run(args)
+    assert exc.value.code == 2
+    assert "Invalid Deep Agent skills" in capture.get()
+    assert not dispatch
+
+
+def test_interactive_initialization_reports_invalid_skills(monkeypatch):
+    monkeypatch.setattr(
+        commands,
+        "_create_experimental_deepagent_backend",
+        lambda *_args, **_kwargs: pytest.fail("must validate before enabling shell"),
+    )
+    with commands.console.capture() as capture:
+        result = commands.initialize_agent(
+            "fake", "deep_agent", False, "state", False, 20, deepagent_skills=[""]
+        )
+    assert result is None
+    assert "must not be empty" in capture.get()
+    with pytest.raises(ValueError, match="requires enable_deepagent"):
+        ChemGraph(
+            workflow_type="single_agent",
+            deepagent_skills="/skills/",
+            enable_memory=False,
+        )
+
+
+@pytest.mark.parametrize("approve", [False, True])
+def test_cwd_workspace_is_named_and_confirmation_is_required(
+    monkeypatch, tmp_path, approve
+):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(commands, "console", Console(width=300))
+    confirmations = []
+    created = []
+    monkeypatch.setattr(
+        commands.Confirm,
+        "ask",
+        lambda *args, **kwargs: confirmations.append(kwargs) or approve,
+    )
+    monkeypatch.setattr(
+        "deepagents.backends.LocalShellBackend",
+        lambda **kwargs: created.append(kwargs) or kwargs,
+    )
+    with commands.console.capture() as capture:
+        if approve:
+            commands._create_experimental_deepagent_backend(None)
+        else:
+            with pytest.raises(RuntimeError, match="not approved"):
+                commands._create_experimental_deepagent_backend(None)
+    assert str(tmp_path.resolve()) in capture.get()
+    assert confirmations == [{"default": False}]
+    assert bool(created) is approve
+
+
+def _review(allowed):
+    return {
+        "action_requests": [{"name": "execute", "args": {"command": "test"}}],
+        "review_configs": [{"action_name": "execute", "allowed_decisions": allowed}],
+    }
+
+
+@pytest.mark.parametrize("main_agent", [False, True])
+@pytest.mark.parametrize(
+    "payload", [_review(["edit"]), {"action_requests": [None], "review_configs": []}]
+)
+def test_prompt_errors_are_reported_without_tracebacks(
+    monkeypatch, main_agent, payload
+):
+    monkeypatch.setattr(commands.time, "sleep", lambda _: None)
+    pending = PendingInterrupt(id="review", payload=payload)
+    if main_agent:
+        session = _FakeMainSession([_turn_result(pending)])
+
+        def run():
+            return commands.run_main_agent_query(session, "test")
+    else:
+
+        class Agent:
+            async def run(self, *args, **kwargs):
+                raise HumanInputRequired("review", interrupts=(pending,))
+
+        def run():
+            return commands.run_query(Agent(), "test")
+
+    with commands.console.capture() as capture:
+        assert run() is None
+    assert "Error" in capture.get()
+
+
+@pytest.mark.parametrize("approval", [False, True])
+def test_main_agent_limit_counts_questions_only(monkeypatch, approval):
+    payload = _review(["approve", "reject"]) if approval else {"question": "Continue?"}
+    pending = [PendingInterrupt(id=str(i), payload=payload) for i in range(12)]
+    session = _FakeMainSession([*(_turn_result(p) for p in pending), _turn_result()])
+    monkeypatch.setattr(
+        commands,
+        "_prompt_for_interrupt",
+        lambda _: {"decisions": [{"type": "approve"}]} if approval else "yes",
+    )
+    result = commands.run_main_agent_query(session, "test")
+    assert (result is not None) is approval
+    assert len(session.calls) == (13 if approval else 11)

--- a/tests/test_deep_agent_review.py
+++ b/tests/test_deep_agent_review.py
@@ -1,0 +1,408 @@
+"""Regressions for workspace namespaces, approvals, and async checkpoints."""
+
+import json
+import sys
+from types import SimpleNamespace
+from typing import TypedDict
+
+import pytest
+from deepagents.backends import LocalShellBackend
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.errors import GraphInterrupt
+from langgraph.graph import END, START, MessagesState, StateGraph
+from langgraph.types import Command, Interrupt, interrupt
+
+from chemgraph.agent.interrupts import collect_pending_interrupts, normalize_interrupts
+from chemgraph.agent.llm_agent import ChemGraph, HumanInputRequired
+from chemgraph.cli import commands
+from chemgraph.graphs.deep_agent import _normalize_backend
+from chemgraph.models.endpoints import PreparedModel
+from tests.test_deep_agent import _shell_command
+from tests.test_main_agent import _ScriptedChatModel
+
+
+def _agent(monkeypatch, tmp_path, *, responses=None, workflow=None, **kwargs):
+    model = _ScriptedChatModel(responses=responses or [AIMessage(content="Done")])
+    monkeypatch.setattr(
+        "chemgraph.agent.llm_agent.load_chat_model_prepared",
+        lambda **_: (
+            model,
+            PreparedModel(
+                endpoint_name="test",
+                protocol="openai_compatible",
+                client_kwargs={},
+            ),
+        ),
+    )
+    if workflow is not None:
+        monkeypatch.setattr(
+            "chemgraph.agent.llm_agent.construct_deep_agent_graph",
+            lambda *_, **__: workflow,
+        )
+    return ChemGraph(
+        workflow_type="deep_agent",
+        log_dir=str(tmp_path / "logs"),
+        memory_db_path=str(tmp_path / "memory.db"),
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_workspace_has_one_file_namespace(tmp_path, asynchronous):
+    (tmp_path / "a.py").write_text("# TODO a\n")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub/b.py").write_text("# TODO b\n")
+    backend = _normalize_backend(LocalShellBackend(root_dir=tmp_path, env={}))
+    results = {}
+
+    class Files(TypedDict):
+        files: dict
+
+    async def inspect_workspace(state):
+        for path in (None, "/", "/workspace/"):
+            glob = (
+                await backend.aglob("**/*.py", path)
+                if asynchronous
+                else backend.glob("**/*.py", path)
+            )
+            grep = (
+                await backend.agrep("TODO", path)
+                if asynchronous
+                else backend.grep("TODO", path)
+            )
+            results[path] = (glob, grep)
+        results["ls"] = await backend.als("/") if asynchronous else backend.ls("/")
+        if asynchronous:
+            await backend.awrite("/scratch.txt", "checkpoint only")
+            await backend.awrite("/workspace/written.txt", "host file")
+        else:
+            backend.write("/scratch.txt", "checkpoint only")
+            backend.write("/workspace/written.txt", "host file")
+        command = _shell_command(sys.executable, "-c", "print('executed')")
+        results["shell"] = (
+            await backend.aexecute(command)
+            if asynchronous
+            else backend.execute(command)
+        )
+        return {}
+
+    builder = StateGraph(Files)
+    builder.add_node("inspect", inspect_workspace)
+    builder.add_edge(START, "inspect")
+    builder.add_edge("inspect", END)
+    state = await builder.compile().ainvoke({"files": {}})
+    for path in (None, "/", "/workspace/"):
+        glob, grep = results[path]
+        assert sorted(item["path"] for item in glob.matches) == [
+            "/workspace/a.py",
+            "/workspace/sub/b.py",
+        ]
+        assert sorted(item["path"] for item in grep.matches) == [
+            "/workspace/a.py",
+            "/workspace/sub/b.py",
+        ]
+        assert not glob.truncated and not grep.truncated
+    assert [item["path"] for item in results["ls"].entries] == ["/workspace/"]
+    assert "/scratch.txt" in state["files"]
+    assert not (tmp_path / "scratch.txt").exists()
+    assert (tmp_path / "written.txt").read_text() == "host file"
+    assert results["shell"].exit_code == 0
+    assert "executed" in results["shell"].output
+
+
+def _approval():
+    return {
+        "action_requests": [{"name": "write_file", "args": {}}],
+        "review_configs": [
+            {"action_name": "write_file", "allowed_decisions": ["approve", "reject"]}
+        ],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("via_cli", [False, True])
+async def test_twelve_file_approvals_complete(monkeypatch, tmp_path, via_cli):
+    responses = [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "write_file",
+                    "args": {"file_path": f"/workspace/{i}.txt", "content": str(i)},
+                    "id": f"write-{i}",
+                    "type": "tool_call",
+                }
+            ],
+        )
+        for i in range(12)
+    ] + [AIMessage(content="Done")]
+    decisions = []
+
+    def approve(payload):
+        decisions.append(payload)
+        return {"decisions": [{"type": "approve"}]}
+
+    agent = _agent(
+        monkeypatch,
+        tmp_path,
+        responses=responses,
+        deepagent_backend=LocalShellBackend(root_dir=tmp_path, env={}),
+        human_input_handler=None
+        if via_cli
+        else lambda question, payload: approve(payload),
+    )
+    if via_cli:
+        monkeypatch.setattr(commands, "_prompt_for_interrupt", approve)
+        monkeypatch.setattr(commands.time, "sleep", lambda _: None)
+        result = commands.run_query(agent, "Write twelve files", thread_id=37)
+    else:
+        result = await agent.run("Write twelve files", config={"thread_id": 37})
+    assert result.content == "Done"
+    assert len(decisions) == 12
+    assert all((tmp_path / f"{i}.txt").read_text() == str(i) for i in range(12))
+    assert len(agent.session_store.get_session(agent.session_id).messages) == 14
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("return_option", ["state", "last_message"])
+async def test_async_saver_recovers_approval_and_logs(
+    monkeypatch, tmp_path, return_option
+):
+    builder = StateGraph(MessagesState)
+
+    def ask(state):
+        decision = interrupt(_approval())
+        assert decision == {"decisions": [{"type": "approve"}]}
+        return {"messages": [AIMessage(content="Approved")]}
+
+    builder.add_node("ask", ask)
+    builder.add_edge(START, "ask")
+    builder.add_edge("ask", END)
+    config = {"configurable": {"thread_id": "async-saver"}}
+    async with AsyncSqliteSaver.from_conn_string(
+        str(tmp_path / "checkpoints.db")
+    ) as saver:
+        workflow = builder.compile(checkpointer=saver)
+        agent = _agent(
+            monkeypatch, tmp_path, workflow=workflow, return_option=return_option
+        )
+        with pytest.raises(HumanInputRequired) as exc:
+            await agent.run("Approve", config=config)
+        assert exc.value.interrupts[0].id
+        final = await workflow.ainvoke(
+            Command(resume={"decisions": [{"type": "approve"}]}), config
+        )
+        result = await agent.afinalize_completed_run(final, config, "Approve")
+        assert (
+            result["messages"][-1]["content"] == "Approved"
+            if return_option == "state"
+            else result.content == "Approved"
+        )
+    logs = list((tmp_path / "logs").glob("*.json"))
+    assert len(logs) == 2
+    assert all(
+        json.loads(log.read_text())["thread_id"] == "async-saver" for log in logs
+    )
+    assert len(agent.session_store.get_session(agent.session_id).messages) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handler", [False, True])
+async def test_bare_interrupt_uses_checkpoint_request(monkeypatch, tmp_path, handler):
+    class Workflow:
+        pending = True
+        state = {"messages": [HumanMessage(content="Continue")]}
+
+        async def astream(self, value, **kwargs):
+            if not isinstance(value, Command):
+                raise GraphInterrupt()
+            self.pending = False
+            self.state = {"messages": [AIMessage(content="Done")]}
+            yield self.state
+
+        async def aget_state(self, config):
+            pending = (
+                (Interrupt(value={"question": "Continue?"}, id="real-id"),)
+                if self.pending
+                else ()
+            )
+            return SimpleNamespace(values=self.state, interrupts=pending, tasks=())
+
+    agent = _agent(
+        monkeypatch,
+        tmp_path,
+        workflow=Workflow(),
+        human_input_handler=(lambda _: "yes") if handler else None,
+    )
+    if handler:
+        assert (await agent.run("Continue")).content == "Done"
+    else:
+        with pytest.raises(HumanInputRequired) as exc:
+            await agent.run("Continue")
+        assert [item.id for item in exc.value.interrupts] == ["real-id"]
+
+
+def test_anonymous_interrupts_are_not_collapsed_or_counted_twice():
+    raw = [Interrupt(value={"a": 1, "b": 2}), Interrupt(value={"b": 2, "a": 1})]
+    normalized = normalize_interrupts(raw)
+    assert [item.id for item in normalized] == ["", ""]
+    snapshot = SimpleNamespace(interrupts=raw, tasks=[SimpleNamespace(interrupts=raw)])
+    assert collect_pending_interrupts(normalized, snapshot) == tuple(normalized)
+    assert len(collect_pending_interrupts(normalized)) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("approval", [False, True])
+async def test_concurrent_interrupts_limit_only_questions(
+    monkeypatch, tmp_path, approval
+):
+    builder = StateGraph(MessagesState)
+
+    def ask(state):
+        interrupt(_approval() if approval else {"question": "Continue?"})
+        return {"messages": [AIMessage(content="Done")]}
+
+    for i in range(11):
+        builder.add_node(str(i), ask)
+        builder.add_edge(START, str(i))
+        builder.add_edge(str(i), END)
+    agent = _agent(
+        monkeypatch,
+        tmp_path,
+        workflow=builder.compile(checkpointer=InMemorySaver()),
+        human_input_handler=lambda question, payload: (
+            {"decisions": [{"type": "approve"}]} if approval else "yes"
+        ),
+    )
+    if approval:
+        assert (await agent.run("Continue")).content == "Done"
+    else:
+        with pytest.raises(RuntimeError, match="maximum of 10"):
+            await agent.run("Continue")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_finalization_scopes_idless_messages_to_thread(
+    monkeypatch, tmp_path, asynchronous
+):
+    state = {
+        "messages": [
+            {"type": "human", "content": "Repeated"},
+            {"type": "ai", "content": "Same reply"},
+        ]
+    }
+
+    class Workflow:
+        def get_state(self, config):
+            return SimpleNamespace(values=state)
+
+        async def aget_state(self, config):
+            return self.get_state(config)
+
+    agent = _agent(monkeypatch, tmp_path, workflow=Workflow(), return_option="state")
+    agent._ensure_session("Repeated")
+    for thread in (7, "7", "new-thread", "new-thread"):
+        config = {"configurable": {"thread_id": thread}}
+        if asynchronous:
+            await agent.afinalize_completed_run(state, config, "Repeated")
+        else:
+            agent.finalize_completed_run(state, config, "Repeated")
+    session = agent.session_store.get_session(agent.session_id)
+    assert [msg.content for msg in session.messages] == ["Repeated", "Same reply"] * 2
+    assert session.query_count == 2
+
+
+def test_registry_worker_delegates_using_canonical_name():
+    from chemgraph.graphs.main_agent import (
+        DEFAULT_MAIN_AGENT_PROMPT,
+        construct_main_agent_graph,
+    )
+    from chemgraph.registry import AgentRegistry
+
+    worker = AgentRegistry().as_subagent(
+        "deepagent",
+        llm=_ScriptedChatModel(responses=[AIMessage(content="Workspace reviewed")]),
+    )
+    assert worker["name"] == "deep_agent"
+    assert worker["name"] in DEFAULT_MAIN_AGENT_PROMPT
+    model = _ScriptedChatModel(
+        responses=[
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": "task",
+                        "args": {
+                            "subagent_type": worker["name"],
+                            "description": "Review workspace",
+                        },
+                        "id": "delegate",
+                        "type": "tool_call",
+                    }
+                ],
+            ),
+            AIMessage(content="Done"),
+        ]
+    )
+    workflow = construct_main_agent_graph(model, subagents=[worker])
+    result = workflow.invoke(
+        {"messages": [HumanMessage(content="Review workspace")]},
+        {"configurable": {"thread_id": "registry"}},
+    )
+    assert any(
+        msg.type == "tool" and "Workspace reviewed" in str(msg.content)
+        for msg in result["messages"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_placeholder_concurrent_requests_are_rejected_before_handler(
+    monkeypatch, tmp_path
+):
+    class Workflow:
+        async def astream(self, value, **kwargs):
+            yield {
+                "messages": [],
+                "__interrupt__": [
+                    Interrupt(value=_approval()),
+                    Interrupt(value=_approval()),
+                ],
+            }
+
+        async def aget_state(self, config):
+            return SimpleNamespace(values={"messages": []}, interrupts=(), tasks=())
+
+    agent = _agent(
+        monkeypatch,
+        tmp_path,
+        workflow=Workflow(),
+        human_input_handler=lambda *_: pytest.fail(
+            "must reject ambiguous requests before prompting"
+        ),
+    )
+    with pytest.raises(RuntimeError, match="stable IDs"):
+        await agent.run("Continue")
+
+
+@pytest.mark.asyncio
+async def test_snapshot_failure_preserves_resumable_stream_interrupt(
+    monkeypatch, tmp_path
+):
+    class Workflow:
+        async def astream(self, value, **kwargs):
+            yield {
+                "messages": [],
+                "__interrupt__": [Interrupt(value=_approval(), id="pending")],
+            }
+
+        async def aget_state(self, config):
+            raise RuntimeError("checkpoint read unavailable")
+
+    agent = _agent(monkeypatch, tmp_path, workflow=Workflow())
+    with pytest.raises(HumanInputRequired) as exc:
+        await agent.run("Continue")
+    assert exc.value.interrupts[0].id == "pending"

--- a/tests/test_graph_constructors.py
+++ b/tests/test_graph_constructors.py
@@ -18,6 +18,7 @@ def _fake_prepared(**_kwargs):
 WORKFLOWS = [
     "single_agent",
     "main_agent",
+    "deep_agent",
     "multi_agent",
     "python_relp",
     "graspa",
@@ -40,6 +41,7 @@ def test_constructor_is_called(monkeypatch, workflow_type):
     constructor_attr = {
         "single_agent": "construct_single_agent_graph",
         "main_agent": "construct_main_agent_graph",
+        "deep_agent": "construct_deep_agent_graph",
         "multi_agent": "construct_multi_agent_graph",
         "python_relp": "construct_relp_graph",
         "graspa": "construct_graspa_graph",

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -192,6 +192,7 @@ def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tm
         prompts=PromptConfig(
             formatter="custom formatter",
             report="custom report",
+            deepagent="custom workspace prompt",
         ),
         structured_output=True,
         generate_report=True,
@@ -218,6 +219,7 @@ def test_main_agent_forwards_supervisor_and_worker_configuration(monkeypatch, tm
     assert captured["kwargs"]["enable_deepagent"] is True
     assert captured["kwargs"]["deepagent_backend"] is deepagent_backend
     assert captured["kwargs"]["deepagent_recursion_limit"] == cg.recursion_limit
+    assert captured["kwargs"]["deepagent_system_prompt"] == "custom workspace prompt"
 
 
 @pytest.mark.asyncio

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -42,6 +42,9 @@ class _FakeWorkflow:
     def get_state(self, config):
         return SimpleNamespace(values=self.last_state)
 
+    async def aget_state(self, config):
+        return self.get_state(config)
+
 
 @pytest.mark.parametrize(
     ("workflow_type", "constructor_attr", "kwargs"),

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -283,6 +283,9 @@ async def test_cli_trace_events_are_emitted_from_astream_path(monkeypatch, tmp_p
         def get_state(self, config):
             return SimpleNamespace(values=self.state)
 
+        async def aget_state(self, config):
+            return self.get_state(config)
+
     monkeypatch.setattr(
         "chemgraph.agent.llm_agent.construct_single_agent_graph",
         lambda *_args, **_kwargs: FakeWorkflow(),

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -533,14 +533,15 @@ def test_deepagent_is_opt_in_and_receives_backend_configuration(monkeypatch):
             captured["config"] = config
             return self
 
-    def fake_create_deep_agent(**kwargs):
+    def fake_construct_deep_agent_graph(llm, **kwargs):
+        captured["llm"] = llm
         captured["kwargs"] = kwargs
         return FakeDeepAgent()
 
     backend = object()
     monkeypatch.setattr(
-        "chemgraph.graphs.main_agent.create_deep_agent",
-        fake_create_deep_agent,
+        "chemgraph.graphs.main_agent.construct_deep_agent_graph",
+        fake_construct_deep_agent_graph,
     )
 
     construct_main_agent_graph(
@@ -554,13 +555,8 @@ def test_deepagent_is_opt_in_and_receives_backend_configuration(monkeypatch):
     assert captured["kwargs"]["backend"] is backend
     assert captured["kwargs"]["tools"] == []
     assert captured["kwargs"]["checkpointer"] is None
-    assert set(captured["kwargs"]["interrupt_on"]) == {
-        "execute",
-        "write_file",
-        "edit_file",
-        "delete",
-    }
-    assert captured["config"] == {"recursion_limit": 17}
+    assert captured["kwargs"]["recursion_limit"] == 17
+    assert captured["kwargs"]["name"] == "deepagent"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_main_agent.py
+++ b/tests/test_main_agent.py
@@ -549,11 +549,13 @@ def test_deepagent_is_opt_in_and_receives_backend_configuration(monkeypatch):
         subagents=[_subagent(_answering_subgraph("chemistry"), name="chemgraph")],
         enable_deepagent=True,
         deepagent_backend=backend,
+        deepagent_skills=["/workspace/skills/"],
         deepagent_recursion_limit=17,
     )
 
     assert captured["kwargs"]["backend"] is backend
     assert captured["kwargs"]["tools"] == []
+    assert captured["kwargs"]["skills"] == ["/workspace/skills/"]
     assert captured["kwargs"]["checkpointer"] is None
     assert captured["kwargs"]["recursion_limit"] == 17
     assert captured["kwargs"]["name"] == "deepagent"
@@ -563,6 +565,7 @@ def test_deepagent_is_opt_in_and_receives_backend_configuration(monkeypatch):
     ("kwargs", "match"),
     [
         ({"deepagent_backend": object()}, "requires enable_deepagent"),
+        ({"deepagent_skills": ["/skills/"]}, "requires enable_deepagent"),
         (
             {"enable_deepagent": True, "deepagent_recursion_limit": 0},
             "must be positive",

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -303,6 +303,9 @@ def test_deepagent_cli_boolean_flags():
     assert parser.parse_args(
         ["--deepagent-dangerously-skip-approvals"]
     ).deepagent_dangerously_skip_approvals is True
+    assert parser.parse_args(
+        ["--deepagent-skill", "/base/", "--deepagent-skill", "/project/"]
+    ).deepagent_skills == ["/base/", "/project/"]
     assert (
         parser.parse_args(["--checkpoint-db", "/tmp/checkpoints.db"]).checkpoint_db
         == "/tmp/checkpoints.db"
@@ -626,6 +629,9 @@ def test_resume_replaces_all_active_graph_settings(monkeypatch, tmp_path):
         reasoning_effort="high",
         max_retries=4,
         terminal_tool_names=("finish",),
+        enable_deepagent=True,
+        deepagent_workspace=str(tmp_path),
+        deepagent_skills=("/workspace/.agents/skills/",),
         topology_fingerprint="target",
     )
     target_db = str(tmp_path / "target-checkpoints.db")
@@ -706,6 +712,10 @@ def test_resume_replaces_all_active_graph_settings(monkeypatch, tmp_path):
         True,
         77,
     )
+    assert resume_kwargs["deepagent_skills"] == (
+        "/workspace/.agents/skills/",
+    )
+    assert rebuild_kwargs["deepagent_skills"] is None
     for kwargs in (resume_kwargs, rebuild_kwargs):
         assert kwargs["human_supervised"] is True
         assert kwargs["reasoning_effort"] == "high"
@@ -796,7 +806,11 @@ def test_interactive_deepagent_setting_survives_workflow_switches(monkeypatch):
 
     def fake_initialize(*_args, **kwargs):
         initialization_calls.append(
-            (kwargs["enable_deepagent"], kwargs["deepagent_workspace"])
+            (
+                kwargs["enable_deepagent"],
+                kwargs["deepagent_workspace"],
+                kwargs["deepagent_skills"],
+            )
         )
         return next(agents)
 
@@ -813,12 +827,13 @@ def test_interactive_deepagent_setting_survives_workflow_switches(monkeypatch):
             generate_report=False,
             enable_deepagent=True,
             deepagent_workspace="/workspace",
+            deepagent_skills=["/workspace/.agents/skills/"],
         )
 
     assert initialization_calls == [
-        (True, "/workspace"),
-        (False, None),
-        (True, "/workspace"),
+        (True, "/workspace", ["/workspace/.agents/skills/"]),
+        (False, None, None),
+        (True, "/workspace", ["/workspace/.agents/skills/"]),
     ]
 
 
@@ -911,6 +926,86 @@ def test_run_query_preserves_structured_deepagent_approval(monkeypatch):
             "run lint",
         )
     ]
+
+
+def test_run_query_maps_multiple_interrupt_responses_by_id(monkeypatch):
+    from chemgraph.agent.llm_agent import HumanInputRequired
+
+    payloads = [
+        {"question": "First approval?"},
+        {"question": "Second approval?"},
+    ]
+    pending = (
+        PendingInterrupt(id="first-id", payload=payloads[0]),
+        PendingInterrupt(id="second-id", payload=payloads[1]),
+    )
+    resume_inputs = []
+
+    class Workflow:
+        async def astream(self, stream_input, **_kwargs):
+            resume_inputs.append(stream_input)
+            yield {"messages": ["done"]}
+
+        def get_state(self, _config):
+            return SimpleNamespace(tasks=(), interrupts=())
+
+    class Agent:
+        workflow = Workflow()
+        recursion_limit = 20
+
+        async def run(self, *_args, **_kwargs):
+            raise HumanInputRequired(
+                "First approval?",
+                payload=payloads[0],
+                interrupts=pending,
+            )
+
+        def _finalize_completed_run(self, state, _config, _query):
+            return state["messages"][-1]
+
+    answers = iter(["approve-first", "reject-second"])
+    prompted = []
+    monkeypatch.setattr(
+        commands,
+        "_prompt_for_interrupt",
+        lambda payload: prompted.append(payload) or next(answers),
+    )
+
+    result = commands.run_query(Agent(), "review actions", thread_id=12)
+
+    assert result == "done"
+    assert prompted == payloads
+    assert resume_inputs[0].resume == {
+        "first-id": "approve-first",
+        "second-id": "reject-second",
+    }
+
+
+def test_run_query_rejects_multiple_interrupts_without_stable_ids(monkeypatch):
+    from chemgraph.agent.llm_agent import HumanInputRequired
+
+    pending = (
+        PendingInterrupt(id="", payload={"question": "First?"}),
+        PendingInterrupt(id="second-id", payload={"question": "Second?"}),
+    )
+
+    class Agent:
+        recursion_limit = 20
+
+        async def run(self, *_args, **_kwargs):
+            raise HumanInputRequired(
+                "First?",
+                payload=pending[0].payload,
+                interrupts=pending,
+            )
+
+    monkeypatch.setattr(commands, "_prompt_for_interrupt", lambda payload: payload)
+
+    with console.capture() as capture:
+        result = commands.run_query(Agent(), "review actions", thread_id=13)
+
+    assert result is None
+    assert "do not expose stable IDs" in capture.get()
 
 
 def test_run_query_persists_chained_deepagent_interrupt(monkeypatch):
@@ -1021,6 +1116,7 @@ def _run_args(**overrides):
         "recursion_limit": 20,
         "deepagent": None,
         "deepagent_workspace": None,
+        "deepagent_skills": None,
         "deepagent_dangerously_skip_approvals": False,
         "query": None,
         "output_file": None,
@@ -1087,11 +1183,13 @@ def test_headless_deepagent_forwards_explicit_unsafe_configuration(
                 workflow="deep_agent",
                 query="inspect the repository",
                 deepagent_workspace=str(tmp_path),
+                deepagent_skills=["/workspace/.agents/skills/"],
                 deepagent_dangerously_skip_approvals=True,
             )
         )
 
     assert captured["deepagent_workspace"] == str(tmp_path)
+    assert captured["deepagent_skills"] == ["/workspace/.agents/skills/"]
     assert captured["deepagent_auto_approve"] is True
 
 
@@ -1125,6 +1223,7 @@ def test_deepagent_toml_and_cli_precedence(
                 "general": {
                     "enable_deepagent": True,
                     "deepagent_workspace": str(tmp_path),
+                    "deepagent_skills": ["/workspace/.agents/skills/"],
                 }
             }
         )
@@ -1147,4 +1246,7 @@ def test_deepagent_toml_and_cli_precedence(
     assert captured["enable_deepagent"] is expected
     assert captured["deepagent_workspace"] == (
         str(tmp_path) if expected else None
+    )
+    assert captured["deepagent_skills"] == (
+        ["/workspace/.agents/skills/"] if expected else None
     )

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -70,6 +70,8 @@ class _FakeMainSession:
 def test_main_agent_is_a_cli_workflow():
     assert "main_agent" in commands.ALL_WORKFLOW_TYPES
     assert "main_agent" in cli_main._WORKFLOW_CHOICES
+    assert "deep_agent" in commands.ALL_WORKFLOW_TYPES
+    assert commands.resolve_workflow("deepagent") == "deep_agent"
 
 
 def test_interactive_event_renders_only_tagged_subagent_tool_calls():
@@ -228,6 +230,31 @@ def test_experimental_backend_stops_when_confirmation_is_declined(
         commands._create_experimental_deepagent_backend(str(tmp_path))
 
 
+def test_experimental_backend_can_explicitly_skip_confirmation(
+    monkeypatch,
+    tmp_path,
+):
+    class FakeBackend:
+        def __init__(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr("deepagents.backends.LocalShellBackend", FakeBackend)
+    monkeypatch.setattr(
+        commands.Confirm,
+        "ask",
+        lambda *_args, **_kwargs: pytest.fail("confirmation should be skipped"),
+    )
+
+    with console.capture() as capture:
+        backend = commands._create_experimental_deepagent_backend(
+            str(tmp_path),
+            require_confirmation=False,
+        )
+
+    assert isinstance(backend, FakeBackend)
+    assert "approvals are disabled" in capture.get().lower()
+
+
 def test_experimental_backend_rejects_missing_workspace(tmp_path):
     with pytest.raises(ValueError, match="not a directory"):
         commands._create_experimental_deepagent_backend(
@@ -272,6 +299,10 @@ def test_deepagent_cli_boolean_flags():
 
     assert parser.parse_args(["--deepagent"]).deepagent is True
     assert parser.parse_args(["--no-deepagent"]).deepagent is False
+    assert parser.parse_args(["--workflow", "deepagent"]).workflow == "deepagent"
+    assert parser.parse_args(
+        ["--deepagent-dangerously-skip-approvals"]
+    ).deepagent_dangerously_skip_approvals is True
     assert (
         parser.parse_args(["--checkpoint-db", "/tmp/checkpoints.db"]).checkpoint_db
         == "/tmp/checkpoints.db"
@@ -791,6 +822,156 @@ def test_interactive_deepagent_setting_survives_workflow_switches(monkeypatch):
     ]
 
 
+def test_interactive_standalone_deepagent_reuses_one_thread(monkeypatch):
+    answers = iter(
+        ["gpt-4o-mini", "deep_agent", "inspect files", "run tests", "quit"]
+    )
+    agent = SimpleNamespace(session_id="deep-session")
+    thread_ids = []
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+    monkeypatch.setattr(commands, "initialize_agent", lambda *_args, **_kwargs: agent)
+
+    def fake_run(_agent, _query, *, thread_id, verbose=False):
+        thread_ids.append(thread_id)
+        return None
+
+    monkeypatch.setattr(commands, "run_query", fake_run)
+
+    with console.capture():
+        commands.interactive_mode(
+            workflow="deep_agent",
+            generate_report=False,
+            deepagent_workspace="/workspace",
+        )
+
+    assert len(thread_ids) == 2
+    assert thread_ids[0] == thread_ids[1]
+
+
+def test_run_query_preserves_structured_deepagent_approval(monkeypatch):
+    from chemgraph.agent.llm_agent import HumanInputRequired
+
+    payload = {
+        "action_requests": [{"name": "execute", "args": {"command": "ruff"}}],
+        "review_configs": [
+            {
+                "action_name": "execute",
+                "allowed_decisions": ["approve", "reject"],
+            }
+        ],
+    }
+    resume_inputs = []
+    finalized = []
+
+    class Workflow:
+        async def astream(self, stream_input, **_kwargs):
+            resume_inputs.append(stream_input)
+            yield {"messages": ["done"]}
+
+        def get_state(self, _config):
+            return SimpleNamespace(tasks=())
+
+    class Agent:
+        workflow = Workflow()
+        recursion_limit = 20
+        return_option = "last_message"
+
+        async def run(self, *_args, **_kwargs):
+            raise HumanInputRequired("approval", payload=payload)
+
+        def _finalize_completed_run(self, state, config, query):
+            finalized.append((state, config, query))
+            return state["messages"][-1]
+
+    prompted = []
+    monkeypatch.setattr(
+        commands,
+        "_prompt_for_interrupt",
+        lambda value: prompted.append(value)
+        or {"decisions": [{"type": "approve"}]},
+    )
+
+    result = commands.run_query(Agent(), "run lint", thread_id=10)
+
+    assert result == "done"
+    assert prompted == [payload]
+    assert resume_inputs[0].resume == {"decisions": [{"type": "approve"}]}
+    assert finalized == [
+        (
+            {"messages": ["done"]},
+            {
+                "configurable": {"thread_id": 10},
+                "recursion_limit": 20,
+            },
+            "run lint",
+        )
+    ]
+
+
+def test_run_query_persists_chained_deepagent_interrupt(monkeypatch):
+    from chemgraph.agent.llm_agent import HumanInputRequired
+
+    payloads = [
+        {"action_requests": [{"name": "write_file", "args": {}}]},
+        {"action_requests": [{"name": "execute", "args": {}}]},
+    ]
+
+    class Workflow:
+        resume_count = 0
+
+        async def astream(self, _stream_input, **_kwargs):
+            self.resume_count += 1
+            if self.resume_count == 1:
+                yield {
+                    "messages": ["waiting"],
+                    "__interrupt__": [SimpleNamespace(value=payloads[1])],
+                }
+            else:
+                yield {"messages": ["done"]}
+
+        def get_state(self, _config):
+            return SimpleNamespace(tasks=())
+
+    persisted = []
+
+    class Agent:
+        workflow = Workflow()
+        recursion_limit = 20
+
+        async def run(self, *_args, **_kwargs):
+            raise HumanInputRequired("approval", payload=payloads[0])
+
+        def _persist_run_state(self, config):
+            persisted.append(config)
+
+        def _finalize_completed_run(self, state, _config, _query):
+            return state["messages"][-1]
+
+    prompted = []
+    monkeypatch.setattr(
+        commands,
+        "_prompt_for_interrupt",
+        lambda payload: prompted.append(payload)
+        or {"decisions": [{"type": "approve"}]},
+    )
+
+    result = commands.run_query(Agent(), "write and run", thread_id=11)
+
+    assert result == "done"
+    assert prompted == payloads
+    assert persisted == [
+        {
+            "configurable": {"thread_id": 11},
+            "recursion_limit": 20,
+        }
+    ]
+
+
 def test_interactive_reports_invalid_slash_commands(monkeypatch):
     agent = SimpleNamespace()
     session = _FakeMainSession([])
@@ -840,6 +1021,11 @@ def _run_args(**overrides):
         "recursion_limit": 20,
         "deepagent": None,
         "deepagent_workspace": None,
+        "deepagent_dangerously_skip_approvals": False,
+        "query": None,
+        "output_file": None,
+        "trace_dir": None,
+        "checkpoint_db": None,
         "mcp_url": None,
         "mcp_command": None,
         "mcp_server_name": None,
@@ -854,6 +1040,59 @@ def test_main_agent_requires_interactive_cli_mode():
 
     assert exc_info.value.code == 2
     assert "requires interactive mode" in capture.get()
+
+
+def test_headless_deepagent_requires_unsafe_flag_and_workspace(tmp_path):
+    with console.capture() as capture, pytest.raises(SystemExit) as exc_info:
+        cli_main._handle_run(
+            _run_args(
+                workflow="deep_agent",
+                query="inspect the repository",
+                deepagent_workspace=str(tmp_path),
+            )
+        )
+
+    assert exc_info.value.code == 2
+    assert "dangerously-skip-approvals" in capture.get()
+
+    with console.capture() as capture, pytest.raises(SystemExit) as exc_info:
+        cli_main._handle_run(
+            _run_args(
+                workflow="deep_agent",
+                query="inspect the repository",
+                deepagent_dangerously_skip_approvals=True,
+            )
+        )
+
+    assert exc_info.value.code == 2
+    assert "explicit --deepagent-workspace" in capture.get()
+
+
+def test_headless_deepagent_forwards_explicit_unsafe_configuration(
+    monkeypatch,
+    tmp_path,
+):
+    captured = {}
+    agent = SimpleNamespace(session_id="deep-session")
+    monkeypatch.setattr(
+        cli_main,
+        "initialize_agent",
+        lambda *_args, **kwargs: captured.update(kwargs) or agent,
+    )
+    monkeypatch.setattr(cli_main, "run_query", lambda *_args, **_kwargs: None)
+
+    with console.capture():
+        cli_main._handle_run(
+            _run_args(
+                workflow="deep_agent",
+                query="inspect the repository",
+                deepagent_workspace=str(tmp_path),
+                deepagent_dangerously_skip_approvals=True,
+            )
+        )
+
+    assert captured["deepagent_workspace"] == str(tmp_path)
+    assert captured["deepagent_auto_approve"] is True
 
 
 def test_main_agent_dispatches_persistent_resume(monkeypatch):

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -252,7 +252,8 @@ def test_experimental_backend_can_explicitly_skip_confirmation(
         )
 
     assert isinstance(backend, FakeBackend)
-    assert "approvals are disabled" in capture.get().lower()
+    rendered = " ".join(capture.get().lower().replace("│", " ").split())
+    assert "approvals are disabled" in rendered
 
 
 def test_experimental_backend_rejects_missing_workspace(tmp_path):
@@ -310,6 +311,8 @@ def test_deepagent_cli_boolean_flags():
         parser.parse_args(["--checkpoint-db", "/tmp/checkpoints.db"]).checkpoint_db
         == "/tmp/checkpoints.db"
     )
+    help_text = " ".join(parser.format_help().split())
+    assert "shell commands are not confined to it" in help_text
 
 
 def test_main_agent_query_failure_suggests_retry():
@@ -899,7 +902,7 @@ def test_run_query_preserves_structured_deepagent_approval(monkeypatch):
         async def run(self, *_args, **_kwargs):
             raise HumanInputRequired("approval", payload=payload)
 
-        def _finalize_completed_run(self, state, config, query):
+        def finalize_completed_run(self, state, config, query):
             finalized.append((state, config, query))
             return state["messages"][-1]
 
@@ -960,7 +963,7 @@ def test_run_query_maps_multiple_interrupt_responses_by_id(monkeypatch):
                 interrupts=pending,
             )
 
-        def _finalize_completed_run(self, state, _config, _query):
+        def finalize_completed_run(self, state, _config, _query):
             return state["messages"][-1]
 
     answers = iter(["approve-first", "reject-second"])
@@ -1041,10 +1044,10 @@ def test_run_query_persists_chained_deepagent_interrupt(monkeypatch):
         async def run(self, *_args, **_kwargs):
             raise HumanInputRequired("approval", payload=payloads[0])
 
-        def _persist_run_state(self, config):
+        def persist_run_state(self, config):
             persisted.append(config)
 
-        def _finalize_completed_run(self, state, _config, _query):
+        def finalize_completed_run(self, state, _config, _query):
             return state["messages"][-1]
 
     prompted = []

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -894,6 +894,9 @@ def test_run_query_preserves_structured_deepagent_approval(monkeypatch):
         def get_state(self, _config):
             return SimpleNamespace(tasks=())
 
+        async def aget_state(self, config):
+            return self.get_state(config)
+
     class Agent:
         workflow = Workflow()
         recursion_limit = 20
@@ -902,7 +905,7 @@ def test_run_query_preserves_structured_deepagent_approval(monkeypatch):
         async def run(self, *_args, **_kwargs):
             raise HumanInputRequired("approval", payload=payload)
 
-        def finalize_completed_run(self, state, config, query):
+        async def afinalize_completed_run(self, state, config, query):
             finalized.append((state, config, query))
             return state["messages"][-1]
 
@@ -952,6 +955,9 @@ def test_run_query_maps_multiple_interrupt_responses_by_id(monkeypatch):
         def get_state(self, _config):
             return SimpleNamespace(tasks=(), interrupts=())
 
+        async def aget_state(self, config):
+            return self.get_state(config)
+
     class Agent:
         workflow = Workflow()
         recursion_limit = 20
@@ -963,7 +969,7 @@ def test_run_query_maps_multiple_interrupt_responses_by_id(monkeypatch):
                 interrupts=pending,
             )
 
-        def finalize_completed_run(self, state, _config, _query):
+        async def afinalize_completed_run(self, state, _config, _query):
             return state["messages"][-1]
 
     answers = iter(["approve-first", "reject-second"])
@@ -1035,6 +1041,9 @@ def test_run_query_persists_chained_deepagent_interrupt(monkeypatch):
         def get_state(self, _config):
             return SimpleNamespace(tasks=())
 
+        async def aget_state(self, config):
+            return self.get_state(config)
+
     persisted = []
 
     class Agent:
@@ -1044,10 +1053,10 @@ def test_run_query_persists_chained_deepagent_interrupt(monkeypatch):
         async def run(self, *_args, **_kwargs):
             raise HumanInputRequired("approval", payload=payloads[0])
 
-        def persist_run_state(self, config):
+        async def apersist_run_state(self, config):
             persisted.append(config)
 
-        def finalize_completed_run(self, state, _config, _query):
+        async def afinalize_completed_run(self, state, _config, _query):
             return state["messages"][-1]
 
     prompted = []


### PR DESCRIPTION
## Summary

Add a reusable workspace Deep Agent that runs through `ChemGraph(workflow_type="deep_agent")` or as the `deepagent` worker under `main_agent`.

- Share graph construction, skills, workspace tools, and structured action approvals across Python and CLI entry points.
- Expose host files through one `/workspace` namespace while preserving shell execution and host-path guidance.
- Support repeated approval rounds, concurrent interrupt recovery, asynchronous checkpoints, and thread-specific message persistence.
- Preserve inactive configuration for interactive workflow switches and report invalid CLI input cleanly.
- Document workspace confirmation, shell scope, explicit command environments, registry names, and asynchronous checkpointer usage.

Rebased onto current `main`, preserving #232's session-history fix. Review fixes retain the existing confirmed current-directory default for interactive use; headless runs require an explicit workspace and approval-skip flag.

## Related issues

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `ruff check .`
- `pytest tests/ -k "not tblite"`: **1,122 passed, 21 skipped, 2 deselected**
- Real graph regressions cover twelve approved file writes through Python and CLI, concurrent interrupts, unique sync/async workspace searches, registry delegation, and async SQLite approval recovery.
- Configuration and persistence regressions cover workflow precedence, inactive settings, malformed input, resumed transcripts, and idless messages across threads.
- Tests use the rebased runtime pins and an isolated session database. No live-LLM, live-Globus, or live-EnsembleLauncher flags were enabled.

## Checklist

- [x] Rebased onto current `main`
- [x] Preserved the original PR's feature commits and first-round review fixes
- [x] Verified later review findings and addressed substantiated issues
- [x] Ruff and the full local test suite pass
- [x] Added regression coverage and updated user-facing documentation
