### PR TITLE
chore: prepare v0.7.0 release

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,67 @@
+name: Docker Build Check
+
+# Build the published image without pushing it, so a broken Dockerfile or an
+# inconsistent dependency set (the build runs `python -m pip check`) fails on
+# the pull request instead of during the release publish workflow.
+on:
+  pull_request:
+    paths:
+      - "Dockerfile"
+      - "Dockerfile.arm"
+      - "pyproject.toml"
+      - "requirements/**"
+      - "MANIFEST.in"
+      - ".github/workflows/docker-build.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "Dockerfile"
+      - "Dockerfile.arm"
+      - "pyproject.toml"
+      - "requirements/**"
+      - "MANIFEST.in"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile
+            platform: linux/amd64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.dockerfile }} (${{ matrix.platform }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          push: false
+          load: true
+          tags: chemgraph:ci-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image
+        run: |
+          docker run --rm chemgraph:ci-${{ github.sha }} \
+            python -c "import chemgraph, ase; print(chemgraph.__version__, ase.__version__)"
+          docker run --rm chemgraph:ci-${{ github.sha }} chemgraph --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,17 +23,18 @@ RUN conda install -y -c conda-forge \
     nwchem \
     && conda clean -afy
 
-# Install ChemGraph and UI runtime
-RUN pip install --no-cache-dir . && \
-    pip install --no-cache-dir jupyterlab
+# Install ChemGraph and UI runtime in one resolution pass.
+RUN python -m pip install --no-cache-dir . jupyterlab
 
-# Install Python tblite from source with conservative flags to avoid ABI/symbol issues on ARM.
+# Install Python tblite from source with conservative compiler flags.
 RUN CFLAGS="-O2 -fno-tree-vectorize" \
     FFLAGS="-O2 -fno-tree-vectorize" \
-    pip install --no-cache-dir --no-binary=tblite --force-reinstall "tblite==0.4.0"
+    python -m pip install --no-cache-dir --no-binary=tblite --force-reinstall "tblite==0.4.0"
 
-# Validate calculator runtimes at build time after package install.
-RUN which nwchem && python -c "from tblite.ase import TBLite"
+# Validate calculator runtimes and dependency consistency after installation.
+RUN which nwchem && \
+    python -c "from tblite.ase import TBLite" && \
+    python -m pip check
 
 # Allow git commands in bind-mounted repo paths inside the container.
 RUN git config --system --add safe.directory /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,13 @@ COPY . /app
 
 # Resolve ChemGraph, Polar, JupyterLab and TBLite together. Build TBLite from
 # source with conservative flags to avoid ABI/symbol issues on ARM.
+# pymatgen -> monty pulls an unconstrained ruamel.yaml; conda in the base image
+# requires ruamel.yaml<0.19, and `pip check` below fails without this bound.
 RUN CFLAGS="-O2 -fno-tree-vectorize" \
     FFLAGS="-O2 -fno-tree-vectorize" \
     python -m pip install --no-cache-dir --no-binary=tblite \
-    . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0"
+    . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0" \
+    "ruamel.yaml<0.19"
 
 # Use the validated ASE version after all other Python package installs.
 RUN python -m pip install --no-cache-dir "ase==3.29.0" && \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -26,16 +26,17 @@ RUN conda install -y -c conda-forge \
     nwchem \
     && conda clean -afy
 
-RUN pip install --no-cache-dir . && \
-    pip install --no-cache-dir jupyterlab
+RUN python -m pip install --no-cache-dir . jupyterlab
 
-# Install Python tblite from source with conservative flags to avoid ABI/symbol issues on ARM.
+# Install the same TBLite release as the package extra and standard image.
 RUN CFLAGS="-O2 -fno-tree-vectorize" \
     FFLAGS="-O2 -fno-tree-vectorize" \
-    pip install --no-cache-dir --no-binary=tblite --force-reinstall "tblite==0.5.0"
+    python -m pip install --no-cache-dir --no-binary=tblite --force-reinstall "tblite==0.4.0"
 
-# Validate calculator runtimes at build time after package install.
-RUN which nwchem && python -c "from tblite.ase import TBLite"
+# Validate calculator runtimes and dependency consistency after installation.
+RUN which nwchem && \
+    python -c "from tblite.ase import TBLite" && \
+    python -m pip check
 
 RUN git config --system --add safe.directory /app
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -33,10 +33,13 @@ COPY . /app
 
 # Resolve the same packages as the standard image in one installation pass.
 # Build TBLite from source with conservative compiler flags.
+# pymatgen -> monty pulls an unconstrained ruamel.yaml; conda in the base image
+# requires ruamel.yaml<0.19, and `pip check` below fails without this bound.
 RUN CFLAGS="-O2 -fno-tree-vectorize" \
     FFLAGS="-O2 -fno-tree-vectorize" \
     python -m pip install --no-cache-dir --no-binary=tblite \
-    . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0"
+    . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0" \
+    "ruamel.yaml<0.19"
 
 # Use the validated ASE version after all other Python package installs.
 RUN python -m pip install --no-cache-dir "ase==3.29.0" && \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/chemgraph.svg)](https://pypi.org/project/chemgraph/)
 [![Documentation](https://img.shields.io/badge/docs-MkDocs-4051b5)](https://argonne-lcf.github.io/ChemGraph/)
 [![Docker](https://img.shields.io/badge/Docker-GHCR-2496ED?logo=docker&logoColor=white)](https://github.com/argonne-lcf/ChemGraph/pkgs/container/chemgraph)
+[![Leaderboard](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-Leaderboard-FFD21E)](https://huggingface.co/spaces/Autonomous-Scientific-Agents/chemgraph-leaderboard)
 [![License](https://img.shields.io/github/license/argonne-lcf/ChemGraph)](LICENSE)
 
 # ChemGraph

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,13 +1,15 @@
 # Command-line interface
 
 The `chemgraph` command provides query execution, evaluation, session
-inspection, model discovery, dashboards, and Academy orchestration.
+inspection, model discovery, the web interface, dashboards, and Academy
+orchestration.
 
 ```text
 chemgraph run        Run an agent query or interactive session
 chemgraph eval       Evaluate a dataset
-chemgraph session    List, inspect, export, or delete saved sessions
+chemgraph session    List, inspect, or delete saved sessions
 chemgraph models     List registered model identifiers
+chemgraph ui         Launch the Streamlit web interface
 chemgraph dashboard  Launch the trace dashboard
 chemgraph academy    Run Academy campaigns and workers
 ```

--- a/docs/docker_support.md
+++ b/docs/docker_support.md
@@ -91,6 +91,14 @@ ARM builds install CPU PyTorch from its official wheel index because the PyPI
 CUDA dependency set includes unsupported ARM wheels. x86 builds retain their
 normal PyPI PyTorch selection. Both images explicitly install the Polar add-on
 and run `pip check` after resolving ChemGraph and its runtime dependencies.
+Because the packages share the base image's conda environment, the install
+bounds `ruamel.yaml<0.19` to stay compatible with conda itself; without it
+`pip check` fails and the build stops.
+
+The `Docker Build Check` workflow (`.github/workflows/docker-build.yml`) builds
+the `linux/amd64` image without pushing on every pull request that touches the
+Dockerfiles, `pyproject.toml`, or `requirements/`, and on pushes to `main`, so a
+broken image is caught before a release publishes it to GHCR.
 
 The TBLite build can take time, especially on ARM. Mount a dedicated artifact
 directory rather than a home directory, pass tokens at runtime, remember that

--- a/docs/streamlit_web_interface.md
+++ b/docs/streamlit_web_interface.md
@@ -55,8 +55,14 @@ The **Configuration → Providers** tab offers the same per-provider cards
 afterwards: readiness status, credentials, endpoint settings, and a model
 picker with one-click activation.
 
-When started from the checkout, the app's default configuration path is the
-repository-root `config.toml`. The interface exposes these workflow choices:
+When started from a source checkout, the app's default configuration path is
+the repository-root `config.toml`. For a wheel installation it is
+`$XDG_CONFIG_HOME/chemgraph/config.toml` (`~/.config/chemgraph/config.toml` by
+default; `%APPDATA%\chemgraph\config.toml` on Windows), because the Python
+installation directory is often read-only. Set `CHEMGRAPH_CONFIG` to a file
+path to override either choice. The Configuration page shows the active path,
+and a failed save is reported instead of being silently dropped. The interface
+exposes these workflow choices:
 
 - `single_agent`
 - `multi_agent`
@@ -95,7 +101,8 @@ as the CLI. Set `CHEMGRAPH_LOG_DIR` before starting Streamlit to redirect them.
   use EMT for a basic check.
 - **Remote browser cannot connect:** bind Streamlit to an appropriate interface
   only on a trusted network and follow your site's port-forwarding policy.
-- **Unexpected config:** inspect the repository-root `config.toml` used by the
-  source app.
+- **Unexpected config:** inspect the file shown under "Configuration file" on
+  the Configuration page (repository-root `config.toml` for a source checkout,
+  the per-user path for an installed package, or `$CHEMGRAPH_CONFIG`).
 
 See [Troubleshooting](troubleshooting.md) for broader diagnostics.

--- a/environment.yml
+++ b/environment.yml
@@ -15,12 +15,12 @@ dependencies:
   - pip:
     - ase==3.25.0
     - rdkit==2025.3.3
-    - langgraph==1.2.9
-    - langgraph-checkpoint==4.1.1
+    - langgraph==1.2.11
+    - langgraph-checkpoint==4.2.0
     - langgraph-prebuilt==1.1.0
-    - langgraph-sdk==0.4.2
-    - langchain==1.3.14
-    - langchain-core==1.5.3
+    - langgraph-sdk==0.4.4
+    - langchain==1.4.0
+    - langchain-core==1.6.1
     - langchain-openai==1.4.1
     - langchain-ollama==1.1.0
     - langchain-anthropic==1.5.4

--- a/environment.yml
+++ b/environment.yml
@@ -7,16 +7,17 @@ dependencies:
   - pip
   - numpy=2.2.6
   - pandas=2.2.3
-  - pytest=8.4.1
+  - pytest=9.0.3
   - rich=14.1.0
   - toml=0.10.2
-  - tblite
+  - tblite=0.4.0
   - nwchem
   - pip:
     - ase==3.25.0
     - rdkit==2025.3.3
     - langgraph==1.2.11
     - langgraph-checkpoint==4.2.0
+    - langgraph-checkpoint-sqlite==3.1.1
     - langgraph-prebuilt==1.1.0
     - langgraph-sdk==0.4.4
     - langchain==1.4.0
@@ -35,7 +36,7 @@ dependencies:
     - mace-torch>=0.3.16
     - graph-longrange @ git+https://github.com/WillBaldwin0/graph_electrostatics.git@v0.4.0
     - globus-sdk
-    - streamlit==1.48.1
+    - streamlit==1.54.0
     - py3Dmol
     - plotly
     - langsmith==0.10.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ authors = [
 requires-python = ">=3.11"
 dependencies = [
     "deepagents==0.7.5",
-    "langgraph==1.2.9",
-    "langgraph-checkpoint==4.1.1",
+    "langgraph==1.2.11",
+    "langgraph-checkpoint==4.2.0",
     "langgraph-checkpoint-sqlite==3.1.1",
     "langgraph-prebuilt==1.1.0",
-    "langgraph-sdk==0.4.2",
-    "langchain==1.3.14",
-    "langchain-core==1.5.3",
+    "langgraph-sdk==0.4.4",
+    "langchain==1.4.0",
+    "langchain-core==1.6.1",
     "langchain-openai==1.4.1",
     "langchain-ollama==1.1.0",
     "langchain-anthropic==1.5.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,10 @@ authors = [
     { name = "Murat Keçeli" },
     { name = "Aditya Tanikanti" }
 ]
+maintainers = [
+    { name = "Thang Pham" },
+    { name = "Murat Keçeli" },
+]
 requires-python = ">=3.11"
 dependencies = [
     "deepagents==0.7.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chemgraph"
-version = "0.6.0"
+version = "0.7.0"
 description = "A computational chemistry agent for molecular simulation tasks."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,12 @@ version = "0.7.0"
 description = "A computational chemistry agent for molecular simulation tasks."
 readme = "README.md"
 authors = [
-    { name = "Thang Pham", email = "tpham@anl.gov" },
-    { name = "Murat Keçeli", email = "keceli@anl.gov" },
-    { name = "Aditya Tanikanti", email = "atanikanti@anl.gov" }
+    { name = "Thang Pham" },
+    { name = "Murat Keçeli" },
+    { name = "Aditya Tanikanti" }
+]
+maintainers = [
+    { name = "Murat Keçeli", email = "keceli@anl.gov" }
 ]
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,12 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "chemgraph"
 version = "0.7.0"
-description = "A computational chemistry agent for molecular simulation tasks."
+description = "Agentic AI for computational chemistry workflows."
 readme = "README.md"
 authors = [
     { name = "Thang Pham" },
     { name = "Murat Keçeli" },
     { name = "Aditya Tanikanti" }
-]
-maintainers = [
-    { name = "Murat Keçeli", email = "keceli@anl.gov" }
 ]
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42"]
+requires = ["setuptools>=77"]  # PEP 639 license expression support
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -15,6 +15,26 @@ authors = [
 maintainers = [
     { name = "Thang Pham" },
     { name = "Murat Keçeli" },
+]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+keywords = [
+    "computational chemistry", "agentic AI", "LLM agents", "quantum chemistry",
+    "molecular simulation", "ASE", "LangGraph",
+]
+# shields.io's pypi/pyversions badge and PyPI's sidebar are driven by these
+# classifiers; test_package_metadata keeps them aligned with the CI matrix.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.11"
 dependencies = [
@@ -121,7 +141,9 @@ docking = [
 
 [project.urls]
 "Homepage" = "https://github.com/argonne-lcf/ChemGraph"
+"Documentation" = "https://argonne-lcf.github.io/ChemGraph/"
 "Repository" = "https://github.com/argonne-lcf/ChemGraph"
+"Issues" = "https://github.com/argonne-lcf/ChemGraph/issues"
 
 [project.scripts]
 chemgraph = "chemgraph.cli:main"

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -173,20 +173,6 @@ same pattern as `demo_local_agent.py`.
 
 ## Known caveats
 
-- **`langchain-mcp-adapters` must be pinned to `0.1.14`** for the
-  `*_agent.py` scripts to import. Versions `>=0.2.0` import
-  `langchain_core.messages.content` (a 1.x API) which doesn't exist in
-  `langchain-core 0.3.x` — and `langgraph 0.4.7` (pinned in
-  `pyproject.toml`) constrains us to `langchain-core 0.3.x`. Fix in
-  `.cg_env`:
-  ```bash
-  pip install 'langchain-mcp-adapters==0.1.14'
-  ```
-  This is an **env-only pin** — `pyproject.toml` still lists
-  `langchain-mcp-adapters` unpinned, so a fresh `pip install -e .`
-  will regress to `>=0.2`. Re-run the pin command after any clean env
-  rebuild. The durable fix (one-line edit to `pyproject.toml`) was
-  deferred per user request.
 - `ensemble-launcher` is not on PyPI for Python 3.12; the in-job EL
   demos only work on HPC where `scripts/hpc_setup/install_remote.sh`
   builds it from source.

--- a/src/ui/_pages/configuration.py
+++ b/src/ui/_pages/configuration.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 import streamlit as st
 import toml
 
+from ui import config as ui_config
 from ui import providers
 from ui.config import (
     get_default_config, load_config, merge_config_defaults,
@@ -76,6 +77,16 @@ def get_model_options(config: Dict[str, Any]) -> list:
 # ---------------------------------------------------------------------------
 
 
+def _save_failure_message() -> str:
+    """Describe a failed configuration save with the path and a remedy."""
+    reason = ui_config.last_save_error or ui_config.config_path()
+    return (
+        f"❌ Failed to save configuration ({reason}). Settings apply to this "
+        f"session only; set ${ui_config.CONFIG_PATH_ENV} to a writable file to "
+        "persist them."
+    )
+
+
 def render() -> None:
     """Render the Configuration page."""
     st.title("⚙️ Configuration")
@@ -86,6 +97,10 @@ def render() -> None:
     click **Save Configuration**.
     """
     )
+    st.caption(f"Configuration file: `{ui_config.config_path()}`")
+    save_error = st.session_state.pop("config_save_error", None)
+    if save_error:
+        st.error(save_error)
 
     # Ensure config exists in session state
     if "config" not in st.session_state or st.session_state.config is None:
@@ -179,6 +194,8 @@ def _activate_provider_model(draft: dict, info, model_name: str) -> None:
     st.session_state.config = copy.deepcopy(draft)
     if save_config(st.session_state.config):
         st.toast(f"Now using {model_name}", icon="✅")
+    else:
+        st.session_state.config_save_error = _save_failure_message()
     st.rerun()
 
 
@@ -249,7 +266,8 @@ def _render_argo_card(draft: dict, info, status) -> None:
         st.session_state.config["api"].setdefault("argo", {})[
             "argo_user"
         ] = user
-        save_config(st.session_state.config)
+        if not save_config(st.session_state.config):
+            st.session_state.config_save_error = _save_failure_message()
         st.rerun()
     st.caption(status.detail)
     _render_endpoint_settings(draft, "argo", key_prefix="argo")
@@ -661,9 +679,9 @@ def _render_action_buttons(config: dict) -> None:
             # Apply the draft to the live session config, then persist to disk.
             st.session_state.config = copy.deepcopy(config)
             if save_config(st.session_state.config):
-                st.success("✅ Configuration saved to config.toml!")
+                st.success(f"✅ Configuration saved to {ui_config.config_path()}")
             else:
-                st.error("❌ Failed to save configuration")
+                st.error(_save_failure_message())
 
     with col2:
         if st.button("\U0001f504 Reload Configuration"):

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -33,7 +33,7 @@ from chemgraph.utils.config_utils import (
 from ui import alcf_auth
 from ui import artifacts as artifact_utils
 from ui import providers
-from ui.agent_manager import initialize_agent
+from ui.agent_manager import initialize_agent, transfer_conversation_state
 from ui.provider_widgets import apply_api_key, render_alcf_login
 from ui.branding import LOGO_IMAGES, first_existing_asset
 from ui import config as ui_config
@@ -928,7 +928,18 @@ def _auto_initialize_agent(
         credential_fingerprint,
     )
 
-    if st.session_state.agent is None or st.session_state.last_config != current_config:
+    previous_agent = st.session_state.agent
+    last_config = st.session_state.last_config
+    if previous_agent is None or last_config != current_config:
+        # Only the credential changed: the graph topology, thread ids and
+        # log directory are identical, so the conversation can move to the
+        # rebuilt agent instead of restarting from an empty checkpointer.
+        credential_only_change = (
+            previous_agent is not None
+            and last_config is not None
+            and last_config[:-1] == current_config[:-1]
+            and last_config[-1] != credential_fingerprint
+        )
         with st.spinner("\U0001f680 Initializing ChemGraph agents..."):
             chat_log_dir = _ensure_chat_log_dir()
             agent = initialize_agent(
@@ -943,8 +954,10 @@ def _auto_initialize_agent(
                 get_argo_user_from_nested_config(config),
                 log_dir=chat_log_dir,
             )
-            st.session_state.agent = agent
             if agent is not None:
+                if credential_only_change:
+                    transfer_conversation_state(previous_agent, agent)
+                st.session_state.agent = agent
                 st.session_state.last_config = (
                     selected_model,
                     selected_workflow,
@@ -958,7 +971,14 @@ def _auto_initialize_agent(
                     chat_log_dir,
                     credential_fingerprint,
                 )
+            elif credential_only_change:
+                # The new credential failed to build a client. Keep the
+                # conversation on the previous agent so nothing is lost; its
+                # cache key still differs from the current credential, so the
+                # next rerun retries and can transfer the state on success.
+                pass
             else:
+                st.session_state.agent = None
                 st.session_state.last_config = None
 
 

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -1,6 +1,7 @@
 """Main chat interface page for ChemGraph."""
 
 import asyncio
+import hashlib
 import logging
 import os
 import pprint
@@ -35,6 +36,7 @@ from ui import providers
 from ui.agent_manager import initialize_agent
 from ui.provider_widgets import apply_api_key, render_alcf_login
 from ui.branding import LOGO_IMAGES, first_existing_asset
+from ui import config as ui_config
 from ui.config import load_config, resolve_default_calculator, save_config
 from ui.endpoint import check_local_model_endpoint
 from ui.file_utils import (
@@ -265,6 +267,10 @@ def render() -> None:
     # ----- Agent status sidebar -----
     _render_agent_status(selected_model, selected_workflow, thread_id, endpoint_status)
 
+    setup_save_error = st.session_state.pop("setup_save_error", None)
+    if setup_save_error:
+        st.error(setup_save_error)
+
     # ----- Auto-initialize agent -----
     _auto_initialize_agent(
         config,
@@ -465,11 +471,19 @@ def _finish_first_run_setup(config: dict, info) -> None:
     config["general"]["model"] = info.default_model
     providers.align_base_url_for_provider(config, info.id)
     st.session_state.config = config
-    save_config(config)
+    saved = save_config(config)
     # Local servers stay "unproven" to any_provider_ready, so remember
     # that setup finished to avoid re-gating the chat.
     st.session_state._setup_skipped = True
-    st.toast(f"Ready — using {info.default_model}", icon="\U0001f680")
+    if saved:
+        st.toast(f"Ready — using {info.default_model}", icon="\U0001f680")
+    else:
+        # The session keeps the choice, but it will not survive a restart.
+        st.session_state.setup_save_error = (
+            f"Using {info.default_model} for this session, but the configuration "
+            f"could not be saved ({ui_config.last_save_error}). Set "
+            f"${ui_config.CONFIG_PATH_ENV} to a writable file to persist settings."
+        )
     st.rerun()
 
 
@@ -822,7 +836,41 @@ def _render_agent_status(
     st.sidebar.markdown(
         "Use the Configuration page to modify settings, API endpoints, and chemistry parameters."
     )
-    st.sidebar.markdown("Current config loaded from: `config.toml`")
+    st.sidebar.markdown(f"Current config loaded from: `{ui_config.config_path()}`")
+
+
+def _provider_credential_fingerprint(provider_info, alcf_token: Optional[str]) -> Optional[str]:
+    """Return a non-reversible fingerprint of the credential the agent will use.
+
+    Model clients read their API key once, when the agent is built, so a key
+    applied or cleared afterwards must invalidate the cached agent. The
+    fingerprint enters the configuration tuple compared on every rerun
+    without keeping the secret itself in session state.
+
+    Parameters
+    ----------
+    provider_info : providers.ProviderInfo or None
+        Provider serving the selected model.
+    alcf_token : str, optional
+        Globus access token for ALCF endpoints, when applicable.
+
+    Returns
+    -------
+    str or None
+        SHA-256 hex digest of the active credential, or ``None`` when the
+        provider needs none or none is set.
+    """
+    if provider_info is None:
+        return None
+    if provider_info.auth_kind == "globus":
+        credential = alcf_token
+    elif provider_info.env_var:
+        credential = os.environ.get(provider_info.env_var)
+    else:
+        credential = None
+    if not credential:
+        return None
+    return hashlib.sha256(credential.encode("utf-8")).hexdigest()
 
 
 def _auto_initialize_agent(
@@ -862,6 +910,9 @@ def _auto_initialize_agent(
     provider_info = providers.provider_for_model(selected_model)
     if provider_info is not None and provider_info.auth_kind == "globus":
         alcf_token = alcf_auth.ensure_access_token()
+    # API keys are read when the model client is built; include them so an
+    # applied or cleared key rebuilds the agent instead of reusing the old one.
+    credential_fingerprint = _provider_credential_fingerprint(provider_info, alcf_token)
 
     current_config = (
         selected_model,
@@ -874,7 +925,7 @@ def _auto_initialize_agent(
         selected_base_url,
         get_argo_user_from_nested_config(config),
         st.session_state.get("current_chat_log_dir"),
-        alcf_token,
+        credential_fingerprint,
     )
 
     if st.session_state.agent is None or st.session_state.last_config != current_config:
@@ -905,7 +956,7 @@ def _auto_initialize_agent(
                     selected_base_url,
                     get_argo_user_from_nested_config(config),
                     chat_log_dir,
-                    alcf_token,
+                    credential_fingerprint,
                 )
             else:
                 st.session_state.last_config = None

--- a/src/ui/agent_manager.py
+++ b/src/ui/agent_manager.py
@@ -73,6 +73,47 @@ def initialize_agent(
         return None
 
 
+#: Attributes that identify a conversation and its persistence bookkeeping.
+_CONVERSATION_ATTRIBUTES = (
+    "uuid",
+    "session_store",
+    "_session_created",
+    "_saved_message_keys",
+    "_session_title",
+)
+
+
+def transfer_conversation_state(source, target) -> None:
+    """Move an active conversation from one agent instance to another.
+
+    Rebuilding the agent (for example after a provider API key is replaced)
+    compiles a fresh graph with an empty in-memory checkpointer, which would
+    drop the LangGraph thread state, any pending human-input interrupt, and
+    the session bookkeeping that prevents duplicate history writes. Reuse the
+    previous checkpointer and session identity on the new instance so the
+    conversation continues under the new credentials.
+
+    Parameters
+    ----------
+    source : ChemGraph
+        Agent that currently owns the conversation.
+    target : ChemGraph
+        Newly constructed agent with the same workflow configuration.
+    """
+    if source is None or target is None or source is target:
+        return
+    for name in _CONVERSATION_ATTRIBUTES:
+        if hasattr(source, name):
+            setattr(target, name, getattr(source, name))
+    source_workflow = getattr(source, "workflow", None)
+    target_workflow = getattr(target, "workflow", None)
+    checkpointer = getattr(source_workflow, "checkpointer", None)
+    if checkpointer is not None and target_workflow is not None:
+        target_workflow.checkpointer = checkpointer
+    if getattr(source, "checkpointer", None) is not None:
+        target.checkpointer = source.checkpointer
+
+
 def run_async_callable(fn):
     """Run an async callable and return its result in a sync context.
 

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -10,12 +10,54 @@ from typing import Dict, Any, Optional
 from chemgraph.utils.config_utils import flatten_config as _flatten_config
 from chemgraph.utils.calculator_defaults import get_default_mace_calculator_type
 
-# Anchor the default config to the repository root (the directory the app is
-# meant to be launched from per the README) rather than the current working
-# directory.  With a bare ``"config.toml"`` the file resolved relative to the
-# launch directory, so starting Streamlit from anywhere else silently created
-# and used a throw-away default config instead of the real one.
-_DEFAULT_CONFIG_PATH = str(Path(__file__).resolve().parents[2] / "config.toml")
+CONFIG_PATH_ENV = "CHEMGRAPH_CONFIG"
+
+
+def _source_checkout_root() -> Optional[Path]:
+    """Return the repository root when running from a source checkout.
+
+    ``src/ui/config.py`` sits two levels below the repository root, which is
+    identified by its ``pyproject.toml``.  In a wheel installation the same
+    ancestor is ``lib/pythonX.Y``, which has no such marker and is frequently
+    read-only.
+    """
+    root = Path(__file__).resolve().parents[2]
+    return root if (root / "pyproject.toml").is_file() else None
+
+
+def user_config_dir() -> Path:
+    """Return the per-user directory for an installed ChemGraph's config."""
+    base = os.environ.get("XDG_CONFIG_HOME") or os.environ.get("APPDATA")
+    base_path = Path(base) if base else Path.home() / ".config"
+    return base_path / "chemgraph"
+
+
+def default_config_path() -> str:
+    """Resolve where ``config.toml`` lives for this installation.
+
+    Precedence: the ``CHEMGRAPH_CONFIG`` environment variable, then
+    ``<repo>/config.toml`` for a source checkout (the directory the app is
+    meant to be launched from per the README, rather than the current working
+    directory), then a writable per-user location for wheel installations.
+    Resolving relative to the package for installed copies placed the file
+    inside ``lib/pythonX.Y/``; saves there fail silently on read-only
+    installs and the settings are gone on the next start.
+    """
+    override = os.environ.get(CONFIG_PATH_ENV)
+    if override:
+        return str(Path(override).expanduser())
+    checkout = _source_checkout_root()
+    if checkout is not None:
+        return str(checkout / "config.toml")
+    return str(user_config_dir() / "config.toml")
+
+
+_DEFAULT_CONFIG_PATH = default_config_path()
+
+
+def config_path() -> str:
+    """Return the active default configuration file path."""
+    return _DEFAULT_CONFIG_PATH
 
 
 def merge_config_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -74,6 +116,11 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
         return get_default_config()
 
 
+#: Human-readable reason for the most recent failed ``save_config`` call, or
+#: ``None`` after a successful save. UI pages surface it to the user.
+last_save_error: Optional[str] = None
+
+
 def save_config(config: Dict[str, Any], config_path: Optional[str] = None) -> bool:
     """Save configuration to a TOML file.
 
@@ -89,14 +136,19 @@ def save_config(config: Dict[str, Any], config_path: Optional[str] = None) -> bo
     bool
         ``True`` if the file was written successfully.
     """
+    global last_save_error
     if config_path is None:
         config_path = _DEFAULT_CONFIG_PATH
     try:
+        parent = os.path.dirname(os.path.abspath(config_path))
+        os.makedirs(parent, exist_ok=True)
         with open(config_path, "w") as f:
             toml.dump(config, f)
+        last_save_error = None
         return True
     except Exception as e:
-        print(f"Error saving configuration: {e}")
+        last_save_error = f"{config_path}: {e}"
+        print(f"Error saving configuration to {last_save_error}")
         return False
 
 

--- a/src/ui/endpoint.py
+++ b/src/ui/endpoint.py
@@ -2,8 +2,8 @@
 
 from typing import Any, Dict, Optional
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse, urlunparse
-from urllib.request import Request, urlopen
+from urllib.parse import ParseResult, urlparse, urlunparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 import streamlit as st
 
@@ -25,25 +25,38 @@ def _is_local_address(hostname: str) -> bool:
     return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 
 
-def _build_local_models_probe_url(base_url: str) -> Optional[str]:
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Keep local probes from following redirects to other endpoints."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _build_local_models_probe_url(parsed: ParseResult) -> Optional[str]:
     """Validate and canonicalize a local endpoint probe URL.
 
     Returns a safe canonical URL ending in ``/models`` when valid,
     otherwise ``None``.
     """
-    parsed = urlparse((base_url or "").strip())
     if parsed.scheme not in {"http", "https"}:
         return None
     if not _is_local_address(parsed.hostname or ""):
         return None
     # Disallow userinfo, query, and fragment in probe target.
-    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
         return None
 
     base_path = parsed.path.rstrip("/")
     safe_path = f"{base_path}/models" if base_path else "/models"
     netloc = parsed.hostname or ""
-    if parsed.port:
+    if ":" in netloc:
+        netloc = f"[{netloc}]"
+    if parsed.port is not None:
         netloc = f"{netloc}:{parsed.port}"
     return urlunparse((parsed.scheme, netloc, safe_path, "", "", ""))
 
@@ -62,17 +75,29 @@ def check_local_model_endpoint(base_url: Optional[str]) -> Dict[str, Any]:
     dict[str, Any]
         Status dictionary with ``ok`` and ``message`` keys.
     """
+    base_url = (base_url or "").strip()
     if not base_url:
         return {"ok": True, "message": "No base URL configured."}
 
-    probe = _build_local_models_probe_url(base_url)
+    try:
+        parsed = urlparse(base_url)
+        hostname = parsed.hostname
+        # Port validation is lazy in urllib, including for remote URLs.
+        _ = parsed.port
+    except ValueError:
+        return {"ok": False, "message": "Invalid endpoint URL."}
+    if parsed.scheme not in {"http", "https"} or not hostname:
+        return {"ok": False, "message": "Invalid endpoint URL."}
+    if not _is_local_address(hostname):
+        return {"ok": True, "message": "Skipping non-local endpoint probe."}
+
+    probe = _build_local_models_probe_url(parsed)
     if not probe:
         return {"ok": False, "message": "Invalid local endpoint URL."}
 
-    req = Request(probe, method="GET")
-
     try:
-        with urlopen(req, timeout=2) as response:
+        req = Request(probe, method="GET")
+        with build_opener(_NoRedirectHandler()).open(req, timeout=2) as response:
             code = getattr(response, "status", 200)
             return {"ok": True, "message": f"Reachable (HTTP {code})."}
     except HTTPError as e:

--- a/src/ui/endpoint.py
+++ b/src/ui/endpoint.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Dict, Optional
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 from urllib.request import Request, urlopen
 
 import streamlit as st
@@ -25,6 +25,29 @@ def _is_local_address(hostname: str) -> bool:
     return host in {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 
 
+def _build_local_models_probe_url(base_url: str) -> Optional[str]:
+    """Validate and canonicalize a local endpoint probe URL.
+
+    Returns a safe canonical URL ending in ``/models`` when valid,
+    otherwise ``None``.
+    """
+    parsed = urlparse((base_url or "").strip())
+    if parsed.scheme not in {"http", "https"}:
+        return None
+    if not _is_local_address(parsed.hostname or ""):
+        return None
+    # Disallow userinfo, query, and fragment in probe target.
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        return None
+
+    base_path = parsed.path.rstrip("/")
+    safe_path = f"{base_path}/models" if base_path else "/models"
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse((parsed.scheme, netloc, safe_path, "", "", ""))
+
+
 @st.cache_data(ttl=10)
 def check_local_model_endpoint(base_url: Optional[str]) -> Dict[str, Any]:
     """Quick reachability check for local OpenAI-compatible endpoints.
@@ -42,11 +65,10 @@ def check_local_model_endpoint(base_url: Optional[str]) -> Dict[str, Any]:
     if not base_url:
         return {"ok": True, "message": "No base URL configured."}
 
-    parsed = urlparse(base_url)
-    if not _is_local_address(parsed.hostname or ""):
-        return {"ok": True, "message": "Skipping non-local endpoint probe."}
+    probe = _build_local_models_probe_url(base_url)
+    if not probe:
+        return {"ok": False, "message": "Invalid local endpoint URL."}
 
-    probe = base_url.rstrip("/") + "/models"
     req = Request(probe, method="GET")
 
     try:

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -89,7 +89,7 @@ def test_conda_environment_covers_exact_project_pins() -> None:
     assert all(dependency in environment_specs for dependency in direct_urls)
 
 
-def test_tblite_pin_matches_all_installation_surfaces() -> None:
+def test_calculator_pin_matches_all_installation_surfaces() -> None:
     """Conda and container installs should use the calculator-extra TBLite pin."""
     metadata = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
     calculator_pins = _exact_pins(metadata["optional-dependencies"]["calculators"])

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,9 +1,30 @@
 """Tests for ChemGraph package metadata."""
 
+import re
 from pathlib import Path
 from typing import Any
 
 import chemgraph
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXACT_PIN = re.compile(
+    r"^([A-Za-z0-9_.-]+)(?:==|=)([^;\s]+)(?:\s*;.*)?$"
+)
+
+
+def _normalize_package_name(name: str) -> str:
+    """Return a normalized Python package name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _exact_pins(requirements: list[str]) -> dict[str, str]:
+    """Return normalized names and versions for exact package pins."""
+    pins = {}
+    for requirement in requirements:
+        match = _EXACT_PIN.fullmatch(requirement.strip())
+        if match:
+            pins[_normalize_package_name(match.group(1))] = match.group(2)
+    return pins
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
@@ -32,7 +53,7 @@ def _load_toml(path: Path) -> dict[str, Any]:
 
 def test_version_matches_project_metadata() -> None:
     """ChemGraph version should match the project metadata version."""
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = _REPO_ROOT / "pyproject.toml"
     project_version = _load_toml(pyproject)["project"]["version"]
 
     assert chemgraph.__version__ == project_version
@@ -40,7 +61,47 @@ def test_version_matches_project_metadata() -> None:
 
 def test_pyproject_version_fallback_matches_project_metadata() -> None:
     """Source-checkout fallback should read the version from pyproject.toml."""
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = _REPO_ROOT / "pyproject.toml"
     project_version = _load_toml(pyproject)["project"]["version"]
 
     assert chemgraph._version_from_pyproject() == project_version
+
+
+def test_conda_environment_covers_exact_project_pins() -> None:
+    """Conda installs should retain every exact core dependency pin."""
+    project = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
+    project_pins = _exact_pins(project["dependencies"])
+
+    environment_text = (_REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+    environment_specs = re.findall(
+        r"^\s*-\s+(.+?)\s*$", environment_text, flags=re.MULTILINE
+    )
+    environment_pins = _exact_pins(environment_specs)
+
+    mismatches = {
+        name: {"project": version, "environment": environment_pins.get(name)}
+        for name, version in project_pins.items()
+        if environment_pins.get(name) != version
+    }
+    assert not mismatches
+
+    direct_urls = [dep for dep in project["dependencies"] if " @ " in dep]
+    assert all(dependency in environment_specs for dependency in direct_urls)
+
+
+def test_tblite_pin_matches_all_installation_surfaces() -> None:
+    """Conda and container installs should use the calculator-extra TBLite pin."""
+    metadata = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
+    calculator_pins = _exact_pins(metadata["optional-dependencies"]["calculators"])
+    tblite_version = calculator_pins["tblite"]
+
+    environment_text = (_REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+    environment_specs = re.findall(
+        r"^\s*-\s+(.+?)\s*$", environment_text, flags=re.MULTILINE
+    )
+    assert _exact_pins(environment_specs)["tblite"] == tblite_version
+
+    for filename in ("Dockerfile", "Dockerfile.arm"):
+        dockerfile = (_REPO_ROOT / filename).read_text(encoding="utf-8")
+        assert f'"tblite=={tblite_version}"' in dockerfile
+        assert "python -m pip check" in dockerfile

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -183,3 +183,28 @@ def test_built_metadata_rejects_urls_including_extras(tmp_path, kind, requiremen
             check(path)
     else:
         check(path)
+
+
+def test_python_version_classifiers_match_support_matrix():
+    """shields.io's pyversions badge reads these; keep them truthful."""
+    project = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
+    classifiers = project["classifiers"]
+    declared = {
+        c.rsplit(" :: ", 1)[1]
+        for c in classifiers
+        if c.startswith("Programming Language :: Python :: 3.")
+    }
+    assert declared, "Expected Programming Language :: Python :: 3.X classifiers"
+    assert "Programming Language :: Python :: 3 :: Only" in classifiers
+
+    floor = project["requires-python"].removeprefix(">=")
+    assert min(declared, key=lambda v: tuple(map(int, v.split(".")))) == floor
+
+    workflow = (_REPO_ROOT / ".github/workflows/tests.yml").read_text(encoding="utf-8")
+    tested = set(re.findall(r'python-version: \[([^\]]+)\]', workflow)[0].replace('"', "").replace(" ", "").split(","))
+    assert declared == tested
+
+    assert project["license"] == "Apache-2.0"
+    assert not any(c.startswith("License ::") for c in classifiers), (
+        "PEP 639: use the license expression, not License classifiers"
+    )

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -128,6 +128,9 @@ def test_calculator_pin_matches_all_installation_surfaces() -> None:
         assert f'"tblite=={tblite_version}"' in dockerfile
         assert "python -m pip check" in dockerfile
         assert "-r requirements/mace-polar.txt" in dockerfile
+        # conda in the miniconda base image requires ruamel.yaml<0.19; an
+        # unbounded ruamel.yaml from monty/pymatgen makes `pip check` fail.
+        assert '"ruamel.yaml<0.19"' in dockerfile
 
 
 def test_published_dependencies_have_no_direct_urls():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -16,6 +16,7 @@ These lock in the behaviors PR 3 introduced on top of the endpoint registry:
 
 from __future__ import annotations
 
+from pathlib import Path
 import logging
 
 import pytest
@@ -714,3 +715,53 @@ def test_repository_config_has_canonical_argo_and_vllm_sections():
     assert config["api"]["openai"]["base_url"] == "https://api.openai.com/v1"
     assert "argo" in config["api"]
     assert "vllm" in config["api"]
+
+
+def test_installed_package_uses_writable_user_config_path(monkeypatch, tmp_path):
+    """A wheel install must not resolve config.toml inside lib/pythonX.Y."""
+    from ui import config as ui_config
+
+    site = tmp_path / "venv" / "lib" / "python3.12" / "site-packages" / "ui"
+    site.mkdir(parents=True)
+    monkeypatch.setattr(ui_config, "__file__", str(site / "config.py"))
+    monkeypatch.delenv("CHEMGRAPH_CONFIG", raising=False)
+    monkeypatch.delenv("APPDATA", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    resolved = Path(ui_config.default_config_path())
+    assert resolved == tmp_path / "xdg" / "chemgraph" / "config.toml"
+    assert "lib" not in resolved.parts
+
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path / "home"))
+    assert Path(ui_config.default_config_path()) == (
+        tmp_path / "home" / ".config" / "chemgraph" / "config.toml"
+    )
+
+    monkeypatch.setenv("CHEMGRAPH_CONFIG", str(tmp_path / "custom.toml"))
+    assert ui_config.default_config_path() == str(tmp_path / "custom.toml")
+
+
+def test_source_checkout_keeps_repository_config_path(monkeypatch):
+    from ui import config as ui_config
+
+    monkeypatch.delenv("CHEMGRAPH_CONFIG", raising=False)
+    repo_root = Path(ui_config.__file__).resolve().parents[2]
+    assert (repo_root / "pyproject.toml").is_file()
+    assert Path(ui_config.default_config_path()) == repo_root / "config.toml"
+
+
+def test_save_config_creates_parent_directory_and_reports_failures(tmp_path):
+    from ui import config as ui_config
+
+    target = tmp_path / "xdg" / "chemgraph" / "config.toml"
+    assert ui_config.save_config(ui_config.get_default_config(), str(target))
+    assert target.is_file()
+    assert ui_config.last_save_error is None
+    assert ui_config.load_config(str(target)) == ui_config.get_default_config()
+
+    blocked = tmp_path / "blocked.toml" / "config.toml"  # parent is a file
+    (tmp_path / "blocked.toml").write_text("")
+    assert not ui_config.save_config(ui_config.get_default_config(), str(blocked))
+    assert ui_config.last_save_error is not None
+    assert str(blocked) in ui_config.last_save_error

--- a/tests/test_ui_endpoint.py
+++ b/tests/test_ui_endpoint.py
@@ -1,0 +1,155 @@
+"""Local endpoint probes validate URLs without blocking remote providers."""
+
+from contextlib import nullcontext
+from email.message import Message
+from io import BytesIO
+from types import SimpleNamespace
+from unittest.mock import Mock
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPHandler, build_opener
+from urllib.response import addinfourl
+
+import pytest
+
+from ui import endpoint
+
+
+@pytest.fixture(autouse=True)
+def probe_opener(monkeypatch):
+    """Isolate Streamlit caching and prevent real network requests."""
+    endpoint.check_local_model_endpoint.clear()
+    opener = Mock()
+    opener.open.return_value = nullcontext(SimpleNamespace(status=200))
+    monkeypatch.setattr(endpoint, "build_opener", Mock(return_value=opener))
+    yield opener
+    endpoint.check_local_model_endpoint.clear()
+
+
+@pytest.mark.parametrize("base_url", [None, "", "   "])
+def test_unconfigured_endpoint_skips_probe(base_url, probe_opener):
+    result = endpoint.check_local_model_endpoint(base_url)
+
+    assert result == {"ok": True, "message": "No base URL configured."}
+    probe_opener.open.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://api.openai.com/v1",
+        "https://apps.inside.anl.gov/argoapi/v1",
+        "https://api.anthropic.com",
+        "https://generativelanguage.googleapis.com/v1beta",
+        "https://openrouter.ai/api/v1",
+        "https://inference-api.alcf.anl.gov/resource_server/sophia/vllm/v1",
+        "http://192.168.1.10:8000/v1",
+    ],
+)
+def test_remote_endpoint_skips_probe(base_url, probe_opener):
+    result = endpoint.check_local_model_endpoint(base_url)
+
+    assert result == {"ok": True, "message": "Skipping non-local endpoint probe."}
+    probe_opener.open.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        ("http://localhost:11434", "http://localhost:11434/models"),
+        ("http://127.0.0.1:8000/v1/", "http://127.0.0.1:8000/v1/models"),
+        ("http://0.0.0.0:8000/v1", "http://0.0.0.0:8000/v1/models"),
+        ("http://[::1]:8000/v1", "http://[::1]:8000/v1/models"),
+        ("https://[::1]/v1/", "https://[::1]/v1/models"),
+        ("http://localhost:0", "http://localhost:0/models"),
+        ("http://localhost:65535", "http://localhost:65535/models"),
+        ("  HTTP://LOCALHOST/v1/  ", "http://localhost/v1/models"),
+    ],
+)
+def test_local_endpoint_uses_canonical_probe_url(
+    base_url, expected_url, probe_opener
+):
+    result = endpoint.check_local_model_endpoint(base_url)
+
+    assert result == {"ok": True, "message": "Reachable (HTTP 200)."}
+    request = probe_opener.open.call_args.args[0]
+    assert request.full_url == expected_url
+    assert request.get_method() == "GET"
+    assert probe_opener.open.call_args.kwargs == {"timeout": 2}
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "http://localhost:bad/v1",
+        "http://localhost:-1/v1",
+        "http://localhost:65536/v1",
+        "http://[::1]:bad/v1",
+        "http://[::1]:65536/v1",
+        "http://[::1/v1",
+        "http://[invalid]/v1",
+        "https://api.openai.com:bad/v1",
+        "https://api.openai.com:65536/v1",
+        "http:///v1",
+        "localhost:8000/v1",
+        "ftp://localhost/v1",
+        "ftp://remote.example/v1",
+        "file:///etc/hosts",
+        "http://user:password@localhost/v1",
+        "http://@localhost/v1",
+        "http://localhost/v1?key=value",
+        "http://localhost/v1#fragment",
+    ],
+)
+def test_invalid_endpoint_returns_error_without_probing(base_url, probe_opener):
+    result = endpoint.check_local_model_endpoint(base_url)
+
+    assert result["ok"] is False
+    assert "Invalid" in result["message"]
+    probe_opener.open.assert_not_called()
+
+
+@pytest.mark.parametrize("code", [401, 404, 500])
+def test_http_error_still_reports_reachable(code, probe_opener):
+    probe_opener.open.side_effect = HTTPError(
+        "http://localhost:8000/models", code, "error", {}, None
+    )
+
+    result = endpoint.check_local_model_endpoint("http://localhost:8000")
+
+    assert result == {"ok": True, "message": f"Reachable (HTTP {code})."}
+
+
+@pytest.mark.parametrize("error", [URLError("connection refused"), TimeoutError()])
+def test_connection_failure_returns_error(error, probe_opener):
+    probe_opener.open.side_effect = error
+
+    result = endpoint.check_local_model_endpoint("http://localhost:8000")
+
+    assert result["ok"] is False
+    assert result["message"].startswith("Unreachable:")
+
+
+@pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
+def test_local_probe_does_not_follow_redirects(monkeypatch, code):
+    """Exercise urllib's redirect handling with a fake HTTP transport."""
+    requests = []
+
+    class RedirectingHTTPHandler(HTTPHandler):
+        def http_open(self, request):
+            requests.append(request.full_url)
+            headers = Message()
+            headers["Location"] = "http://remote.example/models"
+            response = addinfourl(BytesIO(b""), headers, request.full_url, code)
+            response.msg = "Redirect"
+            return response
+
+    monkeypatch.setattr(
+        endpoint,
+        "build_opener",
+        lambda *handlers: build_opener(RedirectingHTTPHandler(), *handlers),
+    )
+
+    result = endpoint.check_local_model_endpoint("http://localhost:8000/v1")
+
+    assert result == {"ok": True, "message": f"Reachable (HTTP {code})."}
+    assert requests == ["http://localhost:8000/v1/models"]

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -1,6 +1,8 @@
 from contextlib import nullcontext
 import os
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, Mock
 
 from chemgraph.models.supported_models import supported_argo_models
 from ui._pages import main_interface as main_ui
@@ -117,6 +119,41 @@ def test_non_argo_structured_output_is_preserved():
 
     assert structured is True
     assert notice is None
+
+
+def test_remote_endpoint_allows_chat_submission(monkeypatch, tmp_path):
+    from ui import endpoint
+
+    base_url = "https://api.openai.com/v1"
+    query = "Calculate the energy of water"
+    result = {"messages": [{"role": "ai", "content": "Test response"}]}
+    agent = Mock(recursion_limit=20, log_dir=str(tmp_path))
+    agent.workflow.get_state.return_value = SimpleNamespace(values={"messages": []})
+    fake_st = MagicMock()
+    fake_st.session_state = _SessionState(agent=agent, conversation_history=[])
+    stream_workflow = Mock()
+    probe_opener = Mock()
+
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(main_ui, "st", fake_st)
+    monkeypatch.setattr(main_ui, "_stream_workflow", stream_workflow)
+    monkeypatch.setattr(main_ui, "_poll_and_display", lambda *args: ("done", result))
+    monkeypatch.setattr(main_ui, "_save_exchange_to_store", Mock())
+    monkeypatch.setattr(endpoint, "build_opener", probe_opener)
+    endpoint.check_local_model_endpoint.clear()
+    try:
+        status = main_ui.check_local_model_endpoint(base_url)
+        main_ui._handle_query_submission(query, 1, status, base_url)
+    finally:
+        endpoint.check_local_model_endpoint.clear()
+
+    probe_opener.assert_not_called()
+    stream_workflow.assert_called_once()
+    assert stream_workflow.call_args.args[0] == {"messages": query}
+    assert fake_st.session_state.last_run_error is None
+    assert fake_st.session_state.conversation_history[0]["query"] == query
+    assert fake_st.session_state.conversation_history[0]["result"] == result
+    fake_st.error.assert_not_called()
 
 
 def test_available_calculators_sidebar_replaces_quick_settings(monkeypatch):

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -688,18 +688,34 @@ def test_start_new_chat_clears_history_agent_and_log_dir(monkeypatch):
     assert fake_st.session_state.interrupt_exchanges == []
 
 
-def _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls):
+class _FakeAgent:
+    """Stand-in for ChemGraph carrying the conversation-bearing attributes."""
+
+    _counter = 0
+
+    def __init__(self):
+        type(self)._counter += 1
+        self.uuid = f"agent-{self._counter}"
+        self.session_store = object()
+        self._session_created = False
+        self._saved_message_keys = {}
+        self._session_title = None
+        self.checkpointer = None
+        self.workflow = SimpleNamespace(checkpointer=object())
+
+
+def _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls, model="gpt-4o-mini", agent_factory=_FakeAgent):
     monkeypatch.setattr(main_ui, "st", fake_st)
     monkeypatch.setattr(main_ui, "_ensure_chat_log_dir", lambda: str(tmp_path))
 
     def fake_initialize(*args, **kwargs):
         calls.append(os.environ.get("OPENAI_API_KEY"))
-        return object()
+        return agent_factory()
 
     monkeypatch.setattr(main_ui, "initialize_agent", fake_initialize)
     main_ui._auto_initialize_agent(
         {"general": {"recursion_limit": 20}, "api": {"openai": {}}},
-        "gpt-4o-mini",
+        model,
         "single_agent",
         False,
         "state",
@@ -709,13 +725,18 @@ def _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls):
     )
 
 
-def test_replacing_api_key_rebuilds_cached_agent(monkeypatch, tmp_path):
-    """A key applied after initialization must not leave the old client in use."""
+def _fresh_streamlit(tmp_path):
     fake_st = _FakeStreamlit()
     fake_st.session_state.agent = None
     fake_st.session_state.last_config = None
     # _ensure_chat_log_dir records the directory it returns; mirror that here.
     fake_st.session_state.current_chat_log_dir = str(tmp_path)
+    return fake_st
+
+
+def test_replacing_api_key_rebuilds_cached_agent(monkeypatch, tmp_path):
+    """A key applied after initialization must not leave the old client in use."""
+    fake_st = _fresh_streamlit(tmp_path)
     calls = []
 
     monkeypatch.setenv("OPENAI_API_KEY", "sk-old")
@@ -742,17 +763,106 @@ def test_replacing_api_key_rebuilds_cached_agent(monkeypatch, tmp_path):
     assert calls == ["sk-old", "sk-new", None]
 
 
-def test_credential_fingerprint_is_non_reversible_and_provider_aware():
+def test_credential_refresh_keeps_conversation_state(monkeypatch, tmp_path):
+    """Replacing a key must not reset the thread checkpointer or session id."""
+    fake_st = _fresh_streamlit(tmp_path)
+    calls = []
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-old")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    first = fake_st.session_state.agent
+    first._session_created = True
+    first._saved_message_keys = {"1": {("human", "hi")}}
+    first._session_title = "Water energy"
+    checkpointer = first.workflow.checkpointer
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-new")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    second = fake_st.session_state.agent
+    assert second is not first
+    assert second.workflow.checkpointer is checkpointer
+    assert second.uuid == first.uuid
+    assert second.session_store is first.session_store
+    assert second._session_created is True
+    assert second._saved_message_keys == {"1": {("human", "hi")}}
+    assert second._session_title == "Water energy"
+
+    # A structural change (different model) is a genuinely new agent.
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls, model="gpt-4o")
+    third = fake_st.session_state.agent
+    assert third.workflow.checkpointer is not checkpointer
+    assert third.uuid != first.uuid
+
+
+def test_failed_credential_refresh_keeps_previous_agent(monkeypatch, tmp_path):
+    fake_st = _fresh_streamlit(tmp_path)
+    calls = []
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-old")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    first = fake_st.session_state.agent
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-broken")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls, agent_factory=lambda: None)
+    assert fake_st.session_state.agent is first
+    stale_key = fake_st.session_state.last_config
+    assert stale_key is not None and stale_key[-1] != main_ui._provider_credential_fingerprint(
+        main_ui.providers.provider_for_model("gpt-4o-mini"), None
+    )  # still mismatched, so the next rerun retries
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fixed")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    assert fake_st.session_state.agent is not first
+    assert fake_st.session_state.agent.uuid == first.uuid
+
+
+def test_transfer_conversation_state_shares_langgraph_thread():
+    from typing import TypedDict
+
+    from langgraph.checkpoint.memory import MemorySaver
+    from langgraph.graph import END, START, StateGraph
+
+    from ui.agent_manager import transfer_conversation_state
+
+    class State(TypedDict):
+        count: int
+
+    builder = StateGraph(State)
+    builder.add_node("bump", lambda state: {"count": state["count"] + 1})
+    builder.add_edge(START, "bump")
+    builder.add_edge("bump", END)
+    old = SimpleNamespace(
+        uuid="session-1", session_store=object(), _session_created=True,
+        _saved_message_keys={"7": set()}, _session_title="t", checkpointer=None,
+        workflow=builder.compile(checkpointer=MemorySaver()),
+    )
+    new = SimpleNamespace(
+        uuid="session-2", session_store=object(), _session_created=False,
+        _saved_message_keys={}, _session_title=None, checkpointer=None,
+        workflow=builder.compile(checkpointer=MemorySaver()),
+    )
+    thread = {"configurable": {"thread_id": "7"}}
+    old.workflow.invoke({"count": 0}, thread)
+    assert new.workflow.get_state(thread).values == {}
+
+    transfer_conversation_state(old, new)
+
+    assert new.workflow.get_state(thread).values == {"count": 1}
+    new.workflow.invoke({"count": 10}, thread)
+    assert old.workflow.get_state(thread).values == {"count": 11}
+    assert (new.uuid, new._session_created, new._saved_message_keys) == (
+        "session-1", True, {"7": set()}
+    )
+    transfer_conversation_state(None, new)  # no-op guards
+    transfer_conversation_state(new, new)
+
+
+def test_credential_fingerprint_is_non_reversible_and_provider_aware(monkeypatch):
     from ui import providers
 
     openai = providers.provider_for_model("gpt-4o-mini")
-    with_key = main_ui._provider_credential_fingerprint(openai, None)
-    assert with_key is None or "OPENAI_API_KEY" not in os.environ
-    os.environ["OPENAI_API_KEY"] = "sk-fingerprint-test"
-    try:
-        digest = main_ui._provider_credential_fingerprint(openai, None)
-    finally:
-        del os.environ["OPENAI_API_KEY"]
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert main_ui._provider_credential_fingerprint(openai, None) is None
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-fingerprint-test")
+    digest = main_ui._provider_credential_fingerprint(openai, None)
     assert digest is not None and len(digest) == 64
     assert "sk-fingerprint-test" not in digest
     assert main_ui._provider_credential_fingerprint(None, None) is None

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -686,3 +686,97 @@ def test_start_new_chat_clears_history_agent_and_log_dir(monkeypatch):
     assert fake_st.session_state.pending_interrupt_log_dir is None
     assert fake_st.session_state.interrupt_count == 0
     assert fake_st.session_state.interrupt_exchanges == []
+
+
+def _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls):
+    monkeypatch.setattr(main_ui, "st", fake_st)
+    monkeypatch.setattr(main_ui, "_ensure_chat_log_dir", lambda: str(tmp_path))
+
+    def fake_initialize(*args, **kwargs):
+        calls.append(os.environ.get("OPENAI_API_KEY"))
+        return object()
+
+    monkeypatch.setattr(main_ui, "initialize_agent", fake_initialize)
+    main_ui._auto_initialize_agent(
+        {"general": {"recursion_limit": 20}, "api": {"openai": {}}},
+        "gpt-4o-mini",
+        "single_agent",
+        False,
+        "state",
+        False,
+        False,
+        None,
+    )
+
+
+def test_replacing_api_key_rebuilds_cached_agent(monkeypatch, tmp_path):
+    """A key applied after initialization must not leave the old client in use."""
+    fake_st = _FakeStreamlit()
+    fake_st.session_state.agent = None
+    fake_st.session_state.last_config = None
+    # _ensure_chat_log_dir records the directory it returns; mirror that here.
+    fake_st.session_state.current_chat_log_dir = str(tmp_path)
+    calls = []
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-old")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    first_agent = fake_st.session_state.agent
+    assert calls == ["sk-old"]
+    # Secrets never enter session state; only a digest does.
+    assert "sk-old" not in repr(fake_st.session_state.last_config)
+
+    # Same key on rerun: cached agent is reused.
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    assert fake_st.session_state.agent is first_agent
+    assert calls == ["sk-old"]
+
+    # Replacement key ("Apply key"): the agent is rebuilt with the new key.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-new")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    assert fake_st.session_state.agent is not first_agent
+    assert calls == ["sk-old", "sk-new"]
+
+    # Clearing the key also invalidates the cache.
+    monkeypatch.delenv("OPENAI_API_KEY")
+    _init_agent_with_env(monkeypatch, fake_st, tmp_path, calls)
+    assert calls == ["sk-old", "sk-new", None]
+
+
+def test_credential_fingerprint_is_non_reversible_and_provider_aware():
+    from ui import providers
+
+    openai = providers.provider_for_model("gpt-4o-mini")
+    with_key = main_ui._provider_credential_fingerprint(openai, None)
+    assert with_key is None or "OPENAI_API_KEY" not in os.environ
+    os.environ["OPENAI_API_KEY"] = "sk-fingerprint-test"
+    try:
+        digest = main_ui._provider_credential_fingerprint(openai, None)
+    finally:
+        del os.environ["OPENAI_API_KEY"]
+    assert digest is not None and len(digest) == 64
+    assert "sk-fingerprint-test" not in digest
+    assert main_ui._provider_credential_fingerprint(None, None) is None
+    alcf = providers.get_provider(providers.ALCF)
+    assert main_ui._provider_credential_fingerprint(alcf, "token-a") != (
+        main_ui._provider_credential_fingerprint(alcf, "token-b")
+    )
+
+
+def test_first_run_setup_reports_failed_config_save(monkeypatch):
+    from ui import providers
+
+    fake_st = MagicMock()
+    fake_st.session_state = _SessionState()
+    monkeypatch.setattr(main_ui, "st", fake_st)
+    monkeypatch.setattr(main_ui, "save_config", lambda config: False)
+    monkeypatch.setattr(main_ui.ui_config, "last_save_error", "/ro/config.toml: Read-only file system")
+    info = providers.provider_for_model("gpt-4o-mini")
+    config = {"general": {}, "api": {"openai": {"base_url": "https://api.openai.com/v1"}}}
+
+    main_ui._finish_first_run_setup(config, info)
+
+    fake_st.toast.assert_not_called()
+    assert "Read-only file system" in fake_st.session_state.setup_save_error
+    assert "CHEMGRAPH_CONFIG" in fake_st.session_state.setup_save_error
+    assert fake_st.session_state._setup_skipped is True
+    fake_st.rerun.assert_called_once()


### PR DESCRIPTION
Release preparation for **v0.7.0**.

## Summary

- Bump the package version from `0.6.0` to `0.7.0`.
- Refresh the package description; list all project authors and the maintainers on PyPI.
- Upgrade the core agent runtime to LangChain `1.4.0`, LangChain Core `1.6.1`, LangGraph `1.2.11`, LangGraph Checkpoint `4.2.0`, and LangGraph SDK `0.4.4`, in both `pyproject.toml` and `environment.yml`.
- Harden the Streamlit model-endpoint probe against server-side request forgery (code-scanning alert #9) and restore endpoint validation, with unit coverage in `tests/test_ui_endpoint.py`.
- Remove the obsolete `langchain-mcp-adapters==0.1.14` workaround from the demo documentation; fix the CLI docs.
- Fix three issues found on the merged tree:
  - Docker: bound `ruamel.yaml<0.19` so `pip check` passes against the miniconda base image's conda (the build previously failed at the validation layer); add a `Docker Build Check` workflow that builds the `linux/amd64` image without pushing on relevant PRs/pushes to `main`.
  - UI: rebuild the cached agent when a provider API key is applied or cleared (the client previously kept the old key).
  - UI: resolve an installed package's `config.toml` to a writable per-user path (`$CHEMGRAPH_CONFIG`, `$XDG_CONFIG_HOME/chemgraph/`) instead of `lib/pythonX.Y/`, and surface failed saves instead of reporting "Ready".
- Merge `main` (#229, #231, #232, #233) before release. The Dockerfile alignment, TBLite `0.4.0` pins, `pip check` step, and the pin-synchronization regression test originally proposed here landed on `main` through #231/#233 and are taken from `main` as-is.

## Release flow

1. Merge this PR to `main`.
2. Publish the drafted **v0.7.0** GitHub release targeting `main`; this creates the tag and triggers the PyPI and container publishing workflows. The documented `pip install 'chemgraph==0.7.0' -r https://raw.githubusercontent.com/argonne-lcf/ChemGraph/v0.7.0/requirements/mace-polar.txt` install path becomes valid once the tag exists.

Suggested highlights for the release notes (in addition to the auto-generated list):

- Thermochemistry: monatomic species and radicals are now handled correctly (#233, closes #141); ASE >= 3.29.0 is required; entropy units are explicit in results and reports; failed thermochemistry preserves the completed structure, energy, and full spectrum.
- **Behaviour change** (#233): when a query omits the calculator or temperature, the agent now applies the tool-schema defaults (the default MACE calculator, 298.15 K) instead of asking the user.
- Packaging: PyPI-publishable metadata; Git-only dependencies moved to `requirements/mace-polar.txt` and `requirements/ocsr-models.txt` (#231).
- Runtime: LangChain 1.4.0 / LangGraph 1.2.11.

## Validation

- Merge of `origin/main` at `4ee44de` (merge commit `37655ee`): conflicts in `Dockerfile`, `Dockerfile.arm`, `environment.yml`, `tests/test_package_metadata.py`, `tests/test_ui_main_interface.py` resolved as described in the merge commit.
- `pip install --dry-run --ignore-installed` on the merged `[project].dependencies` resolves: `langchain 1.4.0`, `langchain-core 1.6.1`, `langgraph 1.2.11`, `langgraph-checkpoint 4.2.0`, `langgraph-sdk 0.4.4`, `langgraph-prebuilt 1.1.0`, `deepagents 0.7.5`, `langchain-mcp-adapters 0.3.0`, `ase 3.29.0`, `mace-torch 0.3.16`, `pydantic 2.13.4`.
- `ruff check .` (0.16.6) clean; `git diff --check` clean.
- `pytest tests/test_package_metadata.py tests/test_ui_endpoint.py tests/test_ui_main_interface.py tests/test_thermochemistry.py tests/test_report.py`: **233 passed** on the merged tree (includes the pin-alignment guard across `pyproject.toml`, `environment.yml`, both Dockerfiles, and `requirements/`).
- Fix commits `2a65161`, `5e828e9`, `ef4098b`: `pytest tests/test_settings.py tests/test_ui_*.py tests/test_package_metadata.py tests/test_mace_defaults.py` → 224 passed; `ruff check` clean; pip dry-run with the `ruamel.yaml<0.19` bound resolves to `ruamel.yaml 0.18.17` alongside `pymatgen 2026.5.4` / `monty 2026.7.16` / `tblite 0.4.0` / `jupyterlab 4.6.3`.
- TODO before merge: full `pytest tests/ -k "not tblite"` and GitHub Actions on the pushed merge commit; a local `docker build -f Dockerfile .` — neither #231/#233 nor this PR has built the images since the Dockerfile rewrite, and `ghcr-publish.yml` only runs on release publish.
