### PR TITLE
Add configurable reasoning effort for GPT-5.6 and Claude Opus

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 [general]
 model = "argo:gpt-4o"
+# reasoning_effort = "medium"  # Supported Argo GPT-5.6 and Claude Opus models only
 workflow = "single_agent"
 output = "state"
 structured = true

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,6 +30,7 @@ Common options:
 | --- | --- |
 | `-q`, `--query` | Natural-language request |
 | `-m`, `--model` | Provider/model identifier |
+| `--reasoning-effort` | Reasoning effort for a supported model |
 | `-w`, `--workflow` | Agent workflow; defaults to `single_agent` |
 | `-o`, `--output` | Full `state` or `last_message` |
 | `-s`, `--structured` | Request a structured final response |
@@ -41,6 +42,24 @@ Common options:
 
 The legacy no-subcommand form, such as `chemgraph -q "..."`, remains supported,
 but new scripts should use `chemgraph run`.
+
+### Reasoning effort
+
+Verified Argo GPT-5.6 and Claude Opus models accept an explicit reasoning
+effort:
+
+```bash
+chemgraph run \
+  --model argo:claude-opus-4.8 \
+  --reasoning-effort xhigh \
+  --query "Analyze the reaction mechanism."
+```
+
+The GPT-5.6 routes accept `none`, `low`, `medium`, `high`, `xhigh`, and `max`.
+The Claude Opus 4.8 and Opus 5 routes accept `low`, `medium`, `high`, `xhigh`,
+and `max`. Both model families default to `medium`. Claude effort controls
+overall response work through Anthropic's `output_config.effort`; it does not
+make ChemGraph explicitly enable adaptive thinking.
 
 ## Validate credentials
 

--- a/docs/configuration_with_toml.md
+++ b/docs/configuration_with_toml.md
@@ -13,6 +13,7 @@ chemgraph run --config config.toml -q "What is the SMILES string for water?"
 ```toml
 [general]
 model = "gpt-4o-mini"
+# reasoning_effort = "medium"  # Supported Argo GPT-5.6 and Claude Opus models
 workflow = "single_agent"
 output = "last_message"
 structured = false
@@ -33,10 +34,11 @@ chemgraph run --model gpt-4o-mini --workflow single_agent \
 ```
 
 The CLI currently honors selected general/config values such as
