### PR TITLE
Add committee voting and calibrated confidence to OCSR

### DIFF
--- a/examples/ocsr/README.md
+++ b/examples/ocsr/README.md
@@ -53,8 +53,9 @@ it. The published accuracies were measured under the other prompt.
 Exact match is over a 722-image benchmark. It ranks the four against each other;
 it does not predict how any of them will do on your images. DECIMER is the default because it is the most accurate of the four.
 
-`list_ocsr_models` reports the same table plus what is actually installed on the
-machine you are on.
+`list_ocsr_models` reports what is actually installed on the machine you are on.
+The accuracies it prints come from the calibration table, so they follow a refit
+(see below); the numbers above are the shipped table's, measured on the benchmark.
 
 ## Installing
 
@@ -138,6 +139,14 @@ which happened, and `latency_s` includes the load when it did.
     "valid": True,           # RDKit parsed it
     "formula": "C9H8O4",
     "n_fragments": 1,        # above 1 means a salt, mixture, or reaction scheme
+    "confidence": None,      # single model: no per-image number, see below
+    "confidence_interval": None,  # the 95% interval, when a committee measured one
+    "confidence_label": "weak",   # bands this model's measured solo accuracy
+    "confidence_unavailable_reason": "single_model_has_no_per_image_confidence",
+    "agreement": None,       # how a committee split, when one ran
+    "votes": None,           # which models produced which SMILES
+    "abstained": None,       # models that ran and returned nothing usable
+    "backend_used": "specialist",   # or "llm", or "ensemble"
     "model_used": "decimer",
     "cold_start": False,
     "latency_s": 0.7,
@@ -146,10 +155,69 @@ which happened, and `latency_s` includes the load when it did.
 }
 ```
 
-No confidence number is reported. A single model cannot say how likely it is to be
-right about one particular image, and quoting its benchmark accuracy here would
-answer a question about someone else's images. If an answer matters, run a second
-model and see whether the two agree.
+A single model reports no confidence, because it cannot say how likely it is to be
+right about one particular image, and quoting its benchmark accuracy would answer a
+question about someone else's images.
+
+## Confidence from a committee
+
+`ensemble=True` reads the image with every installed specialist and votes. How much
+they agree is measurable, and it was measured on 722 benchmark images:
+
+| agreement | meaning | P(correct) | n |
+|-----------|---------|-----------:|---:|
+| `4` | all four agree | 0.9989 | 462 |
+| `3/1` | three against one | 0.9816 | 135 |
+| `2/1/1` | two agree, two differ | 0.8017 | 57 |
+| `2/2` | an even split | below the sample floor | 12 |
+| `1/1/1/1` | all different | 0.3772 | 56 |
+
+The strongest single model is right 89.9% of the time, so a unanimous committee
+turns a one-in-ten error rate into one in a thousand, and an all-different vote is
+worse than a coin flip. A model that ran and returned nothing usable counts as a
+dissenting singleton, so the parts always sum to the committee size.
+
+```python
+result = image_to_smiles_core("molecule.png", ensemble=True)
+# {'ok': True, 'smiles': 'CC(=O)Oc1ccccc1C(=O)O', 'confidence': 0.9989,
+#  'confidence_interval': [0.9946, 1.0], 'confidence_label': 'unanimous',
+#  'agreement': '4',
+#  'votes': {'CC(=O)Oc1ccccc1C(=O)O': ['decimer', 'molnextr', ...]}, ...}
+```
+
+Buckets below 20 observations get a label and an interval but no point estimate: at
+that size the 95% interval is 41 points wide, so a decimal would be false precision.
+`confidence_interval` carries it either way, and is the only quantitative thing a
+thin bucket can honestly offer.
+
+`confidence_label` is one of `unanimous` (p >= 0.99), `strong` (>= 0.95), `weak`
+(>= 0.70), or `conflicting` below that, prefixed `low_n_` when the bucket is thin.
+`unknown` means the table has no bucket for this split, and `unavailable` that no
+number applies at all; `confidence_unavailable_reason` says which case it is. On a
+single-model call the label bands that model's measured solo accuracy, since there
+is no per-image number to band.
+
+### Refitting for your own images
+
+The shipped table describes those four models on RDKit-rendered diagrams. Scans,
+photographs and journal crops have a different relationship between agreement and
+correctness, so fit your own:
+
+```bash
+python -m chemgraph.tools.ocsr_calibrate --labels labels.csv --out mine.json
+export CHEMGRAPH_OCSR_CALIBRATION=mine.json
+```
+
+`labels.csv` is `image_path,smiles` with a reference SMILES per image. If you have
+no labels to spare, `--validate` scores the current table against a sample instead,
+which takes far fewer of them than fitting a new one. It checks whatever the tool
+would use: `CHEMGRAPH_OCSR_CALIBRATION` when that is set, and the packaged table
+otherwise.
+
+When the table covers fewer models than are installed, pass
+`models_wanted=["decimer", "molnextr"]` so the committee that runs is the one the
+table describes. Otherwise every installed model votes and no calibrated number
+applies.
 
 ## Images
 

--- a/examples/ocsr/README.md
+++ b/examples/ocsr/README.md
@@ -20,7 +20,9 @@ image_to_smiles_core("examples/ocsr/images/aspirin.png")
 ```
 
 `python run_ocsr.py` runs all four images and checks each answer against the
-structure it was drawn from. `--agent` routes the same call through an LLM.
+structure it was drawn from. `--ensemble` votes every installed specialist and
+prints the agreement and confidence beside each result. `--agent` routes the same
+call through an LLM, and `--llm` picks which one.
 
 ## Models
 
@@ -28,11 +30,15 @@ structure it was drawn from. `--agent` routes the same call through an LLM.
 
 | model | exact match | speed |
 |-------|-------------|-------|
-| `decimer` (default) | 0.899 | 0.7 s |
+| `decimer` (default) | 0.898 | 0.7 s |
 | `molnextr` | 0.835 | 4.4 s |
 | `molscribe` | 0.824 | 5.0 s |
 | `ocsrglyph` | 0.766 | 0.3 s |
 | `llm` | not measured | varies |
+
+Each figure is the Jeffreys estimate `(k+0.5)/(n+1)` over the 722-image benchmark,
+which is what `list_ocsr_models` prints and what a single-model read bands on. The
+raw counts are in the calibration table's `model_performance`.
 
 `pip install 'chemgraph[ocsr]'` installs all four specialists. `llm` needs no
 install and uses the agent's own model.
@@ -172,7 +178,7 @@ they agree is measurable, and it was measured on 722 benchmark images:
 | `2/2` | an even split | below the sample floor | 12 |
 | `1/1/1/1` | all different | 0.3772 | 56 |
 
-The strongest single model is right 89.9% of the time, so a unanimous committee
+The strongest single model is right 89.8% of the time, so a unanimous committee
 turns a one-in-ten error rate into one in a thousand, and an all-different vote is
 worse than a coin flip. A model that ran and returned nothing usable counts as a
 dissenting singleton, so the parts always sum to the committee size.
@@ -189,6 +195,15 @@ Buckets below 20 observations get a label and an interval but no point estimate:
 that size the 95% interval is 41 points wide, so a decimal would be false precision.
 `confidence_interval` carries it either way, and is the only quantitative thing a
 thin bucket can honestly offer.
+
+The number scores the skeleton only: `"scoring": "stereo_blind"` in the table, so
+the committee is counted after stereochemistry is stripped. Models that agree on
+the skeleton can still have read different wedge bonds, and the answer then takes
+the reading of the model highest in the table's `tie_break` order. That order ranks
+by overall accuracy, which is close to but not the same as accuracy on
+stereochemistry, so the answer is not always the best-placed reading of the wedge
+bonds. `warning` says when a reading was overruled, and it can accompany a
+confidence of 0.9989.
 
 `confidence_label` is one of `unanimous` (p >= 0.99), `strong` (>= 0.95), `weak`
 (>= 0.70), or `conflicting` below that, prefixed `low_n_` when the bucket is thin.
