### PR TITLE
Gate EnsembleLauncher backend tests behind --run-ensemble-launcher

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,10 @@ def pytest_addoption(parser):
         "--run-globus-compute", action="store_true", default=False,
         help="run tests that require a live Globus Compute endpoint"
     )
+    parser.addoption(
+        "--run-ensemble-launcher", action="store_true", default=False,
+        help="run tests that require a live EnsembleLauncher deployment"
+    )
 
 def pytest_collection_modifyitems(config, items):
     skip_llm = None
@@ -45,8 +49,14 @@ def pytest_collection_modifyitems(config, items):
     if not config.getoption("--run-globus-compute"):
         skip_globus = pytest.mark.skip(reason="need --run-globus-compute option to run")
 
+    skip_el = None
+    if not config.getoption("--run-ensemble-launcher"):
+        skip_el = pytest.mark.skip(reason="need --run-ensemble-launcher option to run")
+
     for item in items:
         if skip_llm and "llm" in item.keywords:
             item.add_marker(skip_llm)
         if skip_globus and "globus_compute" in item.keywords:
             item.add_marker(skip_globus)
+        if skip_el and "ensemble_launcher" in item.keywords:
+            item.add_marker(skip_el)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -200,6 +200,7 @@ class TestLocalBackend:
 # ── EnsembleLauncherBackend tests ──────────────────────────────────────────
 
 
+@pytest.mark.ensemble_launcher
 class TestELBackend:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
## Problem

`TestELBackend` (tests/test_execution.py) exercises the cluster-mode EnsembleLauncher API (`EnsembleLauncher.start()` + `ClusterClient`), which requires a **live multi-node EnsembleLauncher deployment** and hardcodes `result(timeout=10)`.

The `ensemble_launcher` marker is already declared in `pyproject.toml` (*"marks tests requiring a live EnsembleLauncher deployment (run with --run-ensemble-launcher)"*), but:

- `conftest.py` never added the `--run-ensemble-launcher` option or a skip gate for the marker (it only gates `llm` and `globus_compute`), and
- `TestELBackend` was never decorated with `@pytest.mark.ensemble_launcher`.

As a result, when `ensemble_launcher` happens to be importable, these tests run by default and time out (they were only skipping before because the package wasn't installed). Discovered while building a shared ALCF env that installs `ensemble_launcher`.

## Fix

Wire up the gate exactly like the existing `--run-llm` / `--run-globus-compute` options:

- add the `--run-ensemble-launcher` option and skip logic in `conftest.py`
- mark `TestELBackend` with `@pytest.mark.ensemble_launcher`

These tests now skip by default and run only with `--run-ensemble-launcher` (against a real EL deployment).

## Verification

`pytest -q` (no flag): the 6 `TestELBackend` tests skip; suite is green (753 passed, 30 skipped, 0 failed on ALCF Polaris).