-`recursion_limit`, `enable_deepagent`, and `checkpoint_db`, but its parser has
-concrete defaults for several other fields. Therefore a historical `[general]`
-value may not override a CLI default. The CLI flag is the reliable source for
-model/workflow/output behavior.
+`reasoning_effort`, `recursion_limit`, `enable_deepagent`, and `checkpoint_db`,
+but its parser has concrete defaults for several other fields. Therefore a
+historical `[general]` value may not override a CLI default. The CLI flag is the
+reliable source for model/workflow/output behavior. An explicit
+`--reasoning-effort` overrides `[general].reasoning_effort`.
 
 ## Provider endpoints
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -37,6 +37,27 @@ chemgraph models
 chemgraph run --model gpt-4o-mini --check-keys
 ```
 
+## Reasoning effort
+
+ChemGraph exposes provider reasoning controls for a manually verified subset of
+Argo models:
+
+| Models | Accepted values | Default |
+| --- | --- | --- |
+| `argo:gpt-5.6-luna`, `argo:gpt-5.6-sol`, `argo:gpt-5.6-terra` | `none`, `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
+| `argo:claude-opus-4.8`, `argo:claude-opus-5` | `low`, `medium`, `high`, `xhigh`, `max` | `medium` |
+
+Select the effort for a run with `--reasoning-effort`:
+
+```bash
+chemgraph run --model argo:gpt-5.6-sol --reasoning-effort high \
+  -q "Compare two reaction pathways."
+```
+
+For Claude, ChemGraph forwards the value as Anthropic's overall response
+effort. It does not explicitly enable adaptive thinking. Other model IDs reject
+an explicit effort until their endpoint behavior has been verified.
+
 ## Public API providers
 
 Set the provider's environment variable before launching ChemGraph:

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -20,8 +20,10 @@ from chemgraph.memory.schemas import (
 from chemgraph.memory.subagent_recorder import SubagentRunRecorder
 from chemgraph.models.loader import load_chat_model_prepared
 from chemgraph.models.supported_models import (
+    DEFAULT_REASONING_EFFORT_BY_MODEL,
     MODELS_WITH_REASONING_EFFORT,
-    SUPPORTED_REASONING_EFFORTS,
+    REASONING_EFFORT_CHOICES,
+    REASONING_EFFORTS_BY_MODEL,
 )
 
 from chemgraph.schemas.ase_input import (
@@ -108,12 +110,19 @@ def _resolve_reasoning_effort(
             )
         return None
 
-    effective_effort = "none" if reasoning_effort is None else reasoning_effort
-    if effective_effort not in SUPPORTED_REASONING_EFFORTS:
-        supported_efforts = ", ".join(sorted(SUPPORTED_REASONING_EFFORTS))
+    supported_efforts = REASONING_EFFORTS_BY_MODEL[model_name]
+    effective_effort = (
+        DEFAULT_REASONING_EFFORT_BY_MODEL[model_name]
+        if reasoning_effort is None
+        else reasoning_effort
+    )
+    if effective_effort not in supported_efforts:
+        supported = ", ".join(
+            effort for effort in REASONING_EFFORT_CHOICES if effort in supported_efforts
+        )
         raise ValueError(
             f"Unsupported reasoning effort '{effective_effort}'. "
-            f"Choose one of: {supported_efforts}."
+            f"Model '{model_name}' supports: {supported}."
         )
     return effective_effort
 
@@ -144,9 +153,9 @@ class ChemGraph:
     api_key : str, optional
         API key for authentication, by default None
     reasoning_effort : str, optional
-        Reasoning effort for manually verified GPT-5.6 models, which default to
-        ``"none"``. Supported values are ``none``, ``low``, ``medium``,
-        ``high``, ``xhigh``, and ``max``.
+        Reasoning effort for manually verified Argo GPT-5.6 and Claude Opus
+        models. GPT-5.6 defaults to ``"none"``; Claude defaults to ``"high"``.
+        Supported values depend on the selected model.
     prompts : PromptConfig, optional
         Prompts for the active workflow. Defaults to ``PromptConfig()``, which
         uses ChemGraph's built-in prompts. Override only the fields relevant to

--- a/src/chemgraph/cli/commands.py
+++ b/src/chemgraph/cli/commands.py
@@ -29,7 +29,10 @@ from chemgraph.models.endpoints import (
     missing_credential_help,
 )
 from chemgraph.models.endpoints.registry import select_endpoint
-from chemgraph.models.supported_models import MODELS_WITH_REASONING_EFFORT
+from chemgraph.models.supported_models import (
+    DEFAULT_REASONING_EFFORT_BY_MODEL,
+    REASONING_EFFORTS_BY_MODEL,
+)
 from chemgraph.utils.async_utils import run_async_callable
 
 from chemgraph.cli.formatting import (
@@ -264,6 +267,8 @@ def initialize_agent(
             console.print(f"  Base URL: {base_url}")
         if argo_user:
             console.print(f"  Argo User: {argo_user}")
+        if reasoning_effort:
+            console.print(f"  Reasoning Effort: {reasoning_effort}")
         if tools:
             console.print(f"  MCP Tools: {len(tools)} loaded")
 
@@ -1011,6 +1016,7 @@ def interactive_mode(
     deepagent_workspace: str | None = None,
     checkpoint_db: str | None = None,
     resume_session: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> None:
     """Start interactive REPL mode for ChemGraph CLI.
 
@@ -1047,6 +1053,8 @@ def interactive_mode(
         selected workflow is ``main_agent``.
     deepagent_workspace : str, optional
         Local workspace used by the experimental host-shell backend.
+    reasoning_effort : str, optional
+        Reasoning effort for models with verified support.
     """
     console.print(create_banner())
     console.print("[bold green]Welcome to ChemGraph Interactive Mode![/bold green]")
@@ -1062,7 +1070,6 @@ def interactive_mode(
     checkpoint_saver = None
     restored_thread_id: str | None = None
     stored_graph_config = None
-    reasoning_effort: str | None = None
     max_retries = 1
     terminal_tool_names: tuple[str, ...] = ()
     if resume_session:
@@ -1154,6 +1161,7 @@ def interactive_mode(
         if checkpoint_runtime is not None:
             checkpoint_runtime.close()
         return
+    reasoning_effort = getattr(agent, "reasoning_effort", reasoning_effort)
 
     main_session = (
         create_main_agent_session(
@@ -1449,11 +1457,15 @@ Example queries:
                     console.print("[red]Usage: /model <name>[/red]")
                     continue
                 new_model = argument
-                new_reasoning_effort = (
-                    reasoning_effort
-                    if new_model in MODELS_WITH_REASONING_EFFORT
-                    else None
-                )
+                supported_efforts = REASONING_EFFORTS_BY_MODEL.get(new_model)
+                if supported_efforts is None:
+                    new_reasoning_effort = None
+                elif reasoning_effort in supported_efforts:
+                    new_reasoning_effort = reasoning_effort
+                else:
+                    new_reasoning_effort = DEFAULT_REASONING_EFFORT_BY_MODEL[
+                        new_model
+                    ]
                 new_agent = initialize_agent(
                     new_model,
                     workflow,
@@ -1482,8 +1494,16 @@ Example queries:
                             "[yellow]Reasoning effort was reset because the new "
                             "model does not support it.[/yellow]"
                         )
+                    elif reasoning_effort != new_reasoning_effort:
+                        console.print(
+                            "[yellow]Reasoning effort changed to "
+                            f"'{new_reasoning_effort}' because the new model does "
+                            "not support the previous value.[/yellow]"
+                        )
                     model = new_model
-                    reasoning_effort = new_reasoning_effort
+                    reasoning_effort = getattr(
+                        new_agent, "reasoning_effort", new_reasoning_effort
+                    )
                     agent = new_agent
                     main_session = (
                         create_main_agent_session(

--- a/src/chemgraph/cli/main.py
+++ b/src/chemgraph/cli/main.py
@@ -17,6 +17,7 @@ from typing import Any, Dict
 import toml
 
 from chemgraph.models.endpoints.registry import match_endpoint
+from chemgraph.models.supported_models import REASONING_EFFORT_CHOICES
 from chemgraph.utils.config_utils import (
     flatten_config,
     get_argo_user_from_flat_config,
@@ -77,6 +78,12 @@ def _add_run_args(parser: argparse.ArgumentParser) -> None:
             "LLM model to use; experimental Codex subscription models use "
             "codex:<model-id> (default: gpt-4o-mini)"
         ),
+    )
+    parser.add_argument(
+        "--reasoning-effort",
+        choices=REASONING_EFFORT_CHOICES,
+        default=None,
+        help="Reasoning effort for supported models",
     )
     parser.add_argument(
         "-w",
@@ -375,6 +382,7 @@ def load_config(config_file: str) -> Dict[str, Any]:
                 "thread": 1,
                 "recursion_limit": 20,
                 "human_supervised": False,
+                "reasoning_effort": None,
                 "enable_deepagent": False,
                 "deepagent_workspace": None,
                 "checkpoint_db": None,
@@ -540,6 +548,7 @@ def _handle_run(args: argparse.Namespace) -> None:
             recursion_limit=args.recursion_limit,
             base_url=base_url,
             argo_user=argo_user,
+            reasoning_effort=getattr(args, "reasoning_effort", None),
             verbose=(args.verbose > 0),
             tools=mcp_tools,
             enable_deepagent=enable_deepagent,
@@ -612,6 +621,7 @@ def _handle_run(args: argparse.Namespace) -> None:
         args.recursion_limit,
         base_url=base_url,
         argo_user=argo_user,
+        reasoning_effort=getattr(args, "reasoning_effort", None),
         verbose=(args.verbose > 0),
         human_supervised=args.human_supervised,
         tools=mcp_tools,

--- a/src/chemgraph/models/endpoints/argo.py
+++ b/src/chemgraph/models/endpoints/argo.py
@@ -279,6 +279,8 @@ def prepare_anthropic(request: ModelRequest) -> PreparedModel:
     )
     if requested_model_name not in MODELS_WITHOUT_TEMPERATURE:
         client_kwargs["temperature"] = request.temperature
+    if request.reasoning_effort is not None:
+        client_kwargs["reasoning_effort"] = request.reasoning_effort
 
     return PreparedModel(
         endpoint_name="argo_anthropic",

--- a/src/chemgraph/models/endpoints/openai_direct.py
+++ b/src/chemgraph/models/endpoints/openai_direct.py
@@ -21,9 +21,9 @@ from chemgraph.models.endpoints.base import (
 )
 from chemgraph.models.protocols import openai_compatible
 from chemgraph.models.supported_models import (
-    MODELS_WITH_REASONING_EFFORT,
     MODELS_WITHOUT_TEMPERATURE,
-    SUPPORTED_REASONING_EFFORTS,
+    REASONING_EFFORT_CHOICES,
+    REASONING_EFFORTS_BY_MODEL,
     supported_openai_models,
 )
 from chemgraph.utils.logging_config import setup_logger
@@ -49,16 +49,19 @@ def validate_reasoning_effort(requested_model_name: str, reasoning_effort: str |
     """Validate reasoning-effort support for a model. Moved from ``openai.py``."""
     if reasoning_effort is None:
         return
-    if requested_model_name not in MODELS_WITH_REASONING_EFFORT:
+    supported_efforts = REASONING_EFFORTS_BY_MODEL.get(requested_model_name)
+    if supported_efforts is None:
         raise ValueError(
             f"Model '{requested_model_name}' does not have verified "
             "reasoning-effort support."
         )
-    if reasoning_effort not in SUPPORTED_REASONING_EFFORTS:
-        supported = ", ".join(sorted(SUPPORTED_REASONING_EFFORTS))
+    if reasoning_effort not in supported_efforts:
+        supported = ", ".join(
+            effort for effort in REASONING_EFFORT_CHOICES if effort in supported_efforts
+        )
         raise ValueError(
             f"Unsupported reasoning effort '{reasoning_effort}'. "
-            f"Choose one of: {supported}."
+            f"Model '{requested_model_name}' supports: {supported}."
         )
 
 

--- a/src/chemgraph/models/supported_models.py
+++ b/src/chemgraph/models/supported_models.py
@@ -220,16 +220,25 @@ MODELS_WITHOUT_TEMPERATURE = frozenset(
 
     }
 )
-MODELS_WITH_REASONING_EFFORT = frozenset(
-    {
-        "argo:gpt-5.6-luna",
-        "argo:gpt-5.6-sol",
-        "argo:gpt-5.6-terra",
-    }
-)
-SUPPORTED_REASONING_EFFORTS = frozenset(
-    {"none", "low", "medium", "high", "xhigh", "max"}
-)
+REASONING_EFFORT_CHOICES = ("none", "low", "medium", "high", "xhigh", "max")
+_GPT_5_6_REASONING_EFFORTS = frozenset(REASONING_EFFORT_CHOICES)
+_CLAUDE_OPUS_REASONING_EFFORTS = frozenset(REASONING_EFFORT_CHOICES[1:])
+REASONING_EFFORTS_BY_MODEL = {
+    "argo:gpt-5.6-luna": _GPT_5_6_REASONING_EFFORTS,
+    "argo:gpt-5.6-sol": _GPT_5_6_REASONING_EFFORTS,
+    "argo:gpt-5.6-terra": _GPT_5_6_REASONING_EFFORTS,
+    "argo:claude-opus-4.8": _CLAUDE_OPUS_REASONING_EFFORTS,
+    "argo:claude-opus-5": _CLAUDE_OPUS_REASONING_EFFORTS,
+}
+DEFAULT_REASONING_EFFORT_BY_MODEL = {
+    "argo:gpt-5.6-luna": "medium",
+    "argo:gpt-5.6-sol": "medium",
+    "argo:gpt-5.6-terra": "medium",
+    "argo:claude-opus-4.8": "medium",
+    "argo:claude-opus-5": "medium",
+}
+MODELS_WITH_REASONING_EFFORT = frozenset(REASONING_EFFORTS_BY_MODEL)
+SUPPORTED_REASONING_EFFORTS = frozenset(REASONING_EFFORT_CHOICES)
 
 all_supported_models = (
     supported_openai_models

--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -47,12 +47,16 @@ def test_chemgraph_initialization(tmp_path):
 @pytest.mark.parametrize(
     ("model_name", "reasoning_effort", "expected_effort"),
     [
-        ("argo:gpt-5.6-luna", None, "none"),
+        ("argo:gpt-5.6-luna", None, "medium"),
+        ("argo:gpt-5.6-sol", None, "medium"),
+        ("argo:gpt-5.6-terra", None, "medium"),
+        ("argo:claude-opus-4.8", None, "medium"),
+        ("argo:claude-opus-5", None, "medium"),
         ("argo:gpt-5.6-sol", "high", "high"),
-        ("argo:gpt-5.6-terra", None, "none"),
+        ("argo:claude-opus-5", "xhigh", "xhigh"),
     ],
 )
-def test_gpt56_reasoning_effort_is_passed_to_loader(
+def test_reasoning_effort_is_passed_to_loader(
     tmp_path, model_name, reasoning_effort, expected_effort
 ):
     with patch("chemgraph.agent.llm_agent.load_chat_model_prepared") as mock_load:
@@ -84,6 +88,11 @@ def test_reasoning_effort_is_not_passed_to_sonnet5(tmp_path):
 def test_reasoning_effort_rejects_unverified_model():
     with pytest.raises(ValueError, match="does not have verified"):
         ChemGraph(model_name="argo:gpt-5.4", reasoning_effort="none")
+
+
+def test_claude_reasoning_effort_rejects_none():
+    with pytest.raises(ValueError, match="supports: low, medium, high, xhigh, max"):
+        ChemGraph(model_name="argo:claude-opus-4.8", reasoning_effort="none")
 
 
 @pytest.mark.parametrize("reasoning_effort", ["fast", ""])

--- a/tests/test_loader_pr2.py
+++ b/tests/test_loader_pr2.py
@@ -180,6 +180,33 @@ def test_reasoning_effort_flows_to_argo_reasoning_model():
     assert prepared.client_kwargs.get("reasoning_effort") == "high"
 
 
+@pytest.mark.parametrize(
+    "model_name",
+    ["argo:claude-opus-4.8", "argo:claude-opus-5"],
+)
+def test_reasoning_effort_flows_to_argo_claude(model_name):
+    client, prepared = load_chat_model_prepared(
+        model_name=model_name,
+        argo_user="alice",
+        reasoning_effort="xhigh",
+    )
+
+    assert prepared.reasoning_effort == "xhigh"
+    assert prepared.client_kwargs["reasoning_effort"] == "xhigh"
+    payload = client._get_request_payload("Analyze this molecule")
+    assert payload["output_config"] == {"effort": "xhigh"}
+    assert "thinking" not in payload
+
+
+def test_argo_claude_rejects_none_reasoning_effort():
+    with pytest.raises(ValueError, match="supports: low, medium, high, xhigh, max"):
+        load_chat_model_prepared(
+            model_name="argo:claude-opus-5",
+            argo_user="alice",
+            reasoning_effort="none",
+        )
+
+
 # --- ChemGraph forwards explicit OpenAI api_key ----------------------------
 
 

--- a/tests/test_main_agent_cli.py
+++ b/tests/test_main_agent_cli.py
@@ -278,6 +278,17 @@ def test_deepagent_cli_boolean_flags():
     )
 
 
+def test_reasoning_effort_cli_flag():
+    parser = cli_main.create_argument_parser()
+
+    assert (
+        parser.parse_args(["run", "--reasoning-effort", "xhigh"]).reasoning_effort
+        == "xhigh"
+    )
+    with pytest.raises(SystemExit):
+        parser.parse_args(["run", "--reasoning-effort", "fast"])
+
+
 def test_main_agent_query_failure_suggests_retry():
     session = _FakeMainSession([RuntimeError("temporary")])
 
@@ -517,6 +528,49 @@ def test_interactive_slash_model_and_workflow_switches(monkeypatch):
         ("Provider/Next-Model", "main_agent"),
         ("Provider/Next-Model", "single_agent"),
     ]
+
+
+def test_interactive_model_switch_uses_supported_reasoning_default(monkeypatch):
+    answers = iter(
+        [
+            "argo:gpt-5.6-sol",
+            "single_agent",
+            "/model argo:claude-opus-4.8",
+            "quit",
+        ]
+    )
+    agents = iter(
+        [
+            SimpleNamespace(session_id="gpt", reasoning_effort="none"),
+            SimpleNamespace(session_id="claude", reasoning_effort="medium"),
+        ]
+    )
+    initialization_calls = []
+
+    monkeypatch.setattr(
+        commands.Prompt,
+        "ask",
+        lambda *_args, **_kwargs: next(answers),
+    )
+
+    def fake_initialize(model, _workflow, *_args, **kwargs):
+        initialization_calls.append((model, kwargs["reasoning_effort"]))
+        return next(agents)
+
+    monkeypatch.setattr(commands, "initialize_agent", fake_initialize)
+
+    with console.capture() as capture:
+        commands.interactive_mode(
+            model="argo:gpt-5.6-sol",
+            generate_report=False,
+            reasoning_effort="none",
+        )
+
+    assert initialization_calls == [
+        ("argo:gpt-5.6-sol", "none"),
+        ("argo:claude-opus-4.8", "medium"),
+    ]
+    assert "Reasoning effort changed to 'medium'" in capture.get()
 
 
 def test_workflow_switch_recovers_from_checkpoint_open_failure(monkeypatch):
@@ -827,6 +881,7 @@ def _run_args(**overrides):
         "show_session": None,
         "delete_session": None,
         "config": None,
+        "query": None,
         "verbose": 0,
         "base_url": None,
         "model": "gpt-4o-mini",
@@ -837,12 +892,14 @@ def _run_args(**overrides):
         "output": "state",
         "report": False,
         "human_supervised": False,
+        "reasoning_effort": None,
         "recursion_limit": 20,
         "deepagent": None,
         "deepagent_workspace": None,
         "mcp_url": None,
         "mcp_command": None,
         "mcp_server_name": None,
+        "output_file": None,
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -867,6 +924,61 @@ def test_main_agent_dispatches_persistent_resume(monkeypatch):
     cli_main._handle_run(_run_args(interactive=True, resume="old-thread"))
 
     assert captured["resume_session"] == "old-thread"
+
+
+def test_noninteractive_run_forwards_reasoning_effort(monkeypatch):
+    captured = {}
+
+    def fake_initialize(*_args, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(session_id=None)
+
+    monkeypatch.setattr(cli_main, "initialize_agent", fake_initialize)
+    monkeypatch.setattr(cli_main, "run_query", lambda *_args, **_kwargs: None)
+
+    with console.capture():
+        cli_main._handle_run(
+            _run_args(
+                model="argo:gpt-5.6-sol",
+                workflow="single_agent",
+                query="Analyze water",
+                reasoning_effort="max",
+            )
+        )
+
+    assert captured["reasoning_effort"] == "max"
+
+
+@pytest.mark.parametrize(
+    ("cli_value", "expected"),
+    [(None, "medium"), ("high", "high")],
+)
+def test_reasoning_effort_toml_and_cli_precedence(
+    monkeypatch,
+    tmp_path,
+    cli_value,
+    expected,
+):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        toml.dumps({"general": {"reasoning_effort": "medium"}})
+    )
+    captured = {}
+    monkeypatch.setattr(
+        cli_main,
+        "interactive_mode",
+        lambda **kwargs: captured.update(kwargs),
+    )
+
+    cli_main._handle_run(
+        _run_args(
+            config=str(config_path),
+            interactive=True,
+            reasoning_effort=cli_value,
+        )
+    )
+
+    assert captured["reasoning_effort"] == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add `--reasoning-effort` support to the ChemGraph CLI and TOML configuration flow.
- Support Argo GPT-5.6 Luna, Sol, and Terra plus Claude Opus 4.8 and Opus 5 with model-specific validation.
- Use `medium` as the default reasoning effort for both model families while preserving explicit user selections.
- Forward Claude effort through Anthropic `output_config.effort` without explicitly enabling adaptive thinking.
- Preserve compatible effort values across interactive model switches and fall back to the target model default when needed.
- Document supported values, defaults, and CLI usage.

## Related issues

None.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs
- [ ] Chore / refactor / CI

## How was this tested?

- `git ls-files -z -- "*.py" | xargs -0 ruff check`
- `pytest tests/test_llm_agent.py tests/test_loader_pr2.py tests/test_main_agent_cli.py -q`: 88 passed
- Clean-checkout-equivalent `pytest tests/ -k "not tblite"`: 711 passed, 30 skipped, 2 deselected
- `git diff --check`

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change
- [x] `ruff check .` passes in a clean checkout
- [x] `pytest tests/ -k "not tblite"` passes in a clean checkout
- [x] Added/updated tests for the change
- [x] Updated docs for the user-facing change