@@ -207,6 +222,11 @@ correctness, so fit your own:
 python -m chemgraph.tools.ocsr_calibrate --labels labels.csv --out mine.json
 export CHEMGRAPH_OCSR_CALIBRATION=mine.json
 ```
+
+`--models` fits a subset of what is installed, `--tie-break` overrides the priority
+the fitter derives from your own measurements, and `--min-n` moves the floor below
+which a bucket gets a label but no number. `image_to_smiles_core` also takes
+`calibration=` for one call, where the environment variable covers a session.
 
 `labels.csv` is `image_path,smiles` with a reference SMILES per image. If you have
 no labels to spare, `--validate` scores the current table against a sample instead,

--- a/examples/ocsr/run_ocsr.py
+++ b/examples/ocsr/run_ocsr.py
@@ -53,7 +53,8 @@ def _same_molecule(a: str | None, b: str) -> bool:
 
 def run_direct(model: str | None, ensemble: bool = False) -> int:
     """Call the tool on every image and report agreement with the known answer."""
-    from chemgraph.tools.ocsr_backends import available_specialists
+    from chemgraph.tools.ocsr_backends import (available_specialists,
+                                                usable_specialists)
     from chemgraph.tools.ocsr_models import describe_models
     from chemgraph.tools.ocsr_tools import (image_to_smiles_core,
                                             measured_accuracies)
@@ -67,6 +68,8 @@ def run_direct(model: str | None, ensemble: bool = False) -> int:
         model = None
     # The llm exemption does not apply to a committee: it never votes.
     if not installed and (ensemble or model != "llm"):
+        # No ready argument: installed is empty here, so nothing can be marked
+        # ready or missing and passing it would be untestable decoration.
         print(describe_models(installed, measured_accuracies()))
         print("\nNo specialist is installed. Install one with:\n"
               "    pip install 'chemgraph[ocsr]'\n"
@@ -74,7 +77,8 @@ def run_direct(model: str | None, ensemble: bool = False) -> int:
               "    python run_ocsr.py --agent --model llm")
         return 1
 
-    print(describe_models(installed, measured_accuracies()), "\n")
+    print(describe_models(installed, measured_accuracies(),
+                          usable_specialists()), "\n")
 
     correct = 0
     for name, expected in EXPECTED.items():

--- a/examples/ocsr/run_ocsr.py
+++ b/examples/ocsr/run_ocsr.py
@@ -3,6 +3,7 @@
 Two ways to use the OCSR tools, both runnable from this directory:
 
     python run_ocsr.py                  # call the tool directly, no agent, no LLM
+    python run_ocsr.py --ensemble       # vote every specialist, with a confidence
     python run_ocsr.py --agent          # drive it through a ChemGraph agent
 
 The direct path needs no API key. It calls ``image_to_smiles_core``, the same
@@ -50,27 +51,35 @@ def _same_molecule(a: str | None, b: str) -> bool:
     )
 
 
-def run_direct(model: str | None) -> int:
+def run_direct(model: str | None, ensemble: bool = False) -> int:
     """Call the tool on every image and report agreement with the known answer."""
     from chemgraph.tools.ocsr_backends import available_specialists
     from chemgraph.tools.ocsr_models import describe_models
-    from chemgraph.tools.ocsr_tools import image_to_smiles_core
+    from chemgraph.tools.ocsr_tools import (image_to_smiles_core,
+                                            measured_accuracies)
 
     installed = available_specialists()
-    if not installed and model != "llm":
-        print(describe_models(installed))
+    if ensemble and model:
+        # The committee is specialists only, so it has no use for a named model.
+        # Saying so beats running four votes the argument had no part in.
+        print(f"--model {model} is ignored with --ensemble, which votes every "
+              f"installed specialist.\n")
+        model = None
+    # The llm exemption does not apply to a committee: it never votes.
+    if not installed and (ensemble or model != "llm"):
+        print(describe_models(installed, measured_accuracies()))
         print("\nNo specialist is installed. Install one with:\n"
               "    pip install 'chemgraph[ocsr]'\n"
               "or read this image with the agent's own model:\n"
               "    python run_ocsr.py --agent --model llm")
         return 1
 
-    print(describe_models(installed), "\n")
+    print(describe_models(installed, measured_accuracies()), "\n")
 
     correct = 0
     for name, expected in EXPECTED.items():
         path = IMAGES / f"{name}.png"
-        result = image_to_smiles_core(str(path), model=model)
+        result = image_to_smiles_core(str(path), model=model, ensemble=ensemble)
 
         if not result["ok"]:
             print(f"  {name:14} FAILED  {result['error'][:90]}")
@@ -82,6 +91,12 @@ def run_direct(model: str | None) -> int:
         print(f"  {name:14} {'match' if hit else 'DIFFERS'}  "
               f"{result['smiles'][:58]}")
         print(f"  {'':14} {result['model_used']}, {result['latency_s']:.1f}s{cold}")
+        if result["agreement"]:
+            number = ("no number: " + (result["confidence_unavailable_reason"] or "")
+                      if result["confidence"] is None
+                      else f"{result['confidence']:.4f}")
+            print(f"  {'':14} agreement {result['agreement']}, "
+                  f"{number} ({result['confidence_label']})")
         if not hit:
             print(f"  {'':14} expected {expected[:58]}")
 
@@ -112,13 +127,17 @@ def main() -> int:
     parser.add_argument("--model", default=None,
                         help="decimer, molnextr, molscribe, ocsrglyph, or llm. "
                              "Unset picks the default specialist.")
+    parser.add_argument("--ensemble", action="store_true",
+                        help="vote every installed specialist and report the "
+                             "measured confidence instead of reading with one; "
+                             "ignores --model, and needs a specialist installed")
     parser.add_argument("--llm", default="gpt-4o",
                         help="which LLM the agent runs on, with --agent")
     args = parser.parse_args()
 
     if args.agent:
         return run_agent(args.llm, args.model)
-    return run_direct(args.model)
+    return run_direct(args.model, ensemble=args.ensemble)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,8 +129,8 @@ where = ["src/"]
 
 [tool.setuptools.package-data]
 "chemgraph.eval" = ["data/*.json"]
-# ocsr_models reads ocsr_registry.json through importlib.resources, so it has to ship.
-"chemgraph.tools" = ["ocsr_registry.json"]
+# ocsr_models and ocsr_core read these through importlib.resources, so they have to ship.
+"chemgraph.tools" = ["ocsr_registry.json", "ocsr_calibration_4model.json"]
 "chemgraph.academy.campaigns" = [
     "example-*/*.json",
     "example-*/*.jsonc",

--- a/src/chemgraph/prompt/ocsr_prompt.py
+++ b/src/chemgraph/prompt/ocsr_prompt.py
@@ -86,11 +86,25 @@ of a bare string. Reach for it when a plain call came back with no SMILES the to
 could read: the answer arrives in a named field, and an image that is not a molecule
 can say so instead of being guessed at. It does nothing for the specialists.
 
+`ensemble=True` reads the image with every installed specialist and votes, returning
+a measured `confidence`: the share of benchmark images where a committee splitting
+this way was right. Four agreeing models are right 99.9% of the time and four
+disagreeing ones 37.7%, which a single model cannot tell you about its own answer.
+It costs one inference per model, so use it when the answer matters more than the
+wait: before feeding a SMILES to a calculation, or when a plain call returned
+something the user doubts. Tell the user the number and the split, and treat
+`confidence_label` of `conflicting` as an answer not to build on.
+
+A committee can come back with no number and a warning about a mismatch. That means
+the calibration table describes a different set of models than this machine ran.
+When the warning names a subset, pass it as `models_wanted` to vote exactly the
+committee the table measured; when it says models are missing, report what the
+warning says rather than retrying.
+
 Read `valid` before you act on the answer. When it is false, RDKit could not parse
 what the model produced, so the string is not a molecule and reporting it as one
-would be wrong. The tool reports no confidence number: a single model cannot say how
-likely it is to be right about this particular image. If the answer matters, run a
-second model and tell the user whether the two agreed.
+would be wrong. A single-model call reports no confidence, because one model cannot
+say how likely it is to be right about this particular image.
 
 If `n_fragments` is greater than 1, the image contained more than one molecule, or a
 salt, or a reaction scheme. Ask the user which molecule they meant. Do not pass a
@@ -102,9 +116,9 @@ read it, and stop. If the user wants a geometry, an energy, or any
 other calculation on the molecule, say that the SMILES is ready for it and let them
 ask; the tools for that are not bound here.
 
-`list_ocsr_models` says which models this machine has and how accurate each was on
-the benchmark. Use it when the user asks what is available, or after an install
-error, so the answer describes this machine instead of your memory.
+`list_ocsr_models` says which models this machine has and how accurate each measured
+on the calibration table in use. Use it when the user asks what is available, or
+after an install error, so the answer describes this machine instead of your memory.
 
 If a SMILES you propose yourself needs checking, `validate_smiles` reports what RDKit
 makes of it. You do not need it for a SMILES that came from `image_to_smiles`, whose

--- a/src/chemgraph/prompt/ocsr_prompt.py
+++ b/src/chemgraph/prompt/ocsr_prompt.py
@@ -95,6 +95,11 @@ wait: before feeding a SMILES to a calculation, or when a plain call returned
 something the user doubts. Tell the user the number and the split, and treat
 `confidence_label` of `conflicting` as an answer not to build on.
 
+Read `warning` even when the confidence is high. The table was fitted stereo-blind,
+so a unanimous committee scores the skeleton and says nothing about wedge bonds: if
+the models read different stereochemistry, the number stays high and the caveat is
+the only sign. Repeat it to the user before they act on the stereocentres.
+
 A committee can come back with no number and a warning about a mismatch. That means
 the calibration table describes a different set of models than this machine ran.
 When the warning names a subset, pass it as `models_wanted` to vote exactly the

--- a/src/chemgraph/tools/ocsr_backends.py
+++ b/src/chemgraph/tools/ocsr_backends.py
@@ -52,10 +52,17 @@ _ERROR_MASQUERADE = (
 
 
 def _narrow(ok=False, smiles=None, raw="", model_used=None,
-            cold_start=False, latency_s=0.0, error="") -> dict:
-    """The shape both backends return. Keeps the two paths honest with each other."""
+            cold_start=False, latency_s=0.0, error="", ran=True) -> dict:
+    """The shape both backends return. Keeps the two paths honest with each other.
+
+    ``ran`` is False when the model never saw the image: not installed, no
+    checkpoint, or the load failed. A committee has to tell that apart from a model
+    that read the image and produced nothing usable, because only the second is
+    evidence about the image.
+    """
     return {"ok": ok, "smiles": smiles, "raw": raw, "model_used": model_used,
-            "cold_start": cold_start, "latency_s": round(latency_s, 3), "error": error}
+            "cold_start": cold_start, "latency_s": round(latency_s, 3),
+            "error": error, "ran": ran}
 
 
 # ---------------------------------------------------------------------------
@@ -258,6 +265,16 @@ def available_specialists() -> list[str]:
 _WEIGHTS_DIR_ENV = "CHEMGRAPH_OCSR_WEIGHTS_DIR"
 
 
+def usable_specialists() -> list[str]:
+    """Installed models whose checkpoint is also present, so a call would run.
+
+    Three of the four need a checkpoint the ocsr extra cannot fetch, so being
+    importable is not the same as being able to read an image.
+    """
+    return [name for name in available_specialists()
+            if not _resolve_weights(name)[1]]
+
+
 def checkpoint_path(name: str) -> str | None:
     """The resolved checkpoint path for ``name``, or None if it needs none.
 
@@ -306,8 +323,14 @@ def _resolve_weights(name: str) -> tuple[str | None, str]:
         return None, ""
     if os.path.exists(path):
         return path, ""
-    return None, (f"{name}'s checkpoint is missing at {path}. "
-                  f"examples/ocsr/README.md lists where to download it, and "
+    # Quote the command rather than pointing at a file to read. A checkpoint is
+    # the one install step the extra cannot do, so this is where most first runs
+    # stop, and the fix is one line the user can paste.
+    spec = models.SPECIALIST_MODELS.get(name, {})
+    cmd = (spec.get("install") or {}).get("download")
+    fix = (f"Download it with: {cmd} --local-dir {os.path.dirname(path)}"
+           if cmd else "examples/ocsr/README.md lists where to download it")
+    return None, (f"{name}'s checkpoint is missing at {path}. {fix}. "
                   f"CHEMGRAPH_OCSR_WEIGHTS_DIR moves where it is looked for.")
 
 
@@ -350,13 +373,13 @@ def smiles_from_specialist(name: str, image_path: str) -> dict:
     bare = name.removeprefix("local:")
 
     if bare not in _LOADERS:
-        return _narrow(model_used=bare, latency_s=time.monotonic() - start,
+        return _narrow(model_used=bare, latency_s=time.monotonic() - start, ran=False,
                        error=f"unknown model {bare!r}. Choose one of: "
                              f"{', '.join(_LOADERS)}, or 'llm'.")
 
     model, cold, error = _get_model(bare)
     if model is None:
-        return _narrow(model_used=bare, cold_start=cold, error=error,
+        return _narrow(model_used=bare, cold_start=cold, error=error, ran=False,
                        latency_s=time.monotonic() - start)
 
     try:

--- a/src/chemgraph/tools/ocsr_calibrate.py
+++ b/src/chemgraph/tools/ocsr_calibrate.py
@@ -1,0 +1,514 @@
+"""Fit a confidence table for your own committee, on your own labelled images.
+
+The table that ships with ChemGraph describes four specific models on RDKit-rendered
+diagrams. It is the right default, but it is not a law of nature: a different set of
+models, or a different kind of image (scans, photographs, journal crops), has a
+different relationship between agreement and correctness. This module measures that
+relationship for whatever you actually run.
+
+    python -m chemgraph.tools.ocsr_calibrate \\
+        --labels my_data/labels.csv \\
+        --models decimer,molnextr,molscribe \\
+        --out my_calibration.json
+
+Then use it, voting the committee the table describes:
+
+    image_to_smiles_core(img, ensemble=True,
+                         models_wanted=["decimer", "molnextr", "molscribe"],
+                         calibration="my_calibration.json")
+    # or, for a whole session:
+    export CHEMGRAPH_OCSR_CALIBRATION=my_calibration.json
+
+``models_wanted`` matters whenever the table covers fewer models than are installed:
+the ensemble runs everything it finds otherwise, and a table fit on three models
+says nothing about what four of them agreeing means.
+
+The method is the one in the shipped table and is deliberately unclever: run every
+model on every image, group predictions that are the same molecule, note the vote
+pattern, and count how often the majority was right. No independence assumption, so
+correlated errors between models are already priced in by construction.
+
+You need labelled images, which is the catch: the reference SMILES has to come from
+somewhere. If you have none, `--validate` against the current table is the cheaper
+question, since detecting "this table is wrong for my images" takes far fewer labels
+than fitting a new one. It checks whatever `load_calibration` would use:
+`CHEMGRAPH_OCSR_CALIBRATION` when that is set, and the packaged table otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from datetime import date
+
+from chemgraph.tools import ocsr_backends as backends
+from chemgraph.tools import ocsr_core as core
+
+# Below this many observations a bucket gets a label and an interval but no point
+# estimate. At n=20 the 95% interval is 41 points wide at the midpoint and 26 even
+# for a lopsided 18/20; quoting a decimal for a bucket of 7 would be false precision,
+# and the shipped table follows the same rule.
+DEFAULT_MIN_N = 20
+
+# How correctness is judged, recorded in every table this fits. Stereo-blind because
+# most reference labels carry no stereochemistry, so scoring with it would mark a
+# model wrong for correctly reading a wedge bond. A table fit under another rule is
+# not comparable, which is why the value travels with the numbers.
+SCORING = "stereo_blind"
+
+
+def _jeffreys(k: int, n: int) -> float:
+    """Posterior mean under Beta(0.5, 0.5). Keeps a perfect bucket below 1.0."""
+    return (k + 0.5) / (n + 1.0)
+
+
+def _interval(k: int, n: int, alpha: float = 0.05) -> tuple[list[float], str]:
+    """A 95% interval and the method that produced it.
+
+    Jeffreys where scipy is importable, Wilson otherwise. The two disagree by up to
+    6.2 pp over the buckets below the sample floor, where the interval is the only
+    thing quoted, and scipy is not a declared ChemGraph dependency: it arrives
+    through ase. The method therefore travels with the table, so two tables fitted
+    on the same labels are comparable only when it matches.
+    """
+    if n == 0:
+        return [0.0, 1.0], "none: no observations"
+    try:
+        from scipy.stats import beta
+
+        lo = 0.0 if k == 0 else float(beta.ppf(alpha / 2, k + 0.5, n - k + 0.5))
+        hi = 1.0 if k == n else float(beta.ppf(1 - alpha / 2, k + 0.5, n - k + 0.5))
+        return [round(lo, 4), round(hi, 4)], "Jeffreys equal-tailed (scipy)"
+    except ImportError:
+        import math
+
+        z = 1.959963984540054
+        p, d = k / n, 1 + z * z / n
+        centre = (p + z * z / (2 * n)) / d
+        half = z * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / d
+        return ([round(max(0.0, centre - half), 4),
+                 round(min(1.0, centre + half), 4)], "Wilson score (no scipy)")
+
+
+def read_labels(path: str) -> list[tuple[str, str]]:
+    """Read ``image_path,smiles`` pairs from a CSV.
+
+    Accepts a header or not, and resolves relative image paths against the CSV's own
+    directory so a labels file can travel with its images.
+    """
+    base = os.path.dirname(os.path.abspath(path))
+    rows: list[tuple[str, str]] = []
+    with open(path, newline="") as fh:
+        for row in csv.reader(fh):
+            if len(row) < 2:
+                continue
+            img, smiles = row[0].strip(), row[1].strip()
+            if not img or not smiles:
+                continue
+            if img.lower() in ("image_path", "image", "path", "file", "filename"):
+                continue  # header
+            if not os.path.isabs(img):
+                img = os.path.join(base, img)
+            rows.append((img, smiles))
+    return rows
+
+
+def collect(labels: list[tuple[str, str]], models: list[str],
+            verbose: bool = True) -> list[tuple[list[dict], str]]:
+    """Run every model over every image. Returns (results, reference) per image.
+
+    The slow part: one model load per model, then one inference per image per model.
+    Failures are kept as ``ok=False`` entries rather than dropped, because a model
+    that fails on hard images is part of what the agreement pattern is measuring.
+    """
+    out = []
+    for i, (image_path, reference) in enumerate(labels, 1):
+        try:
+            # Resolve and sniff once per image rather than once per model, and reject
+            # a missing or non-image file before paying for any inference.
+            resolved = core.resolve_image_path(image_path)
+            core.load_image_bytes(resolved)
+        except Exception as e:
+            if verbose:
+                print(f"  [{i}/{len(labels)}] skipped {image_path}: {e}", file=sys.stderr)
+            continue
+
+        results = []
+        for name in models:
+            r = backends.smiles_from_specialist(name, resolved)
+            results.append({"model": name, "smiles": r["smiles"], "ok": r["ok"],
+                            "error": r["error"], "infer_s": r["latency_s"]})
+        out.append((results, reference))
+        if verbose and (i % 10 == 0 or i == len(labels)):
+            print(f"  {i}/{len(labels)} images", file=sys.stderr)
+    return out
+
+
+def fit_calibration(rows: list[tuple[list[dict], str]], models: list[str],
+                    min_n: int = DEFAULT_MIN_N, dataset: str = "",
+                    tie_break: list[str] | None = None) -> dict:
+    """Turn (per-image results, reference) pairs into a calibration table.
+
+    Correctness is judged the way :func:`ocsr_core.canonicalize` compares, which is
+    stereo-blind by default: most reference labels carry no stereochemistry, so
+    scoring with it would mark a model wrong for correctly reading a wedge bond.
+
+    ``tie_break`` is the model priority that decides an evenly split committee, and
+    it is recorded in the table because the numbers depend on it: the all-different
+    bucket measures how often the *first* model was right. Defaults to ranking the
+    committee by the solo accuracy measured here, so a caller who never thinks about
+    order still gets the strongest model breaking ties. The order of ``models`` is
+    deliberately not used for this: it is a set of names, and treating it as a
+    ranking would bake a caller's arbitrary typing order into their table.
+    """
+    buckets: dict[str, list[int]] = {}
+    # Per-model tallies alongside the committee ones: [correct, scored, abstained].
+    # These become the table's model_performance section, which is what a single-model
+    # backend reports as its confidence. Fitting them here rather than leaving them to
+    # a separate run is what makes a refit update every number the tool reports.
+    solo: dict[str, list[int]] = {m: [0, 0, 0] for m in models}
+
+    # Two passes: score every model first, so an unspecified tie-break can rank the
+    # committee by what the data says rather than by argument order.
+    if tie_break is None:
+        scored: dict[str, list[int]] = {m: [0, 0] for m in models}
+        for results, reference in rows:
+            ref = core.canonicalize(reference)
+            if ref is None:
+                continue
+            for r in results:
+                name = str(r.get("model", "")).removeprefix("local:")
+                if name not in scored:
+                    continue
+                scored[name][1] += 1
+                predicted = (core.canonicalize(r.get("smiles"))
+                             if r.get("ok", True) else None)
+                if predicted == ref:
+                    scored[name][0] += 1
+        order = sorted(models, key=lambda m: (-(scored[m][0] / scored[m][1])
+                                              if scored[m][1] else 0.0, m))
+    else:
+        order = list(tie_break)
+        if sorted(order) != sorted(models):
+            raise ValueError(
+                f"tie_break must name exactly the committee, most accurate first. "
+                f"Committee: {sorted(models)}. Got: {sorted(order)}."
+            )
+
+    for results, reference in rows:
+        ref = core.canonicalize(reference)
+        if ref is None:
+            continue  # an unparseable reference cannot judge anything
+        for r in results:
+            name = str(r.get("model", "")).removeprefix("local:")
+            tally = solo.get(name)
+            if tally is None:
+                continue
+            tally[1] += 1
+            predicted = core.canonicalize(r.get("smiles")) if r.get("ok", True) else None
+            if predicted is None:
+                tally[2] += 1
+            elif predicted == ref:
+                tally[0] += 1
+        v = core.vote(results, priority=order)
+        if v["pattern"] is None:
+            continue  # nobody voted; no pattern to attribute this to
+        entry = buckets.setdefault(v["pattern"], [0, 0])
+        entry[1] += 1
+        if v["winner"] == ref:
+            entry[0] += 1
+
+    patterns = {}
+    ci_method = ""
+    for pattern, (k, n) in sorted(buckets.items(), key=lambda kv: -kv[1][1]):
+        ci, ci_method = _interval(k, n)
+        cell: dict = {"k": k, "n": n, "ci": ci}
+        if n >= min_n:
+            cell["p"] = round(_jeffreys(k, n), 4)
+            cell["label"] = core._label_for(cell["p"])
+        else:
+            # No stored label below the floor: the consumer derives one from the
+            # Jeffreys estimate, which is the same rule confidence() applies.
+            cell["p"] = None
+        patterns[pattern] = cell
+
+    performance = {
+        name: {
+            "accuracy": round(k / n, 4),
+            "k": k,
+            "n": n,
+            "ci": _interval(k, n)[0],
+            "abstention_rate": round(abstained / n, 4),
+        }
+        for name, (k, n, abstained) in solo.items()
+        if n
+    }
+
+    return {
+        "committee": list(models),
+        "n_items": sum(n for _, n in buckets.values()),
+        "dataset": dataset,
+        "scoring": SCORING,
+        # The rule vote() applies. Recorded because a table fit under any other one
+        # has buckets that do not line up with what the tool produces, and
+        # _validate_calibration rejects such a table on the pattern sums alone.
+        "abstention": ("counts as a dissenting singleton vote; pattern parts always "
+                       "sum to the committee size"),
+        "model_performance": performance,
+        "model_performance_rule": (
+            "Per-model accuracy over the same images, used when a backend runs one "
+            "model and there is no agreement pattern to look up. 'accuracy' is the raw "
+            "rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often "
+            "the model returned no parseable SMILES."
+        ),
+        "tie_break": "model-priority: " + ",".join(order),
+        "created": date.today().isoformat(),
+        "min_n_for_point_estimate": min_n,
+        "estimator": "Jeffreys: (k+0.5)/(n+1)",
+        # Which library produced the intervals. Two tables fitted on the same labels
+        # are only comparable when this matches: the Wilson fallback differs from
+        # Jeffreys by up to 6.2 pp on the buckets below the sample floor.
+        "interval_method": ci_method,
+        "label_rule": (
+            "Where p is present, the consumer may quote it. Where p is null (n below min_n_for_point_estimate), no number is quoted: the label comes from the Jeffreys estimate (k+0.5)/(n+1), the same quantity p reports above the floor, so one rule covers the whole table."
+        ),
+        "patterns": patterns,
+    }
+
+
+def report(table: dict, min_n: int) -> str:
+    """A human-readable summary, including what is too thin to quote."""
+    lines = [
+        f"committee : {', '.join(table['committee'])}",
+        f"images    : {table['n_items']}",
+        f"scoring   : {table['scoring']}",
+        "",
+        f"{'pattern':10s} {'k/n':>9s} {'P(correct)':>11s} {'95% CI':>16s}  label",
+    ]
+    thin = []
+    for pattern, cell in table["patterns"].items():
+        k, n = cell["k"], cell["n"]
+        # Every displayed field comes from confidence(), the same call image_to_smiles
+        # makes, so this report cannot drift from what the tool will say. Reading
+        # cell["label"] and cell["ci"] directly crashed with a bare KeyError on the
+        # shipped table, whose above-floor cells store no label, and on any table the
+        # validator accepts without a ci.
+        verdict = core.confidence(pattern, table)
+        if verdict["p"] is None:
+            thin.append((pattern, n))
+        p_str = "  --" if verdict["p"] is None else f"{verdict['p']:.3f}"
+        ci = verdict["ci"]
+        ci_str = f"[{ci[0]:.3f}, {ci[1]:.3f}]" if ci else "(no interval)"
+        lines.append(f"{pattern:10s} {f'{k}/{n}':>9s} {p_str:>11s} "
+                     f"{ci_str:>16s}  {verdict['label']}")
+    if thin:
+        lines += ["", f"Too thin to quote a number (n < {min_n}): " +
+                  ", ".join(f"{p} (n={n})" for p, n in thin)]
+        lines.append("These still get a label from the Jeffreys estimate.")
+    return "\n".join(lines)
+
+
+def validate(rows: list[tuple[list[dict], str]], models: list[str],
+             table: dict) -> str:
+    """Compare an existing table's predictions against measured outcomes.
+
+    Far cheaper than refitting: 20-40 labelled images is enough to notice that a
+    table is badly wrong for your images, where fitting a new one needs a few
+    hundred. This is the question most users actually have.
+    """
+    # Vote by the rule the table was fitted under, so the comparison is like for
+    # like. Using any other order would measure a different quantity than the one
+    # the table's numbers describe. A table that reached here without going through
+    # load_calibration can carry no committee at all, so models is the last resort.
+    order = core.tie_break_order(table) or list(models)
+    seen: dict[str, list[int]] = {}
+    for results, reference in rows:
+        ref = core.canonicalize(reference)
+        if ref is None:
+            continue
+        v = core.vote(results, priority=order)
+        if v["pattern"] is None:
+            continue
+        e = seen.setdefault(v["pattern"], [0, 0])
+        e[1] += 1
+        if v["winner"] == ref:
+            e[0] += 1
+
+    lines = [f"{'pattern':10s} {'yours':>12s} {'table says':>11s} {'gap':>8s}"]
+    worst = 0.0
+    # Tracked separately from `worst`: a bucket that matches the table exactly leaves
+    # worst at 0.0, and overloading that to mean "nothing was judged" reported the
+    # best possible outcome as a failure to gather data.
+    judged = False
+    for pattern, (k, n) in sorted(seen.items(), key=lambda kv: -kv[1][1]):
+        c = core.confidence(pattern, table)
+        observed = k / n
+        if c["p"] is None:
+            lines.append(f"{pattern:10s} {f'{k}/{n}':>12s} {'(no number)':>11s} "
+                         f"{'':>8s}")
+            continue
+        gap = observed - c["p"]
+        if n >= 10:
+            judged = True
+            worst = max(worst, abs(gap))
+        lines.append(f"{pattern:10s} {f'{k}/{n} = {100*observed:.0f}%':>12s} "
+                     f"{100*c['p']:10.0f}% {100*gap:+7.0f} pp")
+
+    lines.append("")
+    if not judged:
+        lines.append("Not enough data in any bucket (n >= 10) to judge. Add more labels.")
+    elif worst < 0.10:
+        lines.append(f"Largest gap {100*worst:.0f} pp. This table looks usable "
+                     f"for your images.")
+    else:
+        lines.append(f"Largest gap {100*worst:.0f} pp. This table does NOT "
+                     f"describe your images well; consider fitting your own.")
+    lines.append("Gaps on small buckets are mostly noise: 10 images cannot "
+                 "distinguish 90% from 70%.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        prog="python -m chemgraph.tools.ocsr_calibrate",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--labels", required=True,
+                   help="CSV of image_path,smiles (relative paths resolve to its directory)")
+    p.add_argument("--models", default=None,
+                   help=("comma-separated committee; default is every installed "
+                         "model. Order does not matter here."))
+    p.add_argument("--tie-break", default=None, metavar="MODELS",
+                   help=("comma-separated models, most accurate first, deciding who "
+                         "wins when the committee splits evenly. Defaults to the "
+                         "most accurate first, measured on your own images."))
+    p.add_argument("--out", default=None, help="where to write the table")
+    p.add_argument("--validate", action="store_true",
+                   help="check the current table (CHEMGRAPH_OCSR_CALIBRATION, or "
+                        "the packaged one) against your images instead of fitting")
+    p.add_argument("--min-n", type=int, default=DEFAULT_MIN_N,
+                   help=f"observations needed for a point estimate (default {DEFAULT_MIN_N})")
+    args = p.parse_args(argv)
+
+    if args.min_n < 0:
+        # Checked here for the same reason as --models below: the pre-write
+        # validator rejects a negative floor, and reaching it costs a full run.
+        print(f"--min-n must be zero or more: {args.min_n}", file=sys.stderr)
+        return 2
+
+    installed = backends.available_specialists()
+    models = ([m.strip() for m in args.models.split(",")] if args.models else installed)
+    missing = [m for m in models if m not in installed]
+    if missing:
+        print(f"not installed: {', '.join(missing)}. Installed: "
+              f"{', '.join(installed) or 'none'}.\n"
+              f"Install with: pip install 'chemgraph[ocsr]'",
+              file=sys.stderr)
+        return 2
+    if not models:
+        print("no specialist models installed; nothing to calibrate", file=sys.stderr)
+        return 2
+    if len(set(models)) != len(models):
+        # Checked here rather than at the pre-write validator, which would reject it
+        # only after running every model over every image.
+        print(f"--models repeats a model: {','.join(models)}", file=sys.stderr)
+        return 2
+
+    if args.validate and args.tie_break is not None:
+        # Checked with the other argument validation, not after collect() has spent
+        # minutes of inference that the return would discard.
+        print("--tie-break has no effect with --validate, which votes by the order "
+              "recorded in the table it is checking", file=sys.stderr)
+        return 2
+
+    tie_break = None
+    if args.tie_break is not None:
+        tie_break = [m.strip() for m in args.tie_break.split(",") if m.strip()]
+        if sorted(tie_break) != sorted(models):
+            print(f"--tie-break must list exactly the committee, in your preferred "
+                  f"order. Committee: {','.join(models)}. Got: {','.join(tie_break)}.",
+                  file=sys.stderr)
+            return 2
+
+    if not os.path.isfile(os.path.expanduser(args.labels)):
+        print(f"no such labels file: {args.labels}. Expected a CSV of "
+              f"image_path,smiles.", file=sys.stderr)
+        return 2
+    labels = read_labels(args.labels)
+    if not labels:
+        print(f"no usable rows in {args.labels}; expected image_path,smiles",
+              file=sys.stderr)
+        return 2
+
+    if not args.validate and len(labels) < 100:
+        print(f"note: {len(labels)} images is thin for fitting a table. Most buckets "
+              f"will be under the n={args.min_n} floor and get a label but no number. "
+              f"About 300 is a sensible minimum; --validate is the better question "
+              f"below that.\n", file=sys.stderr)
+
+    if args.validate:
+        # Load before any inference. Reading it after collect() would discard every
+        # model run over every image to report a typo in a path, and the same
+        # reasoning already governs the write below.
+        try:
+            reference_table = core.load_calibration()
+        except (OSError, ValueError, TypeError) as exc:
+            print(f"cannot validate: {exc}", file=sys.stderr)
+            return 2
+
+    print(f"running {len(models)} model(s) over {len(labels)} images; the first call "
+          f"per model loads it (9-170 s)", file=sys.stderr)
+    rows = collect(labels, models)
+    if not rows:
+        print("no images could be read", file=sys.stderr)
+        return 1
+
+    if args.validate:
+        print(validate(rows, models, reference_table))
+        return 0
+
+    table = fit_calibration(rows, models, min_n=args.min_n,
+                            dataset=os.path.abspath(args.labels),
+                            tie_break=tie_break)
+
+    # Check the table against the loader before writing it. The committee comes from
+    # --models while the patterns come from whatever the rows actually held, so the
+    # two can disagree: a model that never produced a row, a row naming a model not in
+    # --models, or ragged rows all yield patterns that do not sum to the committee
+    # size. Writing first and failing at load leaves the user holding a file this tool
+    # told them to use.
+    try:
+        core._validate_calibration(table, args.out or "the fitted table")
+    except ValueError as exc:
+        print(f"\nthe fitted table is not self-consistent, so it was not written:\n"
+              f"  {exc}\n"
+              f"  Every model in --models must appear in every row, and no row may "
+              f"name a model outside it.", file=sys.stderr)
+        return 1
+
+    print(report(table, args.min_n))
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(table, fh, indent=2)
+        installed = backends.available_specialists()
+        subset = [m for m in installed if m not in models]
+        names = ", ".join(repr(m) for m in models)
+        wanted = f"models_wanted=[{names}], " if subset else ""
+        print(f"\nwrote {args.out}\nUse it with: "
+              f"image_to_smiles_core(img, ensemble=True, {wanted}"
+              f"calibration='{args.out}')")
+        if subset:
+            print(f"  models_wanted is needed here: {', '.join(subset)} "
+                  f"{'is' if len(subset) == 1 else 'are'} also installed, and the "
+                  f"ensemble would otherwise vote {'it' if len(subset) == 1 else 'them'} too.")
+    else:
+        print("\n(no --out given, table not saved)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/chemgraph/tools/ocsr_calibrate.py
+++ b/src/chemgraph/tools/ocsr_calibrate.py
@@ -60,11 +60,6 @@ DEFAULT_MIN_N = 20
 SCORING = "stereo_blind"
 
 
-def _jeffreys(k: int, n: int) -> float:
-    """Posterior mean under Beta(0.5, 0.5). Keeps a perfect bucket below 1.0."""
-    return (k + 0.5) / (n + 1.0)
-
-
 def _interval(k: int, n: int, alpha: float = 0.05) -> tuple[list[float], str]:
     """A 95% interval and the method that produced it.
 
@@ -101,8 +96,14 @@ def read_labels(path: str) -> list[tuple[str, str]]:
     """
     base = os.path.dirname(os.path.abspath(path))
     rows: list[tuple[str, str]] = []
-    with open(path, newline="") as fh:
-        for row in csv.reader(fh):
+    # A labels file is user input: normalise the two ways csv can refuse it into
+    # the ValueError main() already reports, rather than a traceback.
+    with open(path, newline="", errors="replace") as fh:
+        try:
+            parsed = list(csv.reader(fh))
+        except csv.Error as exc:
+            raise ValueError(f"{path} is not readable as CSV: {exc}") from None
+        for row in parsed:
             if len(row) < 2:
                 continue
             img, smiles = row[0].strip(), row[1].strip()
@@ -227,7 +228,7 @@ def fit_calibration(rows: list[tuple[list[dict], str]], models: list[str],
         ci, ci_method = _interval(k, n)
         cell: dict = {"k": k, "n": n, "ci": ci}
         if n >= min_n:
-            cell["p"] = round(_jeffreys(k, n), 4)
+            cell["p"] = round(core.jeffreys(k, n), 4)
             cell["label"] = core._label_for(cell["p"])
         else:
             # No stored label below the floor: the consumer derives one from the
@@ -235,9 +236,16 @@ def fit_calibration(rows: list[tuple[list[dict], str]], models: list[str],
             cell["p"] = None
         patterns[pattern] = cell
 
+    # Two numbers because they answer two questions. 'accuracy' is the raw rate,
+    # the record of what was counted, and it is what the validator cross-checks k
+    # and n against. 'p' is the quotable estimate, Jeffreys like every pattern cell,
+    # so a model perfect on 25 images and the bucket fitted from those same 25
+    # cannot band differently. Withheld below the floor for the same reason a thin
+    # bucket withholds its p.
     performance = {
         name: {
             "accuracy": round(k / n, 4),
+            "p": round(core.jeffreys(k, n), 4) if n >= min_n else None,
             "k": k,
             "n": n,
             "ci": _interval(k, n)[0],
@@ -261,8 +269,10 @@ def fit_calibration(rows: list[tuple[list[dict], str]], models: list[str],
         "model_performance_rule": (
             "Per-model accuracy over the same images, used when a backend runs one "
             "model and there is no agreement pattern to look up. 'accuracy' is the raw "
-            "rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often "
-            "the model returned no parseable SMILES."
+            "rate, the record of what was counted; 'p' is the quotable Jeffreys "
+            "estimate, the same rule the pattern cells use, and is null below "
+            "min_n_for_point_estimate; 'ci' is the 95% Jeffreys interval; "
+            "'abstention_rate' is how often the model returned no parseable SMILES."
         ),
         "tie_break": "model-priority: " + ",".join(order),
         "created": date.today().isoformat(),
@@ -281,16 +291,20 @@ def fit_calibration(rows: list[tuple[list[dict], str]], models: list[str],
 
 def report(table: dict, min_n: int) -> str:
     """A human-readable summary, including what is too thin to quote."""
+    # Only 'committee' and 'patterns' are required by the validator, so the header
+    # reads the rest defensively. The body below already routes through confidence()
+    # for the same reason: a table this function cannot summarise is still a table
+    # the tool will happily use.
     lines = [
         f"committee : {', '.join(table['committee'])}",
-        f"images    : {table['n_items']}",
-        f"scoring   : {table['scoring']}",
+        f"images    : {table.get('n_items', 'unrecorded')}",
+        f"scoring   : {table.get('scoring', 'unrecorded')}",
         "",
         f"{'pattern':10s} {'k/n':>9s} {'P(correct)':>11s} {'95% CI':>16s}  label",
     ]
     thin = []
     for pattern, cell in table["patterns"].items():
-        k, n = cell["k"], cell["n"]
+        k, n = cell.get("k", 0), cell.get("n", 0)
         # Every displayed field comes from confidence(), the same call image_to_smiles
         # makes, so this report cannot drift from what the tool will say. Reading
         # cell["label"] and cell["ci"] directly crashed with a bare KeyError on the
@@ -319,6 +333,22 @@ def validate(rows: list[tuple[list[dict], str]], models: list[str],
     table is badly wrong for your images, where fitting a new one needs a few
     hundred. This is the question most users actually have.
     """
+    # The same check the tool applies before quoting a number. Without it this
+    # endorses a table the tool will then refuse: a committee the table does not
+    # describe produces patterns it has no bucket for, so every row reads
+    # "no number" and the verdict blames the sample size.
+    #
+    # Read from the rows rather than from `models`, so a caller assembling rows by
+    # hand is checked on what they actually contain. main() refuses the same
+    # mismatch earlier, from the argument, before paying for any inference.
+    ran = sorted({str(r.get("model", "")).removeprefix("local:")
+                  for results, _ in rows for r in results} or set(models))
+    mismatch = core.check_committee({"committee": ran}, table)
+    if mismatch:
+        return (f"cannot validate: {mismatch}\n"
+                f"Scoring these models against this table would compare patterns "
+                f"it was never fitted for.")
+
     # Vote by the rule the table was fitted under, so the comparison is like for
     # like. Using any other order would measure a different quantity than the one
     # the table's numbers describe. A table that reached here without going through
@@ -377,7 +407,7 @@ def main(argv: list[str] | None = None) -> int:
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p.add_argument("--labels", required=True,
+    p.add_argument("--labels", required=True, type=os.path.expanduser,
                    help="CSV of image_path,smiles (relative paths resolve to its directory)")
     p.add_argument("--models", default=None,
                    help=("comma-separated committee; default is every installed "
@@ -386,13 +416,39 @@ def main(argv: list[str] | None = None) -> int:
                    help=("comma-separated models, most accurate first, deciding who "
                          "wins when the committee splits evenly. Defaults to the "
                          "most accurate first, measured on your own images."))
-    p.add_argument("--out", default=None, help="where to write the table")
+    p.add_argument("--out", default=None, type=os.path.expanduser,
+                   help="where to write the table")
     p.add_argument("--validate", action="store_true",
                    help="check the current table (CHEMGRAPH_OCSR_CALIBRATION, or "
                         "the packaged one) against your images instead of fitting")
     p.add_argument("--min-n", type=int, default=DEFAULT_MIN_N,
                    help=f"observations needed for a point estimate (default {DEFAULT_MIN_N})")
     args = p.parse_args(argv)
+
+    if args.out:
+        # Probed here for the same reason --validate loads its table here: an
+        # unwritable path found after collect() discards a full run of inference
+        # and the table it produced.
+        try:
+            # Through realpath, so a link is judged by the file it resolves to and
+            # neither branch has to special-case one: append would follow a link and
+            # create its target, and "x" would not follow and would refuse a
+            # dangling one with "File exists" naming a path that does not exist.
+            out_path = os.path.realpath(args.out)
+            if os.path.exists(out_path):
+                # Do not create or remove anything: a zero-byte file the user
+                # already had is indistinguishable from one the probe made, and
+                # this runs before the other argument checks, so a run that then
+                # exits 2 would have destroyed it.
+                with open(out_path, "a"):
+                    pass
+            else:
+                with open(out_path, "x"):
+                    pass
+                os.unlink(out_path)
+        except OSError as exc:
+            print(f"cannot write {args.out}: {exc}", file=sys.stderr)
+            return 2
 
     if args.min_n < 0:
         # Checked here for the same reason as --models below: the pre-write
@@ -434,11 +490,15 @@ def main(argv: list[str] | None = None) -> int:
                   file=sys.stderr)
             return 2
 
-    if not os.path.isfile(os.path.expanduser(args.labels)):
+    if not os.path.isfile(args.labels):
         print(f"no such labels file: {args.labels}. Expected a CSV of "
               f"image_path,smiles.", file=sys.stderr)
         return 2
-    labels = read_labels(args.labels)
+    try:
+        labels = read_labels(args.labels)
+    except (OSError, ValueError) as exc:
+        print(f"cannot read {args.labels}: {exc}", file=sys.stderr)
+        return 2
     if not labels:
         print(f"no usable rows in {args.labels}; expected image_path,smiles",
               file=sys.stderr)
@@ -458,6 +518,15 @@ def main(argv: list[str] | None = None) -> int:
             reference_table = core.load_calibration()
         except (OSError, ValueError, TypeError) as exc:
             print(f"cannot validate: {exc}", file=sys.stderr)
+            return 2
+        # Both inputs are known here, so refuse now rather than after collect() has
+        # run every model over every image to reach the same conclusion.
+        mismatch = core.check_committee({"committee": list(models)}, reference_table)
+        if mismatch:
+            print(f"cannot validate: {mismatch}\n"
+                  f"Scoring these models against this table would compare patterns "
+                  f"it was never fitted for. Name the table's own committee with "
+                  f"--models, or fit a new table for these.", file=sys.stderr)
             return 2
 
     print(f"running {len(models)} model(s) over {len(labels)} images; the first call "
@@ -492,15 +561,24 @@ def main(argv: list[str] | None = None) -> int:
 
     print(report(table, args.min_n))
     if args.out:
-        with open(args.out, "w") as fh:
-            json.dump(table, fh, indent=2)
+        try:
+            # out_path, the same path the pre-flight probe cleared. realpath
+            # strips a trailing slash and open does not, so probing one and
+            # writing the other asks two different questions and the probe stops
+            # meaning anything.
+            with open(out_path, "w") as fh:
+                json.dump(table, fh, indent=2)
+        except OSError as exc:
+            print(f"\nthe table was fitted but could not be written to "
+                  f"{out_path}: {exc}", file=sys.stderr)
+            return 1
         installed = backends.available_specialists()
         subset = [m for m in installed if m not in models]
         names = ", ".join(repr(m) for m in models)
         wanted = f"models_wanted=[{names}], " if subset else ""
-        print(f"\nwrote {args.out}\nUse it with: "
+        print(f"\nwrote {out_path}\nUse it with: "
               f"image_to_smiles_core(img, ensemble=True, {wanted}"
-              f"calibration='{args.out}')")
+              f"calibration='{out_path}')")
         if subset:
             print(f"  models_wanted is needed here: {', '.join(subset)} "
                   f"{'is' if len(subset) == 1 else 'are'} also installed, and the "

--- a/src/chemgraph/tools/ocsr_calibration_4model.json
+++ b/src/chemgraph/tools/ocsr_calibration_4model.json
@@ -1,0 +1,113 @@
+{
+  "committee": [
+    "decimer",
+    "molnextr",
+    "molscribe",
+    "ocsrglyph"
+  ],
+  "n_items": 722,
+  "scoring": "stereo_blind",
+  "abstention": "counts as a dissenting singleton vote; pattern parts always sum to the committee size",
+  "tie_break": "model-priority: decimer,molnextr,molscribe,ocsrglyph",
+  "min_n_for_point_estimate": 20,
+  "estimator": "Jeffreys: (k+0.5)/(n+1)",
+  "datasets": [
+    "eval100_random",
+    "eval100_minmax",
+    "eval100_stratified",
+    "pubchem"
+  ],
+  "model_performance": {
+    "decimer": {
+      "accuracy": 0.8989,
+      "k": 649,
+      "n": 722,
+      "ci": [
+        0.8753,
+        0.9193
+      ],
+      "abstention_rate": 0.0042
+    },
+    "molnextr": {
+      "accuracy": 0.8352,
+      "k": 603,
+      "n": 722,
+      "ci": [
+        0.8068,
+        0.8609
+      ],
+      "abstention_rate": 0.0429
+    },
+    "molscribe": {
+      "accuracy": 0.8241,
+      "k": 595,
+      "n": 722,
+      "ci": [
+        0.7951,
+        0.8505
+      ],
+      "abstention_rate": 0.054
+    },
+    "ocsrglyph": {
+      "accuracy": 0.7659,
+      "k": 553,
+      "n": 722,
+      "ci": [
+        0.734,
+        0.7957
+      ],
+      "abstention_rate": 0.0526
+    }
+  },
+  "patterns": {
+    "4": {
+      "k": 462,
+      "n": 462,
+      "p": 0.9989,
+      "ci": [
+        0.9946,
+        1.0
+      ]
+    },
+    "3/1": {
+      "k": 133,
+      "n": 135,
+      "p": 0.9816,
+      "ci": [
+        0.9533,
+        0.9969
+      ]
+    },
+    "2/1/1": {
+      "k": 46,
+      "n": 57,
+      "p": 0.8017,
+      "ci": [
+        0.6909,
+        0.8929
+      ]
+    },
+    "1/1/1/1": {
+      "k": 21,
+      "n": 56,
+      "p": 0.3772,
+      "ci": [
+        0.2571,
+        0.5055
+      ]
+    },
+    "2/2": {
+      "k": 7,
+      "n": 12,
+      "p": null,
+      "ci": [
+        0.3119,
+        0.8195
+      ]
+    }
+  },
+  "label_rule": "Where p is present, the consumer may quote it. Where p is null (n below min_n_for_point_estimate), no number is quoted: the label comes from the Jeffreys estimate (k+0.5)/(n+1), the same quantity p reports above the floor, so one rule covers the whole table.",
+  "model_performance_rule": "Per-model accuracy over the same images, used when a backend runs one model and there is no agreement pattern to look up. 'accuracy' is the raw rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often the model returned no parseable SMILES.",
+  "note": "Valid ONLY for this exact four-model committee. Refit with chemgraph.tools.ocsr_calibrate for any other set.",
+  "interval_method": "Jeffreys equal-tailed (scipy)"
+}

--- a/src/chemgraph/tools/ocsr_calibration_4model.json
+++ b/src/chemgraph/tools/ocsr_calibration_4model.json
@@ -20,6 +20,7 @@
   "model_performance": {
     "decimer": {
       "accuracy": 0.8989,
+      "p": 0.8983,
       "k": 649,
       "n": 722,
       "ci": [
@@ -30,6 +31,7 @@
     },
     "molnextr": {
       "accuracy": 0.8352,
+      "p": 0.8347,
       "k": 603,
       "n": 722,
       "ci": [
@@ -40,6 +42,7 @@
     },
     "molscribe": {
       "accuracy": 0.8241,
+      "p": 0.8237,
       "k": 595,
       "n": 722,
       "ci": [
@@ -50,6 +53,7 @@
     },
     "ocsrglyph": {
       "accuracy": 0.7659,
+      "p": 0.7656,
       "k": 553,
       "n": 722,
       "ci": [
@@ -107,7 +111,7 @@
     }
   },
   "label_rule": "Where p is present, the consumer may quote it. Where p is null (n below min_n_for_point_estimate), no number is quoted: the label comes from the Jeffreys estimate (k+0.5)/(n+1), the same quantity p reports above the floor, so one rule covers the whole table.",
-  "model_performance_rule": "Per-model accuracy over the same images, used when a backend runs one model and there is no agreement pattern to look up. 'accuracy' is the raw rate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often the model returned no parseable SMILES.",
+  "model_performance_rule": "Per-model accuracy over the same images, used when a backend runs one model and there is no agreement pattern to look up. 'accuracy' is the raw rate, the record of what was counted; 'p' is the quotable Jeffreys estimate, the same rule the pattern cells use, and is null below min_n_for_point_estimate; 'ci' is the 95% Jeffreys interval; 'abstention_rate' is how often the model returned no parseable SMILES.",
   "note": "Valid ONLY for this exact four-model committee. Refit with chemgraph.tools.ocsr_calibrate for any other set.",
   "interval_method": "Jeffreys equal-tailed (scipy)"
 }

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -811,3 +811,55 @@ def confidence(pattern: str | None, table: dict) -> dict:
                 "reason": "below_n_floor"}
     return {"p": p, "label": entry.get("label") or _label_for(p), "n": n, "ci": ci,
             "reason": None}
+
+
+
+def prior_confidence(model: str, table: dict | None = None) -> dict:
+    """Confidence for a single-model backend, from that model's measured solo accuracy.
+
+    A single model has no consensus to measure, so the agreement table does not apply.
+    Do **not** route a one-model result through :func:`vote` and :func:`confidence`:
+    that yields pattern "1", which a four-model table does not contain at all, so the
+    lookup misses and reports unknown_pattern. It would also trip
+    :func:`check_committee`. Use this instead.
+
+    Returns the same shape as :func:`confidence` so callers have one code path.
+
+    Every number here comes from the calibration table's ``model_performance`` section, never from
+    a constant in this file. Measurements belong with the data that produced them: a
+    user who refits on their own images gets priors for their images, and a stale
+    figure cannot outlive the table it was measured on. The registry in ocsr_models
+    describes what a model *is* (how to run it, how fast, what it needs); the table
+    records how well it *did*.
+
+    Passing ``table`` lets a caller that already loaded one avoid a second read.
+    """
+    bare = model.removeprefix("local:")
+    try:
+        t = table if table is not None else load_calibration()
+    except (OSError, ValueError, TypeError) as exc:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": f"calibration_unreadable: {type(exc).__name__}"}
+
+    entry = (t.get("model_performance") or {}).get(bare)
+    if not entry or entry.get("accuracy") is None:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_prior_for_model"}
+    p = entry["accuracy"]
+    return {"p": p, "label": _label_for(p), "n": entry.get("n", 0),
+            "ci": entry.get("ci"), "reason": None}
+
+
+
+def model_performance(model: str, table: dict | None = None) -> dict:
+    """Measured single-model performance from a calibration table, or {} if absent.
+
+    The one place to ask "how good is this model": accuracy, the k and n behind it,
+    a 95% interval, and how often it abstains. Nothing here is compiled into the
+    source, so a table refitted on other images reports that table's numbers.
+    """
+    try:
+        t = table if table is not None else load_calibration()
+    except (OSError, ValueError, TypeError):
+        return {}
+    return dict((t.get("model_performance") or {}).get(model.removeprefix("local:")) or {})

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -40,6 +40,11 @@ _MAX_IMAGE_BYTES = 8_000_000
 # longest in the OCSR benchmark is 224.
 _MAX_SMILES_CHARS = 4000
 
+# Confidence label cut-points, applied to the point estimate. Below the calibration
+# table's n floor these are prefixed "low_n_", because a 30-60 pp interval does not
+# deserve a decimal.
+_LABEL_BANDS = ((0.99, "unanimous"), (0.95, "strong"), (0.70, "weak"))
+
 # The optional quotes around the key let a JSON reply be read at the line level:
 # '"smiles": "CCO"' is the single most common structured form a vision LLM returns,
 # and reaching it here keeps the word-by-word fallback from matching an element
@@ -735,3 +740,74 @@ def _parse_tie_break(value: object) -> list[str] | None:
         return []
     _, _, names = value.partition("model-priority:")
     return [n.strip() for n in names.split(",") if n.strip()]
+
+
+
+def _label_for(p: float, low_n: bool = False) -> str:
+    """Map a probability to a coarse label, prefixed when the bucket is small."""
+    name = "conflicting"
+    for threshold, band in _LABEL_BANDS:
+        if p >= threshold:
+            name = band
+            break
+    return f"low_n_{name}" if low_n else name
+
+
+
+def confidence(pattern: str | None, table: dict) -> dict:
+    """Look up P(majority correct) for an agreement pattern.
+
+    Takes the table as an argument rather than reading a module global, so the tool
+    and the recalibration script share one code path.
+
+    Reports a point estimate only where the bucket cleared the table's sample floor.
+    Below it the 95% interval spans 30-60 pp, so a decimal would be false precision;
+    the label and the interval still carry the actionable part. An unknown pattern
+    gets no number at all rather than a guess.
+
+    Returns
+    -------
+    dict
+        p, label, n, ci, reason
+    """
+    if pattern is None:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_prediction"}
+
+    entry = (table.get("patterns") or {}).get(pattern)
+    if entry is None:
+        return {"p": None, "label": "unknown", "n": 0, "ci": None,
+                "reason": "unknown_pattern"}
+
+    p, n, ci = entry.get("p"), entry.get("n", 0), entry.get("ci")
+    # Honour the floor the table declares, not only the producer's decision to leave
+    # p out. A table written by hand, or fitted with a --min-n lower than the one
+    # recorded, can carry a point estimate over a handful of images; quoting it
+    # would be the false precision the floor exists to prevent.
+    # A JSON 20.0 deserializes to float, and bool is an int in Python, so neither
+    # isinstance(floor, int) alone nor a bare truth test gets this right.
+    floor = table.get("min_n_for_point_estimate")
+    if isinstance(floor, bool) or not isinstance(floor, (int, float)):
+        floor = None
+    if p is not None and floor is not None and n < floor:
+        p = None
+    if p is None:
+        # Below the floor we withhold the number but still owe a useful label, so it
+        # is derived from the Jeffreys estimate: the same quantity the `p` column
+        # reports above the floor, which keeps one rule across the whole table.
+        #
+        # The raw point estimate k/n would call a 7/7 bucket "unanimous", claiming
+        # certainty from seven items. Jeffreys shrinks toward 0.5 in proportion to
+        # how thin the bucket is, putting 7/7 at 0.938 and so at low_n_weak, one
+        # band below the 0.95 cut.
+        # The stored label is ignored here: a producer writes it beside a point
+        # estimate, so it names a full-confidence band. Carrying it through would
+        # report "unanimous" from four images, which is the claim the floor exists
+        # to refuse, and the low_n_ prefix a caller bands on would be missing.
+        k = entry.get("k")
+        est = ((k + 0.5) / (n + 1.0)) if (k is not None and n) else (ci[0] if ci else 0.0)
+        label = _label_for(est, low_n=True)
+        return {"p": None, "label": label, "n": n, "ci": ci,
+                "reason": "below_n_floor"}
+    return {"p": p, "label": entry.get("label") or _label_for(p), "n": n, "ci": ci,
+            "reason": None}

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -37,8 +37,21 @@ _MAX_IMAGE_BYTES = 8_000_000
 # RDKit parsing is superlinear in string length: 20k characters costs about 9 s of
 # CPU and a megabyte-scale string is effectively unbounded. Model output is untrusted,
 # so cap it before RDKit sees it. Real SMILES are well under 1000 characters; the
-# longest in the OCSR benchmark is 224.
+# longest reference label in the OCSR benchmark is 152 and the longest prediction
+# any model returned is 485.
 _MAX_SMILES_CHARS = 4000
+
+# Cap for the free-text fields of a result. Each can echo a caller-supplied path,
+# model name or backend message, and the dict is read back into an agent's context.
+# 1200 clears the longest legitimate warning, which is four caveats at once: a
+# salt, the models that could not run, a committee the table does not describe,
+# and a stereo split. Searching that space by driving image_to_smiles_core puts
+# the maximum near 1190. No per-term breakdown here: it was written four times
+# and wrong four times, because the terms trade off against each other through the
+# number of models running and cannot each be taken at their own maximum. A lower
+# cap drops the refit command off the end of the mismatch note, which is the one
+# part of that message a user has to act on.
+_MAX_MESSAGE_CHARS = 1200
 
 # Confidence label cut-points, applied to the point estimate. Below the calibration
 # table's n floor these are prefixed "low_n_", because a 30-60 pp interval does not
@@ -135,12 +148,14 @@ def load_image_bytes(image_path: str, max_bytes: int = _MAX_IMAGE_BYTES) -> tupl
             f"files are refused (a FIFO would block forever, /dev/zero would not end)."
         )
     if st.st_size > max_bytes:
-        raise ValueError(f"image is {st.st_size} bytes, over the {max_bytes} limit: {path}")
+        raise ValueError(f"image is {st.st_size} bytes, over the {max_bytes} limit: "
+                         f"{echo(path)}")
 
     with open(path, "rb") as fh:
         data = fh.read(max_bytes + 1)  # +1 so a file that grew since lstat is caught
     if len(data) > max_bytes:
-        raise ValueError(f"image grew past the {max_bytes} limit while reading: {path}")
+        raise ValueError(f"image grew past the {max_bytes} limit while reading: "
+                         f"{echo(path)}")
 
     mime = _sniff_mime(data[:16])
     if mime is None:
@@ -156,6 +171,31 @@ def load_image_bytes(image_path: str, max_bytes: int = _MAX_IMAGE_BYTES) -> tupl
 # ---------------------------------------------------------------------------
 
 
+def _encodable(smiles: str) -> bool:
+    """True when the string can cross into RDKit, which takes bytes.
+
+    json.loads accepts a lone surrogate such as ``\\ud800``, so a model reply
+    carrying a broken UTF-16 pair arrives here as a str no encoder can render.
+    Every RDKit entry point then raises UnicodeEncodeError, which is a raise out of
+    two functions whose contract is to return a value for any input.
+    """
+    try:
+        smiles.encode("utf-8")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+def jeffreys(k: int, n: int) -> float:
+    """Posterior mean under Beta(0.5, 0.5). Keeps a perfect bucket below 1.0.
+
+    One definition, because the table records this as the rule covering every
+    number in it and the validator enforces that. ocsr_calibrate imports it, so a
+    table cannot be fitted under one formula and checked against another.
+    """
+    return (k + 0.5) / (n + 1.0)
+
+
 def canonicalize(smiles: str | None, stereo: bool = False) -> str | None:
     """Canonical SMILES, or None when the string does not parse.
 
@@ -168,7 +208,7 @@ def canonicalize(smiles: str | None, stereo: bool = False) -> str | None:
     other three emit aromatic, and on 422 benchmark items raw-string comparison finds
     the four unanimous on 12 where canonical comparison finds it on 289.
     """
-    if not smiles or len(smiles) > _MAX_SMILES_CHARS:
+    if not smiles or len(smiles) > _MAX_SMILES_CHARS or not _encodable(smiles):
         return None
     from rdkit import Chem, RDLogger
 
@@ -324,6 +364,9 @@ def validate_smiles_core(smiles: str) -> dict:
             f"parsing cost grows superlinearly and real SMILES are far shorter"
         )
         return out
+    if not _encodable(smiles):
+        out["errors"].append("SMILES contains characters that are not valid text")
+        return out
 
     try:
         from rdkit import Chem, RDLogger
@@ -378,6 +421,26 @@ def validate_smiles_core(smiles: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def echo(value: object, limit: int = 120) -> str:
+    """A caller-supplied value, shortened for quoting in a message.
+
+    Bounds the echo where it happens. The cap in :func:`build_result` bounds the
+    assembled field, which has to stay wide enough for four legitimate caveats at
+    once, so on its own it lets one 50,000-character path fill the whole budget and
+    push the part a user has to act on off the end.
+
+    Cut from the middle. What is quoted here is usually a path, and a deep directory
+    chain is identical across every file in it, so trimming the tail leaves two
+    different images with byte-identical errors and an agent cannot tell which one
+    failed.
+    """
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    head = (limit - 3) // 2
+    return text[:head] + "..." + text[len(text) - (limit - 3 - head):]
+
+
 def build_result(**overrides) -> dict:
     """Assemble the tool's return dict, with every contract key present.
 
@@ -415,6 +478,14 @@ def build_result(**overrides) -> dict:
     if unknown:
         raise KeyError(f"not part of the OCSR result contract: {sorted(unknown)}")
     result.update(overrides)
+    # Cap the free text here rather than at each site that builds it. Every one of
+    # them can echo something the caller supplied, a path, a model name, a backend
+    # message, and the whole dict goes back into an agent's context. One place to
+    # enforce it means a new message cannot reintroduce an unbounded field.
+    for key in ("error", "warning", "confidence_unavailable_reason"):
+        text = result[key]
+        if isinstance(text, str) and len(text) > _MAX_MESSAGE_CHARS:
+            result[key] = text[:_MAX_MESSAGE_CHARS - 3] + "..."
     return result
 
 
@@ -526,12 +597,25 @@ def load_calibration(path: str | None = None) -> dict:
     """
     candidate = path or os.environ.get("CHEMGRAPH_OCSR_CALIBRATION")
     if candidate:
+        # Before expanduser, which calls __fspath__ on anything that has one. Every
+        # caller guards this function for OSError, ValueError and TypeError, and an
+        # object whose __fspath__ raises something else escapes all three. A Path is
+        # the ordinary way to pass a path, so it is converted here where whatever
+        # __fspath__ raises can be turned into one of the three.
+        if not isinstance(candidate, (str, os.PathLike)):
+            raise ValueError(f"calibration must be a path, got "
+                             f"{type(candidate).__name__}")
+        try:
+            candidate = os.fspath(candidate)
+        except Exception as exc:
+            raise ValueError(f"calibration path is unusable: "
+                             f"{type(exc).__name__}") from None
         resolved = os.path.expanduser(candidate)
         # A FIFO here blocks open() forever with no caller-side timeout, the same
         # reason load_image_bytes checks. Callers of this function have usually just
         # spent real inference time and must not hang holding the result.
         if not stat.S_ISREG(os.lstat(resolved).st_mode):
-            raise ValueError(f"calibration table is not a regular file: {resolved}")
+            raise ValueError(f"calibration table is not a regular file: {echo(resolved)}")
         with open(resolved) as fh:
             return _validate_calibration(_load_json(fh, resolved), resolved)
 
@@ -574,6 +658,24 @@ def _validate_calibration(table: object, origin: str) -> dict:
         except (OverflowError, ValueError, TypeError):
             raise bad(f"{field} is not a usable number: {value!r}") from None
 
+    def check_ci(span: object, where: str) -> None:
+        """A pattern cell and a model_performance entry bound theirs identically.
+
+        isfinite because json.loads accepts NaN and Infinity, and a NaN bound
+        compares false against everything, so a low-n label would come out wrong
+        with nothing to show why.
+        """
+        if span is None:
+            return
+        ok = (isinstance(span, list) and len(span) == 2
+              and all(isinstance(b, (int, float)) and not isinstance(b, bool)
+                      and math.isfinite(num(b, f"{where} ci")) and 0.0 <= b <= 1.0
+                      for b in span))
+        if not ok:
+            raise bad(f"{where} has a malformed ci: {span!r}")
+        if span[0] > span[1]:
+            raise bad(f"{where} has a reversed ci: {span!r}")
+
     if not isinstance(table, dict):
         raise bad(f"top level is {type(table).__name__}, expected an object")
     committee = table.get("committee")
@@ -605,15 +707,18 @@ def _validate_calibration(table: object, origin: str) -> dict:
     # the floor, and the table would quote a point estimate from a handful of images
     # while recording that it does not.
     declared = table.get("min_n_for_point_estimate")
-    # isfinite for the same reason the ci check uses it: json accepts NaN and
-    # Infinity, NaN < anything is False so the floor would never fire, and inf
-    # fires on every bucket however large.
-    if declared is not None and (isinstance(declared, bool)
-                                 or not isinstance(declared, (int, float))
-                                 or not math.isfinite(declared)
-                                 or declared < 0):
-        raise bad(f"'min_n_for_point_estimate' must be a non-negative number: "
-                  f"{declared!r}")
+    if declared is not None:
+        if isinstance(declared, bool) or not isinstance(declared, (int, float)):
+            raise bad(f"'min_n_for_point_estimate' must be a non-negative number: "
+                      f"{declared!r}")
+        # Through num(), so a 400-digit int raises ValueError here rather than
+        # OverflowError from the isfinite call, which no caller guards against.
+        # isfinite for the reason the ci check uses it: json accepts NaN, which
+        # compares false against everything so the floor would never fire, and
+        # Infinity, which fires on every bucket however large.
+        if not math.isfinite(num(declared, "'min_n_for_point_estimate'")) or declared < 0:
+            raise bad(f"'min_n_for_point_estimate' must be a non-negative number: "
+                      f"{declared!r}")
 
     patterns = table.get("patterns")
     if not isinstance(patterns, dict) or not patterns:
@@ -637,6 +742,16 @@ def _validate_calibration(table: object, origin: str) -> dict:
         # what vote() produces, and every lookup would quietly miss or mismatch.
         if sum(parts) != size:
             raise bad(f"pattern {name!r} sums to {sum(parts)}, committee has {size} models")
+        # vote() emits counts largest first, joined by a slash and nothing else, so
+        # a key that differs from that in any way is a bucket no lookup can ever
+        # reach. Descending order is one way to differ. int() also normalises, so
+        # "+4", "0004", " 4 " and the Arabic-Indic digit all parse to the same parts
+        # and none of them is ever looked up. Rejecting the key beats shipping a
+        # silently dead row.
+        canonical = "/".join(str(x) for x in sorted(parts, reverse=True))
+        if str(name) != canonical:
+            raise bad(f"pattern {name!r} is not the key vote() emits, which is "
+                      f"{canonical!r}")
         k, n = cell.get("k"), cell.get("n")
         if (isinstance(k, bool) or isinstance(n, bool)
                 or not isinstance(n, int) or n < 0
@@ -652,6 +767,11 @@ def _validate_calibration(table: object, origin: str) -> dict:
         # the consistency check below pass, so it has to be caught here.
         if n == 0 and cell.get("p") is not None:
             raise bad(f"pattern {name!r} quotes p over 0 observations")
+        # An interval is a quotable number too: below the floor confidence() falls
+        # back to ci[0] as the estimate exactly when n is 0, so a bucket with no
+        # observations would report a band from nothing.
+        if n == 0 and cell.get("ci") is not None:
+            raise bad(f"pattern {name!r} quotes an interval over 0 observations")
 
         # p, ci and label are what a caller acts on, so check them here. Left
         # unchecked, a string p reached _label_for and raised TypeError deep inside a
@@ -663,29 +783,30 @@ def _validate_calibration(table: object, origin: str) -> dict:
                 raise bad(f"pattern {name!r} has a non-numeric p: {p!r}")
             if not 0.0 <= p <= 1.0:
                 raise bad(f"pattern {name!r} has p={p} outside [0, 1]")
-            expected = round((k + 0.5) / (n + 1.0), 4)
+            expected = round(jeffreys(k, n), 4)
             if abs(p - expected) > 5e-4:
                 raise bad(
                     f"pattern {name!r} says p={p} but k/n = {k}/{n} gives {expected}. "
                     f"Refit with python -m chemgraph.tools.ocsr_calibrate "
                     f"instead of editing p."
                 )
-        ci = cell.get("ci")
-        if ci is not None:
-            ok = (isinstance(ci, list) and len(ci) == 2
-                  and all(isinstance(b, (int, float)) and not isinstance(b, bool)
-                          and math.isfinite(num(b, f"pattern {name!r} ci"))
-                          and 0.0 <= b <= 1.0
-                          for b in ci))
-            if not ok:
-                # json.loads accepts NaN and Infinity, and a NaN bound compares false
-                # against everything, so a low-n label would silently come out wrong.
-                raise bad(f"pattern {name!r} has a malformed ci: {ci!r}")
-            if ci[0] > ci[1]:
-                raise bad(f"pattern {name!r} has a reversed ci: {ci!r}")
+        check_ci(cell.get("ci"), f"pattern {name!r}")
         label = cell.get("label")
-        if label is not None and not isinstance(label, str):
-            raise bad(f"pattern {name!r} has a non-string label: {label!r}")
+        if label is not None:
+            if not isinstance(label, str):
+                raise bad(f"pattern {name!r} has a non-string label: {label!r}")
+            # Cross-checked against its own p, the way the p is cross-checked
+            # against its own k/n. confidence() returns a stored label verbatim
+            # above the floor, and an agent is told to band on the label, so a
+            # bucket right on 1 of 100 could be labelled unanimous and nothing in
+            # the result would contradict it.
+            p_value = cell.get("p")
+            if isinstance(p_value, (int, float)) and not isinstance(p_value, bool):
+                want = _label_for(p_value)
+                if label != want:
+                    raise bad(f"pattern {name!r} is labelled {label!r} but p="
+                              f"{p_value} bands as {want!r}. Refit rather than "
+                              f"editing the label.")
 
     # Checked here so prior_confidence and model_performance can read it without
     # each guarding separately. A string accuracy used to reach _label_for and raise
@@ -697,23 +818,77 @@ def _validate_calibration(table: object, origin: str) -> dict:
         for name, entry in performance.items():
             if not isinstance(entry, dict):
                 raise bad(f"model_performance.{name} is not an object")
+            # Every field is checked whether or not accuracy is present. Hanging
+            # the rest of this block off accuracy left an entry stating p, k, n and
+            # ci with no accuracy entirely unchecked, and model_performance() is
+            # documented as the one place to ask how good a model is: it handed
+            # back a NaN p and a k larger than its own n.
             accuracy = entry.get("accuracy")
-            if accuracy is None:
-                continue  # unmeasured is allowed; it reports no_prior_for_model
-            if isinstance(accuracy, bool) or not isinstance(accuracy, (int, float)):
-                raise bad(f"model_performance.{name} has a non-numeric accuracy")
-            if not 0.0 <= accuracy <= 1.0:
-                raise bad(f"model_performance.{name} has accuracy={accuracy} "
-                          f"outside [0, 1]")
+            if accuracy is not None:
+                if (isinstance(accuracy, bool)
+                        or not isinstance(accuracy, (int, float))):
+                    raise bad(f"model_performance.{name} has a non-numeric accuracy")
+                if not 0.0 <= accuracy <= 1.0:
+                    raise bad(f"model_performance.{name} has accuracy={accuracy} "
+                              f"outside [0, 1]")
             count = entry.get("n")
-            if count is not None and (isinstance(count, bool)
-                                      or not isinstance(count, int) or count < 0):
-                raise bad(f"model_performance.{name} has an invalid n: {count!r}")
+            if count is not None:
+                if (isinstance(count, bool) or not isinstance(count, int)
+                        or count < 0):
+                    raise bad(f"model_performance.{name} has an invalid n: {count!r}")
+                # Through num() like every other count: it is compared against the
+                # floor and divided into k, and nothing else should have to stay
+                # bounded for that to be safe.
+                num(count, f"model_performance.{name} n")
             # An accuracy backed by nothing is worse than no accuracy: it reads as a
-            # real measurement and there is no field left to signal otherwise.
-            if count == 0:
-                raise bad(f"model_performance.{name} reports an accuracy over 0 "
-                          f"observations; drop the entry or set accuracy to null")
+            # real measurement and there is no field left to signal otherwise. A
+            # missing n is the same case and looked like the safe one: the floor
+            # test in prior_confidence needs an int, so an accuracy with no n skips
+            # the floor entirely and a model measured on seven images reports 1.0
+            # unanimous, which is exactly what the floor exists to prevent.
+            quoted = entry.get("p")
+            if (accuracy is not None or quoted is not None) and count is None:
+                raise bad(f"model_performance.{name} states a number with no 'n', "
+                          f"so no sample floor can apply to it")
+            if count == 0 and (accuracy is not None or quoted is not None):
+                raise bad(f"model_performance.{name} states a number over 0 "
+                          f"observations; drop the entry or set it to null")
+            # k reaches the same arithmetic the pattern cells do, so it needs the
+            # same guard: a 400-digit int is a valid int and then raises
+            # OverflowError from prior_confidence, past every caller's guard.
+            hits = entry.get("k")
+            if hits is not None:
+                if (isinstance(hits, bool) or not isinstance(hits, int)
+                        or hits < 0 or (count is not None and hits > count)):
+                    raise bad(f"model_performance.{name} has an invalid k: {hits!r}")
+                num(hits, f"model_performance.{name} k")
+            # 'p' is the field prior_confidence quotes and accuracy is what the
+            # listing falls back to, so both owe the cross-check the pattern cells'
+            # p owes. k is what makes that check possible, so a stated number
+            # without one cannot be checked and is refused rather than trusted.
+            if quoted is not None:
+                if isinstance(quoted, bool) or not isinstance(quoted, (int, float)):
+                    raise bad(f"model_performance.{name} has a non-numeric p")
+                if not 0.0 <= quoted <= 1.0:
+                    raise bad(f"model_performance.{name} has p={quoted} "
+                              f"outside [0, 1]")
+            if (accuracy is not None or quoted is not None) and hits is None:
+                raise bad(f"model_performance.{name} states a number with no 'k', "
+                          f"so nothing can be checked against it")
+            if hits is not None and count:
+                if accuracy is not None:
+                    want = round(hits / count, 4)
+                    if abs(accuracy - want) > 5e-4:
+                        raise bad(f"model_performance.{name} says accuracy="
+                                  f"{accuracy} but k/n = {hits}/{count} gives "
+                                  f"{want}. Refit rather than editing accuracy.")
+                if quoted is not None:
+                    want = round(jeffreys(hits, count), 4)
+                    if abs(quoted - want) > 5e-4:
+                        raise bad(f"model_performance.{name} says p={quoted} but "
+                                  f"Jeffreys on {hits}/{count} gives {want}. Refit "
+                                  f"rather than editing p.")
+            check_ci(entry.get("ci"), f"model_performance.{name}")
     return table
 
 
@@ -732,6 +907,8 @@ def tie_break_order(table: dict) -> list[str]:
     rejects it, because falling back would silently vote one way while quoting a
     number measured the other way.
     """
+    if not isinstance(table, dict):
+        return []
     order = _parse_tie_break(table.get("tie_break"))
     return order if order is not None else list(table.get("committee") or [])
 
@@ -780,13 +957,29 @@ def confidence(pattern: str | None, table: dict) -> dict:
     if pattern is None:
         return {"p": None, "label": "unavailable", "n": 0, "ci": None,
                 "reason": "no_prediction"}
+    # Public, so it is reachable with a table that never went through the validator.
+    # A None here used to raise AttributeError from inside a lookup.
+    if not isinstance(table, dict):
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "no_calibration_table"}
 
     entry = (table.get("patterns") or {}).get(pattern)
     if entry is None:
         return {"p": None, "label": "unknown", "n": 0, "ci": None,
                 "reason": "unknown_pattern"}
+    # The table guard above covers the table; the bucket needs its own, for the
+    # same reason: unvalidated, a non-object cell raises out of the lookup.
+    if not isinstance(entry, dict):
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "unusable_bucket"}
 
     p, n, ci = entry.get("p"), entry.get("n", 0), entry.get("ci")
+    # The validator rejects a non-integer or negative n, and this function is public,
+    # so an unvalidated table can still reach the arithmetic below where n == -1
+    # makes the Jeffreys denominator zero.
+    if isinstance(n, bool) or not isinstance(n, int) or n < 0:
+        return {"p": None, "label": "unavailable", "n": 0, "ci": None,
+                "reason": "unusable_bucket"}
     # Honour the floor the table declares, not only the producer's decision to leave
     # p out. A table written by hand, or fitted with a --min-n lower than the one
     # recorded, can carry a point estimate over a handful of images; quoting it
@@ -812,7 +1005,7 @@ def confidence(pattern: str | None, table: dict) -> dict:
         # report "unanimous" from four images, which is the claim the floor exists
         # to refuse, and the low_n_ prefix a caller bands on would be missing.
         k = entry.get("k")
-        est = ((k + 0.5) / (n + 1.0)) if (k is not None and n) else (ci[0] if ci else 0.0)
+        est = jeffreys(k, n) if (k is not None and n) else (ci[0] if ci else 0.0)
         label = _label_for(est, low_n=True)
         return {"p": None, "label": label, "n": n, "ci": ci,
                 "reason": "below_n_floor"}
@@ -848,11 +1041,37 @@ def prior_confidence(model: str, table: dict | None = None) -> dict:
                 "reason": f"calibration_unreadable: {type(exc).__name__}"}
 
     entry = (t.get("model_performance") or {}).get(bare)
-    if not entry or entry.get("accuracy") is None:
+    # Whichever field is quoted below, not accuracy alone. accuracy is the record of
+    # what was counted and nothing requires it, so an entry stating only p reported
+    # no prior at all: unavailable from the tool, n=0 for a model measured on 722
+    # images, and a listing claiming the table measured it on too few.
+    if not entry or (entry.get("p") is None and entry.get("accuracy") is None):
         return {"p": None, "label": "unavailable", "n": 0, "ci": None,
                 "reason": "no_prior_for_model"}
-    p = entry["accuracy"]
-    return {"p": p, "label": _label_for(p), "n": entry.get("n", 0),
+    # 'p' is the quotable estimate the fitter wrote, Jeffreys like every pattern
+    # cell. 'accuracy' is the raw rate and stays the record of what was counted, so
+    # a table without a p (hand-written, or fitted before the field existed) still
+    # reports something rather than nothing.
+    p = entry["p"] if entry.get("p") is not None else entry["accuracy"]
+    n, k = entry.get("n"), entry.get("k")
+    # The same floor the agreement buckets are held to, and the same estimator below
+    # it. An accuracy is fitted from the same images by the same run, so a table that
+    # withholds a bucket's number over three images cannot quote a solo accuracy over
+    # those same three, and cannot call it unanimous either: raw k/n is what the
+    # Jeffreys rule exists to replace.
+    #
+    # n is always present alongside an accuracy: the validator rejects an entry
+    # without one, because a missing n skips this comparison and reports the floor's
+    # opposite. The isinstance guards stay because this function is public and a
+    # caller can hand it a dict that never went through the validator.
+    floor = t.get("min_n_for_point_estimate")
+    if (isinstance(n, int) and not isinstance(n, bool)
+            and isinstance(floor, (int, float)) and not isinstance(floor, bool)
+            and n < floor):
+        est = jeffreys(k, n) if isinstance(k, int) and not isinstance(k, bool) else p
+        return {"p": None, "label": _label_for(est, low_n=True), "n": n,
+                "ci": entry.get("ci"), "reason": "below_n_floor"}
+    return {"p": p, "label": _label_for(p), "n": n if n is not None else 0,
             "ci": entry.get("ci"), "reason": None}
 
 

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -14,7 +14,9 @@ RDKit is a core ChemGraph dependency and is imported lazily here regardless.
 
 from __future__ import annotations
 
+import json
 import logging
+import math
 import os
 import re
 import stat
@@ -495,3 +497,241 @@ def vote(results: list[dict], priority: list[str] | None = None) -> dict:
         "committee": committee,
         "voters": [m for models in groups.values() for m in models],
     }
+
+
+
+def load_calibration(path: str | None = None) -> dict:
+    """Load a calibration table: explicit path, then env var, then the packaged default.
+
+    The packaged default describes the four-model committee on RDKit-rendered images
+    and is what makes ``backend="ensemble"`` work with no configuration. Anyone who
+    builds their own table with the recalibration script points at it here.
+
+    A table drives which answers get a confidence, so a malformed one is rejected on
+    load rather than silently producing wrong numbers deep in a run.
+    """
+    candidate = path or os.environ.get("CHEMGRAPH_OCSR_CALIBRATION")
+    if candidate:
+        resolved = os.path.expanduser(candidate)
+        # A FIFO here blocks open() forever with no caller-side timeout, the same
+        # reason load_image_bytes checks. Callers of this function have usually just
+        # spent real inference time and must not hang holding the result.
+        if not stat.S_ISREG(os.lstat(resolved).st_mode):
+            raise ValueError(f"calibration table is not a regular file: {resolved}")
+        with open(resolved) as fh:
+            return _validate_calibration(_load_json(fh, resolved), resolved)
+
+    from importlib import resources
+
+    # importlib.resources, not a __file__-relative path: the latter works under
+    # `pip install -e` and silently fails on a normal install.
+    ref = resources.files("chemgraph.tools").joinpath("ocsr_calibration_4model.json")
+    with ref.open() as fh:
+        return _validate_calibration(_load_json(fh, "packaged default"), "packaged default")
+
+
+def _load_json(fh, origin: str) -> object:
+    """json.load, with every failure normalised to ValueError.
+
+    Callers guard on (OSError, ValueError, TypeError) so that a bad table costs the
+    confidence and not the prediction. json.load can also raise RecursionError on a
+    deeply nested file, which slipped past all of them and discarded a completed
+    ensemble run.
+    """
+    try:
+        return json.load(fh)
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError(f"could not parse {origin}: {type(exc).__name__}") from None
+
+
+def _validate_calibration(table: object, origin: str) -> dict:
+    """Reject a table that cannot mean what a caller will assume it means."""
+    def bad(why: str) -> ValueError:
+        return ValueError(f"calibration table {origin!r} is unusable: {why}")
+
+    # Arithmetic below converts to float, and an int with hundreds of digits raises
+    # OverflowError, which is neither ValueError nor TypeError and so escaped every
+    # guard in the call chain.
+    def num(value: object, field: str) -> float:
+        try:
+            return float(value)
+        except (OverflowError, ValueError, TypeError):
+            raise bad(f"{field} is not a usable number: {value!r}") from None
+
+    if not isinstance(table, dict):
+        raise bad(f"top level is {type(table).__name__}, expected an object")
+    committee = table.get("committee")
+    if not isinstance(committee, list) or not all(isinstance(m, str) for m in committee):
+        raise bad("'committee' must be a list of model names")
+    # An empty committee disables check_committee, which only compares when both sides
+    # are non-empty, so every mismatch would pass and any table would apply anywhere.
+    if not committee:
+        raise bad("'committee' is empty, which would disable the committee check")
+    # check_committee compares sorted name lists, so a duplicate makes a table that
+    # can never match any real run and reports committee_mismatch forever.
+    if len(set(committee)) != len(committee):
+        raise bad(f"'committee' repeats a model: {committee}")
+    # A tie_break that does not parse, or that does not name exactly the committee,
+    # would fall back to the committee's arbitrary JSON order: the tool would vote one
+    # way and quote a number measured the other way, with nothing in the result to
+    # show it. Reject at load instead.
+    recorded = table.get("tie_break")
+    if recorded is not None:
+        order = _parse_tie_break(recorded)
+        if sorted(order) != sorted(committee):
+            raise bad(
+                f"'tie_break' must name exactly the committee, most accurate first. "
+                f"Committee: {committee}. Parsed from tie_break: {order}. Expected "
+                f"the form 'model-priority: a,b,c'."
+            )
+
+    # Checked because confidence() acts on it: an unusable value silently disables
+    # the floor, and the table would quote a point estimate from a handful of images
+    # while recording that it does not.
+    declared = table.get("min_n_for_point_estimate")
+    # isfinite for the same reason the ci check uses it: json accepts NaN and
+    # Infinity, NaN < anything is False so the floor would never fire, and inf
+    # fires on every bucket however large.
+    if declared is not None and (isinstance(declared, bool)
+                                 or not isinstance(declared, (int, float))
+                                 or not math.isfinite(declared)
+                                 or declared < 0):
+        raise bad(f"'min_n_for_point_estimate' must be a non-negative number: "
+                  f"{declared!r}")
+
+    patterns = table.get("patterns")
+    if not isinstance(patterns, dict) or not patterns:
+        raise bad("'patterns' must be a non-empty object")
+
+    size = len(committee)
+    for name, cell in patterns.items():
+        if not isinstance(cell, dict):
+            raise bad(f"pattern {name!r} is not an object")
+        try:
+            parts = [int(x) for x in str(name).split("/")]
+        except ValueError:
+            raise bad(f"pattern {name!r} is not slash-separated integers") from None
+        # int() accepts a leading minus and unicode digits, so the sum check below is
+        # not enough on its own: "2/-1" sums to 1 and would pass for a one-model
+        # committee. A part is a count of models agreeing, so it is at least 1.
+        if any(p < 1 for p in parts):
+            raise bad(f"pattern {name!r} has a part below 1; each part counts models")
+        # A pattern whose parts do not sum to the committee size means the table was
+        # fit under a different abstention rule; its buckets would not line up with
+        # what vote() produces, and every lookup would quietly miss or mismatch.
+        if sum(parts) != size:
+            raise bad(f"pattern {name!r} sums to {sum(parts)}, committee has {size} models")
+        k, n = cell.get("k"), cell.get("n")
+        if (isinstance(k, bool) or isinstance(n, bool)
+                or not isinstance(n, int) or n < 0
+                or not isinstance(k, int) or not 0 <= k <= n):
+            raise bad(f"pattern {name!r} has invalid k/n: {k!r}/{n!r}")
+        # Not covered by the isinstance checks above: a 400-digit int is a valid
+        # int and satisfies 0 <= k <= n, but the arithmetic below and in confidence()
+        # converts to float, where it raises OverflowError. That is neither ValueError
+        # nor TypeError, so it escapes every caller's guard.
+        num(k, f"pattern {name!r} k")
+        num(n, f"pattern {name!r} n")
+        # A quotable number from no observations at all: (0+0.5)/(0+1) == 0.5 makes
+        # the consistency check below pass, so it has to be caught here.
+        if n == 0 and cell.get("p") is not None:
+            raise bad(f"pattern {name!r} quotes p over 0 observations")
+
+        # p, ci and label are what a caller acts on, so check them here. Left
+        # unchecked, a string p reached _label_for and raised TypeError deep inside a
+        # lookup, and a p that simply disagreed with its own k and n was returned as
+        # a confident answer with nothing to reveal the contradiction.
+        p = cell.get("p")
+        if p is not None:
+            if isinstance(p, bool) or not isinstance(p, (int, float)):
+                raise bad(f"pattern {name!r} has a non-numeric p: {p!r}")
+            if not 0.0 <= p <= 1.0:
+                raise bad(f"pattern {name!r} has p={p} outside [0, 1]")
+            expected = round((k + 0.5) / (n + 1.0), 4)
+            if abs(p - expected) > 5e-4:
+                raise bad(
+                    f"pattern {name!r} says p={p} but k/n = {k}/{n} gives {expected}. "
+                    f"Refit with python -m chemgraph.tools.ocsr_calibrate "
+                    f"instead of editing p."
+                )
+        ci = cell.get("ci")
+        if ci is not None:
+            ok = (isinstance(ci, list) and len(ci) == 2
+                  and all(isinstance(b, (int, float)) and not isinstance(b, bool)
+                          and math.isfinite(num(b, f"pattern {name!r} ci"))
+                          and 0.0 <= b <= 1.0
+                          for b in ci))
+            if not ok:
+                # json.loads accepts NaN and Infinity, and a NaN bound compares false
+                # against everything, so a low-n label would silently come out wrong.
+                raise bad(f"pattern {name!r} has a malformed ci: {ci!r}")
+            if ci[0] > ci[1]:
+                raise bad(f"pattern {name!r} has a reversed ci: {ci!r}")
+        label = cell.get("label")
+        if label is not None and not isinstance(label, str):
+            raise bad(f"pattern {name!r} has a non-string label: {label!r}")
+
+    # Checked here so prior_confidence and model_performance can read it without
+    # each guarding separately. A string accuracy used to reach _label_for and raise
+    # TypeError from inside a lookup, naming neither the table nor the field.
+    performance = table.get("model_performance")
+    if performance is not None:
+        if not isinstance(performance, dict):
+            raise bad("'model_performance' must be an object keyed by model name")
+        for name, entry in performance.items():
+            if not isinstance(entry, dict):
+                raise bad(f"model_performance.{name} is not an object")
+            accuracy = entry.get("accuracy")
+            if accuracy is None:
+                continue  # unmeasured is allowed; it reports no_prior_for_model
+            if isinstance(accuracy, bool) or not isinstance(accuracy, (int, float)):
+                raise bad(f"model_performance.{name} has a non-numeric accuracy")
+            if not 0.0 <= accuracy <= 1.0:
+                raise bad(f"model_performance.{name} has accuracy={accuracy} "
+                          f"outside [0, 1]")
+            count = entry.get("n")
+            if count is not None and (isinstance(count, bool)
+                                      or not isinstance(count, int) or count < 0):
+                raise bad(f"model_performance.{name} has an invalid n: {count!r}")
+            # An accuracy backed by nothing is worse than no accuracy: it reads as a
+            # real measurement and there is no field left to signal otherwise.
+            if count == 0:
+                raise bad(f"model_performance.{name} reports an accuracy over 0 "
+                          f"observations; drop the entry or set accuracy to null")
+    return table
+
+
+def tie_break_order(table: dict) -> list[str]:
+    """The model priority a table was fitted under, from its own tie_break field.
+
+    The order decides which answer wins a tie, so it decides what the all-different
+    bucket's accuracy actually measures. Using the registry's order instead of the
+    table's would attach a number measured for one model's answer to a different
+    model's answer, and check_committee cannot see it because it compares sorted
+    names.
+
+    A table with no tie_break falls back to its committee order, which is the best
+    available guess for a table written before the field existed. A table whose
+    tie_break is present but unusable never reaches here: _validate_calibration
+    rejects it, because falling back would silently vote one way while quoting a
+    number measured the other way.
+    """
+    order = _parse_tie_break(table.get("tie_break"))
+    return order if order is not None else list(table.get("committee") or [])
+
+
+def _parse_tie_break(value: object) -> list[str] | None:
+    """Model names from a tie_break string, or None when there is nothing to parse.
+
+    An unparseable field returns an empty list, which _validate_calibration rejects
+    because it cannot name the committee. A table therefore only reaches
+    :func:`tie_break_order` with a usable order or with none recorded at all.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str) or "model-priority:" not in value:
+        return []
+    _, _, names = value.partition("model-priority:")
+    return [n.strip() for n in names.split(",") if n.strip()]

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -863,3 +863,44 @@ def model_performance(model: str, table: dict | None = None) -> dict:
     except (OSError, ValueError, TypeError):
         return {}
     return dict((t.get("model_performance") or {}).get(model.removeprefix("local:")) or {})
+
+
+def check_committee(vote_result: dict, table: dict) -> str | None:
+    """Return a reason string if the table does not describe this committee, else None.
+
+    Compares the models that were *asked*, not the ones that voted, since abstention
+    is normal and does not change which table applies.
+    """
+    ran = sorted(vote_result.get("committee") or [])
+    fit = sorted(table.get("committee") or [])
+    if not ran or not fit or ran == fit:
+        return None
+
+    # Name the missing models and how to get them. A partial install is the common
+    # case here, and "committee_mismatch: [...] vs [...]" tells a user their answer
+    # has no confidence without telling them what to do about it.
+    absent = [m for m in fit if m not in ran]
+    extra = [m for m in ran if m not in fit]
+    if absent and not extra:
+        return (
+            f"committee_mismatch: the table was fit on {fit} and this machine ran "
+            f"{ran}, so no calibrated number applies. Install the rest with: "
+            f"pip install 'chemgraph[ocsr]'; or refit for the models you have with "
+            f"python -m chemgraph.tools.ocsr_calibrate --labels YOUR_LABELS.csv "
+            f"--models {','.join(ran)}"
+        )
+    if extra and not absent:
+        return (
+            f"committee_mismatch: the table was fit on {fit} and this machine ran "
+            f"the larger set {ran}. Vote only the committee the table describes with "
+            f"models_wanted={fit}."
+        )
+    # Both sets differ. Neither installing nor subsetting alone fixes it, so name the
+    # only two things that do.
+    return (
+        f"committee_mismatch: the table was fit on {fit} and this machine ran {ran}, "
+        f"which is a different set, so no calibrated number applies. Either install "
+        f"{', '.join(absent)} and vote the table's committee, or refit for what you "
+        f"have with python -m chemgraph.tools.ocsr_calibrate --labels YOUR_LABELS.csv "
+        f"--models {','.join(ran)}"
+    )

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -45,6 +45,7 @@ _MAX_SMILES_CHARS = 4000
 # deserve a decimal.
 _LABEL_BANDS = ((0.99, "unanimous"), (0.95, "strong"), (0.70, "weak"))
 
+
 # The optional quotes around the key let a JSON reply be read at the line level:
 # '"smiles": "CCO"' is the single most common structured form a vision LLM returns,
 # and reaching it here keeps the word-by-word fallback from matching an element
@@ -384,8 +385,11 @@ def build_result(**overrides) -> dict:
     never has to test for a missing key. The docstring of ``image_to_smiles`` promises
     these exact fields; changing the set means changing both together.
 
-    The committee keys (agreement, votes, abstained) belong to the ensemble work and
-    are not part of this contract; a single model has nothing to report for them.
+    The committee keys stay None outside an ensemble call, where a single model has
+    nothing to report: it produced one answer and there is no agreement to measure.
+    A single model still carries no per-image confidence, so ``confidence`` is None
+    there and ``confidence_unavailable_reason`` says why; :func:`prior_confidence`
+    is the way to ask how accurate that model is in general.
     """
     result = {
         "ok": False,
@@ -393,18 +397,25 @@ def build_result(**overrides) -> dict:
         "valid": False,
         "formula": None,
         "n_fragments": 0,
+        "confidence": None,
+        "confidence_interval": None,
+        "confidence_label": "unavailable",
+        "confidence_unavailable_reason": None,
+        "agreement": None,
+        "backend_used": None,
         "model_used": None,
         "cold_start": False,
         "latency_s": 0.0,
         "error": "",
         "warning": "",
+        "votes": None,
+        "abstained": None,
     }
     unknown = set(overrides) - set(result)
     if unknown:
         raise KeyError(f"not part of the OCSR result contract: {sorted(unknown)}")
     result.update(overrides)
     return result
-
 
 
 def fragment_warning(validation: dict) -> str:
@@ -418,7 +429,6 @@ def fragment_warning(validation: dict) -> str:
         return ""
     return (f"the image contains {n} disconnected fragments (a salt, a mixture, or "
             f"a reaction scheme). Ask which one is meant before using this SMILES.")
-
 
 
 def vote(results: list[dict], priority: list[str] | None = None) -> dict:
@@ -502,7 +512,6 @@ def vote(results: list[dict], priority: list[str] | None = None) -> dict:
         "committee": committee,
         "voters": [m for models in groups.values() for m in models],
     }
-
 
 
 def load_calibration(path: str | None = None) -> dict:
@@ -742,7 +751,6 @@ def _parse_tie_break(value: object) -> list[str] | None:
     return [n.strip() for n in names.split(",") if n.strip()]
 
 
-
 def _label_for(p: float, low_n: bool = False) -> str:
     """Map a probability to a coarse label, prefixed when the bucket is small."""
     name = "conflicting"
@@ -751,7 +759,6 @@ def _label_for(p: float, low_n: bool = False) -> str:
             name = band
             break
     return f"low_n_{name}" if low_n else name
-
 
 
 def confidence(pattern: str | None, table: dict) -> dict:
@@ -813,7 +820,6 @@ def confidence(pattern: str | None, table: dict) -> dict:
             "reason": None}
 
 
-
 def prior_confidence(model: str, table: dict | None = None) -> dict:
     """Confidence for a single-model backend, from that model's measured solo accuracy.
 
@@ -848,7 +854,6 @@ def prior_confidence(model: str, table: dict | None = None) -> dict:
     p = entry["accuracy"]
     return {"p": p, "label": _label_for(p), "n": entry.get("n", 0),
             "ci": entry.get("ci"), "reason": None}
-
 
 
 def model_performance(model: str, table: dict | None = None) -> dict:

--- a/src/chemgraph/tools/ocsr_core.py
+++ b/src/chemgraph/tools/ocsr_core.py
@@ -399,3 +399,99 @@ def build_result(**overrides) -> dict:
     return result
 
 
+
+def fragment_warning(validation: dict) -> str:
+    """The caveat for a result holding more than one molecule, or "" for one.
+
+    Both backends return it, so the text lives here: an agent that learns to act on
+    the single-model wording must see the same words from a committee.
+    """
+    n = validation.get("n_fragments", 0)
+    if n <= 1:
+        return ""
+    return (f"the image contains {n} disconnected fragments (a salt, a mixture, or "
+            f"a reaction scheme). Ask which one is meant before using this SMILES.")
+
+
+
+def vote(results: list[dict], priority: list[str] | None = None) -> dict:
+    """Group specialist predictions and report the agreement pattern.
+
+    Predictions are canonicalized before grouping, so the same molecule written two
+    ways counts once.
+
+    ``committee`` is every model that was asked; ``voters`` is the subset that
+    returned a parseable SMILES. An abstention counts as a dissenting vote: a model
+    that ran and produced garbage contributes one singleton, so the pattern's parts
+    always sum to the committee size. Four models can only ever produce "4", "3/1",
+    "2/1/1", "2/2", or "1/1/1/1".
+
+    Dropping abstainers and shrinking the pattern was measured on 722 benchmark items
+    and rejected. It split the same situations across eleven buckets instead of five,
+    putting 12% of items below the sample floor where no number can be quoted, against
+    2% under this rule.
+
+    Parameters
+    ----------
+    results : list[dict]
+        One entry per model: ``{"model", "smiles", "ok"}``.
+    priority : list[str], optional
+        Tie-break order, strongest model first. Defaults to the order given.
+
+    Returns
+    -------
+    dict
+        pattern, winner, votes, abstained, committee, voters
+    """
+    def _bare(name: str) -> str:
+        return name.removeprefix("local:")
+
+    committee = [_bare(r.get("model") or "") for r in results]
+    order = [_bare(m) for m in (priority or committee)]
+
+    groups: dict[str, list[str]] = {}
+    abstained: dict[str, str] = {}
+    # Counted separately from the dict: two results carrying the same model name
+    # collapse to one dict key and would drop a singleton from the pattern.
+    n_abstained = 0
+    for r in results:
+        model = _bare(r.get("model") or "")
+        canon = canonicalize(r.get("smiles")) if r.get("ok", True) else None
+        if canon is None:
+            abstained[model] = str(r.get("smiles") or r.get("error") or "")[:80]
+            n_abstained += 1
+            continue
+        groups.setdefault(canon, []).append(model)
+
+    if not groups:
+        # Every model failed. Reporting all-singletons keeps the item in the evidence,
+        # where it counts against that bucket, instead of flattering every other row.
+        return {
+            "pattern": "/".join("1" * len(committee)) if committee else None,
+            "winner": None,
+            "votes": {},
+            "abstained": abstained,
+            "committee": committee,
+            "voters": [],
+        }
+
+    counts = sorted([len(v) for v in groups.values()] + [1] * n_abstained, reverse=True)
+    top = max(len(v) for v in groups.values())
+    tied = [smi for smi, models in groups.items() if len(models) == top]
+    if len(tied) > 1:
+        # Deterministic tie-break by model priority, so an all-different pattern
+        # reports the strongest model's answer and that bucket's measured accuracy is
+        # really that model's solo accuracy. Resolved over the groups, so a model
+        # whose output failed to parse cannot decide the answer.
+        winner = next((smi for m in order for smi in tied if m in groups[smi]), tied[0])
+    else:
+        winner = tied[0]
+
+    return {
+        "pattern": "/".join(str(c) for c in counts),
+        "winner": winner,
+        "votes": groups,
+        "abstained": abstained,
+        "committee": committee,
+        "voters": [m for models in groups.values() for m in models],
+    }

--- a/src/chemgraph/tools/ocsr_models.py
+++ b/src/chemgraph/tools/ocsr_models.py
@@ -107,20 +107,45 @@ LLM_MODEL = "llm"
 MODEL_CHOICES = (*SPECIALIST_MODELS, LLM_MODEL)
 
 
-def describe_models(installed: list[str] | None = None) -> str:
+def describe_models(installed: list[str] | None = None,
+                    measured: dict[str, dict] | None = None,
+                    ready: list[str] | None = None) -> str:
     """A human-readable listing of the models, for docs and error messages.
 
     ``installed`` marks which ones are importable here. Pass
     :func:`chemgraph.tools.ocsr_backends.available_specialists`; it lives there
     because probing imports is not this module's job.
+
+    ``measured`` supplies accuracies from a calibration table, so a user who refit
+    on their own images is shown their own numbers. Omitting it falls back to the
+    registry's figures, which were measured on the shipped benchmark.
+
+    ``ready`` names the ones whose checkpoint is also present. Three of the four
+    need a download the extra cannot do, so "installed" alone tells a user their
+    setup is finished when the next call will still fail. Pass
+    :func:`chemgraph.tools.ocsr_backends.usable_specialists`.
     """
     installed = set(installed or [])
+    ready = set(ready) if ready is not None else installed
+    measured = measured or {}
     lines = ["OCSR models (model=):"]
     for name, m in SPECIALIST_MODELS.items():
-        mark = "installed" if name in installed else "not installed"
+        if name not in installed:
+            mark = "not installed"
+        elif name in ready:
+            mark = "ready"
+        else:
+            mark = "installed, checkpoint missing"
         default = " [default]" if name == DEFAULT_SPECIALIST else ""
-        accuracy = m.get("accuracy")
-        score = f"{accuracy:.3f} exact match" if accuracy is not None else "unmeasured"
+        # Mark which source each number came from. A table covering a subset of the
+        # installed models leaves the rest on the registry's figures, and a listing
+        # mixing the two without saying so cannot be read: the model labelled most
+        # accurate can show the lowest number.
+        refit = (measured.get(name) or {}).get("accuracy")
+        accuracy = refit if refit is not None else m.get("accuracy")
+        source = " (your table)" if refit is not None else ""
+        score = (f"{accuracy:.3f} exact match{source}" if accuracy is not None
+                 else "unmeasured")
         latency = m.get("latency_s")
         speed = f", {latency:g}s/image" if latency else ""
         lines.append(f"  {name}{default}: {score}{speed} ({mark})")

--- a/src/chemgraph/tools/ocsr_models.py
+++ b/src/chemgraph/tools/ocsr_models.py
@@ -141,11 +141,23 @@ def describe_models(installed: list[str] | None = None,
         # installed models leaves the rest on the registry's figures, and a listing
         # mixing the two without saying so cannot be read: the model labelled most
         # accurate can show the lowest number.
-        refit = (measured.get(name) or {}).get("accuracy")
+        # An entry present with a null accuracy is a table that measured this model
+        # and withheld the figure, which is not the same as a table that does not
+        # cover it. Falling back to the registry there would print the packaged
+        # benchmark number for a user whose own data says too little to quote one.
+        entry = measured.get(name)
+        refit = (entry or {}).get("accuracy")
+        # bool(entry), since model_performance returns {} for a model the table does
+        # not cover and `{} is not None` would call every one of them measured.
+        withheld = bool(entry) and refit is None
         accuracy = refit if refit is not None else m.get("accuracy")
         source = " (your table)" if refit is not None else ""
-        score = (f"{accuracy:.3f} exact match{source}" if accuracy is not None
-                 else "unmeasured")
+        if withheld:
+            score = "measured on too few images to quote (your table)"
+        elif accuracy is not None:
+            score = f"{accuracy:.3f} exact match{source}"
+        else:
+            score = "unmeasured"
         latency = m.get("latency_s")
         speed = f", {latency:g}s/image" if latency else ""
         lines.append(f"  {name}{default}: {score}{speed} ({mark})")

--- a/src/chemgraph/tools/ocsr_registry.json
+++ b/src/chemgraph/tools/ocsr_registry.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "_comment": "OCSR specialist models. All four install from the ocsr extra into ChemGraph's own environment; see examples/ocsr/README.md. accuracy is exact match over the 722-image benchmark (n=722 for each). import_name is what ocsr_backends probes to decide whether a model is installed. weights is where a checkpoint is cached and download is the command that fetches it, which the missing-checkpoint error quotes; DECIMER manages its own cache and has neither.",
+  "_comment": "OCSR specialist models. All four install from the ocsr extra into ChemGraph's own environment; see examples/ocsr/README.md. accuracy is exact match over the 722-image benchmark (n=722 for each), the raw rate; the tool quotes the calibration table's Jeffreys estimate instead and falls back to this only for a model the table does not cover. import_name is what ocsr_backends probes to decide whether a model is installed. weights is where a checkpoint is cached and download is the command that fetches it, which the missing-checkpoint error quotes; DECIMER manages its own cache and has neither.",
   "specialists": {
     "decimer": {
       "import_name": "DECIMER",

--- a/src/chemgraph/tools/ocsr_registry.json
+++ b/src/chemgraph/tools/ocsr_registry.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "_comment": "OCSR specialist models. All four install from the ocsr extra into ChemGraph's own environment; see examples/ocsr/README.md. accuracy is exact match over the 722-image benchmark (n=722 for each). import_name is what ocsr_backends probes to decide whether a model is installed. weights is where a checkpoint is cached; DECIMER manages its own cache and has none.",
+  "_comment": "OCSR specialist models. All four install from the ocsr extra into ChemGraph's own environment; see examples/ocsr/README.md. accuracy is exact match over the 722-image benchmark (n=722 for each). import_name is what ocsr_backends probes to decide whether a model is installed. weights is where a checkpoint is cached and download is the command that fetches it, which the missing-checkpoint error quotes; DECIMER manages its own cache and has neither.",
   "specialists": {
     "decimer": {
       "import_name": "DECIMER",
@@ -16,7 +16,8 @@
       "note": "Second by exact match. Needs the timm compatibility shim.",
       "install": {
         "weights": "~/ocsr-weights/molnextr/molnextr_best.pth",
-        "weights_gb": 1.1
+        "weights_gb": 1.1,
+        "download": "hf download CYF200127/MolNexTR molnextr_best.pth --repo-type dataset"
       }
     },
     "molscribe": {
@@ -26,7 +27,8 @@
       "note": "Needs the timm compatibility shim.",
       "install": {
         "weights": "~/ocsr-weights/molscribe/swin_base_char_aux_1m.pth",
-        "weights_gb": 1.1
+        "weights_gb": 1.1,
+        "download": "hf download yujieq/MolScribe swin_base_char_aux_1m.pth"
       }
     },
     "ocsrglyph": {
@@ -36,7 +38,8 @@
       "note": "Fastest of the four. Lowest exact match on this benchmark.",
       "install": {
         "weights": "~/ocsr-weights/ocsrglyph/model.pth",
-        "weights_gb": 0.37
+        "weights_gb": 0.37,
+        "download": "hf download EdisonScientific/OCSRGlyph model.pth"
       }
     }
   },

--- a/src/chemgraph/tools/ocsr_tools.py
+++ b/src/chemgraph/tools/ocsr_tools.py
@@ -56,6 +56,42 @@ def _resolve_model(model: str | None) -> tuple[str, str]:
     return name, ""
 
 
+def _validate_models_wanted(wanted, installed: list[str]) -> str:
+    """Return an error string for an unusable models_wanted, or "" when it is fine.
+
+    A bare string iterates per character, and a non-string element blows up the join
+    below with a TypeError naming neither the argument nor the valid names. An empty
+    list is a caller who filtered down to nothing, which must not silently become
+    "run everything".
+    """
+    choices = ", ".join(models.SPECIALIST_MODELS)
+    if isinstance(wanted, str) or not isinstance(wanted, (list, tuple, set, frozenset)):
+        return (f"models_wanted must be a list of specialist names, got "
+                f"{type(wanted).__name__}. Choose from: {choices}")
+    if not wanted:
+        return (f"models_wanted is empty. Omit it to vote every installed "
+                f"specialist, or name some of: {choices}")
+    unknown = [m for m in wanted if m not in models.SPECIALIST_MODELS]
+    if unknown:
+        return (f"not OCSR specialists: {', '.join(repr(m) for m in unknown)}. "
+                f"Choose from: {choices}")
+    absent = [m for m in wanted if m not in installed]
+    if absent:
+        return (f"requested but not installed: {', '.join(absent)}. Install with: "
+                f"pip install 'chemgraph[ocsr]'")
+    return ""
+
+
+def _trim(text: str, limit: int = 400) -> str:
+    """Cap a message assembled from backend errors.
+
+    Every warning the tool produces is bounded except this one: the errors are
+    joined from as many models as ran, and a long weights directory pushed one past
+    6 kB in testing. The whole result dict goes back into an agent's context.
+    """
+    return text if len(text) <= limit else text[:limit - 3] + "..."
+
+
 def _prior_label(model: str, calibration: str | None) -> str:
     """Band a model's measured accuracy, from the table the caller named.
 
@@ -69,6 +105,154 @@ def _prior_label(model: str, calibration: str | None) -> str:
     except (OSError, ValueError, TypeError):
         return "unavailable"
     return core.prior_confidence(model, table)["label"]
+
+
+def _run_ensemble(resolved: str, calibration: str | None,
+                  models_wanted: list[str] | None) -> dict:
+    """Vote a committee of specialists and attach a calibrated confidence.
+
+    Runs every installed specialist unless ``models_wanted`` names a subset. A subset
+    is worth supporting because the committee is what a table describes: someone who
+    has all four installed but fitted a table on two of them can only get a number by
+    running exactly those two.
+    """
+    installed = backends.available_specialists()
+    if not installed:
+        return core.build_result(
+            ok=False, backend_used="none", error=backends._install_hint(),
+            confidence_unavailable_reason="no_specialists_installed",
+        )
+
+    if models_wanted is not None:
+        error = _validate_models_wanted(models_wanted, installed)
+        if error:
+            return core.build_result(ok=False, backend_used="ensemble", error=error)
+        installed = [m for m in installed if m in models_wanted]
+
+    results, absent, cold, total = [], [], False, 0.0
+    for name in installed:
+        r = backends.smiles_from_specialist(name, resolved)
+        cold = cold or r["cold_start"]
+        total += r["latency_s"]
+        if not r.get("ran", True):
+            # It never saw the image: no checkpoint, or the load failed. Voting it
+            # as a dissenting singleton would read as disagreement about the
+            # picture, and a table fit on four working models would score three
+            # such entries at the all-different rate. Drop it from the committee
+            # and let check_committee report the smaller set.
+            absent.append((name, r["error"]))
+            continue
+        results.append({"model": name, "smiles": r["smiles"], "ok": r["ok"],
+                        "error": r["error"]})
+
+    if not results:
+        # A separate reason from no_specialists_installed: the extra is installed
+        # here and the remedy is whatever each error names, usually a checkpoint to
+        # download. Telling this caller to pip install would send them to a no-op.
+        return core.build_result(
+            ok=False, backend_used="ensemble", cold_start=cold,
+            latency_s=round(total, 3),
+            error="no specialist could run: " + "; ".join(
+                f"{n}: {e}" for n, e in absent),
+            confidence_unavailable_reason="no_specialist_could_run",
+        )
+
+    # Load before voting: the table records the model priority it was fitted under,
+    # and that order decides which answer wins a tie. Voting by the registry's order
+    # would attach a number measured for one model's answer to a different model's
+    # answer, which check_committee cannot detect because it compares sorted names.
+    # A typo in the path must still not throw the prediction away, so an unreadable
+    # table falls back to the registry order and reports no confidence.
+    try:
+        table = core.load_calibration(calibration)
+    except (OSError, ValueError, TypeError) as exc:
+        table, unreadable = None, f"calibration_unreadable: {type(exc).__name__}"
+    else:
+        unreadable = None
+
+    priority = core.tie_break_order(table) if table else list(models.SPECIALIST_MODELS)
+    v = core.vote(results, priority=priority)
+    if v["winner"] is None:
+        return core.build_result(
+            ok=False, backend_used="ensemble", cold_start=cold,
+            latency_s=round(total, 3), abstained=v["abstained"],
+            error="every specialist failed or returned an unparseable SMILES",
+            confidence_unavailable_reason="no_prediction",
+        )
+
+    mismatch = None if table is None else core.check_committee(v, table)
+    if unreadable:
+        conf = {"p": None, "label": "unavailable", "reason": unreadable}
+    elif mismatch:
+        # Do not silently drop the confidence: the caller asked for the ensemble
+        # precisely to get a number, and a partial install is invisible otherwise.
+        conf = {"p": None, "label": "unavailable", "reason": mismatch}
+    else:
+        conf = core.confidence(v["pattern"], table)
+
+    # vote() groups stereo-blind, because that is how the table was fit, so its
+    # winner is the stereo-stripped key. Return a form that keeps the wedge bonds a
+    # model resolved: a unanimous committee must not answer with a racemate where
+    # the single-model path answers with one enantiomer. The strongest model in the
+    # winning group decides, by the same priority that breaks ties, since members
+    # can disagree on stereochemistry while agreeing on the skeleton.
+    winners = v["votes"][v["winner"]]
+    # vote() stores bare names, so the priority has to be bare too. A table writing
+    # "local:molnextr" would otherwise match nothing and fall through to insertion
+    # order, which is the arbitrary choice this whole block exists to avoid.
+    best = next((m for m in (n.removeprefix("local:") for n in priority)
+                 if m in winners), winners[0])
+    raw = next(r["smiles"] for r in results
+               if r["model"].removeprefix("local:") == best)
+    smiles = core.canonicalize(raw, stereo=True) or v["winner"]
+
+    validation = core.validate_smiles_core(smiles)
+    # Both can be true at once: a salt read by a committee whose table is missing
+    # needs both caveats, so they accumulate rather than shadowing each other.
+    warnings = [w for w in [core.fragment_warning(validation)] if w]
+    if absent:
+        # Independent of everything below: a committee can shrink and still find a
+        # table that fits the survivors, which reports a confidence and no mismatch.
+        # Nested under one of those branches, the only sign that three of four
+        # models never ran would be a latency nobody reads.
+        warnings.append("These were installed but could not run: " + _trim(
+            "; ".join(f"{n}: {e}" for n, e in absent)))
+    if mismatch:
+        # Surface this in warning too: the reason alone names a Python exception
+        # class, and anything that prints the result shows a bare missing number.
+        warnings.append(mismatch)
+    elif unreadable:
+        warnings.append(f"the calibration table at {calibration!r} could not be "
+                        f"read, so this answer carries no confidence")
+    elif conf.get("reason") == "unknown_pattern":
+        # The third confidence-less path. Without this it is the only one that
+        # surfaces as a bare missing number, which is what the other two get a
+        # warning to prevent.
+        warnings.append(f"the calibration table has no {v['pattern']!r} bucket, so "
+                        f"this split carries no measured confidence")
+    warning = " ".join(warnings)
+
+    return core.build_result(
+        ok=True,
+        smiles=smiles,
+        valid=validation.get("valid", False),
+        formula=validation.get("formula"),
+        n_fragments=validation.get("n_fragments", 0),
+        confidence=conf["p"],
+        # Carried even where p is withheld: below the sample floor the interval is
+        # the only quantitative thing a thin bucket can honestly offer.
+        confidence_interval=conf.get("ci"),
+        confidence_label=conf["label"],
+        confidence_unavailable_reason=conf.get("reason"),
+        agreement=v["pattern"],
+        backend_used="ensemble",
+        model_used="+".join(v["voters"]),
+        cold_start=cold,
+        latency_s=round(total, 3),
+        warning=warning,
+        votes=v["votes"],
+        abstained=v["abstained"],
+    )
 
 
 def image_to_smiles_core(image_path: str, model: str | None = None,
@@ -120,6 +304,11 @@ def image_to_smiles_core(image_path: str, model: str | None = None,
         return core.build_result(model_used=name, error=str(e))
     except OSError as e:
         return core.build_result(model_used=name, error=f"cannot read {image_path}: {e}")
+
+    if ensemble:
+        # Dispatched after the image checks above, so a committee run rejects a bad
+        # file once instead of once per model.
+        return _run_ensemble(resolved, calibration, models_wanted)
 
     if name == models.LLM_MODEL:
         narrow = backends.smiles_from_llm(image_bytes, mime, llm,
@@ -180,7 +369,7 @@ _TOOL_DOC = """Read a molecule's 2D structure diagram from an image and return i
       - no specialist is installed: use model='llm', which reads the image with the
         agent's own model and needs no installation.
 
-    Do NOT loop through every model hoping one succeeds. A cold model costs 5-60 s to
+    Do NOT loop through every model hoping one succeeds. A cold model costs 9-170 s to
     load, and if the image is unreadable they usually all fail the same way. Two
     attempts is a reasonable ceiling.
 
@@ -190,9 +379,11 @@ _TOOL_DOC = """Read a molecule's 2D structure diagram from an image and return i
     user which one they meant instead of passing the SMILES to a geometry or energy
     calculation.
 
-    No confidence number is reported. A single model cannot say how likely it is to
-    be right about this particular image, and the per-model benchmark accuracy
-    describes someone else's images, so quoting it here would be misleading.
+    A single-model call reports no confidence: one model cannot say how likely it is
+    to be right about this particular image, and its benchmark accuracy describes
+    someone else's images. `ensemble=True` measures it instead, by reading the image
+    with every installed specialist and looking up how often a committee splitting
+    that way was right.
 
     Timing. The first call for a model loads it, which cost 9-170 s when measured on
     a shared CPU node, DECIMER being the slowest. Later calls in the same process are
@@ -212,6 +403,14 @@ _TOOL_DOC = """Read a molecule's 2D structure diagram from an image and return i
     structured : bool, optional
         With model='llm', ask for a JSON reply. Leave it off unless the model is
         returning prose the tool cannot read. No effect on the specialists.
+    ensemble : bool, optional
+        Read the image with every installed specialist and vote. Returns a measured
+        confidence in `confidence`, which a single model cannot give. Costs one
+        inference per model, so use it when the answer matters more than the time:
+        before a calculation, or after a plain call returned something doubtful.
+        Ignores `model`.
+    models_wanted : list of str, optional
+        With ensemble, vote only these specialists. Omit it to vote all installed.
 
     Returns
     -------
@@ -227,6 +426,29 @@ _TOOL_DOC = """Read a molecule's 2D structure diagram from an image and return i
             Molecular formula, when valid.
         n_fragments : int
             Disconnected components; above 1 means more than one molecule.
+        confidence : float or None
+            P(this answer is correct), when a committee measured it. None from a
+            single model, which has no agreement to score.
+        confidence_interval : list or None
+            The 95% interval behind that number. Present even where `confidence`
+            is withheld for a thin bucket, which is the case it matters most in.
+        confidence_label : str
+            One of 'unanimous' (p >= 0.99), 'strong' (>= 0.95), 'weak' (>= 0.70),
+            or 'conflicting' below that, prefixed 'low_n_' when the bucket is too
+            thin to quote a number. 'unknown' means the table has no bucket for
+            this split, and 'unavailable' that no number applies at all. On a
+            single-model call it bands that model's measured solo accuracy, since
+            there is no per-image number to band.
+        confidence_unavailable_reason : str or None
+            Why there is no number, when there is none.
+        agreement : str or None
+            How a committee split, as 'majority/rest', e.g. '4' or '3/1'.
+        votes : dict or None
+            Which models produced which SMILES.
+        abstained : dict or None
+            Models that ran and returned nothing usable.
+        backend_used : str or None
+            'specialist', 'llm', or 'ensemble'.
         model_used : str
             Which model answered.
         cold_start : bool
@@ -250,9 +472,11 @@ def make_ocsr_tools(llm: Any = None) -> list:
     """
 
     def _run(image_path: str, model: str | None = None,
-             structured: bool = False) -> dict:
-        return image_to_smiles_core(image_path, model=model,
-                                    structured=structured, llm=llm)
+             structured: bool = False, ensemble: bool = False,
+             models_wanted: list[str] | None = None) -> dict:
+        return image_to_smiles_core(image_path, model=model, structured=structured,
+                                    ensemble=ensemble, models_wanted=models_wanted,
+                                    llm=llm)
 
     _run.__doc__ = _TOOL_DOC
     return [StructuredTool.from_function(
@@ -263,12 +487,15 @@ def make_ocsr_tools(llm: Any = None) -> list:
 
 
 @tool
-def image_to_smiles(image_path: str, model: str | None = None) -> dict:
+def image_to_smiles(image_path: str, model: str | None = None,
+                    ensemble: bool = False,
+                    models_wanted: list[str] | None = None) -> dict:
     """Read a molecule's 2D structure diagram from an image and return its SMILES.
 
     Module-level tool for callers that bind tools statically. It has no LLM bound, so
     `model='llm'` reports the fallback as unavailable; use `make_ocsr_tools(llm)` to
-    get a version with the agent's model wired in. Every other model works here.
+    get a version with the agent's model wired in. Every other model works here,
+    committee voting included: the committee is specialists only.
 
     See `make_ocsr_tools` for the full contract.
 
@@ -278,8 +505,13 @@ def image_to_smiles(image_path: str, model: str | None = None) -> dict:
         Path to a PNG, JPEG, GIF or WEBP showing ONE molecule's 2D structure.
     model : str, optional
         'decimer', 'molnextr', 'molscribe', 'ocsrglyph', or 'llm'.
+    ensemble : bool, optional
+        Vote every installed specialist and return a measured confidence.
+    models_wanted : list of str, optional
+        With ensemble, vote only these specialists. Omit it to vote all installed.
     """
-    return image_to_smiles_core(image_path, model=model, llm=None)
+    return image_to_smiles_core(image_path, model=model, ensemble=ensemble,
+                                models_wanted=models_wanted, llm=None)
 
 
 @tool

--- a/src/chemgraph/tools/ocsr_tools.py
+++ b/src/chemgraph/tools/ocsr_tools.py
@@ -31,6 +31,12 @@ from chemgraph.tools import ocsr_models as models
 
 logger = logging.getLogger(__name__)
 
+# Cap on stereoisomer enumeration when comparing two readings of one skeleton. 512
+# covers every prediction in the benchmark (max 512, 8 of 2777 above 64), and the
+# count is checked first so a molecule past it takes the substructure path instead
+# of comparing a truncated set.
+_MAX_ISOMERS = 512
+
 
 def measured_accuracies() -> dict[str, dict]:
     """Solo accuracy per model, from the calibration table rather than the registry.
@@ -44,12 +50,24 @@ def measured_accuracies() -> dict[str, dict]:
         table = core.load_calibration()
     except (OSError, ValueError, TypeError):
         return {}
-    return {m: core.model_performance(m, table) for m in models.SPECIALIST_MODELS}
+    out = {}
+    for m in models.SPECIALIST_MODELS:
+        entry = core.model_performance(m, table)
+        # The listing shows the number the tool quotes, which is the table's 'p'.
+        # 'accuracy' beside it is the raw rate, the record of what was counted, and
+        # showing that here would have one install report two different accuracies
+        # for one model. Withheld below the floor, so the listing cannot state a
+        # figure the tool refuses to state.
+        if entry:
+            prior = core.prior_confidence(m, table)
+            entry["accuracy"] = prior["p"] if prior["reason"] is None else None
+        out[m] = entry
+    return out
 
 
 def _unknown_model_error(model: str) -> str:
     installed = backends.available_specialists()
-    return (f"unknown model {model!r}. Choose one of: "
+    return (f"unknown model {core.echo(repr(model))}. Choose one of: "
             f"{', '.join(models.MODEL_CHOICES)}.\n\n"
             f"{models.describe_models(installed, measured_accuracies(), backends.usable_specialists())}")
 
@@ -65,7 +83,15 @@ def _resolve_model(model: str | None) -> tuple[str, str]:
         installed = backends.available_specialists()
         return (installed[0] if installed else models.LLM_MODEL), ""
 
-    name = model.strip().lower()
+    if not isinstance(model, str):
+        # models_wanted is type-checked and this was not, so a non-string reached
+        # .strip() and raised AttributeError past the never-raises contract.
+        return "", (f"model must be a name, got {type(model).__name__}. "
+                    f"Choose one of: {', '.join(models.MODEL_CHOICES)}.")
+    # Through str's own methods: isinstance passes for a subclass, which is free to
+    # override strip and lower with anything, including a raise. No str() call
+    # either, since __str__ is equally overridable and isinstance already passed.
+    name = str.lower(str.strip(model))
     if name not in models.MODEL_CHOICES:
         return "", _unknown_model_error(model)
     return name, ""
@@ -86,25 +112,21 @@ def _validate_models_wanted(wanted, installed: list[str]) -> str:
     if not wanted:
         return (f"models_wanted is empty. Omit it to vote every installed "
                 f"specialist, or name some of: {choices}")
-    unknown = [m for m in wanted if m not in models.SPECIALIST_MODELS]
+    # isinstance first: `m not in dict` hashes m, so an unhashable element raises
+    # from inside the guard that exists to report it.
+    unknown = [m for m in wanted
+               if not isinstance(m, str) or m not in models.SPECIALIST_MODELS]
     if unknown:
-        return (f"not OCSR specialists: {', '.join(repr(m) for m in unknown)}. "
-                f"Choose from: {choices}")
-    absent = [m for m in wanted if m not in installed]
+        # Named by type where the value is not a string: repr is caller-supplied
+        # code too, and this is the guard that has to survive whatever it is given.
+        shown = ", ".join(core.echo(repr(m)) if isinstance(m, str)
+                          else f"a {type(m).__name__}" for m in unknown)
+        return f"not OCSR specialists: {shown}. Choose from: {choices}"
+    absent = [m for m in wanted if m not in installed]  # all strings by now
     if absent:
         return (f"requested but not installed: {', '.join(absent)}. Install with: "
                 f"pip install 'chemgraph[ocsr]'")
     return ""
-
-
-def _trim(text: str, limit: int = 400) -> str:
-    """Cap a message assembled from backend errors.
-
-    Every warning the tool produces is bounded except this one: the errors are
-    joined from as many models as ran, and a long weights directory pushed one past
-    6 kB in testing. The whole result dict goes back into an agent's context.
-    """
-    return text if len(text) <= limit else text[:limit - 3] + "..."
 
 
 def _prior_label(model: str, calibration: str | None) -> str:
@@ -167,8 +189,8 @@ def _run_ensemble(resolved: str, calibration: str | None,
         return core.build_result(
             ok=False, backend_used="ensemble", cold_start=cold,
             latency_s=round(total, 3),
-            error="no specialist could run: " + "; ".join(
-                f"{n}: {e}" for n, e in absent),
+            error="no specialist could run: " + core.echo(
+                "; ".join(f"{n}: {e}" for n, e in absent), 400),
             confidence_unavailable_reason="no_specialist_could_run",
         )
 
@@ -211,34 +233,132 @@ def _run_ensemble(resolved: str, calibration: str | None,
     # the single-model path answers with one enantiomer. The strongest model in the
     # winning group decides, by the same priority that breaks ties, since members
     # can disagree on stereochemistry while agreeing on the skeleton.
+    warnings: list[str] = []
     winners = v["votes"][v["winner"]]
     # vote() stores bare names, so the priority has to be bare too. A table writing
     # "local:molnextr" would otherwise match nothing and fall through to insertion
     # order, which is the arbitrary choice this whole block exists to avoid.
-    best = next((m for m in (n.removeprefix("local:") for n in priority)
-                 if m in winners), winners[0])
-    raw = next(r["smiles"] for r in results
-               if r["model"].removeprefix("local:") == best)
-    smiles = core.canonicalize(raw, stereo=True) or v["winner"]
+    order = [n.removeprefix("local:") for n in priority]
+    stereo_votes: dict[str, list[str]] = {}
+    for r in results:
+        model = r["model"].removeprefix("local:")
+        if model not in winners:
+            continue
+        form = core.canonicalize(r["smiles"], stereo=True)
+        if form is not None:
+            stereo_votes.setdefault(form, []).append(model)
+
+    if stereo_votes:
+        # The strongest model in the group supplies the stereochemistry, by the same
+        # priority that breaks ties. Counting the group again and taking the majority
+        # was measured on the benchmark's 47 stereo-bearing items and rejected: the
+        # models rank the same way on stereochemistry as they do overall (DECIMER
+        # 76.6%, molnextr 57.4%, ocsrglyph 48.9%, molscribe 40.4%), so a majority
+        # lets three weaker readings outvote the one most likely to be right.
+        smiles = next((f for m in order for f in stereo_votes if m in stereo_votes[f]),
+                      next(iter(stereo_votes)))
+
+        # Warn when the answer loses something another member read. A member that
+        # marked less is not a conflict: reading one of two double bonds where the
+        # answer reads both discards nothing. What matters is whether the answer
+        # still carries every centre that member assigned, which RDKit answers by
+        # comparing what each form still leaves open. On the benchmark 115 of 721
+        # groups hold more than one form; 112 lose something and warn, and in the
+        # other 3 the answer already says everything the rest did.
+        def _covered_by_answer(other: str) -> bool:
+            """True when the answer says everything `other` says, and agrees.
+
+            Compared as sets of the stereoisomers each form still admits: the
+            answer covers the other exactly when it leaves no more of them open.
+            That needs no alignment between the two molecules, which is what makes
+            it right where comparing perceived stereo elements is not. Those come
+            back in an order RDKit does not promise, in a count that changes when
+            assigning one centre makes another non-stereogenic, and carrying a
+            descriptor of NoValue for every class except tetrahedral, so square
+            planar sulfur and octahedral metals compare equal whatever they say.
+            """
+            from rdkit import Chem
+            from rdkit.Chem.EnumerateStereoisomers import (
+                EnumerateStereoisomers, GetStereoisomerCount,
+                StereoEnumerationOptions)
+
+            mol = Chem.MolFromSmiles(smiles)
+            ref = Chem.MolFromSmiles(other)
+            if mol is None or ref is None:
+                return False
+            opts = StereoEnumerationOptions(onlyUnassigned=True, unique=True,
+                                            tryEmbedding=False, maxIsomers=_MAX_ISOMERS)
+            try:
+                # Count first. Past the cap EnumerateStereoisomers returns exactly
+                # _MAX_ISOMERS forms with nothing to say it stopped early, and a
+                # truncated set is not a subset of anything: a sugar read with every
+                # centre assigned would report a conflict against the same sugar read
+                # with none, which is the case this function exists to allow. Fall
+                # back to asking whether the answer embeds the other with its
+                # chirality intact. The count overestimates, since it honours
+                # neither the cap nor unique=True, so this path is taken by some
+                # molecules the enumeration could have finished; the two rules agree
+                # on all 115 multi-form groups in the benchmark.
+                if (GetStereoisomerCount(mol, options=opts) > _MAX_ISOMERS
+                        or GetStereoisomerCount(ref, options=opts) > _MAX_ISOMERS):
+                    # Blind to square planar and octahedral centres, which
+                    # HasSubstructMatch ignores. Comparing their tags was tried and
+                    # reverted: _chiralPermutation indexes the neighbour order the
+                    # SMILES was written in, so the same geometry reached two ways
+                    # compares unequal and 12 of 18 same-geometry pairs were
+                    # reported as conflicts. A rare missed conflict beats frequent
+                    # false ones on the case this function exists to allow.
+                    return (mol.GetNumAtoms() == ref.GetNumAtoms()
+                            and mol.HasSubstructMatch(ref, useChirality=True))
+                mine = {Chem.MolToSmiles(x)
+                        for x in EnumerateStereoisomers(mol, options=opts)}
+                theirs = {Chem.MolToSmiles(x)
+                          for x in EnumerateStereoisomers(ref, options=opts)}
+            except Exception:  # pragma: no cover - defensive around RDKit
+                return False
+            # No emptiness guard: a molecule RDKit parsed always enumerates to at
+            # least itself, and the one case that produced a misleading set, the
+            # cap cutting the enumeration short, is caught above by the count.
+            return mine <= theirs
+
+        conflicting = [f for f in stereo_votes
+                       if f != smiles and not _covered_by_answer(f)]
+        if conflicting:
+            # Name the support for the answer, not the largest group. The two are
+            # often different: the strongest model is regularly the one that read
+            # no stereocentre where the rest did, so a leading count would read as
+            # the answer's backing when it belongs to the readings it overruled.
+            backing = sorted(stereo_votes[smiles])
+            outvoted = sum(len(m) for f, m in stereo_votes.items() if f != smiles)
+            warnings.append(
+                f"the committee agreed on the skeleton and read "
+                f"{len(stereo_votes)} different stereochemistries; this answer is "
+                f"{', '.join(backing)}'s reading and {outvoted} other "
+                f"{'model' if outvoted == 1 else 'models'} read otherwise. The "
+                f"confidence was measured stereo-blind and does not cover it")
+    else:
+        smiles = v["winner"]
 
     validation = core.validate_smiles_core(smiles)
     # Both can be true at once: a salt read by a committee whose table is missing
     # needs both caveats, so they accumulate rather than shadowing each other.
-    warnings = [w for w in [core.fragment_warning(validation)] if w]
+    fragments = core.fragment_warning(validation)
+    if fragments:
+        warnings.insert(0, fragments)
     if absent:
         # Independent of everything below: a committee can shrink and still find a
         # table that fits the survivors, which reports a confidence and no mismatch.
         # Nested under one of those branches, the only sign that three of four
         # models never ran would be a latency nobody reads.
-        warnings.append("These were installed but could not run: " + _trim(
-            "; ".join(f"{n}: {e}" for n, e in absent)))
+        warnings.append("These were installed but could not run: " + core.echo(
+            "; ".join(f"{n}: {e}" for n, e in absent), 400))
     if mismatch:
         # Surface this in warning too: the reason alone names a Python exception
         # class, and anything that prints the result shows a bare missing number.
         warnings.append(mismatch)
     elif unreadable:
-        warnings.append(f"the calibration table at {calibration!r} could not be "
-                        f"read, so this answer carries no confidence")
+        warnings.append(f"the calibration table at {core.echo(repr(calibration))} "
+                        f"could not be read, so this answer carries no confidence")
     elif conf.get("reason") == "unknown_pattern":
         # The third confidence-less path. Without this it is the only one that
         # surfaces as a bare missing number, which is what the other two get a
@@ -312,13 +432,21 @@ def image_to_smiles_core(image_path: str, model: str | None = None,
     # Load and sniff before dispatching: this rejects a missing file, an oversized
     # one, and a non-image renamed to .png, and it does so identically for every
     # model instead of once per backend.
+    if not isinstance(image_path, str):
+        return core.build_result(
+            error=f"image_path must be a path, got {type(image_path).__name__}")
+
     try:
         resolved = core.resolve_image_path(image_path)
         image_bytes, mime = core.load_image_bytes(resolved)
     except (FileNotFoundError, ValueError) as e:
         return core.build_result(model_used=name, error=str(e))
     except OSError as e:
-        return core.build_result(model_used=name, error=f"cannot read {image_path}: {e}")
+        # Both halves bounded: an OSError's own text repeats the path it failed on,
+        # so quoting the exception unbounded reintroduces what echo just trimmed.
+        return core.build_result(
+            model_used=name,
+            error=f"cannot read {core.echo(image_path)}: {core.echo(e, 200)}")
 
     if ensemble:
         # Dispatched after the image checks above, so a committee run rejects a bad
@@ -473,7 +601,11 @@ _TOOL_DOC = """Read a molecule's 2D structure diagram from an image and return i
         error : str
             Empty when ok, otherwise what went wrong and what to do about it.
         warning : str
-            Non-fatal caveats, such as multiple fragments.
+            Non-fatal caveats: multiple fragments, a committee the table does not
+            describe, models that could not run, and a committee that agreed on
+            the skeleton while reading different stereochemistry. The last one can
+            accompany a high confidence, because the table was fitted stereo-blind
+            and so scores the skeleton alone.
     """
 
 

--- a/src/chemgraph/tools/ocsr_tools.py
+++ b/src/chemgraph/tools/ocsr_tools.py
@@ -56,8 +56,25 @@ def _resolve_model(model: str | None) -> tuple[str, str]:
     return name, ""
 
 
+def _prior_label(model: str, calibration: str | None) -> str:
+    """Band a model's measured accuracy, from the table the caller named.
+
+    Without threading ``calibration`` through, a user who refit on their own images
+    and passed the path would get their own numbers from a committee and the
+    packaged ones from every single-model read, with nothing in the result to show
+    the two came from different data.
+    """
+    try:
+        table = core.load_calibration(calibration)
+    except (OSError, ValueError, TypeError):
+        return "unavailable"
+    return core.prior_confidence(model, table)["label"]
+
+
 def image_to_smiles_core(image_path: str, model: str | None = None,
-                         structured: bool = False,
+                         structured: bool = False, ensemble: bool = False,
+                         calibration: str | None = None,
+                         models_wanted: list[str] | None = None,
                          llm: Any = None) -> dict:
     """Read a molecule's 2D structure diagram and return its SMILES.
 
@@ -73,6 +90,15 @@ def image_to_smiles_core(image_path: str, model: str | None = None,
         ``decimer``, ``molnextr``, ``molscribe``, ``ocsrglyph``, or ``llm`` for the
         agent's own model. ``None`` picks the default specialist, or the LLM when no
         specialist is installed.
+    ensemble : bool, optional
+        Run every installed specialist and vote, attaching a measured confidence.
+        Costs one inference per model. ``model`` is ignored when this is set.
+    calibration : str, optional
+        Path to a calibration table. Defaults to ``CHEMGRAPH_OCSR_CALIBRATION``,
+        then the packaged four-model table.
+    models_wanted : list of str, optional
+        With ``ensemble``, vote only these specialists instead of every installed
+        one. Needed when the table describes a subset of what is installed.
     structured : bool, optional
         With ``model="llm"``, ask for a JSON reply. Ignored by the specialists,
         which take no prompt.
@@ -119,11 +145,7 @@ def image_to_smiles_core(image_path: str, model: str | None = None,
     # parse it, since an unparseable answer is still worth reporting with valid=False.
     smiles = core.canonicalize(narrow["smiles"], stereo=True) or narrow["smiles"]
 
-    warning = ""
-    if validation.get("n_fragments", 0) > 1:
-        warning = (f"the image contains {validation['n_fragments']} disconnected "
-                   f"fragments (a salt, a mixture, or a reaction scheme). Ask which "
-                   f"one is meant before using this SMILES.")
+    warning = core.fragment_warning(validation)
 
     return core.build_result(
         ok=True,
@@ -131,6 +153,14 @@ def image_to_smiles_core(image_path: str, model: str | None = None,
         valid=validation.get("valid", False),
         formula=validation.get("formula"),
         n_fragments=validation.get("n_fragments", 0),
+        # One model produced one answer, so there is no agreement to score, and
+        # confidence stays None. Naming the reason keeps this apart from a committee
+        # whose table failed to load, which also reports no number. The label still
+        # carries the model's measured solo accuracy, which is the question a caller
+        # asks next and the only one a single read can answer.
+        confidence_label=_prior_label(narrow.get("model_used") or name, calibration),
+        confidence_unavailable_reason="single_model_has_no_per_image_confidence",
+        backend_used="llm" if name == models.LLM_MODEL else "specialist",
         model_used=narrow.get("model_used") or name,
         cold_start=narrow.get("cold_start", False),
         latency_s=narrow.get("latency_s", 0.0),

--- a/src/chemgraph/tools/ocsr_tools.py
+++ b/src/chemgraph/tools/ocsr_tools.py
@@ -32,11 +32,26 @@ from chemgraph.tools import ocsr_models as models
 logger = logging.getLogger(__name__)
 
 
+def measured_accuracies() -> dict[str, dict]:
+    """Solo accuracy per model, from the calibration table rather than the registry.
+
+    The registry describes what a model is: how to run it, how fast, what it needs.
+    How well it did is a measurement, and it belongs with the data that produced it,
+    so a user who refits on their own images sees their own numbers here. An
+    unreadable table costs the accuracies and not the listing.
+    """
+    try:
+        table = core.load_calibration()
+    except (OSError, ValueError, TypeError):
+        return {}
+    return {m: core.model_performance(m, table) for m in models.SPECIALIST_MODELS}
+
+
 def _unknown_model_error(model: str) -> str:
     installed = backends.available_specialists()
     return (f"unknown model {model!r}. Choose one of: "
             f"{', '.join(models.MODEL_CHOICES)}.\n\n"
-            f"{models.describe_models(installed)}")
+            f"{models.describe_models(installed, measured_accuracies(), backends.usable_specialists())}")
 
 
 def _resolve_model(model: str | None) -> tuple[str, str]:
@@ -516,12 +531,14 @@ def image_to_smiles(image_path: str, model: str | None = None,
 
 @tool
 def list_ocsr_models() -> str:
-    """List the OCSR models, their benchmark accuracy, and which are installed here.
+    """List the OCSR models, their measured accuracy, and which are installed here.
 
     Use this when the user asks what models are available, or after an install error,
     so the answer names what this machine actually has instead of guessing.
     """
-    return models.describe_models(backends.available_specialists())
+    return models.describe_models(backends.available_specialists(),
+                                  measured_accuracies(),
+                                  backends.usable_specialists())
 
 
 @tool

--- a/tests/test_ocsr_calibrate.py
+++ b/tests/test_ocsr_calibrate.py
@@ -412,7 +412,10 @@ def test_both_path_arguments_expand_a_tilde(monkeypatch, tmp_path):
     monkeypatch.setattr(backends, "smiles_from_specialist", lambda n, p: {
         "ok": True, "smiles": "CCO", "raw": "", "model_used": n,
         "cold_start": False, "latency_s": 0.1, "error": "", "ran": True})
+    # posixpath.expanduser reads HOME; ntpath.expanduser reads USERPROFILE and
+    # never HOME, so both are set for the same directory.
     monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
     monkeypatch.chdir(tmp_path)
 
     code = calibrate.main(["--labels", "~/labels.csv", "--out", "~/t.json",

--- a/tests/test_ocsr_calibrate.py
+++ b/tests/test_ocsr_calibrate.py
@@ -221,3 +221,372 @@ def test_a_fitted_table_records_which_interval_method_produced_it():
     table = calibrate.fit_calibration(rows, ["a", "b"])
 
     assert table["interval_method"] == core.load_calibration()["interval_method"]
+
+
+def test_validate_refuses_a_table_that_describes_another_committee():
+    """The CLI must not endorse what the tool will refuse.
+
+    Silent when broken: every bucket reads "no number", and the verdict blames the
+    sample size when the committee is the wrong set.
+    """
+    rows = _rows(*[({"decimer": "CCO", "molnextr": "CCO", "molscribe": "CCO",
+                     "imagemol": "CCO"}, "CCO")] * 30)
+
+    out = calibrate.validate(rows, ["decimer", "molnextr", "molscribe", "imagemol"],
+                             core.load_calibration())
+
+    assert "cannot validate" in out
+    assert "committee_mismatch" in out
+
+
+def test_validate_refuses_a_wrong_committee_before_any_inference(monkeypatch,
+                                                                 tmp_path, capsys):
+    """Both inputs are known before collect(), so the refusal must be too.
+
+    Silent when broken: the run reads every image with every model and then
+    reports a mismatch it could have found in the first millisecond.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n"
+                      + "".join(f"/x{i}.png,CCO\n" for i in range(30)))
+    monkeypatch.setattr(backends, "available_specialists",
+                        lambda: ["decimer", "molnextr"])
+
+    def never(name, path):
+        raise AssertionError("inference ran before the committee was checked")
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", never)
+
+    code = calibrate.main(["--labels", str(labels), "--validate"])
+
+    assert code == 2
+    assert "cannot validate" in capsys.readouterr().err
+
+
+def test_validate_checks_the_models_the_rows_actually_carry():
+    """A direct caller assembling rows is checked on their contents.
+
+    Silent when broken: rows holding three models against a two-model table pass,
+    and every bucket then reads "no number" while the verdict blames the sample.
+    """
+    rows = _rows(*[({"a": "CCO", "b": "CCO", "c": "CCO"}, "CCO")] * 30)
+
+    out = calibrate.validate(rows, ["a", "b"],
+                             {"committee": ["a", "b"],
+                              "patterns": {"2": {"k": 19, "n": 20, "p": 0.9286}}})
+
+    assert "cannot validate" in out
+
+
+def test_report_survives_a_table_the_validator_accepts():
+    """Only committee and patterns are required, so the header cannot demand more.
+
+    Silent when broken: a bare KeyError from the summary of a table the tool will
+    happily use, which is the failure the body below it was already rewritten for.
+    """
+    thin = {"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}}}
+    core._validate_calibration(thin, "test")
+
+    text = calibrate.report(thin, 20)
+
+    assert "unrecorded" in text
+    assert "committee : a" in text
+
+
+def test_an_unwritable_out_path_is_refused_before_any_inference(monkeypatch,
+                                                                tmp_path, capsys):
+    """The fitted table is the run's whole output; losing it to a typo is the worst
+    case the argument checks exist to prevent.
+
+    Silent when broken: the run pays for every inference and then tracebacks.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/x.png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+
+    def never(name, path):
+        raise AssertionError("inference ran before --out was checked")
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", never)
+
+    code = calibrate.main(["--labels", str(labels), "--out", "/proc/nope/t.json"])
+
+    assert code == 2
+    assert "cannot write" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("content, why", [
+    (b"\xff\xfe\x00bad", "not valid UTF-8"),
+    (b"image_path,smiles\n" + b"a" * 200000 + b",CCO\n", "a field past csv's limit"),
+])
+def test_a_labels_file_csv_cannot_read_is_reported_not_raised(tmp_path, content, why):
+    labels = tmp_path / "labels.csv"
+    labels.write_bytes(content)
+
+    try:
+        rows = calibrate.read_labels(str(labels))
+        assert rows == [] or all(len(r) == 2 for r in rows)
+    except ValueError as exc:
+        assert "not readable as CSV" in str(exc)
+
+
+def test_a_labels_file_csv_cannot_read_exits_like_its_neighbours(monkeypatch,
+                                                                 tmp_path, capsys):
+    """read_labels raising is only half the fix; main() has to catch it.
+
+    Silent when broken: a traceback and exit 1, where every other bad-argument
+    path exits 2 with a message.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("x" * 200000 + ".png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+
+    code = calibrate.main(["--labels", str(labels)])
+
+    assert code == 2
+    assert "cannot read" in capsys.readouterr().err
+
+
+def test_report_survives_a_cell_missing_its_counts():
+    """The validator's k/n check can be skipped by a cell that omits them."""
+    text = calibrate.report({"committee": ["a"], "patterns": {"1": {}}}, 20)
+
+    assert "0/0" in text
+
+
+def test_the_out_probe_leaves_an_existing_file_alone(monkeypatch, tmp_path):
+    """It cannot tell a zero-byte file the user had from one it just made.
+
+    Silent when broken: the probe runs before the other argument checks, so a run
+    that then exits 2 having done nothing has deleted the user's file.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/x.png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    theirs = tmp_path / "theirs.json"
+    theirs.touch()
+
+    calibrate.main(["--labels", str(labels), "--out", str(theirs), "--min-n", "-1"])
+
+    assert theirs.exists()
+
+
+def test_both_path_arguments_expand_a_tilde(monkeypatch, tmp_path):
+    """A shell expands an unquoted one; a quoted one and argv arrive intact.
+
+    Silent when broken: --labels cleared its existence check expanded and was then
+    opened unexpanded, and --out wrote the table to a directory literally named ~
+    beside wherever the process happened to be.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    from rdkit import Chem
+    from rdkit.Chem.Draw import rdMolDraw2D
+
+    drawer = rdMolDraw2D.MolDraw2DCairo(150, 150)
+    drawer.DrawMolecule(Chem.MolFromSmiles("CCO"))
+    drawer.FinishDrawing()
+    image = tmp_path / "a.png"
+    image.write_bytes(drawer.GetDrawingText())
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / "labels.csv").write_text(f"image_path,smiles\n{image},CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["a", "b"])
+    monkeypatch.setattr(backends, "smiles_from_specialist", lambda n, p: {
+        "ok": True, "smiles": "CCO", "raw": "", "model_used": n,
+        "cold_start": False, "latency_s": 0.1, "error": "", "ran": True})
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(tmp_path)
+
+    code = calibrate.main(["--labels", "~/labels.csv", "--out", "~/t.json",
+                           "--min-n", "1"])
+
+    assert code == 0
+    assert (home / "t.json").is_file()
+    assert not (tmp_path / "~").exists()
+
+
+def test_the_probe_and_the_write_use_one_path(monkeypatch, tmp_path):
+    """realpath strips a trailing slash and open does not.
+
+    Silent when broken: the probe clears one path, the write uses another, and a
+    run that passed the pre-flight check fails after spending its inference.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    from rdkit import Chem
+    from rdkit.Chem.Draw import rdMolDraw2D
+
+    drawer = rdMolDraw2D.MolDraw2DCairo(150, 150)
+    drawer.DrawMolecule(Chem.MolFromSmiles("CCO"))
+    drawer.FinishDrawing()
+    image = tmp_path / "a.png"
+    image.write_bytes(drawer.GetDrawingText())
+    labels = tmp_path / "labels.csv"
+    labels.write_text(f"image_path,smiles\n{image},CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["a", "b"])
+    monkeypatch.setattr(backends, "smiles_from_specialist", lambda n, p: {
+        "ok": True, "smiles": "CCO", "raw": "", "model_used": n,
+        "cold_start": False, "latency_s": 0.1, "error": "", "ran": True})
+
+    code = calibrate.main(["--labels", str(labels),
+                           "--out", str(tmp_path / "table.json") + "/",
+                           "--min-n", "1"])
+
+    assert code == 0
+    assert (tmp_path / "table.json").is_file()
+
+
+def test_the_out_probe_refuses_a_read_only_file_through_a_link(monkeypatch,
+                                                              tmp_path, capsys):
+    """The same file has to get the same answer whichever name reaches it.
+
+    Silent when broken: the link is waved through, the run spends its inference,
+    and the write fails afterwards.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/x.png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    target = tmp_path / "target.json"
+    target.write_text("{}")
+    target.chmod(0o400)
+    link = tmp_path / "link.json"
+    link.symlink_to(target)
+
+    code = calibrate.main(["--labels", str(labels), "--out", str(link),
+                           "--min-n", "20"])
+
+    assert code == 2
+    assert "cannot write" in capsys.readouterr().err
+    target.chmod(0o600)
+
+
+def test_the_out_probe_follows_the_link_to_its_target(monkeypatch, tmp_path,
+                                                     capsys):
+    """A symlink resolves in its target's directory, not the one holding the link.
+
+    Silent when broken: the probe exists to refuse an unwritable --out before a
+    full run of inference, and it waves this one through to fail after it.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/x.png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    readonly = tmp_path / "readonly"
+    readonly.mkdir(mode=0o500)
+    link = tmp_path / "link.json"
+    link.symlink_to(readonly / "out.json")
+
+    code = calibrate.main(["--labels", str(labels), "--out", str(link),
+                           "--min-n", "20"])
+
+    assert code == 2
+    assert "cannot write" in capsys.readouterr().err
+    readonly.chmod(0o700)
+
+
+def test_the_out_probe_accepts_a_dangling_symlink(monkeypatch, tmp_path,
+                                                  capsys):
+    """exists() follows the link, open(x) does not, so they disagree on this one.
+
+    Silent when broken: the run is refused before any inference with "File exists"
+    naming a path that does not exist.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/x.png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    link = tmp_path / "link.json"
+    link.symlink_to(tmp_path / "never_created.json")
+
+    code = calibrate.main(["--labels", str(labels), "--out", str(link),
+                           "--min-n", "-1"])
+
+    # Reaching the --min-n check means the probe let it through. Asserting only
+    # that the link survives passes either way, since the probe never unlinks.
+    assert code == 2
+    err = capsys.readouterr().err
+    assert "--min-n" in err
+    assert "File exists" not in err
+    assert link.is_symlink()
+    # And the probe created nothing through it: appending to a symlink follows it,
+    # so a run that goes on to exit 2 would leave the target behind.
+    assert not (tmp_path / "never_created.json").exists()
+
+
+def test_the_out_probe_creates_nothing_of_its_own(monkeypatch, tmp_path):
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/x.png,CCO\n")
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+    fresh = tmp_path / "fresh.json"
+
+    calibrate.main(["--labels", str(labels), "--out", str(fresh), "--min-n", "-1"])
+
+    assert not fresh.exists()
+
+
+def test_the_fitter_scores_stereo_blind_as_it_records():
+    """SCORING travels with every table, so the fitter has to match the string.
+
+    Silent when broken: nothing in the suite reads a stereo-bearing reference, and
+    scoring stereo-aware moves every headline number: on the shipped benchmark
+    decimer falls from 649 correct to 609 and molscribe from 595 to 458.
+    """
+    # A reference with a centre assigned, read flat by both models.
+    rows = _rows(*([({"a": "CC(N)C(=O)O", "b": "CC(N)C(=O)O"},
+                     "C[C@H](N)C(=O)O")] * 25))
+
+    t = calibrate.fit_calibration(rows, ["a", "b"], min_n=20)
+
+    assert t["scoring"] == calibrate.SCORING == "stereo_blind"
+    assert t["patterns"]["2"]["k"] == 25
+    assert t["model_performance"]["a"]["k"] == 25
+
+
+def test_the_fitter_writes_a_quotable_solo_estimate_beside_the_raw_rate():
+    """Two fields because they answer two questions, and the tool quotes one.
+
+    Silent when broken: prior_confidence falls back to the raw rate, so a model
+    perfect on its images reports 1.0 unanimous while the bucket fitted from those
+    same images reports the Jeffreys estimate one band lower.
+    """
+    rows = _rows(*([({"a": "CCO", "b": "CCO"}, "CCO")] * 90
+                   + [({"a": "CCN", "b": "CCN"}, "CCO")] * 10))
+
+    t = calibrate.fit_calibration(rows, ["a", "b"], min_n=20)
+    entry = t["model_performance"]["a"]
+
+    assert (entry["k"], entry["n"]) == (90, 100)
+    assert entry["accuracy"] == 0.9
+    assert entry["p"] == round(90.5 / 101, 4) == 0.896
+    assert core.prior_confidence("a", t)["p"] == entry["p"]
+
+
+def test_a_thin_solo_estimate_is_withheld_the_way_a_thin_bucket_is():
+    """The floor applies to both, since both are fitted from the same images.
+
+    Silent when broken: the bucket withholds its number and the solo accuracy
+    beside it quotes one, from the same six images.
+    """
+    rows = _rows(*([({"a": "CCO", "b": "CCO"}, "CCO")] * 6))
+
+    t = calibrate.fit_calibration(rows, ["a", "b"], min_n=20)
+
+    assert t["patterns"]["2"]["p"] is None
+    assert t["model_performance"]["a"]["p"] is None
+    assert t["model_performance"]["a"]["accuracy"] == 1.0
+    assert core.prior_confidence("a", t)["reason"] == "below_n_floor"

--- a/tests/test_ocsr_calibrate.py
+++ b/tests/test_ocsr_calibrate.py
@@ -315,16 +315,23 @@ def test_an_unwritable_out_path_is_refused_before_any_inference(monkeypatch,
 
     monkeypatch.setattr(backends, "smiles_from_specialist", never)
 
-    code = calibrate.main(["--labels", str(labels), "--out", "/proc/nope/t.json"])
+    # A path under a directory that does not exist: unwritable on every platform,
+    # where /proc/... is a writable relative path on Windows.
+    missing = tmp_path / "nope" / "t.json"
+
+    code = calibrate.main(["--labels", str(labels), "--out", str(missing)])
 
     assert code == 2
     assert "cannot write" in capsys.readouterr().err
 
 
+# ids are given explicitly: pytest builds one from the parameter itself, and the
+# 200 kB field would put a 200 kB test id into the environment variable pytest
+# exports for it, past the 32767-character limit Windows enforces.
 @pytest.mark.parametrize("content, why", [
     (b"\xff\xfe\x00bad", "not valid UTF-8"),
     (b"image_path,smiles\n" + b"a" * 200000 + b",CCO\n", "a field past csv's limit"),
-])
+], ids=["not-utf8", "field-past-csv-limit"])
 def test_a_labels_file_csv_cannot_read_is_reported_not_raised(tmp_path, content, why):
     labels = tmp_path / "labels.csv"
     labels.write_bytes(content)

--- a/tests/test_ocsr_calibrate.py
+++ b/tests/test_ocsr_calibrate.py
@@ -4,6 +4,8 @@ Hermetic: no model is loaded and no image is read. The fitter takes per-image
 prediction rows, so everything below is built from literal SMILES.
 """
 
+import os
+
 import pytest
 
 pytest.importorskip("rdkit")
@@ -445,6 +447,8 @@ def test_the_probe_and_the_write_use_one_path(monkeypatch, tmp_path):
     assert (tmp_path / "table.json").is_file()
 
 
+@pytest.mark.skipif(os.name != "posix",
+                    reason="POSIX modes and symlinks are platform-specific")
 def test_the_out_probe_refuses_a_read_only_file_through_a_link(monkeypatch,
                                                               tmp_path, capsys):
     """The same file has to get the same answer whichever name reaches it.
@@ -471,6 +475,8 @@ def test_the_out_probe_refuses_a_read_only_file_through_a_link(monkeypatch,
     target.chmod(0o600)
 
 
+@pytest.mark.skipif(os.name != "posix",
+                    reason="POSIX modes and symlinks are platform-specific")
 def test_the_out_probe_follows_the_link_to_its_target(monkeypatch, tmp_path,
                                                      capsys):
     """A symlink resolves in its target's directory, not the one holding the link.
@@ -496,6 +502,8 @@ def test_the_out_probe_follows_the_link_to_its_target(monkeypatch, tmp_path,
     readonly.chmod(0o700)
 
 
+@pytest.mark.skipif(os.name != "posix",
+                    reason="POSIX modes and symlinks are platform-specific")
 def test_the_out_probe_accepts_a_dangling_symlink(monkeypatch, tmp_path,
                                                   capsys):
     """exists() follows the link, open(x) does not, so they disagree on this one.

--- a/tests/test_ocsr_calibrate.py
+++ b/tests/test_ocsr_calibrate.py
@@ -1,0 +1,223 @@
+"""Tests for the OCSR recalibration CLI.
+
+Hermetic: no model is loaded and no image is read. The fitter takes per-image
+prediction rows, so everything below is built from literal SMILES.
+"""
+
+import pytest
+
+pytest.importorskip("rdkit")
+
+from chemgraph.tools import ocsr_calibrate as calibrate  # noqa: E402
+from chemgraph.tools import ocsr_core as core  # noqa: E402
+
+
+def _rows(*specs):
+    """Build (per-image results, reference) pairs from {model: smiles} dicts."""
+    return [([{"model": m, "smiles": s, "ok": s is not None, "error": ""}
+              for m, s in preds.items()], ref) for preds, ref in specs]
+
+
+def test_fit_calibration_counts_what_actually_happened():
+    # 25 unanimous and right, 5 unanimous and wrong.
+    rows = _rows(*([({"a": "CCO", "b": "CCO"}, "CCO")] * 25
+                   + [({"a": "CCN", "b": "CCN"}, "CCO")] * 5))
+
+    t = calibrate.fit_calibration(rows, ["a", "b"], min_n=20)
+
+    cell = t["patterns"]["2"]
+    assert (cell["k"], cell["n"]) == (25, 30)
+    assert 0.80 < cell["p"] < 0.85  # Jeffreys on 25/30
+    assert cell["ci"][0] < cell["p"] < cell["ci"][1]
+    assert t["committee"] == ["a", "b"]
+
+
+def test_a_fitted_table_is_usable_by_confidence():
+    """Round trip: what the fitter writes, the reader must understand.
+
+    Silent when broken: a table that fits cleanly and then reports unknown_pattern
+    on every lookup leaves the user with no way to see which half is wrong.
+    """
+    t = calibrate.fit_calibration(_rows(*([({"a": "CCO", "b": "CCO"}, "CCO")] * 40)),
+                                  ["a", "b"], min_n=20)
+
+    got = core.confidence("2", t)
+
+    assert got["p"] is not None and got["reason"] is None
+    core._validate_calibration(t, "fitted")
+
+
+def test_the_fitter_withholds_a_number_below_the_sample_floor():
+    """False precision is what the floor exists to prevent.
+
+    A bucket of seven with a quoted decimal reads as a measurement; its interval is
+    50 points wide.
+    """
+    thin = calibrate.fit_calibration(
+        _rows(*[({"a": "CCO", "b": "CCO"}, "CCO")] * 7), ["a", "b"], min_n=20)
+    assert thin["patterns"]["2"]["n"] == 7
+    assert thin["patterns"]["2"]["p"] is None
+    assert core.confidence("2", thin)["label"].startswith("low_n_")
+
+
+def test_the_tie_break_comes_from_the_data_not_the_argument_order():
+    """--models is a set of names; nobody should have to know it is also a ranking.
+
+    Silent when broken: the order decides who wins an even split, and the
+    all-different bucket measures how often that first model was right. Taking it
+    from the order a caller happened to type bakes an arbitrary choice into their
+    table.
+    """
+    data = _rows(*([({"decimer": "CCC", "molnextr": "CCO"}, "CCO")] * 7
+                   + [({"decimer": "CCO", "molnextr": "CCO"}, "CCO")] * 2
+                   + [({"decimer": "CCO", "molnextr": "CCC"}, "CCO")] * 1))
+
+    # molnextr is right 9/10 here and decimer 3/10, so molnextr must break ties.
+    for order in (["decimer", "molnextr"], ["molnextr", "decimer"]):
+        table = calibrate.fit_calibration(data, order)
+        assert core.tie_break_order(table) == ["molnextr", "decimer"], order
+
+    explicit = calibrate.fit_calibration(data, ["decimer", "molnextr"],
+                                         tie_break=["decimer", "molnextr"])
+    assert core.tie_break_order(explicit) == ["decimer", "molnextr"]
+
+
+def test_report_renders_the_shipped_table():
+    """The report reads through confidence(), so it cannot drift from the tool.
+
+    Silent when broken: it used to read cell["label"], which the fitter writes only
+    above the sample floor, so it crashed on the table ChemGraph ships.
+    """
+    text = calibrate.report(core.load_calibration(), 20)
+    assert "unanimous" in text
+    assert "low_n_conflicting" in text  # the 2/2 bucket, below the floor
+
+    thin = {"committee": ["a"], "n_items": 5, "scoring": "stereo_blind",
+            "patterns": {"1": {"k": 3, "n": 5}}}
+    core._validate_calibration(thin, "test")
+    assert "no interval" in calibrate.report(thin, 20)
+
+
+def test_validate_votes_by_the_table_being_checked():
+    """Comparing observed accuracy against a table means voting the table's way."""
+    table = {
+        "committee": ["a", "b"], "tie_break": "model-priority: b,a",
+        "n_items": 1, "scoring": "stereo_blind",
+        "patterns": {"1/1": {"k": 10, "n": 12, "p": round(10.5 / 13, 4)}},
+    }
+    core._validate_calibration(table, "test")
+
+    # b is right and a is wrong: voting b first scores 1/1, voting a first scores 0/1.
+    rows = _rows(({"a": "CCC", "b": "CCO"}, "CCO"))
+
+    assert "1/1 = 100%" in calibrate.validate(rows, ["a", "b"], table)
+
+
+def test_the_refit_instruction_names_this_module():
+    """A table rejected for an edited p is told how to regenerate it.
+
+    Silent when broken: the message points at a module that does not exist and the
+    user gets ModuleNotFoundError from following it.
+    """
+    import importlib
+
+    bad = {"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "p": 0.99}}}
+    with pytest.raises(ValueError, match="ocsr_calibrate"):
+        core._validate_calibration(bad, "test")
+    assert importlib.import_module("chemgraph.tools.ocsr_calibrate")
+
+
+def test_collect_passes_a_path_to_the_specialists(monkeypatch, tmp_path):
+    """The backend takes a path, and collect must resolve it before handing it over.
+
+    Silent when broken: an earlier signature took image bytes, so passing what
+    load_image_bytes returns leaves every model reading a bytes object as a filename
+    and abstaining on every image.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    image = tmp_path / "mol.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    seen = []
+
+    def one(name, path):
+        seen.append(path)
+        return {"ok": True, "smiles": "CCO", "raw": "", "model_used": name,
+                "cold_start": False, "latency_s": 0.1, "error": ""}
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", one)
+
+    rows = calibrate.collect([(str(image), "CCO")], ["a"], verbose=False)
+
+    assert len(rows) == 1
+    assert seen == [str(image)]
+
+
+def test_collect_skips_an_unreadable_image_without_stopping(tmp_path):
+    """One bad path in a label file must not abandon the rest of the run."""
+    rows = calibrate.collect([("/nonexistent/mol.png", "CCO")], ["a"], verbose=False)
+    assert rows == []
+
+
+def test_validate_rejects_a_bad_table_before_spending_any_inference(monkeypatch,
+                                                                    tmp_path,
+                                                                    capsys):
+    """A typo in a path must not cost a full run over every image.
+
+    Silent when broken: the table loads after collect(), so hours of inference are
+    discarded with a traceback to report an unparseable file.
+    """
+    from chemgraph.tools import ocsr_backends as backends
+
+    labels = tmp_path / "labels.csv"
+    labels.write_text("image_path,smiles\n/nonexistent/a.png,CCO\n")
+    bad = tmp_path / "cal.json"
+    bad.write_text("{not json")
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(bad))
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+
+    def never(name, path):
+        raise AssertionError("collect() ran before the table was checked")
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", never)
+
+    code = calibrate.main(["--labels", str(labels), "--validate"])
+
+    assert code == 2
+    assert "cannot validate" in capsys.readouterr().err
+
+
+def test_a_fitted_table_carries_the_same_rules_as_the_shipped_one():
+    """A refit must be describable in the same terms as the default.
+
+    Silent when broken: the shipped table records a rule the fitter never writes,
+    so a user comparing the two cannot tell which differences are their data and
+    which are the tool.
+    """
+    rows = _rows(*[({"a": "CCO", "b": "CCO"}, "CCO")] * 30)
+    fitted = calibrate.fit_calibration(rows, ["a", "b"])
+    shipped = core.load_calibration()
+
+    for key in ["scoring", "abstention", "estimator", "label_rule",
+                "model_performance_rule"]:
+        assert fitted[key] == shipped[key], key
+
+
+def test_an_empty_bucket_gets_the_whole_interval_and_not_a_crash():
+    """Wilson divides by n. An unpopulated bucket must not raise."""
+    ci, method = calibrate._interval(0, 0)
+    assert ci == [0.0, 1.0]
+    assert "no observations" in method
+
+
+def test_a_fitted_table_records_which_interval_method_produced_it():
+    """scipy is not a declared dependency, so the two methods must be told apart.
+
+    Silent when broken: the same labels yield intervals differing by up to 5.5 pp
+    on the small buckets, depending on whether scipy happened to be importable.
+    """
+    rows = _rows(*[({"a": "CCO", "b": "CCO"}, "CCO")] * 30)
+
+    table = calibrate.fit_calibration(rows, ["a", "b"])
+
+    assert table["interval_method"] == core.load_calibration()["interval_method"]

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -525,3 +525,163 @@ def test_a_repeated_model_name_still_contributes_its_own_singleton():
                    {"model": "decimer", "ok": True, "smiles": "???"},
                    {"model": "molnextr", "ok": True, "smiles": "CCO"}])
     assert v["pattern"] == "1/1/1"
+
+
+# ---------------------------------------------------------------------------
+# Calibration tables
+# ---------------------------------------------------------------------------
+
+
+def test_packaged_table_is_internally_consistent():
+    """The shipped table must satisfy the validator it is loaded through."""
+    t = core.load_calibration()
+    assert t["committee"] == ["decimer", "molnextr", "molscribe", "ocsrglyph"]
+    assert t["n_items"] == 722
+    for name, cell in t["patterns"].items():
+        assert sum(int(x) for x in name.split("/")) == len(t["committee"])
+        assert 0 <= cell["k"] <= cell["n"]
+
+
+def test_the_shipped_tie_break_matches_its_own_measured_accuracies():
+    """The recorded priority must be strongest model first.
+
+    Silent when broken: the all-different bucket's accuracy was measured under this
+    order, so a different order quotes a number measured for another model's answer.
+    """
+    t = core.load_calibration()
+    order = core.tie_break_order(t)
+    accuracies = [t["model_performance"][m]["accuracy"] for m in order]
+    assert accuracies == sorted(accuracies, reverse=True), order
+
+
+def test_a_table_with_no_tie_break_falls_back_to_committee_order(tmp_path):
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({"committee": ["a", "b"],
+                                  "patterns": {"2": {"k": 1, "n": 1}}}))
+    assert core.tie_break_order(core.load_calibration(str(custom))) == ["a", "b"]
+
+
+@pytest.mark.parametrize("tie_break, why", [
+    ("decimer,molnextr,molscribe,ocsrglyph", "no 'model-priority:' prefix to parse"),
+    ("model-priority: decimer,molnextr", "names fewer models than the committee"),
+    ("model-priority: a,b,c,d", "names models the committee does not contain"),
+])
+def test_an_unusable_tie_break_is_rejected_at_load(tmp_path, tie_break, why):
+    """A tie_break that cannot be trusted must fail loudly.
+
+    Silent when broken: the fallback is the committee's arbitrary JSON order, so the
+    tool votes one way and quotes a number measured the other way.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["decimer", "molnextr", "molscribe", "ocsrglyph"],
+        "tie_break": tie_break,
+        "patterns": {"4": {"k": 1, "n": 1}},
+    }))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration(str(custom))
+
+
+@pytest.mark.parametrize("table, why", [
+    ([], "top level is not an object"),
+    ({"patterns": {"1": {"k": 1, "n": 2}}}, "no committee at all"),
+    ({"committee": "a,b", "patterns": {"2": {"k": 1, "n": 2}}},
+     "committee is a string"),
+    ({"committee": [], "patterns": {"1": {"k": 1, "n": 1}}},
+     "an empty committee would disable the mismatch guard entirely"),
+    ({"committee": ["a", "a"], "patterns": {"1/1": {"k": 1, "n": 1}}},
+     "a repeated model mismatches forever"),
+    ({"committee": ["a"], "patterns": {}}, "no patterns"),
+    ({"committee": ["a", "b"], "patterns": {"3": {"k": 1, "n": 2}}},
+     "pattern sums past the committee, so it was fit under another abstention rule"),
+    ({"committee": ["a"], "patterns": {"2/-1": {"k": 1, "n": 1}}},
+     "int() accepts a minus sign, so this sums to 1 and passes the sum check"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 5, "n": 2}}}, "k exceeds n"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "p": "high"}}},
+     "p is a string, which used to raise TypeError inside a lookup"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 0, "n": 100, "p": 0.99}}},
+     "p contradicts its own k and n"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1,
+                                             "ci": [float("nan"), 1.0]}}},
+     "json accepts NaN, which compares false against everything"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1, "ci": [0.99, 0.1]}}},
+     "a reversed interval"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"decimer": {"accuracy": 0.9, "n": 0}}},
+     "an accuracy backed by zero observations reads as a real measurement"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"decimer": {"accuracy": "90%"}}},
+     "accuracy is a string"),
+])
+def test_a_table_that_cannot_mean_what_it_says_is_rejected_at_load(
+        tmp_path, monkeypatch, table, why):
+    """A table decides which answers get a confidence, so it fails at load.
+
+    Every case here once loaded cleanly and then either raised a TypeError from deep
+    inside a lookup, naming neither the table nor the field, or returned a confident
+    number that contradicted the table's own k and n.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps(table))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration(str(custom))
+    # Same rejection whichever route the table arrives by.
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(custom))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration()
+
+
+def test_a_calibration_path_that_is_not_a_regular_file_is_refused(tmp_path):
+    """A FIFO blocks open() forever, and the caller has already paid for inference."""
+    fifo = tmp_path / "cal.json"
+    os.mkfifo(fifo)
+    with pytest.raises(ValueError, match="not a regular file"):
+        core.load_calibration(str(fifo))
+
+
+def test_unparseable_json_is_a_valueerror_not_a_recursionerror(tmp_path):
+    """Callers guard on ValueError, so a bad table costs the confidence, not the run.
+
+    Silent when broken: json.load raises RecursionError on a deeply nested file, which
+    is neither ValueError nor TypeError and discarded a completed ensemble run.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text("[" * 400)
+    with pytest.raises(ValueError):
+        core.load_calibration(str(custom))
+
+
+@pytest.mark.parametrize("floor, why", [
+    ("20", "a string floor silently disables the check"),
+    (True, "bool is an int in Python, so isinstance alone lets it through"),
+    (-5, "a negative floor can never hold"),
+])
+def test_an_unusable_sample_floor_is_refused_at_load(tmp_path, floor, why):
+    """The floor decides whether a number is quotable, so it fails at load.
+
+    Silent when broken: the table records a floor, confidence() cannot read it, and
+    a point estimate over four images is quoted as measured.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({"committee": ["a"],
+                                  "min_n_for_point_estimate": floor,
+                                  "patterns": {"1": {"k": 4, "n": 4}}}))
+    with pytest.raises(ValueError, match="min_n_for_point_estimate"):
+        core.load_calibration(str(custom))
+
+
+@pytest.mark.parametrize("literal, why", [
+    ("NaN", "NaN < anything is False, so the floor would never fire"),
+    ("Infinity", "inf fires on every bucket, however large"),
+])
+def test_a_non_finite_sample_floor_is_refused(tmp_path, literal, why):
+    """json accepts both, and each disables the floor in a different direction.
+
+    Silent when broken: NaN quotes a number from four images, inf reports a bucket
+    of a thousand as too thin to quote.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text('{"committee": ["a"], "min_n_for_point_estimate": '
+                      + literal + ', "patterns": {"1": {"k": 990, "n": 1000}}}')
+    with pytest.raises(ValueError, match="min_n_for_point_estimate"):
+        core.load_calibration(str(custom))

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -943,3 +943,20 @@ def test_a_committee_differing_both_ways_is_told_both_remedies():
     assert "install a" in why
     assert "ocsr_calibrate" in why
 
+
+def test_a_thin_bucket_cannot_keep_a_full_confidence_label(tmp_path):
+    """A stored label names a band measured with a point estimate behind it.
+
+    Silent when broken: a bucket of four reports "unanimous" with no low_n_ prefix,
+    so a caller banding on the label string never learns the number was withheld.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a", "b"], "min_n_for_point_estimate": 20,
+        "patterns": {"2": {"k": 4, "n": 4, "p": 0.9, "label": "unanimous"}},
+    }))
+
+    got = core.confidence("2", core.load_calibration(str(custom)))
+
+    assert got["p"] is None
+    assert got["label"] == "low_n_weak"

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -651,6 +651,69 @@ def test_unparseable_json_is_a_valueerror_not_a_recursionerror(tmp_path):
         core.load_calibration(str(custom))
 
 
+# ---------------------------------------------------------------------------
+# Confidence lookup
+# ---------------------------------------------------------------------------
+
+
+def test_agreement_is_worth_more_than_any_single_model():
+    """The measurement the whole committee exists for.
+
+    Four agreeing models beat the strongest model alone, and four disagreeing ones
+    are worse than a coin flip. An agent that cannot see this difference has no
+    reason to pay for four inferences.
+    """
+    t = core.load_calibration()
+    assert core.confidence("4", t)["p"] > t["model_performance"]["decimer"]["accuracy"]
+    assert core.confidence("1/1/1/1", t)["p"] < 0.5
+
+
+@pytest.mark.parametrize("pattern, label", [
+    ("4", "unanimous"),
+    ("3/1", "strong"),
+    ("2/1/1", "weak"),
+    ("1/1/1/1", "conflicting"),
+])
+def test_each_shipped_pattern_gets_its_band(pattern, label):
+    assert core.confidence(pattern, core.load_calibration())["label"] == label
+
+
+def test_a_thin_bucket_reports_a_label_but_no_number():
+    """Below the sample floor the interval spans tens of points.
+
+    Silent when broken: quoting a decimal from twelve items reads as a measurement.
+    """
+    got = core.confidence("2/2", core.load_calibration())
+    assert got["p"] is None
+    assert got["reason"] == "below_n_floor"
+    assert got["label"].startswith("low_n_")
+    assert got["n"] == 12
+
+
+def test_a_thin_bucket_label_comes_from_the_jeffreys_estimate(tmp_path):
+    """7/7 is low_n_weak: thin evidence pointing one way.
+
+    The raw estimate would call it unanimous, claiming certainty from seven items;
+    the interval's lower bound would call it conflicting, overstating the doubt.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({"committee": ["a", "b"],
+                                  "patterns": {"2": {"k": 7, "n": 7}}}))
+    got = core.confidence("2", core.load_calibration(str(custom)))
+    assert got["label"] == "low_n_weak"
+
+
+def test_an_unknown_pattern_gets_no_number_at_all():
+    """A pattern the table never measured must not borrow another bucket's number."""
+    got = core.confidence("5/5", core.load_calibration())
+    assert (got["p"], got["reason"]) == (None, "unknown_pattern")
+
+
+def test_no_prediction_is_distinct_from_an_unknown_pattern():
+    got = core.confidence(None, core.load_calibration())
+    assert (got["p"], got["reason"]) == (None, "no_prediction")
+
+
 @pytest.mark.parametrize("floor, why", [
     ("20", "a string floor silently disables the check"),
     (True, "bool is an int in Python, so isinstance alone lets it through"),
@@ -685,3 +748,35 @@ def test_a_non_finite_sample_floor_is_refused(tmp_path, literal, why):
                       + literal + ', "patterns": {"1": {"k": 990, "n": 1000}}}')
     with pytest.raises(ValueError, match="min_n_for_point_estimate"):
         core.load_calibration(str(custom))
+
+
+
+
+
+def test_a_table_declaring_a_floor_is_held_to_it(tmp_path):
+    """A point estimate over fewer images than the table's own floor is withheld.
+
+    Silent when broken: a hand-written table, or one fitted with a lower --min-n
+    than it records, quotes a hard number from four images with a 45 pp interval.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a", "b"], "min_n_for_point_estimate": 20,
+        "patterns": {"2": {"k": 4, "n": 4, "p": 0.9}},
+    }))
+
+    got = core.confidence("2", core.load_calibration(str(custom)))
+
+    assert got["p"] is None
+    assert got["reason"] == "below_n_floor"
+    assert got["label"].startswith("low_n_")
+
+
+def test_a_floor_written_as_a_json_decimal_still_holds(tmp_path):
+    """JSON 20.0 deserializes to float, which an int-only check would skip."""
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({"committee": ["a"],
+                                  "min_n_for_point_estimate": 20.0,
+                                  "patterns": {"1": {"k": 4, "n": 4, "p": 0.9}}}))
+
+    assert core.confidence("1", core.load_calibration(str(custom)))["p"] is None

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -848,3 +848,81 @@ def test_model_performance_reports_the_counts_behind_an_accuracy():
     assert got["k"] == 649 and got["n"] == 722
     assert got["ci"][0] < got["accuracy"] < got["ci"][1]
 
+
+# ---------------------------------------------------------------------------
+# Committee mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_a_matching_committee_reports_no_problem():
+    t = core.load_calibration()
+    v = core.vote(_results(*[(m, "CCO") for m in t["committee"]]))
+    assert core.check_committee(v, t) is None
+
+
+def test_a_partial_install_is_told_how_to_complete_itself():
+    """The common case: fewer models installed than the table was fit on.
+
+    Silent when broken: every ensemble call reports no confidence, and the message
+    that says so does not say what to do about it.
+    """
+    t = core.load_calibration()
+    v = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO")))
+    why = core.check_committee(v, t)
+    assert "committee_mismatch" in why
+    assert "pip install 'chemgraph[ocsr]'" in why
+    assert "molscribe" in why and "ocsrglyph" in why
+    # The command has to exist: an earlier version named a module this repo does
+    # not ship, so following the instruction gave ModuleNotFoundError.
+    assert "ocsr_setup" not in why and "ocsr_download" not in why
+
+
+def test_running_more_models_than_the_table_describes_is_also_a_mismatch():
+    """A larger set is told to subset rather than to install."""
+    t = core.load_calibration()
+    v = core.vote(_results(*[(m, "CCO") for m in t["committee"] + ["extra"]]))
+    why = core.check_committee(v, t)
+    assert "models_wanted" in why
+
+
+def test_abstention_does_not_change_which_table_applies():
+    """The check compares the models asked, not the ones that voted.
+
+    Silent when broken: a model that failed to read one image would look like a
+    partial install and null the confidence for that image alone.
+    """
+    t = core.load_calibration()
+    v = core.vote([{"model": m, "smiles": "CCO", "ok": m != "ocsrglyph"}
+                   for m in t["committee"]])
+    assert "ocsrglyph" in v["abstained"]
+    assert core.check_committee(v, t) is None
+
+
+def test_an_integer_too_large_for_float_is_refused_at_load(tmp_path):
+    """A 400-digit k passes every isinstance check and then breaks the arithmetic.
+
+    Silent when broken: float() raises OverflowError, which is neither ValueError
+    nor TypeError, so it escapes the guard at every call site and surfaces from
+    inside a lookup instead of from the load.
+    """
+    huge = 10 ** 400
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({"committee": ["a"],
+                                  "patterns": {"1": {"k": huge, "n": huge}}}))
+    with pytest.raises(ValueError, match="not a usable number"):
+        core.load_calibration(str(custom))
+
+
+def test_a_committee_differing_both_ways_is_told_both_remedies():
+    """Neither installing nor subsetting alone fixes this, so the message says both.
+
+    Silent when broken: the user follows one instruction and still gets no number.
+    """
+    t = {"committee": ["a", "b"], "patterns": {"2": {"k": 1, "n": 1}}}
+    v = core.vote(_results(("b", "CCO"), ("c", "CCO")))
+
+    why = core.check_committee(v, t)
+
+    assert "install a" in why
+    assert "ocsr_calibrate" in why
+

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -232,8 +232,25 @@ def test_build_result_has_every_contract_key():
     r = core.build_result()
     assert set(r) == {
         "ok", "smiles", "valid", "formula", "n_fragments",
+        "confidence", "confidence_interval", "confidence_label",
+        "confidence_unavailable_reason",
+        "agreement", "backend_used",
         "model_used", "cold_start", "latency_s", "error", "warning",
+        "votes", "abstained",
     }
+
+
+def test_the_committee_keys_are_empty_until_a_committee_runs():
+    """A single model has no agreement to report, and says so rather than omitting.
+
+    Silent when broken: an agent reading `confidence` from a one-model call would
+    get None with no reason, indistinguishable from a committee whose table failed
+    to load.
+    """
+    r = core.build_result()
+    assert (r["agreement"], r["votes"], r["abstained"]) == (None, None, None)
+    assert r["confidence"] is None
+    assert r["confidence_label"] == "unavailable"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -413,3 +413,115 @@ def test_weights_dir_env_relocates_every_checkpoint(monkeypatch, tmp_path):
 
     # DECIMER caches its own weights, so the override has nothing to relocate.
     assert ocsr_backends.checkpoint_path("decimer") is None
+
+
+# ---------------------------------------------------------------------------
+# Committee voting
+# ---------------------------------------------------------------------------
+
+
+def _results(*pairs):
+    return [{"model": m, "smiles": s, "ok": True} for m, s in pairs]
+
+
+def test_the_local_prefix_names_the_same_model():
+    """Silent when broken: a "local:" name never matches the table's committee, so
+    check_committee nulls the confidence on every ensemble call."""
+    v = core.vote(_results(("local:decimer", "CCO"), ("molnextr", "CCO")))
+    assert v["committee"] == ["decimer", "molnextr"]
+
+
+def test_vote_groups_by_canonical_form_not_string():
+    """Same molecule written two ways is one vote."""
+    v = core.vote(_results(("decimer", "C(=O)(C(Br)(F)F)O"),
+                           ("molnextr", "O=C(O)C(F)(F)Br"),
+                           ("molscribe", "O=C(O)C(F)(F)Br"),
+                           ("ocsrglyph", "CC(C)(Br)C(=O)O")))
+    assert v["pattern"] == "3/1"
+    assert v["winner"] == core.canonicalize("O=C(O)C(F)(F)Br")
+
+
+def test_an_abstainer_stays_in_the_committee_but_out_of_the_voters():
+    """A model that ran and produced junk is counted, and named as abstaining.
+
+    Silent when broken: it vanishes from the committee, which makes a partial
+    install look like a full one to check_committee.
+    """
+    v = core.vote(_results(("decimer", "CCO"), ("molnextr", "CCO"),
+                           ("molscribe", "CCO"), ("ocsrglyph", "@@@junk")))
+    assert v["committee"] == ["decimer", "molnextr", "molscribe", "ocsrglyph"]
+    assert v["voters"] == ["decimer", "molnextr", "molscribe"]
+    assert "ocsrglyph" in v["abstained"]
+
+
+@pytest.mark.parametrize("smiles, expected", [
+    (("CCO", "CCO", "CCO", "CCO"), "4"),
+    (("CCO", "CCO", "CCO", "@@@"), "3/1"),
+    (("CCO", "CCO", "@@@", "???"), "2/1/1"),
+    (("CCO", "CCO", "CCC", "CCC"), "2/2"),
+    (("CCO", "CCC", "@@@", "???"), "1/1/1/1"),
+    (("@@@", "???", "!!!", "###"), "1/1/1/1"),
+])
+def test_pattern_always_sums_to_the_committee_size(smiles, expected):
+    """Every four-model outcome lands in one of five buckets.
+
+    Silent when broken: a shorter pattern reads as a smaller committee and looks up
+    the wrong row.
+    """
+    models = ["decimer", "molnextr", "molscribe", "ocsrglyph"]
+    v = core.vote(_results(*zip(models, smiles)))
+    assert v["pattern"] == expected
+    assert sum(int(x) for x in v["pattern"].split("/")) == 4
+
+
+def test_vote_breaks_ties_by_model_priority():
+    v = core.vote(
+        _results(("decimer", "CCO"), ("molnextr", "CCN"),
+                 ("molscribe", "CCC"), ("ocsrglyph", "CCF")),
+        priority=["decimer", "molnextr", "molscribe", "ocsrglyph"],
+    )
+    assert v["pattern"] == "1/1/1/1"
+    assert v["winner"] == "CCO"
+
+
+def test_an_abstaining_model_cannot_win_the_tie_break():
+    """Only a model that actually voted may decide the answer.
+
+    Silent when broken: the winner comes from outside `voters`, and the all-different
+    bucket stops carrying the strongest model's solo accuracy it is assumed to.
+    """
+    v = core.vote(
+        [{"model": "decimer", "ok": False, "smiles": "CCN"},
+         {"model": "molnextr", "ok": True, "smiles": "CCO"},
+         {"model": "molscribe", "ok": True, "smiles": "CCN"},
+         {"model": "ocsrglyph", "ok": True, "smiles": "CCF"}],
+        ["decimer", "molnextr", "molscribe", "ocsrglyph"],
+    )
+    assert v["winner"] == "CCO"
+    assert "decimer" in v["abstained"]
+    assert set(v["votes"][v["winner"]]) <= set(v["voters"])
+
+
+def test_vote_with_nobody_voting():
+    """Total failure is the all-singletons bucket, not a missing row.
+
+    Dropping the item would remove it from the calibration table and flatter every
+    other bucket.
+    """
+    v = core.vote(_results(("decimer", "@@@"), ("molnextr", "???")))
+    assert v["pattern"] == "1/1"
+    assert v["winner"] is None
+    assert v["voters"] == []
+    assert len(v["abstained"]) == 2
+
+
+def test_a_repeated_model_name_still_contributes_its_own_singleton():
+    """Two results for one model must not collapse into one dict key.
+
+    Silent when broken: the pattern loses a part and stops summing to the committee
+    size, which `--models decimer,decimer` and the "local:" alias both produce.
+    """
+    v = core.vote([{"model": "decimer", "ok": True, "smiles": "@@@"},
+                   {"model": "decimer", "ok": True, "smiles": "???"},
+                   {"model": "molnextr", "ok": True, "smiles": "CCO"}])
+    assert v["pattern"] == "1/1/1"

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -648,6 +648,7 @@ def test_a_table_that_cannot_mean_what_it_says_is_rejected_at_load(
         core.load_calibration()
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="mkfifo is POSIX-only")
 def test_a_calibration_path_that_is_not_a_regular_file_is_refused(tmp_path):
     """A FIFO blocks open() forever, and the caller has already paid for inference."""
     fifo = tmp_path / "cal.json"

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -780,3 +780,71 @@ def test_a_floor_written_as_a_json_decimal_still_holds(tmp_path):
                                   "patterns": {"1": {"k": 4, "n": 4, "p": 0.9}}}))
 
     assert core.confidence("1", core.load_calibration(str(custom)))["p"] is None
+
+
+# ---------------------------------------------------------------------------
+# Single-model priors
+# ---------------------------------------------------------------------------
+
+
+def test_single_model_must_not_be_routed_through_vote():
+    """The trap prior_confidence exists to avoid.
+
+    Silent when broken: a one-model vote yields pattern "1", which a four-model
+    table does not contain, so the strongest model reports unknown_pattern instead
+    of its measured accuracy.
+    """
+    from chemgraph.tools.ocsr_models import DEFAULT_SPECIALIST
+
+    t = core.load_calibration()
+    assert core.vote(_results(("decimer", "CCO")))["pattern"] == "1"
+    assert core.confidence("1", t)["reason"] == "unknown_pattern"
+    assert core.prior_confidence(DEFAULT_SPECIALIST, t)["p"] is not None
+
+
+def test_every_registered_specialist_has_a_prior():
+    """A model the registry offers must have a measured accuracy to report."""
+    from chemgraph.tools.ocsr_models import SPECIALIST_MODELS
+
+    t = core.load_calibration()
+    for name in SPECIALIST_MODELS:
+        assert core.prior_confidence(name, t)["p"] is not None, name
+
+
+def test_a_prior_reads_the_table_and_not_a_constant(tmp_path):
+    """Refitting on other images must move the priors.
+
+    Silent when broken: a figure compiled into the source outlives the table it was
+    measured on and reports another dataset's accuracy.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"decimer": {"accuracy": 0.5, "n": 10}},
+    }))
+    t = core.load_calibration(str(custom))
+    assert core.prior_confidence("decimer", t)["p"] == 0.5
+    assert core.prior_confidence("local:decimer", t)["p"] == 0.5
+
+
+def test_an_unmeasured_model_reports_why_it_has_no_prior():
+    got = core.prior_confidence("nosuchmodel", core.load_calibration())
+    assert (got["p"], got["reason"]) == (None, "no_prior_for_model")
+
+
+def test_an_unreadable_table_costs_the_prior_and_not_the_run(tmp_path, monkeypatch):
+    """A broken table must not raise out of a call that already read the image."""
+    bad = tmp_path / "cal.json"
+    bad.write_text("{not json")
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(bad))
+    got = core.prior_confidence("decimer")
+    assert got["p"] is None
+    assert got["reason"].startswith("calibration_unreadable")
+    assert core.model_performance("decimer") == {}
+
+
+def test_model_performance_reports_the_counts_behind_an_accuracy():
+    got = core.model_performance("decimer", core.load_calibration())
+    assert got["k"] == 649 and got["n"] == 722
+    assert got["ci"][0] < got["accuracy"] < got["ci"][1]
+

--- a/tests/test_ocsr_core.py
+++ b/tests/test_ocsr_core.py
@@ -837,7 +837,7 @@ def test_a_prior_reads_the_table_and_not_a_constant(tmp_path):
     custom = tmp_path / "cal.json"
     custom.write_text(json.dumps({
         "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
-        "model_performance": {"decimer": {"accuracy": 0.5, "n": 10}},
+        "model_performance": {"decimer": {"accuracy": 0.5, "k": 5, "n": 10}},
     }))
     t = core.load_calibration(str(custom))
     assert core.prior_confidence("decimer", t)["p"] == 0.5
@@ -947,16 +947,390 @@ def test_a_committee_differing_both_ways_is_told_both_remedies():
 def test_a_thin_bucket_cannot_keep_a_full_confidence_label(tmp_path):
     """A stored label names a band measured with a point estimate behind it.
 
-    Silent when broken: a bucket of four reports "unanimous" with no low_n_ prefix,
-    so a caller banding on the label string never learns the number was withheld.
+    Silent when broken: a bucket of 19 reports "strong" with no low_n_ prefix, so a
+    caller banding on the label string never learns the number was withheld.
     """
     custom = tmp_path / "cal.json"
     custom.write_text(json.dumps({
         "committee": ["a", "b"], "min_n_for_point_estimate": 20,
-        "patterns": {"2": {"k": 4, "n": 4, "p": 0.9, "label": "unanimous"}},
+        "patterns": {"2": {"k": 19, "n": 19, "p": 0.975, "label": "strong"}},
     }))
 
     got = core.confidence("2", core.load_calibration(str(custom)))
 
     assert got["p"] is None
-    assert got["label"] == "low_n_weak"
+    assert got["label"] == "low_n_strong"
+
+
+@pytest.mark.parametrize("where, table", [
+    ("pattern", {"committee": ["a"], "patterns": {"1": {"k": 1, "n": 2,
+                                                        "ci": [0.9, 0.1]}}}),
+    ("model_performance", {"committee": ["a"], "patterns": {"1": {"k": 1, "n": 2}},
+                           "model_performance": {"a": {"accuracy": 0.5, "k": 1,
+                                                       "n": 2, "ci": [0.9, 0.1]}}}),
+])
+def test_an_interval_running_backwards_is_refused(tmp_path, where, table):
+    """Below the floor confidence() quotes ci[0] as the estimate.
+
+    Silent when broken: a reversed interval reports its upper bound as the point
+    estimate, so the thinnest bucket in the table reads as the most confident.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps(table))
+
+    with pytest.raises(ValueError, match="reversed ci"):
+        core.load_calibration(str(custom))
+
+
+def test_a_label_contradicting_its_own_p_is_refused(tmp_path):
+    """The p is cross-checked against its k/n, so the label owes the same check.
+
+    Silent when broken: confidence() returns a stored label verbatim above the
+    floor, and an agent told to band on the label reads 1 correct in 100 as
+    unanimous with nothing in the result to contradict it.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a", "b", "c", "d"], "min_n_for_point_estimate": 5,
+        "patterns": {"4": {"k": 1, "n": 100, "p": 0.0149, "label": "unanimous"}},
+    }))
+
+    with pytest.raises(ValueError, match="bands as"):
+        core.load_calibration(str(custom))
+
+
+def test_a_floor_too_large_for_float_is_refused_not_raised(tmp_path):
+    """OverflowError is neither ValueError nor TypeError, so no caller guards it.
+
+    Silent when broken: a completed four-model ensemble is discarded by an
+    exception escaping the contract that says the tool never raises.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text('{"committee": ["a"], "min_n_for_point_estimate": '
+                      + str(10 ** 400) + ', "patterns": {"1": {"k": 1, "n": 1}}}')
+    with pytest.raises(ValueError, match="min_n_for_point_estimate"):
+        core.load_calibration(str(custom))
+
+
+def test_a_solo_accuracy_is_held_to_the_same_floor_as_a_bucket(tmp_path):
+    """Both are fitted from the same images by the same run.
+
+    Silent when broken: a six-image fit withholds the bucket's number and quotes
+    the solo accuracy as 1.0 unanimous, from those same six.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a", "b"], "min_n_for_point_estimate": 20,
+        "patterns": {"2": {"k": 6, "n": 6}},
+        "model_performance": {"a": {"accuracy": 1.0, "k": 6, "n": 6}},
+    }))
+    t = core.load_calibration(str(custom))
+
+    got = core.prior_confidence("a", t)
+
+    assert got["p"] is None
+    assert got["reason"] == "below_n_floor"
+    assert got["label"].startswith("low_n_")
+
+
+@pytest.mark.parametrize("entry, why", [
+    ({"accuracy": 0.9, "n": None}, "a null n states no sample size"),
+    ({"accuracy": 0.9}, "no n key at all"),
+])
+def test_an_accuracy_without_a_sample_size_is_refused(tmp_path, entry, why):
+    """No n means no floor, and no floor means the floor's opposite.
+
+    Silent when broken: a model measured on seven images reports 1.0 unanimous,
+    while the bucket fitted from those same seven withholds its number.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"a": entry},
+    }))
+
+    with pytest.raises(ValueError, match="no 'n'"):
+        core.load_calibration(str(custom))
+
+
+@pytest.mark.parametrize("entry", [{"accuracy": 0.9, "n": None}, {"accuracy": 0.9}])
+def test_a_prior_from_an_unvalidated_table_still_returns(entry):
+    """prior_confidence is public, so a hand-built dict reaches it unvalidated.
+
+    Silent when broken: None < 20 raises TypeError out of a call documented as
+    never raising, discarding a completed read.
+    """
+    got = core.prior_confidence("a", {"min_n_for_point_estimate": 20,
+                                      "model_performance": {"a": entry}})
+
+    assert got["p"] == 0.9
+    assert got["reason"] is None
+
+
+def test_a_thin_prior_is_banded_the_way_a_thin_bucket_is(tmp_path):
+    """Both withhold the number, so both must withhold the word too.
+
+    Silent when broken: three images report "unanimous" from raw k/n, which is
+    exactly what the Jeffreys rule replaced in confidence().
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a", "b"], "min_n_for_point_estimate": 20,
+        "patterns": {"2": {"k": 3, "n": 3}},
+        "model_performance": {"a": {"accuracy": 1.0, "k": 3, "n": 3}},
+    }))
+    t = core.load_calibration(str(custom))
+
+    assert core.prior_confidence("a", t)["label"] == core.confidence("2", t)["label"]
+
+
+@pytest.mark.parametrize("entry, why", [
+    ({"accuracy": 0.9, "n": 3, "k": 10 ** 400}, "k reaches the same float() as a bucket's"),
+    ({"accuracy": 0.9, "n": 3, "k": 5}, "k above n cannot be a count of successes"),
+    ({"accuracy": 0.9, "n": 3, "ci": "garbage"}, "ci is returned to the caller as-is"),
+    ({"accuracy": 0.9, "n": 3, "ci": [0.9, 0.1]}, "a reversed interval"),
+])
+def test_a_model_performance_entry_is_checked_like_a_bucket(tmp_path, entry, why):
+    """Only accuracy and n were checked, and every field here reaches a caller.
+
+    Silent when broken: a 400-digit k raises OverflowError out of
+    prior_confidence, which no caller guards, and a malformed ci is handed to an
+    agent as confidence_interval.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"a": entry},
+    }))
+    with pytest.raises(ValueError, match="model_performance"):
+        core.load_calibration(str(custom))
+
+
+def test_every_count_in_a_table_is_bounded(tmp_path):
+    """model_performance.n is compared to the floor and divided into k.
+
+    Silent when broken: it is safe today only because the floor is capped first,
+    so the guard on one field is carrying another.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"a": {"accuracy": 0.9, "n": int("9" * 400)}},
+    }))
+    with pytest.raises(ValueError, match="model_performance"):
+        core.load_calibration(str(custom))
+
+
+@pytest.mark.parametrize("call", [
+    lambda: core.canonicalize("CC\ud800O"),
+    lambda: core.validate_smiles_core("C\ud800C"),
+])
+def test_a_string_python_cannot_encode_is_refused_not_raised(call):
+    """json.loads accepts a lone surrogate, so a model reply can carry one.
+
+    Silent when broken: RDKit raises UnicodeEncodeError out of two functions whose
+    contract is to return a value for any input, discarding a completed read.
+    """
+    call()
+
+
+@pytest.mark.parametrize("call, why", [
+    (lambda: core.confidence("4", None), "a table that failed to load is None"),
+    (lambda: core.tie_break_order(None), "same, through the other lookup"),
+    (lambda: core.confidence("4", {"patterns": {"4": {"k": 1, "n": -1}},
+                                   "min_n_for_point_estimate": 5}),
+     "n = -1 makes the Jeffreys denominator zero"),
+    (lambda: core.confidence("4", {"patterns": {"4": "hello"}}),
+     "a bucket that is not an object has no .get"),
+])
+def test_a_lookup_on_an_unvalidated_table_returns_rather_than_raises(call, why):
+    """Both are public, so a caller can reach them without load_calibration.
+
+    Silent when broken: AttributeError or ZeroDivisionError out of a lookup, which
+    is neither of the types every caller of these guards for.
+    """
+    call()
+
+
+def test_a_calibration_argument_that_is_not_a_path_is_refused(tmp_path):
+    """expanduser calls __fspath__, which is caller code and can raise anything.
+
+    Silent when broken: whatever that object raises escapes the OSError, ValueError
+    and TypeError every caller catches, discarding a completed read.
+    """
+    class Hostile:
+        def __fspath__(self):
+            raise RuntimeError("not one of the three")
+
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration(Hostile())
+
+    with pytest.raises(ValueError, match="must be a path"):
+        core.load_calibration(object())
+
+
+def test_a_calibration_path_may_be_a_path_object(tmp_path):
+    """Path is the ordinary way to pass one, and expanduser always took it.
+
+    Silent when broken: callers catch ValueError, so the read survives and the
+    confidence quietly disappears instead of anything reporting a bad argument.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+    }))
+
+    assert core.load_calibration(custom)["committee"] == ["a"]
+
+
+@pytest.mark.parametrize("entry, why", [
+    ({"accuracy": 0.30, "p": 0.99, "n": 1000},
+     "no k, so nothing cross-checks the p the tool quotes"),
+    ({"p": float("inf"), "n": 5, "k": 2},
+     "no accuracy, which used to skip every check below it"),
+    ({"p": 5.0, "n": 5, "k": 2}, "same, through a p outside [0, 1]"),
+    ({"n": -1, "k": 3}, "same, through a negative n"),
+    ({"k": 9999, "n": 2}, "same, through a k larger than its own n"),
+])
+def test_a_model_performance_entry_is_checked_whole(tmp_path, entry, why):
+    """Every field, whether or not accuracy is one of them.
+
+    Silent when broken: model_performance is documented as the one place to ask
+    how good a model is, and it handed back a NaN p and a k larger than its n.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"a": entry},
+    }))
+
+    with pytest.raises(ValueError, match="model_performance"):
+        core.load_calibration(str(custom))
+
+
+@pytest.mark.parametrize("entry", [
+    {}, {"k": 5, "n": 10}, {"accuracy": 0.9, "p": 0.896, "k": 90, "n": 100},
+    {"accuracy": 1.0, "p": None, "k": 7, "n": 7},
+])
+def test_the_shapes_a_fitted_table_produces_are_all_accepted(tmp_path, entry):
+    """The check above must not reject anything ocsr_calibrate writes."""
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"a": entry},
+    }))
+
+    assert core.load_calibration(str(custom))
+
+
+def test_a_solo_accuracy_is_estimated_the_way_a_bucket_is(tmp_path):
+    """One estimator across the table, which its own estimator field claims.
+
+    Silent when broken: a model perfect on 25 images reports 1.0 unanimous while
+    the bucket fitted from those same 25 reports 0.9808 strong.
+    """
+    custom = tmp_path / "cal.json"
+    jeffreys = round(25.5 / 26, 4)
+    custom.write_text(json.dumps({
+        "committee": ["a", "b"], "min_n_for_point_estimate": 20,
+        "patterns": {"2": {"k": 25, "n": 25, "p": jeffreys}},
+        "model_performance": {"a": {"accuracy": 1.0, "p": jeffreys,
+                                    "k": 25, "n": 25}},
+    }))
+    t = core.load_calibration(str(custom))
+
+    assert core.prior_confidence("a", t)["p"] == core.confidence("2", t)["p"]
+    assert core.prior_confidence("a", t)["label"] == core.confidence("2", t)["label"]
+
+
+def test_a_solo_p_that_is_not_the_jeffreys_estimate_is_refused(tmp_path):
+    """The quotable number owes the same cross-check the pattern cells owe.
+
+    Silent when broken: the field the tool actually quotes is the one field in the
+    table nothing checks, so an edited p is returned as a measurement.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 25, "n": 25, "p": round(25.5 / 26, 4)}},
+        "model_performance": {"a": {"accuracy": 1.0, "p": 1.0, "k": 25, "n": 25}},
+    }))
+
+    with pytest.raises(ValueError, match="model_performance"):
+        core.load_calibration(str(custom))
+
+
+def test_a_solo_entry_stating_only_p_still_reports_it(tmp_path):
+    """Nothing requires accuracy: it is the record of what was counted.
+
+    Silent when broken: a model measured on 722 images reports label unavailable
+    and n=0, and the listing claims the table measured it on too few images.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 649, "n": 722, "p": 0.8983}},
+        "model_performance": {"a": {"p": 0.8983, "k": 649, "n": 722}},
+    }))
+
+    got = core.prior_confidence("a", core.load_calibration(str(custom)))
+
+    assert (got["p"], got["n"], got["reason"]) == (0.8983, 722, None)
+
+
+def test_a_solo_accuracy_falls_back_when_the_table_has_no_p(tmp_path):
+    """A table written before the field existed still reports something.
+
+    Silent when broken: a hand-written or older table loses every solo number and
+    the listing says unmeasured for a model it measured.
+    """
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps({
+        "committee": ["a"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 90, "n": 100, "p": round(90.5 / 101, 4)}},
+        "model_performance": {"a": {"accuracy": 0.9, "k": 90, "n": 100}},
+    }))
+
+    assert core.prior_confidence("a", core.load_calibration(str(custom)))["p"] == 0.9
+
+
+@pytest.mark.parametrize("table, why", [
+    ({"committee": ["a"], "patterns": {"1": {"k": 0, "n": 0, "ci": [0.99, 1.0]}}},
+     "confidence() falls back to ci[0] as the estimate exactly when n is 0"),
+    ({"committee": ["a", "b", "c", "d"], "patterns": {"1/3": {"k": 1, "n": 2}}},
+     "vote() emits counts largest first, so this bucket can never be looked up"),
+    ({"committee": ["a", "b", "c", "d"], "patterns": {"0004": {"k": 1, "n": 2}}},
+     "int() normalises the key, so this parses and is then never looked up"),
+    ({"committee": ["a", "b", "c", "d"], "patterns": {" 4 ": {"k": 1, "n": 2}}},
+     "same, through whitespace int() strips"),
+    ({"committee": ["a", "b", "c", "d"], "patterns": {"\u0664": {"k": 1, "n": 2}}},
+     "same, through an Arabic-Indic digit int() accepts"),
+    ({"committee": ["a"], "patterns": {"1": {"k": 1, "n": 1}},
+      "model_performance": {"a": {"accuracy": 0.999, "k": 1, "n": 100}}},
+     "an accuracy contradicting its own counts, which pattern p is checked for"),
+])
+def test_a_table_a_consumer_would_misread_is_rejected(tmp_path, table, why):
+    """Each of these loads cleanly and then reports something it cannot support."""
+    custom = tmp_path / "cal.json"
+    custom.write_text(json.dumps(table))
+    with pytest.raises(ValueError, match="unusable"):
+        core.load_calibration(str(custom))
+
+
+def test_two_deep_paths_do_not_produce_the_same_error(tmp_path):
+    """echo trims a path, and a directory chain is identical across its files.
+
+    Silent when broken: a batch run reports the same 251-character error for every
+    image in one deep directory, and nothing says which one failed.
+    """
+    deep = "/flare/ChemGraph/reosze/" + "level_00_subdirectory/" * 8
+
+    first = core.echo(deep + "batch07_item0042_300dpi.png")
+    second = core.echo(deep + "batch07_item0043_300dpi.png")
+
+    assert first != second
+    assert len(first) == len(second) == 120
+    assert core.echo("short.png") == "short.png"

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -918,3 +918,90 @@ def test_the_failure_list_in_a_warning_is_bounded(monkeypatch, image):
     result = tools.image_to_smiles_core(image, ensemble=True)
 
     assert len(result["warning"]) < 1000
+
+
+def test_the_model_listing_reports_the_table_and_not_the_registry(monkeypatch,
+                                                                  tmp_path):
+    """A user who refit on their own images must see their own accuracies.
+
+    Silent when broken: the listing quotes the benchmark figures compiled into the
+    registry, which say nothing about the images this install actually reads.
+    """
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"decimer": {"accuracy": 0.123, "n": 50}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
+
+    listing = tools.list_ocsr_models.func()
+
+    assert "0.123 exact match" in listing
+    assert "0.899" not in listing  # the registry figure
+
+
+def test_an_unreadable_table_still_returns_the_read(monkeypatch, image, tmp_path):
+    """The label degrades; the SMILES the model produced still comes back."""
+    _stub(monkeypatch, ok=True, smiles=ASPIRIN)
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(tmp_path / "nope.json"))
+
+    result = tools.image_to_smiles_core(image, model="decimer")
+
+    assert result["ok"]
+    assert result["confidence_label"] == "unavailable"
+
+
+def test_the_example_script_prints_what_the_tool_reports(monkeypatch, tmp_path):
+    """Both read accuracies through the same call, so a refit moves both.
+
+    Silent when broken: the example prints the registry's benchmark figures while
+    the tool prints the user's own, and nothing says why they differ.
+    """
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"decimer": {"accuracy": 0.42, "n": 99}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
+
+    assert tools.measured_accuracies()["decimer"]["accuracy"] == 0.42
+    assert "0.420 exact match" in tools.list_ocsr_models.func()
+
+
+def test_the_listing_separates_installed_from_ready(monkeypatch, tmp_path):
+    """Three of four need a checkpoint the extra cannot fetch.
+
+    Silent when broken: the listing says "installed", the user believes setup is
+    finished, and the next call fails on a missing 1.1 GB file.
+    """
+    monkeypatch.setenv("CHEMGRAPH_OCSR_WEIGHTS_DIR", str(tmp_path))
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    listing = tools.list_ocsr_models.func()
+
+    assert "decimer [default]" in listing and "(ready)" in listing
+    assert listing.count("installed, checkpoint missing") == 3
+
+
+def test_a_missing_checkpoint_error_quotes_a_command_that_downloads_it(monkeypatch,
+                                                                       tmp_path):
+    """The one install step the extra cannot do, so most first runs stop here.
+
+    Silent when broken: the error points at a README the user then has to find,
+    parse, and adapt to their own weights directory.
+    """
+    monkeypatch.setenv("CHEMGRAPH_OCSR_WEIGHTS_DIR", str(tmp_path))
+
+    _, error = backends._resolve_weights("molnextr")
+
+    assert "hf download" in error
+    assert f"--local-dir {tmp_path}/molnextr" in error
+
+
+def test_decimer_needs_no_checkpoint_and_is_never_called_unready(monkeypatch,
+                                                                 tmp_path):
+    """It caches its own weights, so a weights directory says nothing about it."""
+    monkeypatch.setenv("CHEMGRAPH_OCSR_WEIGHTS_DIR", str(tmp_path))
+    monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
+
+    assert backends.usable_specialists() == ["decimer"]

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -7,6 +7,7 @@ business and is checked by `examples/ocsr/run_ocsr.py` against known structures.
 """
 
 import json
+import os
 
 import pytest
 
@@ -1090,7 +1091,8 @@ def test_a_missing_checkpoint_error_quotes_a_command_that_downloads_it(monkeypat
     _, error = backends._resolve_weights("molnextr")
 
     assert "hf download" in error
-    assert f"--local-dir {tmp_path}/molnextr" in error
+    # os.path.join, so the separator is the platform's own.
+    assert f"--local-dir {os.path.join(str(tmp_path), 'molnextr')}" in error
 
 
 def test_decimer_needs_no_checkpoint_and_is_never_called_unready(monkeypatch,

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -188,16 +188,21 @@ def test_result_keys_match_the_contract(monkeypatch, image):
     assert set(result) == set(core.build_result())
 
 
-def test_committee_keys_are_gone():
-    """The ensemble surface belongs to the follow-up PR, not this contract."""
-    contract = set(core.build_result())
-    assert not contract & {"votes", "abstained", "agreement", "confidence"}
+def test_a_single_model_result_says_why_it_carries_no_confidence(monkeypatch, image):
+    """The reason distinguishes "nothing to measure" from "the table failed".
 
+    Silent when broken: an agent sees confidence=None on a perfectly good read and
+    cannot tell whether to retry with a committee or to fix its calibration table.
+    """
+    _stub(monkeypatch, ok=True, smiles=ASPIRIN)
 
-# --------------------------------------------------------------------------- #
-# Tool wiring
-# --------------------------------------------------------------------------- #
+    result = tools.image_to_smiles_core(image)
 
+    assert result["confidence"] is None
+    assert result["confidence_unavailable_reason"] == (
+        "single_model_has_no_per_image_confidence")
+    assert result["backend_used"] == "specialist"
+    assert result["agreement"] is None
 
 def test_make_ocsr_tools_binds_the_llm(monkeypatch, image):
     """The whole point of the factory: model='llm' reaches the agent's own model."""

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -664,7 +664,7 @@ def test_a_single_model_label_bands_its_measured_accuracy(monkeypatch, image,
     table = tmp_path / "cal.json"
     table.write_text(json.dumps({
         "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
-        "model_performance": {"decimer": {"accuracy": 0.996, "n": 500}},
+        "model_performance": {"decimer": {"accuracy": 0.996, "k": 498, "n": 500}},
     }))
     monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
 
@@ -765,9 +765,10 @@ def test_a_prefixed_priority_still_picks_the_strongest_model(monkeypatch, image,
     falls back to dict insertion order, which is the arbitrary choice the
     tie-break exists to replace.
     """
+    # An even split, so the priority decides rather than the count.
     flat = core.canonicalize(PENICILLIN)
     _committee(monkeypatch, {"decimer": flat, "molnextr": PENICILLIN,
-                             "molscribe": flat, "ocsrglyph": flat})
+                             "molscribe": PENICILLIN, "ocsrglyph": flat})
     table = tmp_path / "cal.json"
     # A table has to prefix both fields to load: the validator makes tie_break name
     # exactly the committee. It then reports a mismatch, since vote() bares the
@@ -798,7 +799,7 @@ def test_a_single_model_label_uses_the_table_the_caller_named(monkeypatch, image
     mine = tmp_path / "mine.json"
     mine.write_text(json.dumps({
         "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
-        "model_performance": {"decimer": {"accuracy": 0.55, "n": 200}},
+        "model_performance": {"decimer": {"accuracy": 0.55, "k": 110, "n": 200}},
     }))
 
     result = tools.image_to_smiles_core(image, model="decimer",
@@ -930,13 +931,13 @@ def test_the_model_listing_reports_the_table_and_not_the_registry(monkeypatch,
     table = tmp_path / "cal.json"
     table.write_text(json.dumps({
         "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
-        "model_performance": {"decimer": {"accuracy": 0.123, "n": 50}},
+        "model_performance": {"decimer": {"accuracy": 0.12, "k": 6, "n": 50}},
     }))
     monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
 
     listing = tools.list_ocsr_models.func()
 
-    assert "0.123 exact match" in listing
+    assert "0.120 exact match" in listing  # this table states no p, so accuracy
     assert "0.899" not in listing  # the registry figure
 
 
@@ -951,6 +952,32 @@ def test_an_unreadable_table_still_returns_the_read(monkeypatch, image, tmp_path
     assert result["confidence_label"] == "unavailable"
 
 
+def test_the_example_script_marks_a_missing_checkpoint(monkeypatch, capsys):
+    """describe_models defaults ready to installed, so omitting it is vacuous.
+
+    Silent when broken: the example tells a first-time user setup is finished, and
+    the next call fails on a checkpoint that was never downloaded.
+    """
+    import runpy
+    import pathlib
+
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+    monkeypatch.setattr(backends, "usable_specialists", lambda: ["decimer"])
+    monkeypatch.setattr(backends, "smiles_from_specialist", lambda name, path: {
+        "ok": True, "smiles": ASPIRIN, "raw": "", "model_used": name,
+        "cold_start": False, "latency_s": 0.1, "error": ""})
+    script = (pathlib.Path(__file__).parent.parent / "examples" / "ocsr"
+              / "run_ocsr.py")
+
+    runpy.run_path(str(script))["run_direct"](None)
+
+    listing = capsys.readouterr().out
+
+    assert "molnextr" in listing and "installed, checkpoint missing" in listing
+    assert "molnextr: 0.835 exact match (your table), 4.35s/image (ready)" \
+        not in listing
+
+
 def test_the_example_script_prints_what_the_tool_reports(monkeypatch, tmp_path):
     """Both read accuracies through the same call, so a refit moves both.
 
@@ -960,12 +987,80 @@ def test_the_example_script_prints_what_the_tool_reports(monkeypatch, tmp_path):
     table = tmp_path / "cal.json"
     table.write_text(json.dumps({
         "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
-        "model_performance": {"decimer": {"accuracy": 0.42, "n": 99}},
+        "model_performance": {"decimer": {"accuracy": 0.4242, "k": 42, "n": 99}},
     }))
     monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
 
-    assert tools.measured_accuracies()["decimer"]["accuracy"] == 0.42
-    assert "0.420 exact match" in tools.list_ocsr_models.func()
+    assert tools.measured_accuracies()["decimer"]["accuracy"] == 0.4242
+    assert "0.424 exact match" in tools.list_ocsr_models.func()
+
+
+def test_the_listing_quotes_the_number_the_tool_quotes(monkeypatch, tmp_path):
+    """One install cannot report two accuracies for one model.
+
+    Silent when broken: the listing prints the table's raw rate while a single-model
+    read reports the Jeffreys estimate, and nothing says why they differ.
+    """
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 90, "n": 100}},
+        "model_performance": {"decimer": {"accuracy": 0.9, "p": 0.8960,
+                                          "k": 90, "n": 100}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
+
+    shown = tools.measured_accuracies()["decimer"]["accuracy"]
+
+    assert shown == core.prior_confidence("decimer")["p"] == 0.8960
+    assert "0.896 exact match" in tools.list_ocsr_models.func()
+
+
+def test_the_listing_withholds_what_the_tool_withholds(monkeypatch, tmp_path):
+    """Below the floor the tool quotes no number, so neither can the listing.
+
+    Silent when broken: a model measured on seven images is listed at 1.000 while
+    asking the tool for the same model returns no figure at all.
+    """
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 7, "n": 7}},
+        "model_performance": {"decimer": {"accuracy": 1.0, "p": None,
+                                          "k": 7, "n": 7}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
+
+    listing = tools.list_ocsr_models.func()
+
+    assert core.prior_confidence("decimer")["p"] is None
+    # Positively, so falling back to the registry's packaged figure fails here too:
+    # a negative assertion alone is satisfied by printing 0.899 instead of 1.000.
+    assert "measured on too few images to quote (your table)" in listing
+    assert "0.899" not in listing
+
+
+def test_a_model_the_table_omits_falls_back_to_the_registry(monkeypatch, tmp_path):
+    """A table that never measured a model is not a table that withheld its figure.
+
+    Silent when broken: model_performance returns {} for an uncovered model, and
+    `{} is not None` reports every one of them as measured on too few images, by a
+    table that does not mention them.
+    """
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"], "min_n_for_point_estimate": 20,
+        "patterns": {"1": {"k": 90, "n": 100}},
+        "model_performance": {"decimer": {"accuracy": 0.9, "p": 0.896,
+                                          "k": 90, "n": 100}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
+
+    listing = tools.list_ocsr_models.func()
+
+    assert "0.896 exact match (your table)" in listing  # covered
+    assert "0.835 exact match" in listing               # uncovered: the registry
+    assert listing.count("too few images") == 0
 
 
 def test_the_listing_separates_installed_from_ready(monkeypatch, tmp_path):
@@ -1005,3 +1100,425 @@ def test_decimer_needs_no_checkpoint_and_is_never_called_unready(monkeypatch,
     monkeypatch.setattr(backends, "available_specialists", lambda: ["decimer"])
 
     assert backends.usable_specialists() == ["decimer"]
+
+
+L_ALANINE = "C[C@@H](N)C(=O)O"
+D_ALANINE = "C[C@H](N)C(=O)O"
+
+
+def test_the_strongest_model_supplies_the_stereochemistry(monkeypatch, image):
+    """Not the majority: the models rank the same way on stereochemistry.
+
+    Silent when broken: three weaker readings outvote the one measured most likely
+    to be right. On the benchmark's stereo-bearing items DECIMER is exact 76.6% of
+    the time against molnextr 57.4%, ocsrglyph 48.9% and molscribe 40.4%, and where
+    the two rules disagreed the priority pick matched gold 55 times to nil.
+    """
+    _committee(monkeypatch, {"decimer": D_ALANINE, "molnextr": L_ALANINE,
+                             "molscribe": L_ALANINE, "ocsrglyph": L_ALANINE})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["agreement"] == "4"
+    assert result["smiles"] == core.canonicalize(D_ALANINE, stereo=True)
+    # The three that read otherwise are not silently discarded.
+    assert "different stereochemistries" in result["warning"]
+
+def test_a_stereo_split_says_the_number_does_not_cover_it(monkeypatch, image):
+    """The table was fitted stereo-blind, so it scores the skeleton only.
+
+    Silent when broken: an even split on the wedge bonds reports 0.9989 unanimous
+    with nothing to show half the committee read the other enantiomer.
+    """
+    _committee(monkeypatch, {"decimer": D_ALANINE, "molnextr": D_ALANINE,
+                             "molscribe": L_ALANINE, "ocsrglyph": L_ALANINE})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["confidence"] > 0.99  # the skeleton really is unanimous
+    assert "different stereochemistries" in result["warning"]
+    assert "stereo-blind" in result["warning"]
+
+
+def test_agreeing_on_the_stereochemistry_raises_no_caveat(monkeypatch, image):
+    """The warning has to stay off the path where every model read the same thing."""
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, L_ALANINE))
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == core.canonicalize(L_ALANINE, stereo=True)
+    assert result["warning"] == ""
+
+
+def test_reading_no_stereocentre_is_not_a_conflict(monkeypatch, image):
+    """A model that marked nothing read less, it did not read differently.
+
+    Silent when broken: on the benchmark this warns on all 115 groups that hold
+    more than one stereo form instead of the 112 that lose something, and an agent
+    taught to treat the caveat as meaningful learns to ignore it.
+    """
+    flat = core.canonicalize(L_ALANINE)
+    _committee(monkeypatch, {"decimer": L_ALANINE, "molnextr": L_ALANINE,
+                             "molscribe": L_ALANINE, "ocsrglyph": flat})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == core.canonicalize(L_ALANINE, stereo=True)
+    assert result["warning"] == ""
+
+
+def test_dropping_a_stereocentre_the_minority_read_is_a_conflict(monkeypatch, image):
+    """The answer loses information one model supplied, so it has to say so."""
+    flat = core.canonicalize(L_ALANINE)
+    _committee(monkeypatch, {"decimer": flat, "molnextr": flat,
+                             "molscribe": flat, "ocsrglyph": L_ALANINE})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == flat
+    assert "different stereochemistries" in result["warning"]
+
+
+DIENE_BOTH = "C/C=C/C=C/C"
+DIENE_ONE = "C/C=C/C=CC"
+
+
+def test_an_answer_that_says_more_is_not_a_conflict(monkeypatch, image):
+    """Reading one of two double bonds where the answer reads both loses nothing.
+
+    Silent when broken: 29 of the 115 real multi-form groups warn about a
+    difference in which the answer already carries everything the others read.
+    """
+    _committee(monkeypatch, {"decimer": DIENE_BOTH, "molnextr": DIENE_ONE,
+                             "molscribe": DIENE_ONE, "ocsrglyph": DIENE_ONE})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == core.canonicalize(DIENE_BOTH, stereo=True)
+    assert result["warning"] == ""
+
+
+def test_an_answer_that_says_less_is_a_conflict(monkeypatch, image):
+    """The mirror case: the answer drops a centre the others assigned."""
+    _committee(monkeypatch, {"decimer": DIENE_ONE, "molnextr": DIENE_BOTH,
+                             "molscribe": DIENE_BOTH, "ocsrglyph": DIENE_BOTH})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == core.canonicalize(DIENE_ONE, stereo=True)
+    assert "different stereochemistries" in result["warning"]
+
+
+def test_the_caveat_names_who_backs_the_answer(monkeypatch, image):
+    """The largest group is regularly not the answer's.
+
+    Silent when broken: a leading count reads as the answer's support when it
+    belongs to the readings the answer overruled, which is half of the real cases.
+    """
+    flat = core.canonicalize(L_ALANINE)
+    _committee(monkeypatch, {"decimer": flat, "molnextr": L_ALANINE,
+                             "molscribe": L_ALANINE, "ocsrglyph": L_ALANINE})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == flat
+    assert "decimer's reading" in result["warning"]
+    assert "3 other models read otherwise" in result["warning"]
+    # The largest group is the one that lost, so its size must not lead.
+    assert "3 different" not in result["warning"]
+
+
+def test_a_centre_the_answer_lacks_entirely_is_still_a_conflict(monkeypatch, image):
+    """The comparison is keyed on the atom, so a one-sided centre cannot be skipped.
+
+    Silent when broken: zipping the two elementwise truncates to the shorter list,
+    so an answer carrying no stereo at all covers everything by default. On the
+    benchmark that hid 26 of the 112 groups where the answer discards a reading,
+    including a sulfur centre three models never saw.
+    """
+    plain = "O=[N+]([O-])c1cccnc1S(=O)(=O)O"
+    marked = "O=[N+]([O-])c1cccnc1[S@SP3](=O)(=O)O"
+    _committee(monkeypatch, {"decimer": plain, "molnextr": marked,
+                             "molscribe": plain, "ocsrglyph": plain})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["smiles"] == core.canonicalize(plain, stereo=True)
+    assert "different stereochemistries" in result["warning"]
+
+
+@pytest.mark.parametrize("answer, other, covered, why", [
+    ("O=[N+]([O-])c1cccnc1S(=O)(=O)O",
+     "O=[N+]([O-])c1cccnc1[S@SP3](=O)(=O)O",
+     False, "the answer drops a square-planar sulfur centre entirely"),
+    ("O=[S@SP1](=O)(NCCCBr)c1ccccc1",
+     "O=[S@SP2](=O)(NCCCBr)c1ccccc1",
+     False, "two square-planar assignments RDKit both describes as NoValue"),
+    ("C[C@H](Cl)[C@@H](C)N", "C[C@H](N)[C@@H](C)Cl",
+     False, "same atom indices, opposite substituents at each centre"),
+    ("O=C(O)[C@@H](O)C(O)[C@H](O)C(=O)O",
+     "O=C(O)[C@@H](O)C(O)[C@@H](O)C(=O)O",
+     False, "the meso form perceives one fewer centre than its diastereomer"),
+    ("C/C=C/C=C/C", "C/C=C/C=CC", True, "the answer assigns a bond the other left open"),
+    ("C[C@@H](N)C(=O)O", "C[C@@H](N)C(=O)O", True, "identical"),
+])
+def test_stereo_coverage_holds_where_element_comparison_does_not(monkeypatch, image,
+                                                                 answer, other,
+                                                                 covered, why):
+    """Each of these defeats a comparison of perceived stereo elements.
+
+    Silent when broken: RDKit returns those in an unpromised order, in a count
+    that changes when one assignment settles another centre, and with a descriptor
+    of NoValue for every class but tetrahedral. Comparing the stereoisomers each
+    form still admits needs no alignment and reads every class.
+    """
+    # decimer leads the shipped tie-break, so its reading becomes the answer.
+    _committee(monkeypatch, {"decimer": answer, "molnextr": other,
+                             "molscribe": other, "ocsrglyph": other})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    warned = "different stereochemistries" in (result["warning"] or "")
+    assert warned is not covered, why
+
+
+@pytest.mark.parametrize("model", [5, 5.0, True, ["decimer"], {"a": 1}])
+def test_a_model_that_is_not_a_name_is_refused_not_raised(model):
+    """models_wanted is type-checked and this was not.
+
+    Silent when broken: .strip() on an int raises AttributeError past the contract
+    that says every failure comes back as ok=False.
+    """
+    result = tools.image_to_smiles_core("/nonexistent.png", model=model)
+
+    assert not result["ok"]
+    assert "must be a name" in result["error"]
+
+
+def test_an_image_path_that_is_not_a_path_is_refused_not_raised():
+    result = tools.image_to_smiles_core(42)
+
+    assert not result["ok"]
+    assert "must be a path" in result["error"]
+
+
+# Raffinose, a trisaccharide with 14 unassigned centres flat. Chosen over sucrose
+# because sucrose sits at exactly 512 isomers, the cap itself, so the enumeration
+# still completes and the truncation branch below is never taken.
+RAFFINOSE_FLAT = "OCC1OC(OCC2OC(OC3(CO)OC(CO)C(O)C3O)C(O)C(O)C2O)C(O)C(O)C1O"
+RAFFINOSE = ("OC[C@H]1O[C@H](OC[C@H]2O[C@H](O[C@]3(CO)O[C@H](CO)[C@@H](O)[C@@H]3O)"
+             "[C@H](O)[C@@H](O)[C@@H]2O)[C@H](O)[C@@H](O)[C@@H]1O")
+# The same skeleton with only the middle ring's two centres read, in each of two
+# incompatible ways. Both leave 4096 forms open, so both take the fallback.
+RAFFINOSE_ONE_RING = ("OCC1OC(OC[C@H]2O[C@H](OC3(CO)OC(CO)C(O)C3O)C(O)C(O)C2O)"
+                      "C(O)C(O)C1O")
+RAFFINOSE_OTHER_RING = ("OCC1OC(OC[C@@H]2O[C@@H](OC3(CO)OC(CO)C(O)C3O)C(O)C(O)C2O)"
+                        "C(O)C(O)C1O")
+
+
+def test_a_sugar_read_flat_by_the_rest_is_not_a_conflict(monkeypatch, image):
+    """Past the enumeration cap a truncated set is not a subset of anything.
+
+    Silent when broken: any sugar or polyol with 9 or more unassigned centres warns
+    that the committee read different stereochemistries when three of four read
+    none at all, which is the case the coverage rule exists to allow.
+    """
+    _committee(monkeypatch, {"decimer": RAFFINOSE, "molnextr": RAFFINOSE_FLAT,
+                             "molscribe": RAFFINOSE_FLAT,
+                             "ocsrglyph": RAFFINOSE_FLAT})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["agreement"] == "4"
+    assert result["warning"] == ""
+
+
+def test_a_sugar_read_with_a_flipped_centre_still_conflicts(monkeypatch, image):
+    """The fallback must not wave everything through: it still catches a real one.
+
+    Both readings leave 4096 forms open, so both take the fallback, and they
+    disagree on the two centres each does assign.
+    """
+    _committee(monkeypatch, {"decimer": RAFFINOSE_ONE_RING,
+                             "molnextr": RAFFINOSE_OTHER_RING,
+                             "molscribe": RAFFINOSE_OTHER_RING,
+                             "ocsrglyph": RAFFINOSE_OTHER_RING})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert "different stereochemistries" in result["warning"]
+
+
+def test_an_unread_square_planar_centre_is_still_less_detail(monkeypatch, image):
+    """Reading one centre where the others read none stays less detail.
+
+    Silent when broken: comparing _chiralPermutation to catch a metal-centre
+    conflict was tried and reverted, because the index depends on the neighbour
+    order the SMILES was written in and 12 of 18 same-geometry pairs came back as
+    conflicts. This is the case that regression broke.
+    """
+    pad = "C(O)" * 11
+    cis = f"Cl[Pt@SP1](Cl)([NH3])[NH2]{pad}O"
+    flat = f"Cl[Pt](Cl)([NH3])[NH2]{pad}O"
+    _committee(monkeypatch, {"decimer": cis, "molnextr": flat,
+                             "molscribe": flat, "ocsrglyph": flat})
+
+    assert tools.image_to_smiles_core(image, ensemble=True)["warning"] == ""
+
+
+def test_the_truncation_fallback_is_the_path_these_two_take(monkeypatch, image):
+    """Guards the pair above: at or under the cap they never exercise it.
+
+    Silent when broken: the molecule drifts to one the enumeration can finish, both
+    tests keep passing, and the branch they exist for stops being reached at all.
+    """
+    from rdkit import Chem
+    from rdkit.Chem.EnumerateStereoisomers import (GetStereoisomerCount,
+                                                   StereoEnumerationOptions)
+
+    opts = StereoEnumerationOptions(onlyUnassigned=True, unique=True,
+                                    tryEmbedding=False, maxIsomers=tools._MAX_ISOMERS)
+    for smiles in (RAFFINOSE_FLAT, RAFFINOSE_ONE_RING, RAFFINOSE_OTHER_RING):
+        mol = Chem.MolFromSmiles(core.canonicalize(smiles, stereo=True))
+        assert GetStereoisomerCount(mol, options=opts) > tools._MAX_ISOMERS
+
+    # And the cap is above what a real prediction reaches: the largest count over
+    # the benchmark's 2777 predictions is 512, so no ordinary molecule pays for the
+    # fallback's weaker comparison.
+    assert tools._MAX_ISOMERS >= 512
+
+
+def test_the_no_specialist_error_is_bounded(monkeypatch, image):
+    """It joins one backend error per model and goes into an agent's context.
+
+    Silent when broken: a long weights directory measured 32,932 characters.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+    monkeypatch.setattr(backends, "smiles_from_specialist", lambda n, p: {
+        "ok": False, "smiles": None, "raw": "", "model_used": n, "cold_start": False,
+        "latency_s": 0.1, "ran": False, "error": "x" * 9000})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert not result["ok"]
+    assert len(result["error"]) < 1000
+
+
+def test_a_str_subclass_model_cannot_run_its_own_code(image):
+    """isinstance passes for a subclass, which is free to override strip.
+
+    Silent when broken: whatever the subclass raises escapes the never-raises
+    contract from inside the guard added to keep a non-string out.
+    """
+    class HostileStrip(str):
+        def strip(self, *a):
+            raise RuntimeError("boom")
+
+    class HostileStr(str):
+        def __str__(self):
+            raise RuntimeError("boom")
+
+    for hostile in (HostileStrip("decimer"), HostileStr("decimer")):
+        assert isinstance(tools.image_to_smiles_core(image, model=hostile), dict)
+
+
+def test_the_models_wanted_error_does_not_call_a_caller_supplied_repr(monkeypatch,
+                                                                     image):
+    """The guard reports what it rejected, and repr is caller code too.
+
+    Silent when broken: the object's own exception replaces the error message the
+    guard exists to produce.
+    """
+    class Hostile:
+        def __repr__(self):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        models_wanted=[Hostile()])
+
+    assert not result["ok"]
+    assert "a Hostile" in result["error"]
+
+
+@pytest.mark.parametrize("wanted", [[["decimer"]], [{"a": 1}], [set()], [None], [5]])
+def test_an_unhashable_models_wanted_element_is_refused_not_raised(monkeypatch,
+                                                                   image, wanted):
+    """The guard tests membership in a dict, which hashes before it can report.
+
+    Silent when broken: TypeError from inside the check written to prevent it.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    result = tools.image_to_smiles_core(image, ensemble=True, models_wanted=wanted)
+
+    assert not result["ok"]
+    assert "not OCSR specialists" in result["error"]
+
+
+@pytest.mark.parametrize("call, field", [
+    (lambda: tools.image_to_smiles_core("/x" + "y" * 50000 + ".png"), "error"),
+    (lambda: tools.image_to_smiles_core("/x.png", model="z" * 50000), "error"),
+])
+def test_no_result_field_echoes_an_unbounded_input(call, field):
+    """Every message can quote a path, a model name or a backend error.
+
+    Silent when broken: 100,000 characters of one bad argument go back into an
+    agent's context.
+    """
+    assert len(call()[field]) <= core._MAX_MESSAGE_CHARS
+
+
+@pytest.mark.parametrize("call, field", [
+    (lambda: tools.image_to_smiles_core("/x" + "y" * 50000 + ".png"), "error"),
+    (lambda: tools.image_to_smiles_core("/x.png", model="z" * 50000), "error"),
+])
+def test_the_echo_is_bounded_before_the_field_is(call, field):
+    """The field cap has to hold four legitimate caveats, so it is too wide alone.
+
+    Silent when broken: one 50,000-character argument fills the whole budget and
+    pushes off the end the part of the message a user has to act on.
+    """
+    assert len(call()[field]) < 900
+
+
+def test_the_cap_applies_to_the_warning_and_the_reason_too(monkeypatch, image):
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, ASPIRIN))
+
+    result = tools.image_to_smiles_core(
+        image, ensemble=True, calibration="/q" + "w" * 50000 + ".json")
+
+    assert len(result["warning"]) <= core._MAX_MESSAGE_CHARS
+    assert len(result["confidence_unavailable_reason"]) <= core._MAX_MESSAGE_CHARS
+    # The echo is what keeps this well under the cap: the path appears in the
+    # warning, and the actionable half of the sentence follows it.
+    assert result["warning"].endswith("carries no confidence")
+
+
+def test_a_legitimate_four_caveat_warning_is_not_truncated(monkeypatch, image):
+    """A salt, read by a shrunken committee whose two absentees named a download.
+
+    Silent when broken: the cap cuts the refit command off the mismatch note, which
+    is the one part of that message a user can act on.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    def one(name, path):
+        if name in ("molscribe", "ocsrglyph"):
+            return {"ok": False, "smiles": None, "raw": "", "model_used": name,
+                    "cold_start": False, "latency_s": 0.1, "ran": False,
+                    "error": "checkpoint not found at ~/ocsr-weights/x/model.pth; "
+                             "download it with: hf download Org/Repo model.pth"}
+        return {"ok": True, "smiles": "C[C@H](N)C(=O)O.Cl.O" if name == "decimer"
+                else "CC(N)C(=O)O.Cl.O", "raw": "", "model_used": name,
+                "cold_start": False, "latency_s": 0.1, "error": "", "ran": True}
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", one)
+
+    warning = tools.image_to_smiles_core(image, ensemble=True)["warning"]
+
+    assert not warning.endswith("...")
+    assert "disconnected fragments" in warning
+    assert "could not run" in warning
+    assert "--models decimer,molnextr" in warning

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -6,6 +6,8 @@ shape of the result contract. Whether a model reads an image correctly is the mo
 business and is checked by `examples/ocsr/run_ocsr.py` against known structures.
 """
 
+import json
+
 import pytest
 
 pytest.importorskip("rdkit")
@@ -416,3 +418,503 @@ def test_an_unparseable_smiles_is_still_reported(monkeypatch, image):
     result = tools.image_to_smiles_core(image)
 
     assert result["smiles"] == "C1CC" and not result["valid"]
+
+
+# --------------------------------------------------------------------------- #
+# Committee runs
+# --------------------------------------------------------------------------- #
+
+
+def _committee(monkeypatch, answers: dict):
+    """Make each specialist return its own SMILES, or None to abstain."""
+    monkeypatch.setattr(backends, "available_specialists", lambda: list(answers))
+
+    def one(name, path):
+        smiles = answers[name]
+        return {"ok": smiles is not None, "smiles": smiles, "raw": "",
+                "model_used": name, "cold_start": False, "latency_s": 0.1,
+                "error": "" if smiles else "unreadable"}
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", one)
+
+
+ALL_FOUR = ["decimer", "molnextr", "molscribe", "ocsrglyph"]
+
+
+def test_a_unanimous_committee_earns_the_top_confidence(monkeypatch, image):
+    """What the whole feature is for: agreement the caller can act on."""
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, ASPIRIN))
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["ok"] and result["agreement"] == "4"
+    assert result["confidence"] > 0.99
+    assert result["confidence_label"] == "unanimous"
+    assert result["backend_used"] == "ensemble"
+    assert result["model_used"] == "+".join(ALL_FOUR)
+
+
+def test_a_split_committee_reports_the_lower_number(monkeypatch, image):
+    _committee(monkeypatch, {"decimer": ASPIRIN, "molnextr": ASPIRIN,
+                             "molscribe": ASPIRIN, "ocsrglyph": "CCO"})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["agreement"] == "3/1"
+    assert result["smiles"] == core.canonicalize(ASPIRIN)
+    assert 0.9 < result["confidence"] < 0.99
+    assert result["abstained"] == {}
+    assert set(result["votes"]) == {core.canonicalize(ASPIRIN), core.canonicalize("CCO")}
+
+
+def test_a_committee_that_all_failed_returns_no_molecule(monkeypatch, image):
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, None))
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert not result["ok"]
+    assert result["smiles"] is None
+    assert result["confidence_unavailable_reason"] == "no_prediction"
+    assert len(result["abstained"]) == 4
+
+
+def test_a_partial_install_gets_no_number_and_is_told_why(monkeypatch, image):
+    """Silent when broken: the caller paid for an ensemble and gets a bare None."""
+    _committee(monkeypatch, {"decimer": ASPIRIN, "molnextr": ASPIRIN})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["ok"] and result["smiles"] == core.canonicalize(ASPIRIN)
+    assert result["confidence"] is None
+    assert "committee_mismatch" in result["confidence_unavailable_reason"]
+    assert "committee_mismatch" in result["warning"]
+
+
+def test_an_unreadable_table_keeps_the_prediction(monkeypatch, image, tmp_path):
+    """A typo in the path must not throw away four inferences."""
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, ASPIRIN))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(tmp_path / "nope.json"))
+
+    assert result["ok"] and result["smiles"] == core.canonicalize(ASPIRIN)
+    assert result["agreement"] == "4"
+    assert result["confidence"] is None
+    assert result["confidence_unavailable_reason"].startswith("calibration_unreadable")
+    assert "could not be read" in result["warning"]
+
+
+def test_models_wanted_votes_the_subset_a_table_describes(monkeypatch, image,
+                                                          tmp_path):
+    """Someone with four installed but a two-model table can still get a number."""
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, ASPIRIN))
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer", "molnextr"],
+        "tie_break": "model-priority: decimer,molnextr",
+        "patterns": {"2": {"k": 19, "n": 20, "p": 0.9286}},
+    }))
+
+    result = tools.image_to_smiles_core(
+        image, ensemble=True, calibration=str(table),
+        models_wanted=["decimer", "molnextr"])
+
+    assert result["agreement"] == "2"
+    assert result["confidence"] == 0.9286
+    assert result["model_used"] == "decimer+molnextr"
+
+
+@pytest.mark.parametrize("wanted, expect", [
+    ("decimer", "must be a list"),
+    ([], "is empty"),
+    (["nosuch"], "not OCSR specialists"),
+    (["decimer", "molscribe"], "not installed"),
+])
+def test_an_unusable_models_wanted_says_what_to_pass_instead(monkeypatch, image,
+                                                             wanted, expect):
+    """Silent when broken: a bare string iterates per character and votes nothing."""
+    _committee(monkeypatch, {"decimer": ASPIRIN, "molnextr": ASPIRIN})
+
+    result = tools.image_to_smiles_core(image, ensemble=True, models_wanted=wanted)
+
+    assert not result["ok"]
+    assert expect in result["error"]
+
+
+def test_the_tool_exposes_the_committee_to_an_agent():
+    """The flag has to be callable and the description has to recommend it.
+
+    Silent when broken: the argument is invisible to the agent, or the description
+    tells it no confidence number exists, and the feature is never reached.
+    """
+    built = tools.make_ocsr_tools(llm=None)[0]
+    schema = built.args_schema.model_json_schema()
+
+    assert "ensemble" in schema["properties"]
+    assert "models_wanted" in schema["properties"]
+    assert "No confidence number is reported" not in built.description
+    assert "ensemble" in built.description and "confidence" in built.description
+
+
+def test_the_tie_break_comes_from_the_table_and_not_the_registry(monkeypatch, image,
+                                                                 tmp_path):
+    """An all-different vote must be decided by the order the table was fit under.
+
+    Silent when broken: the registry's order wins the tie, so the answer comes from
+    one model while the number quoted for it was measured for another's. A committee
+    check cannot see this, because it compares sorted names.
+    """
+    _committee(monkeypatch, {"decimer": "CCO", "molnextr": "CCN",
+                             "molscribe": "CCC", "ocsrglyph": "CCF"})
+    table = tmp_path / "cal.json"
+    # Reverse of the registry order, so the two disagree about who wins.
+    table.write_text(json.dumps({
+        "committee": ALL_FOUR,
+        "tie_break": "model-priority: ocsrglyph,molscribe,molnextr,decimer",
+        "patterns": {"1/1/1/1": {"k": 5, "n": 20, "p": 0.2619}},
+    }))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(table))
+
+    assert result["agreement"] == "1/1/1/1"
+    assert result["smiles"] == core.canonicalize("CCF")
+
+
+def test_an_unreadable_table_still_lists_the_models(monkeypatch, tmp_path):
+    """The listing is how a user finds out what they have; it must not depend on it."""
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(tmp_path / "nope.json"))
+
+    listing = tools.list_ocsr_models.func()
+
+    assert "decimer" in listing and "ocsrglyph" in listing
+
+
+PENICILLIN = "CC1(C)S[C@@H]2[C@H](NC(=O)Cc3ccccc3)C(=O)N2[C@H]1C(=O)O"
+
+
+def test_a_unanimous_committee_keeps_the_stereochemistry_it_read(monkeypatch, image):
+    """Four models reading one enantiomer must not answer with the racemate.
+
+    Silent when broken: vote() groups stereo-blind, so its winner is the stripped
+    key. Returning that directly hands back less chemistry than a single-model call
+    does, with 0.9989 confidence attached and nothing in the result to show it.
+    """
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, PENICILLIN))
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["agreement"] == "4"
+    assert result["smiles"] == core.canonicalize(PENICILLIN, stereo=True)
+    assert "@" in result["smiles"]
+    # The same molecule a single model would have returned for the same reading.
+    assert result["smiles"] == tools.image_to_smiles_core(image)["smiles"]
+
+
+def test_the_strongest_model_in_the_group_supplies_the_stereochemistry(monkeypatch,
+                                                                       image,
+                                                                       tmp_path):
+    """Members of one group can agree on the skeleton and differ on the wedges.
+
+    Silent when broken: which enantiomer comes back depends on dict ordering.
+    """
+    flat = core.canonicalize(PENICILLIN)  # same skeleton, no stereocentres marked
+    _committee(monkeypatch, {"decimer": flat, "molnextr": PENICILLIN,
+                             "molscribe": PENICILLIN, "ocsrglyph": flat})
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ALL_FOUR,
+        "tie_break": "model-priority: molnextr,molscribe,decimer,ocsrglyph",
+        "patterns": {"4": {"k": 99, "n": 100, "p": 0.9851}},
+    }))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(table))
+
+    assert result["agreement"] == "4"
+    # molnextr leads this table's priority and read the wedges.
+    assert result["smiles"] == core.canonicalize(PENICILLIN, stereo=True)
+
+
+def test_a_fragment_warning_does_not_hide_the_calibration_warning(monkeypatch,
+                                                                  image, tmp_path):
+    """Both conditions are independent, so both caveats have to survive.
+
+    Silent when broken: a salt read against a missing table looks like a normal
+    fragment warning, and the missing confidence shows only as a bare None.
+    """
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, "[Na+].CC(=O)[O-]"))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(tmp_path / "nope.json"))
+
+    assert result["n_fragments"] == 2
+    assert "disconnected" in result["warning"]
+    assert "could not be read" in result["warning"]
+
+
+def test_a_single_model_label_bands_its_measured_accuracy(monkeypatch, image,
+                                                          tmp_path):
+    """The one confidence question a single read can answer.
+
+    Silent when broken: the field is always 'unavailable', so it carries nothing
+    and an agent has no way to tell a strong model from a weak one at the call site.
+    """
+    _stub(monkeypatch, ok=True, smiles=ASPIRIN)
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"decimer": {"accuracy": 0.996, "n": 500}},
+    }))
+    monkeypatch.setenv("CHEMGRAPH_OCSR_CALIBRATION", str(table))
+
+    result = tools.image_to_smiles_core(image, model="decimer")
+
+    assert result["confidence"] is None  # still no per-image number
+    assert result["confidence_label"] == "unanimous"  # the model's own accuracy
+
+
+def test_both_backends_word_the_fragment_warning_the_same(monkeypatch, image):
+    """An agent that learns to act on one wording must see it from the other.
+
+    Silent when broken: the two copies drift and a committee's salt warning stops
+    matching whatever the agent was told to look for.
+    """
+    salt = "[Na+].CC(=O)[O-]"
+    _stub(monkeypatch, ok=True, smiles=salt)
+    single = tools.image_to_smiles_core(image)
+
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, salt))
+    committee = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert "disconnected" in single["warning"]
+    assert single["warning"] == committee["warning"]
+
+
+def test_both_tools_of_the_same_name_offer_the_committee(monkeypatch, image):
+    """A static binding must not silently lack the feature the factory has.
+
+    Silent when broken: two tools called image_to_smiles take different arguments,
+    and which one an agent got decides whether ensemble=True is even accepted.
+    """
+    _committee(monkeypatch, dict.fromkeys(ALL_FOUR, ASPIRIN))
+
+    static = tools.image_to_smiles.func(image, ensemble=True)
+    built = tools.make_ocsr_tools(llm=None)[0].func(image, ensemble=True)
+
+    assert static["agreement"] == built["agreement"] == "4"
+    assert static["smiles"] == built["smiles"]
+
+    # Every committee argument, not only the flag that turns it on.
+    committee_args = {"ensemble", "models_wanted"}
+    static_schema = tools.image_to_smiles.args_schema.model_json_schema()
+    built_schema = tools.make_ocsr_tools(llm=None)[0].args_schema.model_json_schema()
+    assert committee_args <= set(static_schema["properties"])
+    assert committee_args <= set(built_schema["properties"])
+
+
+def test_a_model_that_never_ran_is_not_a_dissenting_vote(monkeypatch, image,
+                                                         tmp_path):
+    """A missing checkpoint is not evidence about the image.
+
+    Silent when broken: three specialists install without their checkpoints, the
+    fourth reads the image correctly, and the pattern is 1/1/1/1, so the tool
+    reports 0.3772 for an answer its own table measures at 0.8989.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    def one(name, path):
+        if name == "decimer":
+            return {"ok": True, "smiles": ASPIRIN, "raw": "", "model_used": name,
+                    "cold_start": False, "latency_s": 0.1, "error": "", "ran": True}
+        return {"ok": False, "smiles": None, "raw": "", "model_used": name,
+                "cold_start": False, "latency_s": 0.0, "ran": False,
+                "error": "checkpoint not found"}
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", one)
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["ok"] and result["smiles"] == core.canonicalize(ASPIRIN)
+    assert result["agreement"] == "1"  # one voter, not four
+    assert result["confidence"] is None
+    assert "committee_mismatch" in result["confidence_unavailable_reason"]
+
+
+def test_no_specialist_able_to_run_says_which_and_why(monkeypatch, image):
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+    monkeypatch.setattr(backends, "smiles_from_specialist", lambda n, p: {
+        "ok": False, "smiles": None, "raw": "", "model_used": n, "cold_start": False,
+        "latency_s": 0.0, "ran": False, "error": "checkpoint not found"})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert not result["ok"]
+    assert "no specialist could run" in result["error"]
+    assert "checkpoint not found" in result["error"]
+    # Distinct from nothing being pip-installed: the remedy is a download, not
+    # an install, and a caller branching on the reason has to tell them apart.
+    assert result["confidence_unavailable_reason"] == "no_specialist_could_run"
+
+
+def test_a_prefixed_priority_still_picks_the_strongest_model(monkeypatch, image,
+                                                             tmp_path):
+    """vote() stores bare names, so the tie-break order has to be compared bare.
+
+    Silent when broken: the membership test matches nothing and the stereo answer
+    falls back to dict insertion order, which is the arbitrary choice the
+    tie-break exists to replace.
+    """
+    flat = core.canonicalize(PENICILLIN)
+    _committee(monkeypatch, {"decimer": flat, "molnextr": PENICILLIN,
+                             "molscribe": flat, "ocsrglyph": flat})
+    table = tmp_path / "cal.json"
+    # A table has to prefix both fields to load: the validator makes tie_break name
+    # exactly the committee. It then reports a mismatch, since vote() bares the
+    # names, but the stereo pick still runs and must not fall back to dict order.
+    prefixed = ["local:" + m for m in ALL_FOUR]
+    table.write_text(json.dumps({
+        "committee": prefixed,
+        "tie_break": "model-priority: " + ",".join(
+            ["local:molnextr", "local:decimer", "local:molscribe",
+             "local:ocsrglyph"]),
+        "patterns": {"4": {"k": 99, "n": 100, "p": 0.9851}},
+    }))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(table))
+
+    assert result["smiles"] == core.canonicalize(PENICILLIN, stereo=True)
+
+
+def test_a_single_model_label_uses_the_table_the_caller_named(monkeypatch, image,
+                                                              tmp_path):
+    """An explicit calibration path outranks the env var and the packaged table.
+
+    Silent when broken: a caller who refit gets their own numbers from a committee
+    and someone else's from every single-model read.
+    """
+    _stub(monkeypatch, ok=True, smiles=ASPIRIN)
+    mine = tmp_path / "mine.json"
+    mine.write_text(json.dumps({
+        "committee": ["decimer"], "patterns": {"1": {"k": 1, "n": 1}},
+        "model_performance": {"decimer": {"accuracy": 0.55, "n": 200}},
+    }))
+
+    result = tools.image_to_smiles_core(image, model="decimer",
+                                        calibration=str(mine))
+
+    assert result["confidence_label"] == "conflicting"  # 0.55, from the given table
+
+
+def test_a_shrunken_committee_says_what_stopped_the_others(monkeypatch, image):
+    """The mismatch text advises an install that is already done.
+
+    Silent when broken: three models are installed and cannot load, the warning
+    tells the user to install them, and the checkpoint path that would actually
+    fix it is collected and then dropped.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    def one(name, path):
+        if name == "decimer":
+            return {"ok": True, "smiles": ASPIRIN, "raw": "", "model_used": name,
+                    "cold_start": False, "latency_s": 0.5, "error": "", "ran": True}
+        return {"ok": False, "smiles": None, "raw": "", "model_used": name,
+                "cold_start": True, "latency_s": 3.0, "ran": False,
+                "error": f"{name} checkpoint is missing at /weights/{name}"}
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", one)
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert "checkpoint is missing" in result["warning"]
+    for name in ["molnextr", "molscribe", "ocsrglyph"]:
+        assert name in result["warning"]
+
+
+def test_a_split_the_table_never_measured_says_so(monkeypatch, image, tmp_path):
+    """The third confidence-less path, which used to surface as a bare None.
+
+    Silent when broken: an agent sees no number, no warning, and a label of
+    'unknown' that no document explains.
+    """
+    _committee(monkeypatch, {"decimer": ASPIRIN, "molnextr": "CCO"})
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer", "molnextr"],
+        "patterns": {"2": {"k": 19, "n": 20, "p": 0.9286}},
+    }))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(table))
+
+    assert result["confidence_unavailable_reason"] == "unknown_pattern"
+    assert result["confidence_label"] == "unknown"
+    assert "no '1/1' bucket" in result["warning"]
+
+
+def test_a_thin_bucket_still_hands_back_its_interval(monkeypatch, image, tmp_path):
+    """Withholding the number is only defensible if the interval survives.
+
+    Silent when broken: the docs offer the interval as what a thin bucket gives
+    instead of a point estimate, and the caller receives neither.
+    """
+    _committee(monkeypatch, {"decimer": ASPIRIN, "molnextr": ASPIRIN,
+                             "molscribe": "CCO", "ocsrglyph": "CCO"})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert result["agreement"] == "2/2"
+    assert result["confidence"] is None
+    assert result["confidence_interval"] == [0.3119, 0.8195]
+
+
+def test_a_shrunken_committee_that_finds_a_fitting_table_still_says_so(monkeypatch,
+                                                                       image,
+                                                                       tmp_path):
+    """A table can describe the survivors, so no mismatch fires to carry the news.
+
+    Silent when broken: three of four models never ran, the answer comes back with
+    a real confidence and an empty warning, and the only trace is a latency nobody
+    reads.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+
+    def one(name, path):
+        if name == "decimer":
+            return {"ok": True, "smiles": ASPIRIN, "raw": "", "model_used": name,
+                    "cold_start": False, "latency_s": 0.5, "error": "", "ran": True}
+        return {"ok": False, "smiles": None, "raw": "", "model_used": name,
+                "cold_start": True, "latency_s": 3.0, "ran": False,
+                "error": f"{name} checkpoint is missing"}
+
+    monkeypatch.setattr(backends, "smiles_from_specialist", one)
+    table = tmp_path / "cal.json"
+    table.write_text(json.dumps({
+        "committee": ["decimer"],
+        "patterns": {"1": {"k": 88, "n": 100, "p": round(88.5 / 101, 4)}},
+    }))
+
+    result = tools.image_to_smiles_core(image, ensemble=True,
+                                        calibration=str(table))
+
+    assert result["confidence"] is not None  # the table fits the one that ran
+    assert "could not run" in result["warning"]
+    assert "molscribe" in result["warning"]
+
+
+def test_the_failure_list_in_a_warning_is_bounded(monkeypatch, image):
+    """The errors are joined per model and go back into an agent's context.
+
+    Silent when broken: a long weights directory pushes the warning past 6 kB.
+    """
+    monkeypatch.setattr(backends, "available_specialists", lambda: ALL_FOUR)
+    monkeypatch.setattr(backends, "smiles_from_specialist", lambda n, p: {
+        "ok": n == "decimer", "smiles": ASPIRIN if n == "decimer" else None,
+        "raw": "", "model_used": n, "cold_start": False, "latency_s": 0.1,
+        "ran": n == "decimer", "error": "" if n == "decimer" else "x" * 3000})
+
+    result = tools.image_to_smiles_core(image, ensemble=True)
+
+    assert len(result["warning"]) < 1000


### PR DESCRIPTION
## Summary

This PR adds committee voting to `image_to_smiles`, for a committee of any size, and a measured probability with a confidence interval behind each result. The interval comes from a calibration table, and a CLI refits that table from the user's own labelled images, so the statistic and its interval describe the committee and the images actually in use.

`ensemble=True` reads the image with every specialist that can run and votes. How much the models agree is measurable, so the vote pattern looks up a probability measured on labelled images. Nothing fixes the committee at four: the vote reports a pattern for whatever set of models ran, and the validator checks a table against the committee it was fitted on. Four models give five patterns:

| agreement | meaning |
|-----------|---------|
| `4` | all four agree |
| `3/1` | three against one |
| `2/1/1` | two agree, two differ |
| `2/2` | an even split |
| `1/1/1/1` | all different |

```python
image_to_smiles_core("molecule.png", ensemble=True)
# {'smiles': 'CC(=O)Oc1ccccc1C(=O)O', 'confidence': ...,
#  'confidence_label': 'unanimous', 'agreement': '4', 'votes': {...}}
```

One table ships as the default, fitted for these four models on RDKit-rendered diagrams. A different committee, or scans and journal crops instead of clean diagrams, can behave differently, so `python -m chemgraph.tools.ocsr_calibrate` refits a table from your own labelled images and `--validate` checks the shipped one against a sample of them.

This builds on #198, which added the specialists and the model selection. `ensemble` defaults to off, so a single-model call runs the same model and returns the same SMILES it did there. The result gains confidence fields, which stay `None` on a single-model call because one model produces no agreement to score.

## Related issues

Follow-up to #198. No open issue.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Docs
- [ ] Chore / refactor / CI

## How was this tested?

`pytest tests/`: 949 passed, 32 skipped, 21 failed. `ruff check .` clean. This branch adds 150 test functions, 218 cases once parametrized. All are hermetic: the backends are stubbed, so no model is loaded and no image is read.

The 21 failures are already on `main` and are unrelated to this PR.

Every figure quoted in the code and the docs was checked against the raw benchmark predictions, and the shipped table regenerates from them.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on a single logical change (split if it grew large)
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"`: 949 passed, 30 skipped, 2 deselected, 21 failed. The 21 are already on `main`.
- [x] Added/updated tests for the change
- [x] Updated docs / README for any user-facing change

## What changed

- **`ocsr_core.py`** votes the predictions, and loads a calibration table through a validator that refuses one which cannot mean what a caller will assume.
- **`ocsr_tools.py`** runs the specialists, votes the ones that returned a reading, and attaches the confidence. `models_wanted` votes a subset, for when a table covers fewer models than are installed.
- **`ocsr_calibrate.py`** is new: it fits a table from labelled images, and `--validate` scores the shipped one against a sample.
