### PR TITLE
Use connectivity_smiles for PubChem name lookups

### DIFF
--- a/.opencode/skills/chemgraph/SKILL.md
+++ b/.opencode/skills/chemgraph/SKILL.md
@@ -130,7 +130,7 @@ def molecule_name_to_smiles(name: str) -> str:
     comps = pcp.get_compounds(name.strip(), "name")
     if not comps:
         raise ValueError(f"No PubChem compound found for: {name}")
-    return comps[0].connectivity_smiles
+    return comps[0].connectivity_smiles  # .smiles keeps stereochemistry
 ```
 
 ## How to add a new MCP server tool

--- a/.opencode/skills/chemgraph/SKILL.md
+++ b/.opencode/skills/chemgraph/SKILL.md
@@ -130,7 +130,7 @@ def molecule_name_to_smiles(name: str) -> str:
     comps = pcp.get_compounds(name.strip(), "name")
     if not comps:
         raise ValueError(f"No PubChem compound found for: {name}")
-    return comps[0].canonical_smiles
+    return comps[0].connectivity_smiles
 ```
 
 ## How to add a new MCP server tool

--- a/src/chemgraph/mcp/mcp_tools.py
+++ b/src/chemgraph/mcp/mcp_tools.py
@@ -35,22 +35,33 @@ mcp = FastMCP(
 
 @mcp.tool(
     name="molecule_name_to_smiles",
-    description="Convert a molecule name to a canonical SMILES string using PubChem.",
+    description=(
+        "Convert a molecule name to a SMILES string using PubChem. "
+        "Set include_stereochemistry=true to distinguish enantiomers."
+    ),
 )
-async def molecule_name_to_smiles(name: str) -> str:
-    """Resolve a molecule name to its canonical SMILES via PubChem.
+async def molecule_name_to_smiles(
+    name: str, include_stereochemistry: bool = False
+) -> str:
+    """Resolve a molecule name to its SMILES via PubChem.
 
     Parameters
     ----------
     name : str
         Molecule name to resolve.
+    include_stereochemistry : bool, optional
+        Set to True to keep stereochemistry, which is required to tell
+        enantiomers apart: with the default of False, "L-alanine" and
+        "D-alanine" both resolve to the same SMILES.
 
     Returns
     -------
     str
-        Canonical SMILES string.
+        SMILES string.
     """
-    return molecule_name_to_smiles_core(name)
+    return molecule_name_to_smiles_core(
+        name, include_stereochemistry=include_stereochemistry
+    )
 
 
 @mcp.tool(

--- a/src/chemgraph/tools/cheminformatics_core.py
+++ b/src/chemgraph/tools/cheminformatics_core.py
@@ -69,18 +69,30 @@ def smiles_to_3d(
 # ---------------------------------------------------------------------------
 
 
-def molecule_name_to_smiles_core(name: str) -> str:
-    """Resolve a molecule name to its canonical SMILES via PubChem.
+def molecule_name_to_smiles_core(
+    name: str, include_stereochemistry: bool = False
+) -> str:
+    """Resolve a molecule name to its SMILES via PubChem.
 
     Parameters
     ----------
     name : str
         Common or IUPAC molecule name.
+    include_stereochemistry : bool, optional
+        If ``False`` (the default), return the connectivity SMILES, which
+        carries no stereochemistry.  If ``True``, return the isomeric SMILES,
+        which encodes stereocentres and double-bond geometry.
+
+        The default is stereochemistry-free for backwards compatibility.
+        Note that it cannot distinguish enantiomers: ``"L-alanine"`` and
+        ``"D-alanine"`` both resolve to ``"CC(C(=O)O)N"``, and RDKit will pick
+        an arbitrary mirror image when embedding that into 3D.  Pass ``True``
+        whenever the caller cares which enantiomer it gets.
 
     Returns
     -------
     str
-        Canonical SMILES string.
+        SMILES string.
 
     Raises
     ------
@@ -94,7 +106,10 @@ def molecule_name_to_smiles_core(name: str) -> str:
     if not comps:
         raise ValueError(f"No PubChem compound found for name: {name!r}")
 
-    smiles = comps[0].connectivity_smiles
+    if include_stereochemistry:
+        smiles = comps[0].smiles
+    else:
+        smiles = comps[0].connectivity_smiles
     if not smiles:
         raise ValueError(f"PubChem returned an empty SMILES for {name!r}.")
     return smiles

--- a/src/chemgraph/tools/cheminformatics_core.py
+++ b/src/chemgraph/tools/cheminformatics_core.py
@@ -94,7 +94,7 @@ def molecule_name_to_smiles_core(name: str) -> str:
     if not comps:
         raise ValueError(f"No PubChem compound found for name: {name!r}")
 
-    smiles = comps[0].canonical_smiles
+    smiles = comps[0].connectivity_smiles
     if not smiles:
         raise ValueError(f"PubChem returned an empty SMILES for {name!r}.")
     return smiles

--- a/src/chemgraph/tools/cheminformatics_tools.py
+++ b/src/chemgraph/tools/cheminformatics_tools.py
@@ -19,20 +19,26 @@ from chemgraph.tools.cheminformatics_core import (
 
 
 @tool
-def molecule_name_to_smiles(name: str) -> dict:
+def molecule_name_to_smiles(name: str, include_stereochemistry: bool = False) -> dict:
     """Convert a molecule name to SMILES format.
 
     Parameters
     ----------
     name : str
         The name of the molecule to convert.
+    include_stereochemistry : bool, optional
+        Set to True to keep stereochemistry, which is required to tell
+        enantiomers apart: with the default of False, "L-alanine" and
+        "D-alanine" both resolve to the same SMILES.
 
     Returns
     -------
     dict
         A JSON-serializable dict with the resolved SMILES.
     """
-    smiles = molecule_name_to_smiles_core(name)
+    smiles = molecule_name_to_smiles_core(
+        name, include_stereochemistry=include_stereochemistry
+    )
     return {"name": str(name), "smiles": smiles}
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,21 +16,29 @@ from chemgraph.schemas.ase_input import ASEInputSchema
 TEST_DIR = Path(__file__).parent
 
 
-def test_molecule_name_to_smiles(monkeypatch):
-    class FakeCompound:
-        def __init__(self, smiles):
-            self.connectivity_smiles = smiles
+class FakeCompound:
+    def __init__(self, connectivity_smiles, smiles=None):
+        self.connectivity_smiles = connectivity_smiles
+        self.smiles = smiles if smiles is not None else connectivity_smiles
 
+
+def _patch_pubchem(monkeypatch, lookup):
     def fake_get_compounds(name, namespace):
         assert namespace == "name"
-        lookup = {"water": "O", "methane": "C"}
         if name in lookup:
-            return [FakeCompound(lookup[name])]
+            return [lookup[name]]
         return []
 
     import chemgraph.tools.cheminformatics_core as _core
 
     monkeypatch.setattr(_core.pcp, "get_compounds", fake_get_compounds)
+
+
+def test_molecule_name_to_smiles(monkeypatch):
+    _patch_pubchem(
+        monkeypatch,
+        {"water": FakeCompound("O"), "methane": FakeCompound("C")},
+    )
 
     # Test with a known molecule
     assert molecule_name_to_smiles.invoke("water")['smiles'] == "O"
@@ -39,6 +47,22 @@ def test_molecule_name_to_smiles(monkeypatch):
     # Test with invalid molecule name
     with pytest.raises(Exception):
         molecule_name_to_smiles.invoke("not_a_real_molecule_name")
+
+
+def test_molecule_name_to_smiles_stereochemistry(monkeypatch):
+    """The stereochemistry flag picks the isomeric SMILES, and defaults off."""
+    _patch_pubchem(
+        monkeypatch,
+        {"L-alanine": FakeCompound("CC(C(=O)O)N", "C[C@@H](C(=O)O)N")},
+    )
+
+    stripped = molecule_name_to_smiles.invoke("L-alanine")["smiles"]
+    assert stripped == "CC(C(=O)O)N"
+
+    kept = molecule_name_to_smiles.invoke(
+        {"name": "L-alanine", "include_stereochemistry": True}
+    )["smiles"]
+    assert kept == "C[C@@H](C(=O)O)N"
 
 
 def test_smiles_to_atomsdata():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,7 +19,7 @@ TEST_DIR = Path(__file__).parent
 def test_molecule_name_to_smiles(monkeypatch):
     class FakeCompound:
         def __init__(self, smiles):
-            self.canonical_smiles = smiles
+            self.connectivity_smiles = smiles
 
     def fake_get_compounds(name, namespace):
         assert namespace == "name"


### PR DESCRIPTION
## Summary

`molecule_name_to_smiles` emitted a `PubChemPyDeprecationWarning` on every call: pubchempy 1.0.5 deprecates `canonical_smiles` in favour of `connectivity_smiles`. The first commit does that rename, with no behaviour change: the deprecated property returns `self.connectivity_smiles`.

The second commit is an optional follow-up. Connectivity SMILES carries no stereochemistry, so `"L-alanine"` and `"D-alanine"` both resolve to `CC(C(=O)O)N`: the requested enantiomer is already lost in the returned string. Embedding that string still produces an assigned centre, S or R depending on the seed, and at `smiles_to_3d`'s default seed both names give S: a request for D-alanine produces the L configuration. An opt-in `include_stereochemistry` flag returns PubChem's isomeric SMILES instead. It defaults to `False`, so existing callers are unaffected.

Happy to drop the second commit if you would rather keep this to the deprecation fix.

## Related issues

Closes #200

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

`pytest tests/test_tools.py`: 12 passed, run with `-W error::pubchempy.PubChemPyDeprecationWarning` to confirm the warning is gone. New test asserts both the default and the flag.

Against live PubChem:

```
L-alanine    off='CC(C(=O)O)N'   on='C[C@@H](C(=O)O)N'
D-alanine    off='CC(C(=O)O)N'   on='C[C@H](C(=O)O)N'
```

Embedded to 3D through `smiles_to_3d`, the default path gives the S centre for both names, while the flag separates them into S and R.

`pytest tests/ -k "not tblite"`: 21 failed, 731 passed, 30 skipped. A clean `main` (`ceee78e`) fails the same 21 tests, name for name. This branch adds no new failures.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [ ] `pytest tests/ -k "not tblite"` passes (plus extras tests if Academy/backends touched)
- [x] Added/updated tests for the change
- [ ] Updated docs / README for any user-facing change

`pytest` unticked: 21 pre-existing failures on `main`, unchanged by this PR. Docs unticked: no page under `docs/` documents this tool's arguments, so the new flag is described in its docstrings and the MCP tool description only.