### PR TITLE
fix: start the Streamlit UI on macOS and contain native TBLite crashes

### DIFF
--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -57,7 +57,7 @@ def _command_available(command_name: str, env_var_name: str) -> bool:
     return bool(os.environ.get(env_var_name)) or shutil.which(command_name) is not None
 
 
-if not _engine_available("fairchem.core"):
+if not _engine_available("fairchem"):
     FAIRChemCalc = None
 
 if not _engine_available("mace"):

--- a/src/chemgraph/schemas/calculators/fairchem_calc.py
+++ b/src/chemgraph/schemas/calculators/fairchem_calc.py
@@ -1,15 +1,14 @@
+import logging
+from typing import Any, Dict, Optional
+
 from pydantic import BaseModel, Field, model_validator
 
-from typing import Any, Optional, Dict
-import torch
-import logging
 
-try:
-    from fairchem.core import FAIRChemCalculator, pretrained_mlip
-except ImportError:
-    logging.warning("fairchem is not installed. .")
-    FAIRChemCalculator = None
-    pretrained_mlip = None
+def _default_device() -> str:
+    """Choose a FairChem device without importing PyTorch at module import time."""
+    import torch
+
+    return "cuda" if torch.cuda.is_available() else "cpu"
 
 
 class FAIRChemCalc(BaseModel):
