### PR TITLE
Prioritize ARGO_USER for Argo models

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -59,6 +59,12 @@ export ARGO_USER="<anl-username>"
 chemgraph run --model argo:gpt-4o -q "Summarize the water molecule."
 ```
 
+For every `argo:` model, ChemGraph resolves the identity from an explicit or
+configured `argo_user`, then `ARGO_USER`, and finally the internal `chemgraph`
+placeholder required by the client libraries. Argo routes do not read an
+explicit `api_key` or `OPENAI_API_KEY`, so OpenAI credentials are never sent to
+an Argo endpoint.
+
 ALCF-hosted inference routes use `ALCF_ACCESS_TOKEN`. Available endpoints and
 access policies are facility-managed, so use `chemgraph models` and the current
 ALCF service instructions rather than copying an old model name.

--- a/src/chemgraph/models/endpoints/argo.py
+++ b/src/chemgraph/models/endpoints/argo.py
@@ -151,19 +151,14 @@ def _normalize_argo_wire_model(model_name: str) -> str:
     return fallback
 
 
-def _resolve_argo_api_key(request: ModelRequest) -> str:
-    """Resolve the value passed in the API-key field for Argo routes.
+def _resolve_argo_identity(request: ModelRequest) -> str:
+    """Resolve the identity passed through Argo client credential fields.
 
-    Mirrors the previous ``load_openai_model``: explicit key, else
-    ``OPENAI_API_KEY``, else the argo user / ``ARGO_USER`` / ``"chemgraph"``
-    placeholder.
+    Argo routes use an Argonne username rather than an API key. Keep their
+    identity isolated from explicit API keys and ``OPENAI_API_KEY`` so an
+    OpenAI credential can never be forwarded to an Argo endpoint.
     """
-    api_key = request.api_key
-    if api_key is None:
-        api_key = os.getenv("OPENAI_API_KEY")
-        if not api_key:
-            api_key = request.argo_user or os.getenv("ARGO_USER", "chemgraph")
-    return api_key
+    return request.argo_user or os.getenv("ARGO_USER") or "chemgraph"
 
 
 def _normalize_argo_anthropic_base_url(base_url: str | None) -> str:
@@ -214,7 +209,7 @@ def prepare_openai(request: ModelRequest) -> PreparedModel:
     if request.base_url is None:
         logger.info("Using default Argo base URL: %s", base_url)
 
-    api_key = _resolve_argo_api_key(request)
+    argo_identity = _resolve_argo_identity(request)
 
     if requested_model_name not in supported_argo_models:
         raise ValueError(
@@ -224,11 +219,7 @@ def prepare_openai(request: ModelRequest) -> PreparedModel:
 
     is_argo_claude_model = requested_model_name.startswith("argo:claude-")
     is_argo_endpoint = bool(base_url and "argoapi" in base_url)
-    argo_user = (
-        request.argo_user or os.getenv("ARGO_USER", "chemgraph")
-        if is_argo_endpoint
-        else None
-    )
+    argo_user = argo_identity if is_argo_endpoint else None
 
     logger.info("Using custom base URL: %s", base_url)
     wire_model = _normalize_argo_model(requested_model_name, base_url)
@@ -238,7 +229,7 @@ def prepare_openai(request: ModelRequest) -> PreparedModel:
     client_kwargs = assemble_client_kwargs(
         model=wire_model,
         requested_model_name=requested_model_name,
-        api_key=api_key,
+        api_key=argo_identity,
         base_url=base_url,
         temperature=request.temperature,
         reasoning_effort=request.reasoning_effort,
@@ -266,13 +257,13 @@ def prepare_anthropic(request: ModelRequest) -> PreparedModel:
         )
 
     base_url = resolve_anthropic_base_url(requested_model_name, request.base_url)
-    api_key = _resolve_argo_api_key(request)
+    argo_identity = _resolve_argo_identity(request)
     wire_model = _normalize_argo_model(requested_model_name, base_url)
 
     logger.info("Using Argo Anthropic base URL: %s", base_url)
     client_kwargs = dict(
         model=wire_model,
-        api_key=api_key,
+        api_key=argo_identity,
         base_url=base_url,
         max_tokens=4000,
         streaming=True,

--- a/tests/test_endpoints_route_matrix.py
+++ b/tests/test_endpoints_route_matrix.py
@@ -81,6 +81,7 @@ def test_argo_hosted_route_uses_wire_name_and_user_payload():
     assert prepared.supports_structured_output is False
     kwargs = prepared.client_kwargs
     assert kwargs["model"] == "gpt4o"  # wire name
+    assert kwargs["api_key"] == "alice"
     assert kwargs["base_url"] == ARGO_HOSTED_URL
     assert kwargs["model_kwargs"] == {"user": "alice"}
     assert kwargs["max_tokens"] == 4000
@@ -141,6 +142,52 @@ def test_argo_anthropic_never_uses_anthropic_api_key(monkeypatch):
     assert prepared.client_kwargs["api_key"] == "alice"
 
 
+@pytest.mark.parametrize(
+    ("prepare", "model"),
+    [
+        (argo_ep.prepare_openai, "argo:gpt-4o"),
+        (argo_ep.prepare_anthropic, "argo:claude-opus-4.8"),
+    ],
+)
+def test_argo_identity_never_uses_api_keys(monkeypatch, prepare, model):
+    monkeypatch.setenv("ARGO_USER", "argo-env-user")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+
+    prepared = prepare(ModelRequest(model=model, api_key="sk-explicit-secret"))
+
+    assert prepared.client_kwargs["api_key"] == "argo-env-user"
+
+
+def test_argo_configured_user_overrides_environment_and_keys(monkeypatch):
+    monkeypatch.setenv("ARGO_USER", "argo-env-user")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+    prepared = argo_ep.prepare_openai(
+        ModelRequest(
+            model="argo:gpt-4o",
+            api_key="sk-explicit-secret",
+            argo_user="configured-user",
+        )
+    )
+
+    assert prepared.client_kwargs["api_key"] == "configured-user"
+    assert prepared.client_kwargs["model_kwargs"] == {"user": "configured-user"}
+
+
+@pytest.mark.parametrize(
+    ("prepare", "model"),
+    [
+        (argo_ep.prepare_openai, "argo:gpt-4o"),
+        (argo_ep.prepare_anthropic, "argo:claude-opus-4.8"),
+    ],
+)
+def test_argo_uses_placeholder_instead_of_api_keys(monkeypatch, prepare, model):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+
+    prepared = prepare(ModelRequest(model=model, api_key="sk-explicit-secret"))
+
+    assert prepared.client_kwargs["api_key"] == "chemgraph"
+
+
 def test_argo_minimal_parameter_model_omits_sampling():
     prepared = argo_ep.prepare_openai(
         ModelRequest(model="argo:gpt-5", base_url=ARGO_HOSTED_URL)
@@ -153,13 +200,20 @@ def test_argo_minimal_parameter_model_omits_sampling():
 # --- Argo compatible (shim/proxy, prefix stripped) -------------------------
 
 
-def test_argo_compatible_route_strips_prefix_for_local_shim():
+def test_argo_compatible_route_strips_prefix_for_local_shim(monkeypatch):
+    monkeypatch.setenv("ARGO_USER", "argo-env-user")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
     prepared = argo_ep.prepare_openai(
-        ModelRequest(model="argo:gpt-4.1-mini", base_url="http://localhost:8080/v1")
+        ModelRequest(
+            model="argo:gpt-4.1-mini",
+            base_url="http://localhost:8080/v1",
+            api_key="sk-explicit-secret",
+        )
     )
     # A non-argoapi custom endpoint keeps the OpenAI-style name (prefix
     # stripped) and does not attach a hosted-Argo user payload.
     assert prepared.client_kwargs["model"] == "gpt-4.1-mini"
+    assert prepared.client_kwargs["api_key"] == "argo-env-user"
     assert "model_kwargs" not in prepared.client_kwargs
 
 

--- a/tests/test_loader_pr2.py
+++ b/tests/test_loader_pr2.py
@@ -167,6 +167,18 @@ def test_explicit_openai_key_is_forwarded_and_overrides_env(monkeypatch):
     assert prepared.client_kwargs["api_key"] == "sk-explicit"
 
 
+def test_argo_loader_uses_argo_user_instead_of_api_keys(monkeypatch):
+    monkeypatch.setenv("ARGO_USER", "argo-env-user")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-secret")
+
+    _client, prepared = load_chat_model_prepared(
+        model_name="argo:gpt-4o",
+        api_key="sk-explicit-secret",
+    )
+
+    assert prepared.client_kwargs["api_key"] == "argo-env-user"
+
+
 # --- reasoning_effort flow --------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Resolve Argo identity from configured argo_user, then ARGO_USER, then the chemgraph placeholder.
- Prevent explicit api_key and OPENAI_API_KEY values from being forwarded to any Argo route.
- Document the credential precedence and add coverage for hosted, Anthropic-native, and local/custom Argo endpoints.

## Testing

- ruff check .
- Focused endpoint, loader, and settings tests: 101 passed
- Full suite with .cg_fix_ase Python and tests excluding tblite: 741 passed, 30 skipped, 2 deselected