@@ -57,7 +56,7 @@ class FAIRChemCalc(BaseModel):
         default="uma-s-1p1", description="Model names. Options are 'uma-s-1p1' and 'uma-m-1'"
     )
     device: str = Field(
-        default="cuda" if torch.cuda.is_available() else "cpu",
+        default_factory=_default_device,
         description="Computation device to use, either 'cpu' or 'cuda'.",
     )
     inference_settings: str = Field(
@@ -100,8 +99,12 @@ class FAIRChemCalc(BaseModel):
             ASE-compatible calculator instance.
         """
 
-        if pretrained_mlip is None or FAIRChemCalculator is None:
-            raise ImportError("fairchem is not installed.")
+        try:
+            from fairchem.core import FAIRChemCalculator, pretrained_mlip
+        except ImportError as exc:
+            raise ImportError(
+                "FairChem is not installed. Install the 'uma' extra to use it."
+            ) from exc
 
         predict_unit = pretrained_mlip.get_predict_unit(
             model_name=self.model_name,

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Literal, Optional, Union
 from pydantic import BaseModel, Field
-import torch
 
 _logger = logging.getLogger(__name__)
 
@@ -195,6 +194,7 @@ class MaceCalc(BaseModel):
         ValueError
             If an invalid calculator_type is specified
         """
+        import torch
         from mace.modules.models import ScaleShiftMACE
 
         # Allow loading slice and ScaleShiftMACE objects for compatibility with older model files

--- a/src/chemgraph/schemas/calculators/tblite_calc.py
+++ b/src/chemgraph/schemas/calculators/tblite_calc.py
@@ -2,14 +2,6 @@
 # TBLite calculator parameters for CompChemAgent
 from pydantic import BaseModel, Field
 from typing import List, Optional
-import logging
-
-try:
-    from tblite.ase import TBLite
-except ImportError:
-    logging.warning(
-        "tblite is not installed. If you want to use tblite, please install it using 'pip install tblite'."
-    )
 
 
 class TBLiteCalc(BaseModel):
@@ -96,6 +88,13 @@ class TBLiteCalc(BaseModel):
             An ASE-compatible TBLite calculator instance with the specified
             configuration parameters
         """
+        try:
+            from tblite.ase import TBLite
+        except ImportError as exc:
+            raise ImportError(
+                "TBLite is not installed. Install the 'calculators' extra to use it."
+            ) from exc
+
         return TBLite(
             method=self.method,
             charge=self.charge,

--- a/src/chemgraph/tools/_ase_worker.py
+++ b/src/chemgraph/tools/_ase_worker.py
@@ -1,0 +1,46 @@
+"""Private subprocess entry point for isolated ASE calculator execution."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.tools.ase_core import _run_ase_core_in_process
+
+
+def _json_default(value):
+    """Convert NumPy scalars and paths used in minimal ASE result payloads."""
+    item = getattr(value, "item", None)
+    if callable(item):
+        return item()
+    if isinstance(value, Path):
+        return str(value)
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def main() -> int:
+    """Read an ASE request from stdin and write its result to the given path."""
+    if len(sys.argv) != 2:
+        return 2
+
+    result_path = Path(sys.argv[1])
+    try:
+        params = ASEInputSchema.model_validate_json(sys.stdin.read())
+        result = _run_ase_core_in_process(params)
+    except Exception as exc:
+        result = {
+            "status": "failure",
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+
+    result_path.write_text(
+        json.dumps(result, default=_json_default), encoding="utf-8"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -12,7 +12,10 @@ import glob
 import json
 import logging
 import os
+import signal
 import shutil
+import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -452,6 +455,111 @@ def run_ase_core(params: ASEInputSchema) -> dict:
     dict
         Minimal result payload (status, message, key numbers).
     """
+    calculator_type = str(
+        getattr(params.calculator, "calculator_type", "")
+    ).lower()
+
+    try:
+        # The macOS TBLite and PyTorch wheels each bundle libomp.dylib. Loading
+        # both copies in one interpreter raises SIGABRT, which no Python
+        # try/except can catch. Keep TBLite in a fresh interpreter so a native
+        # loader failure is contained and reported to the caller.
+        if calculator_type == "tblite":
+            return _run_ase_core_isolated(params)
+        return _run_ase_core_in_process(params)
+    except Exception as exc:
+        logger.exception("run_ase_core failed with %s: %s", type(exc).__name__, exc)
+        return {
+            "status": "failure",
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+
+
+def _run_ase_core_isolated(params: ASEInputSchema) -> dict:
+    """Run a native calculator in a child process and contain hard crashes."""
+    env = os.environ.copy()
+    source_root = str(Path(__file__).resolve().parents[2])
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        os.pathsep.join((source_root, existing_pythonpath))
+        if existing_pythonpath
+        else source_root
+    )
+
+    with tempfile.TemporaryDirectory(prefix="chemgraph_ase_worker_") as tmpdir:
+        env.setdefault("MPLCONFIGDIR", os.path.join(tmpdir, "matplotlib"))
+        env.setdefault("XDG_CACHE_HOME", os.path.join(tmpdir, "cache"))
+        result_path = Path(tmpdir) / "result.json"
+        command = [
+            sys.executable,
+            "-m",
+            "chemgraph.tools._ase_worker",
+            str(result_path),
+        ]
+        completed = subprocess.run(
+            command,
+            input=params.model_dump_json(),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            check=False,
+        )
+
+        if completed.returncode != 0:
+            if completed.returncode < 0:
+                signal_number = -completed.returncode
+                try:
+                    signal_name = signal.Signals(signal_number).name
+                except ValueError:
+                    signal_name = f"signal {signal_number}"
+                termination = f"terminated by {signal_name}"
+            else:
+                termination = f"exited with status {completed.returncode}"
+
+            calculator_name = getattr(
+                params.calculator, "calculator_type", "native calculator"
+            )
+            message = f"{calculator_name} worker {termination}."
+            if "OMP: Error #15" in completed.stderr or "libomp" in completed.stderr:
+                message += (
+                    " A conflicting OpenMP runtime was detected and contained; "
+                    "the ChemGraph process is still running."
+                )
+            logger.error(
+                "%s Worker stderr: %s",
+                message,
+                completed.stderr.strip() or "<empty>",
+            )
+            return {
+                "status": "failure",
+                "error_type": "CalculatorProcessError",
+                "message": message,
+                "returncode": completed.returncode,
+            }
+
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Calculator worker returned no valid result: %s", exc)
+            return {
+                "status": "failure",
+                "error_type": "CalculatorProcessError",
+                "message": f"Calculator worker returned no valid result: {exc}",
+            }
+
+        if not isinstance(result, dict):
+            return {
+                "status": "failure",
+                "error_type": "CalculatorProcessError",
+                "message": "Calculator worker returned a non-object result.",
+            }
+        return result
+
+
+def _run_ase_core_in_process(params: ASEInputSchema) -> dict:
+    """Execute the ASE simulation in the current interpreter."""
     from ase.io import read
     from ase.optimize import BFGS, LBFGS, GPMin, FIRE, MDMin
 
@@ -530,6 +638,18 @@ def run_ase_core(params: ASEInputSchema) -> dict:
         }
     logger.info("Calculator loaded successfully: %s", type(calc).__name__)
     simulation_input = _simulation_input_for_output(params, calc_model)
+
+    if driver == "ir" and "dipole" not in getattr(
+        calc, "implemented_properties", ()
+    ):
+        return {
+            "status": "failure",
+            "error_type": "PropertyNotImplementedError",
+            "message": (
+                "IR calculations require a calculator that implements dipole "
+                f"moments; {type(calc).__name__} does not provide the dipole property."
+            ),
+        }
 
     try:
         atoms = read(input_structure_file)

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -1,4 +1,7 @@
 import importlib.util
+import subprocess
+import sys
+
 import pytest
 import numpy as np
 from pydantic import ValidationError
@@ -7,6 +10,21 @@ from chemgraph.schemas.calculators.mace_calc import MaceCalc
 from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
 from chemgraph.schemas.calculators.orca_calc import OrcaCalc
 from ase import Atoms
+
+
+def test_ase_schema_import_does_not_load_optional_native_engines():
+    """Schema discovery must not initialize mutually incompatible runtimes."""
+    script = """
+import sys
+import chemgraph.schemas.ase_input  # noqa: F401
+
+optional_modules = ("torch", "tblite.ase", "fairchem.core", "mace")
+loaded = [name for name in optional_modules if name in sys.modules]
+if loaded:
+    raise SystemExit(f"optional native modules loaded: {loaded}")
+"""
+
+    subprocess.run([sys.executable, "-c", script], check=True)
 
 
 @pytest.mark.skipif(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -234,6 +234,118 @@ def test_run_ase_core_creates_output_parent_directory(monkeypatch, tmp_path):
     assert output_path.parent.is_dir()
 
 
+def _tblite_params_for_isolation_test():
+    """Build TBLite params without requiring the optional engine package."""
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
+
+    return ASEInputSchema.model_construct(
+        input_structure_file="water.xyz",
+        output_results_file="output.json",
+        driver="energy",
+        calculator=TBLiteCalc(),
+    )
+
+
+def test_run_ase_core_isolates_tblite(monkeypatch):
+    from chemgraph.tools import ase_core
+
+    expected = {"status": "success", "message": "isolated"}
+    monkeypatch.setattr(
+        ase_core, "_run_ase_core_isolated", lambda _params: expected
+    )
+    monkeypatch.setattr(
+        ase_core,
+        "_run_ase_core_in_process",
+        lambda _params: pytest.fail("TBLite ran in the parent process"),
+    )
+
+    assert ase_core.run_ase_core(_tblite_params_for_isolation_test()) == expected
+
+
+def test_isolated_ase_core_contains_native_abort(monkeypatch):
+    import signal
+    import subprocess
+
+    from chemgraph.tools import ase_core
+
+    def fake_run(command, **_kwargs):
+        return subprocess.CompletedProcess(
+            command,
+            -signal.SIGABRT,
+            stdout="",
+            stderr="OMP: Error #15: found libomp.dylib already initialized.",
+        )
+
+    monkeypatch.setattr(ase_core.subprocess, "run", fake_run)
+
+    result = ase_core._run_ase_core_isolated(_tblite_params_for_isolation_test())
+
+    assert result["status"] == "failure"
+    assert result["error_type"] == "CalculatorProcessError"
+    assert result["returncode"] == -signal.SIGABRT
+    assert "contained" in result["message"]
+
+
+def test_isolated_ase_core_returns_worker_result(monkeypatch):
+    import subprocess
+
+    from chemgraph.tools import ase_core
+
+    expected = {"status": "success", "potential_energy": -1.23}
+
+    def fake_run(command, **_kwargs):
+        Path(command[-1]).write_text(json.dumps(expected), encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(ase_core.subprocess, "run", fake_run)
+
+    assert (
+        ase_core._run_ase_core_isolated(_tblite_params_for_isolation_test())
+        == expected
+    )
+
+
+def test_ase_worker_serializes_numpy_scalars():
+    import numpy as np
+
+    from chemgraph.tools._ase_worker import _json_default
+
+    assert _json_default(np.bool_(True)) is True
+
+
+def test_ir_rejects_calculator_without_dipole_before_reading_structure(
+    monkeypatch, tmp_path
+):
+    from ase import Atoms
+    from ase.io import write as ase_write
+
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.tools import ase_core
+
+    input_path = tmp_path / "h2.xyz"
+    ase_write(input_path, Atoms("H2", positions=[[0, 0, 0], [0, 0, 0.74]]))
+
+    class _NoDipoleCalc:
+        implemented_properties = ["energy", "forces"]
+
+    monkeypatch.setattr(
+        ase_core, "load_calculator", lambda _calculator: (_NoDipoleCalc(), {}, None)
+    )
+    params = ASEInputSchema(
+        input_structure_file=str(input_path),
+        output_results_file=str(tmp_path / "ir.json"),
+        driver="ir",
+        calculator={"calculator_type": "emt"},
+    )
+
+    result = ase_core.run_ase_core(params)
+
+    assert result["status"] == "failure"
+    assert result["error_type"] == "PropertyNotImplementedError"
+    assert "implements dipole moments" in result["message"]
+
+
 @pytest.mark.parametrize(
     ("converged", "expected_steps", "expected_message"),
     [


### PR DESCRIPTION
## Problem

Two related failures with native calculator runtimes:

1. **The Streamlit UI cannot start on macOS.** Importing `chemgraph.schemas.ase_input` for schema discovery eagerly imported PyTorch (via `fairchem_calc` / `mace_calc`) and TBLite. The macOS TBLite and PyTorch wheels each bundle their own `libomp.dylib`; loading both into one interpreter raises `SIGABRT` before the app renders.

2. **A TBLite crash takes the whole app down.** A native OpenMP loader abort is not a Python exception, so no `try/except` can contain it — the Streamlit process dies instead of reporting a tool error.

## Changes

**Defer native imports** (`5d0625b`)
- `mace_calc` / `fairchem_calc` / `tblite_calc` import torch, mace, fairchem, and tblite inside the methods that use them rather than at module scope.
- `FAIRChemCalc.device` uses `default_factory` so torch is not imported to compute a field default.
- Availability probing uses `find_spec("fairchem")` instead of `find_spec("fairchem.core")`: resolving a submodule spec imports the parent package (and transitively torch), which defeated the point of the gate.
- Missing engines now raise `ImportError` naming the extra to install, replacing a module-scope `logging.warning` that left the calculator name undefined and surfaced later as a confusing `NameError`.

**Contain native crashes** (`3c951f9`)
- TBLite runs in a fresh interpreter (`chemgraph/tools/_ase_worker.py`) via `_run_ase_core_isolated`. A worker killed by a signal becomes a structured `CalculatorProcessError` result, with an added note when the stderr shows an OpenMP runtime conflict.
- `run_ase_core` is now a thin dispatcher; the existing body moved to `_run_ase_core_in_process` unchanged.
- IR runs are rejected up front when the calculator does not implement `dipole`, instead of failing partway through a vibrational analysis.

## Verification

- Full suite on the branch merged into `main`: **690 passed, 29 skipped**. The 10 failures are identical to those on `main` at `d1dcdcb` in the same environment (pre-existing; unrelated to this branch).
- The eager-import fix was checked against tripwire packages that raise on import: `main` fails with `RuntimeError: EAGER IMPORT of torch`, this branch imports cleanly with all seven calculators still discovered.
- The isolation path was exercised end-to-end (subprocess spawn, `PYTHONPATH`, result round-trip, artifact writing into `CHEMGRAPH_LOG_DIR`) for the `opt` and `vib` drivers.
- Confirmed the parent→worker JSON round-trip preserves `TBLiteCalc` rather than coercing it into another member of the non-discriminated calculator union, and that every TBLite alias (`xtb`, `GFN2-xTB`, …) normalizes to `calculator_type="TBLite"` so isolation always triggers.

## Notes for reviewers

Non-blocking observations, listed for the record:

- Isolation costs ~0.4 s of interpreter startup per TBLite call (measured). Negligible interactively; noticeable for large TBLite ensembles or scans, where it can dominate a sub-second single-point.
- `subprocess.run` has no timeout, so a hung worker hangs the caller. Not a regression — an in-process hang did the same — but the subprocess boundary now makes a timeout easy to add.
- `MPLCONFIGDIR` is redirected into a per-call temp dir, so an isolated TBLite **IR** run rebuilds the matplotlib font cache each time.
- If `json.dumps` fails in the worker (e.g. a multi-element NumPy array, which `_json_default` raises `ValueError` on rather than `TypeError`), the write happens outside the worker's `try`, so the failure degrades to an opaque "exited with status 1".
