### PR TITLE
fix: make package metadata publishable and detect Polar availability

### DIFF
--- a/.github/workflows/conda-tests.yml
+++ b/.github/workflows/conda-tests.yml
@@ -63,8 +63,8 @@ jobs:
     - name: Install ChemGraph with MACE support
       shell: bash -l {0}
       run: |
-        pip install --no-cache-dir -e .
-        pip install --no-cache-dir pytest
+        python -m pip install --no-cache-dir -e . -r requirements/mace-polar.txt
+        python -m pip check
     
     - name: Run tests with MACE
       shell: bash -l {0}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,13 +23,15 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build twine packaging
 
       - name: Build package
         run: python -m build
 
       - name: Check package
-        run: twine check dist/*
+        run: |
+          python scripts/check_distribution_metadata.py dist/*
+          twine check dist/*
 
       - name: Publish to PyPI
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,9 @@ jobs:
     - name: Install and verify wheel
       run: |
         python -m pip install dist/*.whl
+        python scripts/check_distribution_metadata.py dist/*
         python -c "import chemgraph; print(f'ChemGraph {chemgraph.__version__}')"
+        chemgraph --help
         python -m pip check
 
   # Exercises the distributed/HPC feature set: the Academy multi-agent module

--- a/.opencode/skills/chemgraph/SKILL.md
+++ b/.opencode/skills/chemgraph/SKILL.md
@@ -234,7 +234,7 @@ streamlit run src/ui/app.py
 
 `config.toml` at the project root controls runtime settings:
 - `[general]` -- model, workflow, recursion_limit, verbosity
-- `[chemistry.calculators]` -- default calculator (mace_polar), fallback (emt)
+- `[chemistry.calculators]` -- omit `default` for automatic selection (mace_polar when the graph-longrange add-on is installed, otherwise mace_mp); an explicit `default` preserves that selection. Fallback is emt.
 - `[chemistry.optimization]` -- optimizer method, fmax, steps
 - `[api.*]` -- LLM provider base URLs and timeouts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM continuumio/miniconda3:latest
 
 WORKDIR /app
 
-COPY . /app
-
 # System packages required by the scientific Python stack
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -23,17 +21,24 @@ RUN conda install -y -c conda-forge \
     nwchem \
     && conda clean -afy
 
-# Install ChemGraph and UI runtime
-RUN pip install --no-cache-dir . && \
-    pip install --no-cache-dir jupyterlab
+# The PyPI CUDA dependency set includes unsupported wheels on Linux ARM.
+# Use PyTorch's CPU distribution on ARM; x86 retains its normal PyPI selection.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    python -m pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch; \
+    fi
 
-# Install Python tblite from source with conservative flags to avoid ABI/symbol issues on ARM.
+COPY . /app
+
+# Resolve ChemGraph, Polar, JupyterLab and TBLite together. Build TBLite from
+# source with conservative flags to avoid ABI/symbol issues on ARM.
 RUN CFLAGS="-O2 -fno-tree-vectorize" \
     FFLAGS="-O2 -fno-tree-vectorize" \
-    pip install --no-cache-dir --no-binary=tblite --force-reinstall "tblite==0.4.0"
+    python -m pip install --no-cache-dir --no-binary=tblite \
+    . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0"
 
 # Validate calculator runtimes at build time after package install.
-RUN which nwchem && python -c "from tblite.ase import TBLite"
+RUN which nwchem && python -c "from tblite.ase import TBLite; import graph_longrange" && \
+    python -m pip check
 
 # Allow git commands in bind-mounted repo paths inside the container.
 RUN git config --system --add safe.directory /app

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -2,8 +2,6 @@ FROM continuumio/miniconda3:latest
 
 WORKDIR /app
 
-COPY . /app
-
 # ARM-friendly variant of the standard ChemGraph image.
 # This image intentionally does not include any vLLM setup.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -26,16 +24,23 @@ RUN conda install -y -c conda-forge \
     nwchem \
     && conda clean -afy
 
-RUN pip install --no-cache-dir . && \
-    pip install --no-cache-dir jupyterlab
+# Avoid the unsupported CUDA dependency wheels selected by PyPI on Linux ARM.
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+    python -m pip install --no-cache-dir --index-url https://download.pytorch.org/whl/cpu torch; \
+    fi
 
-# Install Python tblite from source with conservative flags to avoid ABI/symbol issues on ARM.
+COPY . /app
+
+# Resolve the same packages as the standard image in one installation pass.
+# Build TBLite from source with conservative compiler flags.
 RUN CFLAGS="-O2 -fno-tree-vectorize" \
     FFLAGS="-O2 -fno-tree-vectorize" \
-    pip install --no-cache-dir --no-binary=tblite --force-reinstall "tblite==0.5.0"
+    python -m pip install --no-cache-dir --no-binary=tblite \
+    . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0"
 
 # Validate calculator runtimes at build time after package install.
-RUN which nwchem && python -c "from tblite.ase import TBLite"
+RUN which nwchem && python -c "from tblite.ase import TBLite; import graph_longrange" && \
+    python -m pip check
 
 RUN git config --system --add safe.directory /app
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements/mace-polar.txt
+include requirements/ocsr-models.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include requirements/mace-polar.txt
 include requirements/ocsr-models.txt
+include config.toml environment.yml Dockerfile Dockerfile.arm
+include scripts/check_distribution_metadata.py

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ available in that environment.
 | Capability | Installation | Notes |
 | --- | --- | --- |
 | EMT | Core install | Lightweight; useful for setup checks, not general high-accuracy chemistry |
-| MACE | Core install | MACE-Polar medium is the default and supports molecular dipole moments; first use downloads ASL-licensed model weights |
+| MACE | MACE-MP in core; Polar add-on optional | Defaults to MACE-Polar medium when its add-on is installed, otherwise MACE-MP. Dipole/IR require a capable calculator; Polar weights use the ASL. See [installation instructions](docs/calculators.md#mace-downloads). |
 | TBLite / xTB | `pip install "chemgraph[calculators]"` | May require a Fortran toolchain when no wheel is available |
 | UMA / FAIRChem | `pip install "chemgraph[uma]"` | Use a separate environment from MACE if `e3nn` resolution conflicts |
 | NWChem | Install the `nwchem` executable separately | Must be on `PATH` or configured through ASE |

--- a/config.toml
+++ b/config.toml
@@ -84,7 +84,8 @@ displacement = 0.01
 nprocs = 1
 
 [chemistry.calculators]
-default = "mace_polar"
+# Omit default to detect MACE-Polar when installed, otherwise MACE-MP.
+# Set default explicitly here to preserve a particular calculator selection.
 fallback = "emt"
 
 [output.files]

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -9,7 +9,7 @@ runtime; optional engines that cannot be imported or located are omitted.
 | Calculator | Setup | Best use in onboarding |
 | --- | --- | --- |
 | EMT | Included with ASE | Fast, offline smoke tests; limited elements/accuracy |
-| MACE | Included in core ChemGraph | MACE-Polar medium is the default; supports energies, forces, and molecular dipole moments |
+| MACE | MACE-MP included in core; Polar requires an add-on | Polar medium is preferred when installed; otherwise MACE-MP supplies energies and forces |
 | TBLite | `pip install "chemgraph[calculators]"` | Semiempirical calculations |
 | UMA / fairchem | `pip install "chemgraph[uma]"` in a separate environment | Advanced universal ML potential |
 | AIMNet2 | Install its package/model dependencies separately | Supported molecular ML route when importable |
@@ -45,14 +45,38 @@ result as scientifically appropriate merely because the workflow completed.
 ## MACE downloads
 
 MACE is installed with the core package. When no calculator is specified,
-ChemGraph uses the MACE-Polar medium checkpoint (`mace_polar` with
-`polar-1-m`). Pretrained weights may be fetched on first use. In restricted or
+ChemGraph uses MACE-Polar (`mace_polar`, `polar-1-m`) if the `graph-longrange`
+add-on is installed; otherwise it uses MACE-MP (`mace_mp`, reported as
+`medium-mpa-0`). Explicit calculator selections are preserved.
+
+Starting with v0.7.0, install Polar from the matching source checkout or extracted
+source distribution with:
+
+```bash
+python -m pip install . -r requirements/mace-polar.txt
+python -m pip check
+```
+
+For a published release, pin both ChemGraph and its requirements to that release:
+
+```bash
+python -m pip install 'chemgraph==0.7.0' -r https://raw.githubusercontent.com/argonne-lcf/ChemGraph/v0.7.0/requirements/mace-polar.txt
+```
+
+Use the matching tag or commit when installing another version; the add-on files
+are introduced in v0.7.0. The conda environment and Docker images explicitly
+install Polar. Run `conda env create -f environment.yml` from the checkout root
+so its supplemental requirements path resolves correctly.
+
+Pretrained weights may be fetched on first use. In restricted or
 offline environments, pre-stage the required model cache or choose EMT for the
 initial test. MACE-Polar checkpoints are distributed under the Academic
 Software License (ASL); review its terms before use.
 
 MACE-Polar can calculate molecular dipole moments with `driver="dipole"`.
 ChemGraph reports these dipole vectors in Debye.
+MACE-MP does not supply Polar's dipole or IR capabilities. An explicit Polar
+request without the add-on reports installation instructions before loading weights.
 
 ## UMA dependency isolation
 

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -49,15 +49,18 @@ ChemGraph uses MACE-Polar (`mace_polar`, `polar-1-m`) if the `graph-longrange`
 add-on is installed; otherwise it uses MACE-MP (`mace_mp`, reported as
 `medium-mpa-0`). Explicit calculator selections are preserved.
 
-Starting with v0.7.0, install Polar from the matching source checkout or extracted
-source distribution with:
+Starting with v0.7.0, install Polar from the root of the matching source checkout
+or extracted source distribution (the directory containing `pyproject.toml`):
 
 ```bash
 python -m pip install . -r requirements/mace-polar.txt
 python -m pip check
 ```
 
-For a published release, pin both ChemGraph and its requirements to that release:
+After v0.7.0 is published on PyPI and its Git tag exists, a wheel installation
+can use the command below from any directory. Before publication, use the
+development checkout instructions above. Pin both ChemGraph and its requirements
+to the same release:
 
 ```bash
 python -m pip install 'chemgraph==0.7.0' -r https://raw.githubusercontent.com/argonne-lcf/ChemGraph/v0.7.0/requirements/mace-polar.txt
@@ -77,6 +80,13 @@ MACE-Polar can calculate molecular dipole moments with `driver="dipole"`.
 ChemGraph reports these dipole vectors in Debye.
 MACE-MP does not supply Polar's dipole or IR capabilities. An explicit Polar
 request without the add-on reports installation instructions before loading weights.
+Unsupported dipole and IR requests return a failure with an explanation; IR checks
+dipole support before starting optimization or vibrational analysis.
+
+In the UI, **Automatic** leaves `chemistry.calculators.default` absent from the
+saved TOML, so unrelated settings changes preserve detection. Selecting a named
+calculator stores an explicit choice. Restart ChemGraph after installing an add-on
+so its initialization-time calculator descriptions reflect the new environment.
 
 ## UMA dependency isolation
 

--- a/docs/docker_support.md
+++ b/docs/docker_support.md
@@ -83,6 +83,11 @@ checkout's `cg_logs/` directory.
 docker build -t chemgraph:local .
 ```
 
+ARM builds install CPU PyTorch from its official wheel index because the PyPI
+CUDA dependency set includes unsupported ARM wheels. x86 builds retain their
+normal PyPI PyTorch selection. Both images explicitly install the Polar add-on
+and run `pip check` after resolving ChemGraph and its runtime dependencies.
+
 The TBLite build can take time, especially on ARM. Mount a dedicated artifact
 directory rather than a home directory, pass tokens at runtime, remember that
 container paths may differ from host paths, and pin an image tag or digest for

--- a/environment.yml
+++ b/environment.yml
@@ -7,16 +7,17 @@ dependencies:
   - pip
   - numpy=2.2.6
   - pandas=2.2.3
-  - pytest=8.4.1
+  - pytest=9.0.3
   - rich=14.1.0
   - toml=0.10.2
-  - tblite
+  - tblite=0.4.0
   - nwchem
   - pip:
     - ase==3.25.0
     - rdkit==2025.3.3
     - langgraph==1.2.9
     - langgraph-checkpoint==4.1.1
+    - langgraph-checkpoint-sqlite==3.1.1
     - langgraph-prebuilt==1.1.0
     - langgraph-sdk==0.4.2
     - langchain==1.3.14
@@ -33,9 +34,9 @@ dependencies:
     - numexpr==2.11.0
     - pymatgen==2025.3.10
     - mace-torch>=0.3.16
-    - graph-longrange @ git+https://github.com/WillBaldwin0/graph_electrostatics.git@v0.4.0
+    - -r requirements/mace-polar.txt
     - globus-sdk
-    - streamlit==1.48.1
+    - streamlit==1.54.0
     - py3Dmol
     - plotly
     - langsmith==0.10.10

--- a/examples/ocsr/README.md
+++ b/examples/ocsr/README.md
@@ -83,6 +83,9 @@ needs timm 1.x, and no single version satisfies both.
 The complete specialist installation is supported on Linux. On Apple Silicon
 with Python 3.12, the `pyonmttok` dependency has no matching macOS wheel; use a
 Linux container or host for the full set of specialists.
+When extending ChemGraph's ARM Docker images, add
+`--extra-index-url https://download.pytorch.org/whl/cpu` to the OCSR installation
+command so torchvision uses the same CPU build as the image's PyTorch.
 
 Installing them one at a time lets the later install replace the timm the earlier one
 needs, and pip reports success while OCSRGlyph fails at inference with

--- a/examples/ocsr/README.md
+++ b/examples/ocsr/README.md
@@ -34,7 +34,8 @@ structure it was drawn from. `--agent` routes the same call through an LLM.
 | `ocsrglyph` | 0.766 | 0.3 s |
 | `llm` | not measured | varies |
 
-`pip install 'chemgraph[ocsr]'` installs all four specialists. `llm` needs no
+`pip install 'chemgraph[ocsr]'` installs DECIMER and shared support; the other
+three specialists need the pinned add-on requirements below. `llm` needs no
 install and uses the agent's own model.
 
 The specialists return a SMILES and nothing else. An LLM returns whatever it likes,
@@ -59,16 +60,29 @@ machine you are on.
 ## Installing
 
 ```bash
-pip install 'chemgraph[ocsr]'
+python -m pip install '.[ocsr]' -r requirements/ocsr-models.txt
+python -m pip check
 ```
 
+Run this from the matching ChemGraph checkout or extracted source distribution.
 That installs all four specialists. Three of them also need a checkpoint on disk,
 listed under Checkpoints below; DECIMER fetches its own.
 
 DECIMER is on PyPI. The other three install from GitHub, pinned to a commit so the
-extra keeps resolving to what was tested here. MolNexTR and MolScribe point at forks
+add-on keeps resolving to what was tested here. PyPI rejects Git dependencies in
+package metadata, even in extras. Starting with v0.7.0, a published install can use:
+
+```bash
+python -m pip install 'chemgraph[ocsr]==0.7.0' -r https://raw.githubusercontent.com/argonne-lcf/ChemGraph/v0.7.0/requirements/ocsr-models.txt
+```
+
+Use the matching tag or commit for another version. MolNexTR and MolScribe point at forks
 whose only change is two lines of `setup.py` each: both pin `timm==0.4.12`, OCSRGlyph
 needs timm 1.x, and no single version satisfies both.
+
+The complete specialist installation is supported on Linux. On Apple Silicon
+with Python 3.12, the `pyonmttok` dependency has no matching macOS wheel; use a
+Linux container or host for the full set of specialists.
 
 Installing them one at a time lets the later install replace the timm the earlier one
 needs, and pip reports success while OCSRGlyph fails at inference with

--- a/examples/ocsr/README.md
+++ b/examples/ocsr/README.md
@@ -59,18 +59,23 @@ machine you are on.
 
 ## Installing
 
+Run this from the root of the matching ChemGraph checkout or extracted source
+distribution (the directory containing `pyproject.toml`). If you are currently
+in `examples/ocsr/`, first run `cd ../..`.
+
 ```bash
 python -m pip install '.[ocsr]' -r requirements/ocsr-models.txt
 python -m pip check
 ```
 
-Run this from the matching ChemGraph checkout or extracted source distribution.
 That installs all four specialists. Three of them also need a checkpoint on disk,
 listed under Checkpoints below; DECIMER fetches its own.
 
 DECIMER is on PyPI. The other three install from GitHub, pinned to a commit so the
 add-on keeps resolving to what was tested here. PyPI rejects Git dependencies in
-package metadata, even in extras. Starting with v0.7.0, a published install can use:
+package metadata, even in extras. After v0.7.0 is published on PyPI and its Git tag
+exists, a wheel installation can use this command from any directory. Before
+publication, use the development checkout instructions above:
 
 ```bash
 python -m pip install 'chemgraph[ocsr]==0.7.0' -r https://raw.githubusercontent.com/argonne-lcf/ChemGraph/v0.7.0/requirements/ocsr-models.txt

--- a/examples/ocsr/run_ocsr.py
+++ b/examples/ocsr/run_ocsr.py
@@ -60,7 +60,7 @@ def run_direct(model: str | None) -> int:
     if not installed and model != "llm":
         print(describe_models(installed))
         print("\nNo specialist is installed. Install one with:\n"
-              "    pip install 'chemgraph[ocsr]'\n"
+              "    python -m pip install '.[ocsr]' -r requirements/ocsr-models.txt\n"
               "or read this image with the agent's own model:\n"
               "    python run_ocsr.py --agent --model llm")
         return 1

--- a/examples/ocsr/run_ocsr.py
+++ b/examples/ocsr/run_ocsr.py
@@ -52,16 +52,15 @@ def _same_molecule(a: str | None, b: str) -> bool:
 
 def run_direct(model: str | None) -> int:
     """Call the tool on every image and report agreement with the known answer."""
-    from chemgraph.tools.ocsr_backends import available_specialists
+    from chemgraph.tools.ocsr_backends import _install_hint, available_specialists
     from chemgraph.tools.ocsr_models import describe_models
     from chemgraph.tools.ocsr_tools import image_to_smiles_core
 
     installed = available_specialists()
     if not installed and model != "llm":
         print(describe_models(installed))
-        print("\nNo specialist is installed. Install one with:\n"
-              "    python -m pip install '.[ocsr]' -r requirements/ocsr-models.txt\n"
-              "or read this image with the agent's own model:\n"
+        print("\nNo specialist is installed. " + _install_hint() +
+              "\nor read this image with the agent's own model:\n"
               "    python run_ocsr.py --agent --model llm")
         return 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "rdkit",
     "pymatgen",
     "mace-torch>=0.3.16",
-    "graph-longrange @ git+https://github.com/WillBaldwin0/graph_electrostatics.git@v0.4.0",
     "globus_sdk",
     "streamlit==1.54.0",
     "py3Dmol",
@@ -55,16 +54,12 @@ dependencies = [
 [project.optional-dependencies]
 # Optical Chemical Structure Recognition: read a structure diagram, get a SMILES.
 #
-# All four specialists run in this environment, so none needs one of its own. Two are
-# installed from forks that relax pins predating Python 3.12; the upstream pins are
-# mutually unsatisfiable, so pip refuses to resolve them together. The forks change
-# dependency metadata only, and chemgraph.tools.timm_compat handles the import paths
-# timm moved after 0.4.12. Checkpoints are covered in examples/ocsr/README.md.
+# DECIMER and shared support packages are installable from PyPI. The three Git-only
+# specialists live in requirements/ocsr-models.txt because PyPI rejects direct URL
+# dependencies, including extras. See examples/ocsr/README.md for the pinned forks,
+# timm compatibility shim, installation instructions, and checkpoints.
 ocsr = [
     "decimer>=2.8",
-    "glyph @ git+https://github.com/EdisonScientific/glyph@0bf782f863d26b041ace157668928ef07c38b972",
-    "MolNexTR @ git+https://github.com/reowszer/MolNexTR@f450b9661557b1f91ae36f59dd1fadfbcb3a0967",
-    "MolScribe @ git+https://github.com/reowszer/MolScribe@b03b30fbac9a78434116e626ebef6c7b7bdcdb6e",
     # Upper bound because timm_compat reaches into private modules (models._builder,
     # models._registry), which carry no stability promise across minor releases.
     "timm>=1.0,<1.1",

--- a/requirements/mace-polar.txt
+++ b/requirements/mace-polar.txt
@@ -1,0 +1,2 @@
+# Optional MACE-Polar engine; keep outside published Requires-Dist metadata.
+graph-longrange @ git+https://github.com/WillBaldwin0/graph_electrostatics.git@v0.4.0

--- a/requirements/ocsr-models.txt
+++ b/requirements/ocsr-models.txt
@@ -1,0 +1,4 @@
+# Install together with ChemGraph's ocsr extra; these forks relax incompatible pins.
+glyph @ git+https://github.com/EdisonScientific/glyph@0bf782f863d26b041ace157668928ef07c38b972
+MolNexTR @ git+https://github.com/reowszer/MolNexTR@f450b9661557b1f91ae36f59dd1fadfbcb3a0967
+MolScribe @ git+https://github.com/reowszer/MolScribe@b03b30fbac9a78434116e626ebef6c7b7bdcdb6e

--- a/scripts/check_distribution_metadata.py
+++ b/scripts/check_distribution_metadata.py
@@ -1,0 +1,46 @@
+"""Reject direct-URL dependencies before uploading ChemGraph distributions."""
+
+import argparse
+from email.parser import BytesParser
+from pathlib import Path
+import tarfile
+import zipfile
+
+from packaging.requirements import Requirement
+
+
+def check_distribution(path: Path) -> None:
+    """Check built metadata, including extras, and the sdist add-on files."""
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path) as archive:
+            names = [n for n in archive.namelist() if n.endswith(".dist-info/METADATA")]
+            if len(names) != 1:
+                raise ValueError(f"{path}: expected exactly one wheel METADATA file")
+            metadata = archive.read(names[0])
+    elif path.name.endswith(".tar.gz"):
+        with tarfile.open(path) as archive:
+            names = archive.getnames()
+            roots = [n for n in names if n.count("/") == 1 and n.endswith("/PKG-INFO")]
+            if len(roots) != 1:
+                raise ValueError(f"{path}: expected exactly one root PKG-INFO file")
+            root = roots[0].split("/")[0]
+            for filename in ("mace-polar.txt", "ocsr-models.txt"):
+                if f"{root}/requirements/{filename}" not in names:
+                    raise ValueError(f"{path}: missing requirements/{filename}")
+            with archive.extractfile(roots[0]) as source:
+                metadata = source.read()
+    else:
+        raise ValueError(f"Unsupported distribution: {path}")
+
+    requirements = BytesParser().parsebytes(metadata).get_all("Requires-Dist", [])
+    for raw in requirements:
+        if Requirement(raw).url is not None:
+            raise ValueError(f"{path}: direct-URL dependency is not publishable: {raw}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("distributions", nargs="+", type=Path)
+    for distribution in parser.parse_args().distributions:
+        check_distribution(distribution)
+        print(f"Metadata checked: {distribution}")

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -253,10 +253,10 @@ def get_calculator_selection_context() -> str:
         f"- Default calculator when the user does not specify one: "
         f"{_default_calculator_description()}.\n"
         "- When calling run_ase, choose only from the available calculators above. "
-        "If the user requests an unavailable calculator, choose the default "
-        "available calculator when that substitution is appropriate; otherwise "
-        "ask for clarification or explain that the requested calculator is not "
-        "available."
+        "Preserve explicit calculator selections; explain missing dependencies "
+        "instead of silently substituting another calculator. MACE-Polar requires "
+        "the graph-longrange add-on. MACE-MP does not provide Polar's dipole or "
+        "IR capabilities."
     )
 
 

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -13,6 +13,7 @@ from chemgraph.schemas.calculators.fairchem_calc import FAIRChemCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
 from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
 from chemgraph.schemas.calculators.aimnet2_calc import AIMNET2Calc
+from chemgraph.utils.calculator_defaults import mace_polar_available
 
 # Gate optional calculators on whether their engine package is installed.
 # Schema classes are always importable (internal to ChemGraph), so we must
@@ -253,8 +254,11 @@ def get_calculator_selection_context() -> str:
         f"- Default calculator when the user does not specify one: "
         f"{_default_calculator_description()}.\n"
         "- When calling run_ase, choose only from the available calculators above. "
-        "Preserve explicit calculator selections; explain missing dependencies "
-        "instead of silently substituting another calculator. MACE-Polar requires "
+        "Preserve explicit calculator selections. If a requested engine is "
+        "unavailable, explain the missing dependencies or ask for clarification "
+        "before calling run_ase; do not silently substitute another calculator. "
+        f"The MACE-Polar add-on is {'installed' if mace_polar_available() else 'not installed'} "
+        "in this environment. MACE-Polar requires "
         "the graph-longrange add-on. MACE-MP does not provide Polar's dipole or "
         "IR capabilities."
     )

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -2,6 +2,7 @@
 Reference: https://github.com/ACEsuit/mace/blob/main/mace/calculators/foundations_models.py"""
 
 import functools
+import importlib.util
 import logging
 import os
 import tempfile
@@ -19,6 +20,16 @@ _DEFAULT_MODEL_NAMES = {
     "mace_mp": "medium-mpa-0",
     "mace_off": "medium",
 }
+
+
+def mace_polar_available() -> bool:
+    """Detect the Polar add-on without importing it or loading model weights."""
+    return importlib.util.find_spec("graph_longrange") is not None
+
+
+def get_default_mace_calculator_type() -> str:
+    """Prefer Polar when its add-on is installed, otherwise use MACE-MP."""
+    return "mace_polar" if mace_polar_available() else "mace_mp"
 
 # Process-wide lock for MACE operations.
 # MACE model deserialization (torch.load) triggers torch.fx.symbolic_trace
@@ -113,8 +124,8 @@ class MaceCalc(BaseModel):
     Parameters
     ----------
     calculator_type : str, optional
-        Type of calculator to use. Options: 'mace_polar' (default), 'mace_mp',
-        'mace_off', or 'mace_anicc'.
+        Type of calculator to use: 'mace_polar', 'mace_mp', 'mace_off', or
+        'mace_anicc'. Defaults to Polar when its add-on is installed, else MACE-MP.
     model : str or Path, optional
         Name or path to the model file. If None, uses default model for selected calculator type.
     device : str, optional
@@ -143,9 +154,10 @@ class MaceCalc(BaseModel):
     calculator_type: Literal[
         "mace_polar", "mace_mp", "mace_off", "mace_anicc"
     ] = Field(
-        default="mace_polar",
-        description="Type of calculator. Options: 'mace_polar' (default), "
-        "'mace_mp', 'mace_off', or 'mace_anicc'. MACE-Polar supports "
+        default_factory=get_default_mace_calculator_type,
+        description="Type of calculator. Defaults to 'mace_polar' when the "
+        "graph-longrange add-on is installed, otherwise 'mace_mp'. Other options "
+        "are 'mace_off' and 'mace_anicc'. MACE-Polar supports "
         "energies, forces, and molecular dipole moments.",
     )
     model: Optional[Union[str, Path]] = Field(
@@ -238,6 +250,15 @@ class MaceCalc(BaseModel):
         ValueError
             If an invalid calculator_type is specified
         """
+        if self.calculator_type == "mace_polar" and not mace_polar_available():
+            raise ImportError(
+                "MACE-Polar requires the graph-longrange add-on. From the matching "
+                "ChemGraph source checkout or extracted source distribution, run "
+                "'python -m pip install -r requirements/mace-polar.txt'. "
+                "See https://argonne-lcf.github.io/ChemGraph/calculators/ "
+                "for versioned installation instructions."
+            )
+
         from mace.modules.models import ScaleShiftMACE
 
         # Allow loading slice and ScaleShiftMACE objects for compatibility with older model files

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -2,7 +2,6 @@
 Reference: https://github.com/ACEsuit/mace/blob/main/mace/calculators/foundations_models.py"""
 
 import functools
-import importlib.util
 import logging
 import os
 import tempfile
@@ -13,6 +12,9 @@ from typing import Literal, Optional, Union
 from pydantic import BaseModel, Field
 import torch
 
+from chemgraph.utils import calculator_defaults
+from chemgraph.utils.calculator_defaults import get_default_mace_calculator_type
+
 _logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL_NAMES = {
@@ -22,14 +24,11 @@ _DEFAULT_MODEL_NAMES = {
 }
 
 
-def mace_polar_available() -> bool:
-    """Detect the Polar add-on without importing it or loading model weights."""
-    return importlib.util.find_spec("graph_longrange") is not None
-
-
-def get_default_mace_calculator_type() -> str:
-    """Prefer Polar when its add-on is installed, otherwise use MACE-MP."""
-    return "mace_polar" if mace_polar_available() else "mace_mp"
+def _calculator_type_schema(schema: dict) -> None:
+    """Expose the detected default and availability to schema consumers."""
+    schema["default"] = get_default_mace_calculator_type()
+    availability = "installed" if schema["default"] == "mace_polar" else "not installed"
+    schema["description"] += f" The MACE-Polar add-on is {availability} in this environment."
 
 # Process-wide lock for MACE operations.
 # MACE model deserialization (torch.load) triggers torch.fx.symbolic_trace
@@ -155,6 +154,7 @@ class MaceCalc(BaseModel):
         "mace_polar", "mace_mp", "mace_off", "mace_anicc"
     ] = Field(
         default_factory=get_default_mace_calculator_type,
+        json_schema_extra=_calculator_type_schema,
         description="Type of calculator. Defaults to 'mace_polar' when the "
         "graph-longrange add-on is installed, otherwise 'mace_mp'. Other options "
         "are 'mace_off' and 'mace_anicc'. MACE-Polar supports "
@@ -250,9 +250,9 @@ class MaceCalc(BaseModel):
         ValueError
             If an invalid calculator_type is specified
         """
-        if self.calculator_type == "mace_polar" and not mace_polar_available():
+        if self.calculator_type == "mace_polar" and not calculator_defaults.mace_polar_available():
             raise ImportError(
-                "MACE-Polar requires the graph-longrange add-on. From the matching "
+                "MACE-Polar requires the graph-longrange add-on. From the root of the matching "
                 "ChemGraph source checkout or extracted source distribution, run "
                 "'python -m pip install -r requirements/mace-polar.txt'. "
                 "See https://argonne-lcf.github.io/ChemGraph/calculators/ "

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -359,20 +359,33 @@ def _simulation_input_for_output(
     return params.model_copy(update={"calculator": output_calculator})
 
 
-def _extract_dipole_moment(atoms) -> List[Optional[float]]:
+def _validate_dipole_moment(dipole) -> List[float]:
+    """Require a finite three-component dipole before reporting success."""
+    from ase.calculators.calculator import PropertyNotImplementedError
+
+    if dipole is None:
+        raise PropertyNotImplementedError(
+            "The calculator does not provide dipole moments. Dipole and IR "
+            "calculations require a dipole-capable calculator, such as "
+            "MACE-Polar with the graph-longrange add-on installed."
+        )
+    components = np.asarray(dipole, dtype=float)
+    if components.shape != (3,) or not np.isfinite(components).all():
+        raise ValueError("The calculator must return three finite dipole components.")
+    return [round(float(component), 4) for component in components]
+
+
+def _extract_dipole_moment(atoms) -> List[float]:
     """Return an ASE dipole, including calculators that expose it via results."""
+    from ase.calculators.calculator import PropertyNotImplementedError
+
     try:
         dipole = atoms.get_dipole_moment()
-    except Exception:
+    except PropertyNotImplementedError:
         dipole = getattr(getattr(atoms, "calc", None), "results", {}).get(
             "dipole"
         )
-    if dipole is None:
-        return [None, None, None]
-    try:
-        return [round(float(component), 4) for component in dipole]
-    except (TypeError, ValueError):
-        return [None, None, None]
+    return _validate_dipole_moment(dipole)
 
 
 # ---------------------------------------------------------------------------
@@ -503,6 +516,19 @@ def run_ase_core(params: ASEInputSchema) -> dict:
     dict
         Minimal result payload (status, message, key numbers).
     """
+    try:
+        return _run_ase_core(params)
+    except Exception as e:
+        logger.exception("run_ase_core failed with %s: %s", type(e).__name__, e)
+        return {
+            "status": "failure",
+            "error_type": type(e).__name__,
+            "message": str(e),
+        }
+
+
+def _run_ase_core(params: ASEInputSchema) -> dict:
+    """Execute a simulation inside the shared public error boundary."""
     from ase.io import read
     from ase.optimize import BFGS, LBFGS, GPMin, FIRE, MDMin
 
@@ -595,6 +621,17 @@ def run_ase_core(params: ASEInputSchema) -> dict:
     logger.info("Read %d atoms from %s", len(atoms), input_structure_file)
     atoms.info.update(system_info)
     atoms.calc = calc
+
+    if driver == "ir":
+        # Infrared calls this ASE method at every displacement. Check it before
+        # optimization and vibrations; a result-only fallback cannot support IR.
+        from ase.calculators.calculator import PropertyNotImplementedError
+
+        try:
+            dipole = atoms.get_dipole_moment()
+        except PropertyNotImplementedError:
+            dipole = None
+        _validate_dipole_moment(dipole)
 
     # ------------------------------------------------------------------
     # Driver: energy / dipole  (single-point, no optimization)

--- a/src/chemgraph/tools/ocsr_backends.py
+++ b/src/chemgraph/tools/ocsr_backends.py
@@ -294,8 +294,10 @@ def _preload_torchvision() -> None:
 
 
 def _install_hint() -> str:
-    """How to install a missing model. One extra covers all four."""
-    return (f"Install it with: pip install 'chemgraph[ocsr]'. "
+    """Install PyPI support and the pinned Git specialists together."""
+    return ("From the matching ChemGraph source checkout or extracted source "
+            "distribution, run: python -m pip install '.[ocsr]' "
+            "-r requirements/ocsr-models.txt. "
             f"Installed here: {', '.join(available_specialists()) or 'none'}.")
 
 
@@ -383,4 +385,3 @@ def smiles_from_specialist(name: str, image_path: str) -> dict:
 
     return _narrow(ok=True, smiles=smiles, raw=str(raw or "")[:200],
                    model_used=bare, cold_start=cold, latency_s=elapsed)
-

--- a/src/chemgraph/tools/ocsr_backends.py
+++ b/src/chemgraph/tools/ocsr_backends.py
@@ -295,9 +295,11 @@ def _preload_torchvision() -> None:
 
 def _install_hint() -> str:
     """Install PyPI support and the pinned Git specialists together."""
-    return ("From the matching ChemGraph source checkout or extracted source "
+    return ("From the root of the matching ChemGraph source checkout or extracted source "
             "distribution, run: python -m pip install '.[ocsr]' "
             "-r requirements/ocsr-models.txt. "
+            "For release installation instructions, see "
+            "https://github.com/argonne-lcf/ChemGraph/blob/main/examples/ocsr/README.md#installing. "
             f"Installed here: {', '.join(available_specialists()) or 'none'}.")
 
 

--- a/src/chemgraph/tools/ocsr_registry.json
+++ b/src/chemgraph/tools/ocsr_registry.json
@@ -1,6 +1,6 @@
 {
   "schema": 1,
-  "_comment": "OCSR specialist models. All four install from the ocsr extra into ChemGraph's own environment; see examples/ocsr/README.md. accuracy is exact match over the 722-image benchmark (n=722 for each). import_name is what ocsr_backends probes to decide whether a model is installed. weights is where a checkpoint is cached; DECIMER manages its own cache and has none.",
+  "_comment": "OCSR specialist models. DECIMER installs from the ocsr extra; the other three require requirements/ocsr-models.txt in the same environment. See examples/ocsr/README.md. accuracy is exact match over the 722-image benchmark (n=722 for each). import_name is what ocsr_backends probes to decide whether a model is installed. weights is where a checkpoint is cached; DECIMER manages its own cache and has none.",
   "specialists": {
     "decimer": {
       "import_name": "DECIMER",

--- a/src/chemgraph/utils/calculator_defaults.py
+++ b/src/chemgraph/utils/calculator_defaults.py
@@ -1,0 +1,16 @@
+"""Lightweight calculator defaults shared by schemas and the UI."""
+
+import importlib.util
+
+
+def mace_polar_available() -> bool:
+    """Detect the Polar add-on without importing engines or loading weights."""
+    try:
+        return importlib.util.find_spec("graph_longrange") is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def get_default_mace_calculator_type() -> str:
+    """Prefer Polar when its add-on is installed, otherwise use MACE-MP."""
+    return "mace_polar" if mace_polar_available() else "mace_mp"

--- a/src/ui/_pages/configuration.py
+++ b/src/ui/_pages/configuration.py
@@ -8,7 +8,10 @@ import streamlit as st
 import toml
 
 from ui import providers
-from ui.config import get_default_config, load_config, save_config
+from ui.config import (
+    get_default_config, load_config, merge_config_defaults,
+    resolve_default_calculator, save_config,
+)
 from ui.endpoint import check_local_model_endpoint
 from ui.provider_widgets import apply_api_key, clear_api_key, render_alcf_login
 
@@ -568,16 +571,25 @@ def _render_chemistry_settings(config: dict) -> None:
             "orca",
             "nwchem",
         ]
-        config["chemistry"]["calculators"]["default"] = st.selectbox(
+        calculators = config["chemistry"]["calculators"]
+        default = calculators.get("default")
+        default_options = [None, *calc_options]
+        if default not in default_options:
+            default_options.append(default)
+        selected = st.selectbox(
             "Default Calculator",
-            calc_options,
-            index=(
-                calc_options.index(config["chemistry"]["calculators"]["default"])
-                if config["chemistry"]["calculators"]["default"] in calc_options
-                else 0
+            default_options,
+            index=default_options.index(default),
+            format_func=lambda value: (
+                f"Automatic ({resolve_default_calculator({})})"
+                if value is None else value
             ),
             key=_wkey("config_calc_default"),
         )
+        if selected is None:
+            calculators.pop("default", None)
+        else:
+            calculators["default"] = selected
         config["chemistry"]["calculators"]["fallback"] = st.selectbox(
             "Fallback Calculator",
             calc_options,
@@ -620,7 +632,10 @@ def _render_raw_toml(config: dict) -> None:
             new_config = toml.loads(edited_config)
             # Update the draft, not the live config.  The user must still
             # click "Save Configuration" to persist and apply the changes.
-            st.session_state._config_draft = new_config
+            st.session_state._config_draft = merge_config_defaults(new_config)
+            st.session_state._config_widget_nonce = (
+                st.session_state.get("_config_widget_nonce", 0) + 1
+            )
             st.success(
                 "✅ Draft updated from TOML.  "
                 "Click **Save Configuration** to apply."
@@ -690,7 +705,7 @@ def _render_config_summary(config: dict) -> None:
         st.write(f"- Model: {config['general']['model']}")
         st.write(f"- Workflow: {config['general']['workflow']}")
         st.write(
-            f"- Default Calculator: {config['chemistry']['calculators']['default']}"
+            f"- Default Calculator: {resolve_default_calculator(config)}"
         )
 
         st.write("**Providers:**")

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -35,7 +35,7 @@ from ui import providers
 from ui.agent_manager import initialize_agent
 from ui.provider_widgets import apply_api_key, render_alcf_login
 from ui.branding import LOGO_IMAGES, first_existing_asset
-from ui.config import load_config, save_config
+from ui.config import load_config, resolve_default_calculator, save_config
 from ui.endpoint import check_local_model_endpoint
 from ui.file_utils import (
     extract_log_dir_from_messages,
@@ -1843,12 +1843,12 @@ def _render_example_queries(config: dict, selected_model: str) -> None:
         st.markdown("**Based on your current configuration:**")
         st.markdown(f"- Model: {selected_model}")
         st.markdown(
-            f"- Default Calculator: {config['chemistry']['calculators']['default']}"
+            f"- Default Calculator: {resolve_default_calculator(config)}"
         )
 
         examples = [
             "What is the SMILES string for caffeine?",
-            f"Optimize the geometry of water molecule using {config['chemistry']['calculators']['default']}",
+            f"Optimize the geometry of water molecule using {resolve_default_calculator(config)}",
             "Calculate the infrared spectrum of methanol with xtb calculator",
             "What is the reaction enthalpy of methane combustion using mace_mp",
         ]

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -97,6 +97,8 @@ def save_config(config: Dict[str, Any], config_path: Optional[str] = None) -> bo
 
 def get_default_config() -> Dict[str, Any]:
     """Return default configuration."""
+    from chemgraph.schemas.calculators.mace_calc import get_default_mace_calculator_type
+
     return {
         "general": {
             "model": "gpt-4o-mini",
@@ -140,7 +142,9 @@ def get_default_config() -> Dict[str, Any]:
         },
         "chemistry": {
             "optimization": {"method": "BFGS", "fmax": 0.05, "steps": 200},
-            "calculators": {"default": "mace_polar", "fallback": "emt"},
+            "calculators": {
+                "default": get_default_mace_calculator_type(), "fallback": "emt"
+            },
         },
         "output": {
             "files": {

--- a/src/ui/config.py
+++ b/src/ui/config.py
@@ -2,11 +2,13 @@
 Configuration management for ChemGraph Streamlit app.
 """
 
+import copy
 import toml
 import os
 from pathlib import Path
 from typing import Dict, Any, Optional
 from chemgraph.utils.config_utils import flatten_config as _flatten_config
+from chemgraph.utils.calculator_defaults import get_default_mace_calculator_type
 
 # Anchor the default config to the repository root (the directory the app is
 # meant to be launched from per the README) rather than the current working
@@ -14,6 +16,33 @@ from chemgraph.utils.config_utils import flatten_config as _flatten_config
 # launch directory, so starting Streamlit from anywhere else silently created
 # and used a throw-away default config instead of the real one.
 _DEFAULT_CONFIG_PATH = str(Path(__file__).resolve().parents[2] / "config.toml")
+
+
+def merge_config_defaults(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Fill missing settings without resolving automatic calculator selection."""
+    config = copy.deepcopy(config)
+    default_config = get_default_config()
+    for section in ["general", "api", "chemistry", "output"]:
+        if section not in config:
+            config[section] = default_config[section]
+        elif isinstance(config[section], dict):
+            for key, value in default_config[section].items():
+                if key not in config[section]:
+                    if section == "api" and key in {"argo", "vllm"}:
+                        continue
+                    config[section][key] = value
+                elif isinstance(config[section][key], dict) and isinstance(value, dict):
+                    for subkey, subvalue in value.items():
+                        config[section][key].setdefault(subkey, subvalue)
+    return config
+
+
+def resolve_default_calculator(config: Dict[str, Any]) -> str:
+    """Resolve a calculator for display/use without persisting the detection."""
+    calculators = config.get("chemistry", {}).get("calculators", {})
+    if "default" in calculators:
+        return calculators["default"]
+    return get_default_mace_calculator_type()
 
 
 def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
@@ -34,31 +63,7 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
     try:
         if os.path.exists(config_path):
             with open(config_path, "r") as f:
-                config = toml.load(f)
-                # Validate configuration structure
-                default_config = get_default_config()
-
-                # Ensure all required sections exist
-                for section in ["general", "api", "chemistry", "output"]:
-                    if section not in config:
-                        config[section] = default_config[section]
-                    elif isinstance(config[section], dict) and isinstance(
-                        default_config[section], dict
-                    ):
-                        # Merge missing keys from default
-                        for key, value in default_config[section].items():
-                            if key not in config[section]:
-                                if section == "api" and key in {"argo", "vllm"}:
-                                    continue
-                                config[section][key] = value
-                            elif isinstance(config[section][key], dict) and isinstance(
-                                value, dict
-                            ):
-                                for subkey, subvalue in value.items():
-                                    if subkey not in config[section][key]:
-                                        config[section][key][subkey] = subvalue
-
-                return config
+                return merge_config_defaults(toml.load(f))
         else:
             # Create default configuration file if it doesn't exist
             default_config = get_default_config()
@@ -97,8 +102,6 @@ def save_config(config: Dict[str, Any], config_path: Optional[str] = None) -> bo
 
 def get_default_config() -> Dict[str, Any]:
     """Return default configuration."""
-    from chemgraph.schemas.calculators.mace_calc import get_default_mace_calculator_type
-
     return {
         "general": {
             "model": "gpt-4o-mini",
@@ -142,9 +145,7 @@ def get_default_config() -> Dict[str, Any]:
         },
         "chemistry": {
             "optimization": {"method": "BFGS", "fmax": 0.05, "steps": 200},
-            "calculators": {
-                "default": get_default_mace_calculator_type(), "fallback": "emt"
-            },
+            "calculators": {"fallback": "emt"},
         },
         "output": {
             "files": {

--- a/tests/test_ase_failures.py
+++ b/tests/test_ase_failures.py
@@ -1,0 +1,118 @@
+"""Simulation failures must reach every caller without successful artifacts."""
+
+import json
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from ase.build import molecule
+from ase.calculators.calculator import Calculator
+from ase.calculators.emt import EMT
+from ase.io import write
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.calculators.emt_calc import EMTCalc
+from chemgraph.schemas.calculators.mace_calc import MaceCalc
+from chemgraph.tools import ase_core
+from chemgraph.utils import calculator_defaults
+
+
+@pytest.fixture
+def params(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(ase_core, "_ensure_ase_core_file_log", lambda: None)
+    write(tmp_path / "water.xyz", molecule("H2O"))
+    return ASEInputSchema(
+        input_structure_file=str(tmp_path / "water.xyz"),
+        output_results_file=str(tmp_path / "result.json"),
+        calculator=EMTCalc(), driver="energy",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("entrypoint", ["core", "langchain", "mcp"])
+async def test_missing_polar_returns_install_guidance(params, monkeypatch, tmp_path, entrypoint):
+    import mace.calculators
+
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: False)
+    loader = Mock(side_effect=AssertionError("must not download model weights"))
+    monkeypatch.setattr(mace.calculators, "mace_polar", loader)
+    params.calculator = MaceCalc(calculator_type="mace_polar")
+    if entrypoint == "core":
+        result = ase_core.run_ase_core(params)
+    elif entrypoint == "langchain":
+        from chemgraph.tools.ase_tools import run_ase
+        result = run_ase.invoke({"params": params.model_dump()})
+    else:
+        from chemgraph.mcp.mcp_tools import run_ase
+        result = await run_ase(params)
+    assert result["status"] == "failure"
+    assert result["error_type"] == "ImportError"
+    assert "requirements/mace-polar.txt" in result["message"]
+    loader.assert_not_called()
+    assert not (tmp_path / "result.json").exists()
+
+
+@pytest.mark.parametrize("driver", ["dipole", "ir"])
+def test_unsupported_dipole_fails_before_optimization(params, monkeypatch, tmp_path, driver):
+    import ase.optimize
+    import ase.vibrations
+
+    optimization = Mock(side_effect=AssertionError("must not optimize"))
+    vibrations = Mock(side_effect=AssertionError("must not run vibrations"))
+    monkeypatch.setattr(ase.optimize, "BFGS", optimization)
+    monkeypatch.setattr(ase.vibrations, "Vibrations", vibrations)
+    params.driver = driver
+    params.calculator = MaceCalc(calculator_type="mace_mp")
+    monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: EMT())
+    result = ase_core.run_ase_core(params)
+    assert result["status"] == "failure"
+    assert result["error_type"] == "PropertyNotImplementedError"
+    assert "dipole-capable" in result["message"]
+    optimization.assert_not_called()
+    vibrations.assert_not_called()
+    assert not (tmp_path / "result.json").exists()
+
+
+@pytest.mark.parametrize("dipole", [None, [1, 2], [1, 2, 3, 4], [0, np.nan, 1], [0, np.inf, 1], [0, "bad", 1], [0, 0, 0]])
+def test_dipole_result_requires_three_finite_components(params, monkeypatch, tmp_path, dipole):
+    class DipoleCalculator(Calculator):
+        implemented_properties = ["energy", "dipole"]
+
+        def calculate(self, atoms=None, properties=None, system_changes=None):
+            super().calculate(atoms, properties, system_changes)
+            self.results = {"energy": -1.0, "dipole": dipole}
+
+    params.driver = "dipole"
+    monkeypatch.setattr(EMTCalc, "get_calculator", lambda self: DipoleCalculator())
+    result = ase_core.run_ase_core(params)
+    if dipole == [0, 0, 0]:
+        assert result["status"] == "success"
+        assert result["dipole_moment"] == [0, 0, 0]
+        assert json.loads((tmp_path / "result.json").read_text())["success"] is True
+    else:
+        assert result["status"] == "failure"
+        assert not (tmp_path / "result.json").exists()
+
+
+def test_single_point_engine_failure_returns_original_message(params, monkeypatch, tmp_path):
+    monkeypatch.setattr(EMT, "get_potential_energy", Mock(side_effect=RuntimeError("engine failed")))
+    result = ase_core.run_ase_core(params)
+    assert result == {"status": "failure", "error_type": "RuntimeError", "message": "engine failed"}
+    assert not (tmp_path / "result.json").exists()
+
+
+def test_ir_with_dipole_support_still_completes(params, monkeypatch, tmp_path):
+    class DipoleEMT(EMT):
+        def get_dipole_moment(self, atoms=None):
+            return np.zeros(3)
+
+    monkeypatch.setattr(EMTCalc, "get_calculator", lambda self: DipoleEMT())
+    params.driver = "ir"
+    params.fmax = 100  # Keep the fixture geometry; exercise the full IR path.
+    result = ase_core.run_ase_core(params)
+    assert result["status"] == "success", result
+    output = json.loads((tmp_path / "result.json").read_text())
+    assert output["success"] is True
+    assert (tmp_path / "ir_spectrum_water.csv").exists()
+    assert (tmp_path / "ir_peaks_water.csv").exists()

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -4,6 +4,7 @@ import numpy as np
 from pydantic import ValidationError
 from chemgraph.schemas.calculators.emt_calc import EMTCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
+from chemgraph.schemas.calculators import mace_calc
 from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
 from chemgraph.schemas.calculators.orca_calc import OrcaCalc
 from ase import Atoms
@@ -42,15 +43,15 @@ def test_default_calculator_is_in_detected_available_calculators():
     assert default in context
     if importlib.util.find_spec("mace") is not None:
         assert default == "MaceCalc"
-        assert "calculator_type='mace_polar'" in context
-        assert "model='polar-1-m'" in context
+        expected = MaceCalc()
+        assert f"calculator_type={expected.calculator_type!r}" in context
+        assert f"model={expected.get_model_name_for_output()!r}" in context
 
         from chemgraph.schemas.ase_input import ASEInputSchema
 
         params = ASEInputSchema(input_structure_file="water.xyz", driver="energy")
         assert isinstance(params.calculator, MaceCalc)
-        assert params.calculator.calculator_type == "mace_polar"
-        assert params.calculator.get_model_name_for_output() == "polar-1-m"
+        assert params.calculator == expected
 
 
 def test_invalid_calculator_type_error_lists_accepted_values():
@@ -125,7 +126,8 @@ def test_mace_model_name_for_output(calculator_type, model, expected):
     assert calc.get_model_name_for_output() == expected
 
 
-def test_mace_polar_medium_is_default():
+def test_mace_polar_medium_is_default_when_available(monkeypatch):
+    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: True)
     calc = MaceCalc()
 
     assert calc.calculator_type == "mace_polar"
@@ -164,8 +166,9 @@ def test_mace_polar_loader_uses_selected_model(monkeypatch, model, expected_mode
         return sentinel
 
     monkeypatch.setattr(mace.calculators, "mace_polar", fake_mace_polar)
+    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: True)
 
-    calc = MaceCalc(model=model, device="cpu", default_dtype="float64")
+    calc = MaceCalc(calculator_type="mace_polar", model=model, device="cpu", default_dtype="float64")
 
     assert calc.get_calculator() is sentinel
     assert received == [
@@ -229,6 +232,7 @@ def test_mace_calculator(monkeypatch):
     from ase.calculators.emt import EMT
 
     monkeypatch.setattr(mace.calculators, "mace_polar", lambda **kwargs: EMT())
+    monkeypatch.setattr(mace.calculators, "mace_mp", lambda **kwargs: EMT())
 
     calc = MaceCalc()
     ase_calc = calc.get_calculator()

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -4,7 +4,7 @@ import numpy as np
 from pydantic import ValidationError
 from chemgraph.schemas.calculators.emt_calc import EMTCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
-from chemgraph.schemas.calculators import mace_calc
+from chemgraph.utils import calculator_defaults
 from chemgraph.schemas.calculators.tblite_calc import TBLiteCalc
 from chemgraph.schemas.calculators.orca_calc import OrcaCalc
 from ase import Atoms
@@ -43,15 +43,18 @@ def test_default_calculator_is_in_detected_available_calculators():
     assert default in context
     if importlib.util.find_spec("mace") is not None:
         assert default == "MaceCalc"
-        expected = MaceCalc()
-        assert f"calculator_type={expected.calculator_type!r}" in context
-        assert f"model={expected.get_model_name_for_output()!r}" in context
+        polar = importlib.util.find_spec("graph_longrange") is not None
+        expected_type = "mace_polar" if polar else "mace_mp"
+        expected_model = "polar-1-m" if polar else "medium-mpa-0"
+        assert f"calculator_type={expected_type!r}" in context
+        assert f"model={expected_model!r}" in context
 
         from chemgraph.schemas.ase_input import ASEInputSchema
 
         params = ASEInputSchema(input_structure_file="water.xyz", driver="energy")
         assert isinstance(params.calculator, MaceCalc)
-        assert params.calculator == expected
+        assert params.calculator.calculator_type == expected_type
+        assert params.calculator.get_model_name_for_output() == expected_model
 
 
 def test_invalid_calculator_type_error_lists_accepted_values():
@@ -127,7 +130,7 @@ def test_mace_model_name_for_output(calculator_type, model, expected):
 
 
 def test_mace_polar_medium_is_default_when_available(monkeypatch):
-    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: True)
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: True)
     calc = MaceCalc()
 
     assert calc.calculator_type == "mace_polar"
@@ -166,7 +169,7 @@ def test_mace_polar_loader_uses_selected_model(monkeypatch, model, expected_mode
         return sentinel
 
     monkeypatch.setattr(mace.calculators, "mace_polar", fake_mace_polar)
-    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: True)
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: True)
 
     calc = MaceCalc(calculator_type="mace_polar", model=model, device="cpu", default_dtype="float64")
 

--- a/tests/test_mace_defaults.py
+++ b/tests/test_mace_defaults.py
@@ -1,0 +1,90 @@
+"""Default calculator behavior on core-only and Polar-enabled installations."""
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+from unittest.mock import Mock
+
+import pytest
+
+from chemgraph.schemas.calculators import mace_calc
+
+
+@pytest.mark.parametrize("polar", [False, True])
+def test_defaults_agree_at_initialization(polar):
+    # Import in a fresh process so schema descriptions see the same installation
+    # state as the default factories, without changing other tests' model classes.
+    source = f'''
+import importlib.util
+import json
+find_spec = importlib.util.find_spec
+importlib.util.find_spec = lambda name, *a, **kw: (
+    object() if {polar!r} else None
+) if name == "graph_longrange" else find_spec(name, *a, **kw)
+from chemgraph.schemas.ase_input import (
+    ASEInputSchema, ase_input_schema_ensemble, get_calculator_selection_context,
+)
+from chemgraph.schemas.calculators.mace_calc import MaceCalc
+from ui.config import get_default_config, load_config
+schemas = [ASEInputSchema, ase_input_schema_ensemble]
+params = [ASEInputSchema(input_structure_file="water.xyz"), ase_input_schema_ensemble()]
+print(json.dumps({{
+    "types": [MaceCalc().calculator_type, *[p.calculator.calculator_type for p in params]],
+    "model": MaceCalc().get_model_name_for_output(),
+    "context": get_calculator_selection_context(),
+    "descriptions": [s.model_json_schema()["properties"]["calculator"]["description"] for s in schemas],
+    "ui": get_default_config()["chemistry"]["calculators"]["default"],
+    "shipped": load_config("config.toml")["chemistry"]["calculators"]["default"],
+}}))
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", source], cwd=Path(__file__).resolve().parents[1],
+        check=True, capture_output=True, text=True,
+    )
+    data = json.loads(result.stdout.splitlines()[-1])
+    expected_type = "mace_polar" if polar else "mace_mp"
+    expected_model = "polar-1-m" if polar else "medium-mpa-0"
+    assert data["types"] == [expected_type] * 3
+    assert data["model"] == expected_model
+    assert data["ui"] == data["shipped"] == expected_type
+    for description in [data["context"], *data["descriptions"]]:
+        assert f"calculator_type={expected_type!r}" in description
+        assert f"model={expected_model!r}" in description
+
+
+@pytest.mark.parametrize("polar", [False, True])
+def test_explicit_mace_selection_and_ui_configuration_are_preserved(monkeypatch, tmp_path, polar):
+    from ui.config import load_config
+
+    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: polar)
+    for variant in ("mace_polar", "mace_mp", "mace_off", "mace_anicc"):
+        calc = mace_calc.MaceCalc(calculator_type=variant, model="/models/custom.model")
+        assert calc.calculator_type == variant
+        assert calc.get_model_name_for_output() == "/models/custom.model"
+    config = tmp_path / "explicit.toml"
+    config.write_text('[chemistry.calculators]\ndefault = "mace_polar"\n')
+    assert load_config(str(config))["chemistry"]["calculators"]["default"] == "mace_polar"
+
+
+def test_missing_polar_fails_before_loader(monkeypatch):
+    import mace.calculators
+
+    loader = Mock(side_effect=AssertionError("must not load or download weights"))
+    monkeypatch.setattr(mace.calculators, "mace_polar", loader)
+    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: False)
+    with pytest.raises(ImportError, match="requirements/mace-polar.txt"):
+        mace_calc.MaceCalc(calculator_type="mace_polar").get_calculator()
+    loader.assert_not_called()
+
+
+def test_default_mp_preserves_upstream_model_default(monkeypatch):
+    import mace.calculators
+
+    loader = Mock(return_value=object())
+    monkeypatch.setattr(mace.calculators, "mace_mp", loader)
+    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: False)
+    calc = mace_calc.MaceCalc()
+    assert calc.get_calculator() is loader.return_value
+    assert loader.call_args.kwargs["model"] is None
+    assert calc.get_model_name_for_output() == "medium-mpa-0"

--- a/tests/test_mace_defaults.py
+++ b/tests/test_mace_defaults.py
@@ -4,15 +4,23 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+from types import ModuleType
 from unittest.mock import Mock
 
 import pytest
+import toml
 
 from chemgraph.schemas.calculators import mace_calc
+from chemgraph.utils import calculator_defaults
 
 
 @pytest.mark.parametrize("polar", [False, True])
-def test_defaults_agree_at_initialization(polar):
+def test_defaults_agree_at_initialization(polar, tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    shipped_text = (root / "config.toml").read_text(encoding="utf-8")
+    assert "default" not in toml.loads(shipped_text)["chemistry"]["calculators"]
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(shipped_text, encoding="utf-8")
     # Import in a fresh process so schema descriptions see the same installation
     # state as the default factories, without changing other tests' model classes.
     source = f'''
@@ -26,7 +34,7 @@ from chemgraph.schemas.ase_input import (
     ASEInputSchema, ase_input_schema_ensemble, get_calculator_selection_context,
 )
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
-from ui.config import get_default_config, load_config
+from ui.config import get_default_config, load_config, resolve_default_calculator
 schemas = [ASEInputSchema, ase_input_schema_ensemble]
 params = [ASEInputSchema(input_structure_file="water.xyz"), ase_input_schema_ensemble()]
 print(json.dumps({{
@@ -34,12 +42,13 @@ print(json.dumps({{
     "model": MaceCalc().get_model_name_for_output(),
     "context": get_calculator_selection_context(),
     "descriptions": [s.model_json_schema()["properties"]["calculator"]["description"] for s in schemas],
-    "ui": get_default_config()["chemistry"]["calculators"]["default"],
-    "shipped": load_config("config.toml")["chemistry"]["calculators"]["default"],
+    "ui": resolve_default_calculator(get_default_config()),
+    "shipped": resolve_default_calculator(load_config(sys.argv[1])),
+    "mace_schema": MaceCalc.model_json_schema()["properties"]["calculator_type"],
 }}))
 '''
     result = subprocess.run(
-        [sys.executable, "-c", source], cwd=Path(__file__).resolve().parents[1],
+        [sys.executable, "-c", "import sys\n" + source, str(config_path)], cwd=root,
         check=True, capture_output=True, text=True,
     )
     data = json.loads(result.stdout.splitlines()[-1])
@@ -48,6 +57,10 @@ print(json.dumps({{
     assert data["types"] == [expected_type] * 3
     assert data["model"] == expected_model
     assert data["ui"] == data["shipped"] == expected_type
+    assert data["mace_schema"]["default"] == expected_type
+    availability = "installed" if polar else "not installed"
+    assert f"add-on is {availability}" in data["mace_schema"]["description"]
+    assert "before calling run_ase" in data["context"]
     for description in [data["context"], *data["descriptions"]]:
         assert f"calculator_type={expected_type!r}" in description
         assert f"model={expected_model!r}" in description
@@ -57,7 +70,8 @@ print(json.dumps({{
 def test_explicit_mace_selection_and_ui_configuration_are_preserved(monkeypatch, tmp_path, polar):
     from ui.config import load_config
 
-    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: polar)
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: polar)
+    assert mace_calc.MaceCalc().calculator_type == ("mace_polar" if polar else "mace_mp")
     for variant in ("mace_polar", "mace_mp", "mace_off", "mace_anicc"):
         calc = mace_calc.MaceCalc(calculator_type=variant, model="/models/custom.model")
         assert calc.calculator_type == variant
@@ -72,7 +86,7 @@ def test_missing_polar_fails_before_loader(monkeypatch):
 
     loader = Mock(side_effect=AssertionError("must not load or download weights"))
     monkeypatch.setattr(mace.calculators, "mace_polar", loader)
-    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: False)
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: False)
     with pytest.raises(ImportError, match="requirements/mace-polar.txt"):
         mace_calc.MaceCalc(calculator_type="mace_polar").get_calculator()
     loader.assert_not_called()
@@ -83,8 +97,61 @@ def test_default_mp_preserves_upstream_model_default(monkeypatch):
 
     loader = Mock(return_value=object())
     monkeypatch.setattr(mace.calculators, "mace_mp", loader)
-    monkeypatch.setattr(mace_calc, "mace_polar_available", lambda: False)
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: False)
     calc = mace_calc.MaceCalc()
     assert calc.get_calculator() is loader.return_value
     assert loader.call_args.kwargs["model"] is None
     assert calc.get_model_name_for_output() == "medium-mpa-0"
+
+
+@pytest.mark.parametrize("error", [ImportError, ModuleNotFoundError, ValueError])
+def test_unreliable_polar_probe_uses_mp(monkeypatch, error):
+    from ui.config import get_default_config, resolve_default_calculator
+
+    monkeypatch.setattr(calculator_defaults.importlib.util, "find_spec", Mock(side_effect=error))
+    assert mace_calc.MaceCalc().calculator_type == "mace_mp"
+    assert resolve_default_calculator(get_default_config()) == "mace_mp"
+
+
+def test_polar_module_without_spec_does_not_break_defaults(monkeypatch):
+    monkeypatch.setitem(sys.modules, "graph_longrange", ModuleType("graph_longrange"))
+    assert mace_calc.MaceCalc().calculator_type == "mace_mp"
+
+
+def test_saving_unrelated_settings_preserves_automatic_selection(monkeypatch, tmp_path):
+    from ui.config import load_config, resolve_default_calculator, save_config
+
+    path = tmp_path / "config.toml"
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: False)
+    config = load_config(str(path))
+    assert resolve_default_calculator(config) == "mace_mp"
+    config["api"]["argo"]["argo_user"] = "test-user"
+    assert save_config(config, str(path))
+    assert "default" not in toml.load(path)["chemistry"]["calculators"]
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: True)
+    reloaded = load_config(str(path))
+    assert resolve_default_calculator(reloaded) == "mace_polar"
+    assert reloaded["api"]["argo"]["argo_user"] == "test-user"
+    reloaded["chemistry"]["calculators"]["default"] = "mace_mp"
+    assert save_config(reloaded, str(path))
+    assert resolve_default_calculator(load_config(str(path))) == "mace_mp"
+
+
+def test_configuration_recovery_does_not_import_torch(tmp_path):
+    path = tmp_path / "invalid.toml"
+    path.write_text("[broken", encoding="utf-8")
+    source = '''
+import builtins
+import sys
+original_import = builtins.__import__
+def guarded_import(name, *args, **kwargs):
+    if name == "torch" or name.startswith("torch."):
+        raise OSError("simulated broken Torch library")
+    return original_import(name, *args, **kwargs)
+builtins.__import__ = guarded_import
+from ui.config import get_default_config, load_config, resolve_default_calculator
+assert load_config(sys.argv[1]) == get_default_config()
+assert resolve_default_calculator(get_default_config()) in {"mace_mp", "mace_polar"}
+assert "torch" not in sys.modules
+'''
+    subprocess.run([sys.executable, "-c", source, str(path)], check=True, capture_output=True)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -408,7 +408,7 @@ def test_run_ase_core_reads_mace_polar_dipole_from_calculator_results(
         input_structure_file=str(input_path),
         output_results_file=str(output_path),
         driver="dipole",
-        calculator=MaceCalc(),
+        calculator=MaceCalc(calculator_type="mace_polar"),
     )
 
     result = ase_core.run_ase_core(params)

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -257,9 +257,11 @@ def test_an_explicit_model_is_never_silently_swapped(monkeypatch, image):
     assert "molscribe" in result["error"]
 
 
-def test_install_hint_names_the_extra():
-    """One command installs all four, so every missing model points at the same one."""
-    assert "chemgraph[ocsr]" in backends._install_hint()
+def test_install_hint_names_the_extra_and_supplemental_requirements():
+    """The extra and pinned Git specialists must be resolved together."""
+    hint = backends._install_hint()
+    assert "'.[ocsr]' -r requirements/ocsr-models.txt" in hint
+    assert "matching ChemGraph source" in hint
 
 
 def test_importing_the_backends_does_not_import_torchvision():

--- a/tests/test_ocsr_tools.py
+++ b/tests/test_ocsr_tools.py
@@ -262,6 +262,8 @@ def test_install_hint_names_the_extra_and_supplemental_requirements():
     hint = backends._install_hint()
     assert "'.[ocsr]' -r requirements/ocsr-models.txt" in hint
     assert "matching ChemGraph source" in hint
+    assert "root of" in hint
+    assert "README.md#installing" in hint
 
 
 def test_importing_the_backends_does_not_import_torchvision():

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,9 +1,36 @@
 """Tests for ChemGraph package metadata."""
 
+import re
+import io
+import runpy
+import tarfile
+import zipfile
 from pathlib import Path
 from typing import Any
 
 import chemgraph
+import pytest
+from packaging.requirements import Requirement
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXACT_PIN = re.compile(
+    r"^([A-Za-z0-9_.-]+)(?:==|=)([^;\s]+)(?:\s*;.*)?$"
+)
+
+
+def _normalize_package_name(name: str) -> str:
+    """Return a normalized Python package name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _exact_pins(requirements: list[str]) -> dict[str, str]:
+    """Return normalized names and versions for exact package pins."""
+    pins = {}
+    for requirement in requirements:
+        match = _EXACT_PIN.fullmatch(requirement.strip())
+        if match:
+            pins[_normalize_package_name(match.group(1))] = match.group(2)
+    return pins
 
 
 def _load_toml(path: Path) -> dict[str, Any]:
@@ -32,7 +59,7 @@ def _load_toml(path: Path) -> dict[str, Any]:
 
 def test_version_matches_project_metadata() -> None:
     """ChemGraph version should match the project metadata version."""
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = _REPO_ROOT / "pyproject.toml"
     project_version = _load_toml(pyproject)["project"]["version"]
 
     assert chemgraph.__version__ == project_version
@@ -40,7 +67,99 @@ def test_version_matches_project_metadata() -> None:
 
 def test_pyproject_version_fallback_matches_project_metadata() -> None:
     """Source-checkout fallback should read the version from pyproject.toml."""
-    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    pyproject = _REPO_ROOT / "pyproject.toml"
     project_version = _load_toml(pyproject)["project"]["version"]
 
     assert chemgraph._version_from_pyproject() == project_version
+
+
+def test_conda_environment_covers_exact_project_pins() -> None:
+    """Conda installs should retain every exact core dependency pin."""
+    project = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
+    project_pins = _exact_pins(project["dependencies"])
+
+    environment_text = (_REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+    environment_specs = re.findall(
+        r"^\s*-\s+(.+?)\s*$", environment_text, flags=re.MULTILINE
+    )
+    environment_pins = _exact_pins(environment_specs)
+
+    mismatches = {
+        name: {"project": version, "environment": environment_pins.get(name)}
+        for name, version in project_pins.items()
+        if environment_pins.get(name) != version
+    }
+    assert not mismatches
+
+    assert "-r requirements/mace-polar.txt" in environment_specs
+
+
+def test_calculator_pin_matches_all_installation_surfaces() -> None:
+    """Conda and container installs should use the calculator-extra TBLite pin."""
+    metadata = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
+    calculator_pins = _exact_pins(metadata["optional-dependencies"]["calculators"])
+    tblite_version = calculator_pins["tblite"]
+
+    environment_text = (_REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+    environment_specs = re.findall(
+        r"^\s*-\s+(.+?)\s*$", environment_text, flags=re.MULTILINE
+    )
+    assert _exact_pins(environment_specs)["tblite"] == tblite_version
+
+    for filename in ("Dockerfile", "Dockerfile.arm"):
+        dockerfile = (_REPO_ROOT / filename).read_text(encoding="utf-8")
+        assert f'"tblite=={tblite_version}"' in dockerfile
+        assert "python -m pip check" in dockerfile
+        assert "-r requirements/mace-polar.txt" in dockerfile
+
+
+def test_published_dependencies_have_no_direct_urls():
+    project = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
+    groups = [project["dependencies"], *project["optional-dependencies"].values()]
+    assert all(Requirement(dep).url is None for group in groups for dep in group)
+
+
+def test_supplemental_dependency_pins():
+    expected = {
+        "mace-polar.txt": [
+            "graph-longrange @ git+https://github.com/WillBaldwin0/graph_electrostatics.git@v0.4.0",
+        ],
+        "ocsr-models.txt": [
+            "glyph @ git+https://github.com/EdisonScientific/glyph@0bf782f863d26b041ace157668928ef07c38b972",
+            "MolNexTR @ git+https://github.com/reowszer/MolNexTR@f450b9661557b1f91ae36f59dd1fadfbcb3a0967",
+            "MolScribe @ git+https://github.com/reowszer/MolScribe@b03b30fbac9a78434116e626ebef6c7b7bdcdb6e",
+        ],
+    }
+    for filename, pins in expected.items():
+        lines = (_REPO_ROOT / "requirements" / filename).read_text().splitlines()
+        assert [line for line in lines if line and not line.startswith("#")] == pins
+
+
+@pytest.mark.parametrize("kind", ["whl", "tar.gz"])
+@pytest.mark.parametrize("requirement", [
+    "numpy>=2", "engine @ https://example.org/engine.whl",
+    'engine @ git+https://example.org/engine.git@v1 ; extra == "optional"',
+])
+def test_built_metadata_rejects_urls_including_extras(tmp_path, kind, requirement):
+    check = runpy.run_path(str(_REPO_ROOT / "scripts/check_distribution_metadata.py"))[
+        "check_distribution"
+    ]
+    path = tmp_path / f"chemgraph-0.6.0.{kind}"
+    metadata = f"Metadata-Version: 2.4\nRequires-Dist: {requirement}\n".encode()
+    if kind == "whl":
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("chemgraph-0.6.0.dist-info/METADATA", metadata)
+    else:
+        with tarfile.open(path, "w:gz") as archive:
+            for name, data in {
+                "PKG-INFO": metadata, "requirements/mace-polar.txt": b"",
+                "requirements/ocsr-models.txt": b"",
+            }.items():
+                member = tarfile.TarInfo(f"chemgraph-0.6.0/{name}")
+                member.size = len(data)
+                archive.addfile(member, io.BytesIO(data))
+    if Requirement(requirement).url:
+        with pytest.raises(ValueError, match="direct-URL dependency"):
+            check(path)
+    else:
+        check(path)

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -11,25 +11,29 @@ from typing import Any
 import chemgraph
 import pytest
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_EXACT_PIN = re.compile(
-    r"^([A-Za-z0-9_.-]+)(?:==|=)([^;\s]+)(?:\s*;.*)?$"
-)
-
-
-def _normalize_package_name(name: str) -> str:
-    """Return a normalized Python package name."""
-    return re.sub(r"[-_.]+", "-", name).lower()
 
 
 def _exact_pins(requirements: list[str]) -> dict[str, str]:
     """Return normalized names and versions for exact package pins."""
     pins = {}
     for requirement in requirements:
-        match = _EXACT_PIN.fullmatch(requirement.strip())
-        if match:
-            pins[_normalize_package_name(match.group(1))] = match.group(2)
+        requirement = requirement.strip()
+        if requirement == "pip:" or requirement.startswith("-r "):
+            continue  # Environment structure and supplemental requirements.
+        # Conda's name=version syntax; parse Python requirements with packaging.
+        requirement = re.sub(r"^([A-Za-z0-9_.-]+)=(?!=)", r"\1==", requirement)
+        parsed = Requirement(requirement)
+        for specifier in parsed.specifier:
+            if specifier.operator != "==" or "*" in specifier.version:
+                continue
+            name = canonicalize_name(parsed.name)
+            assert name not in pins or pins[name] == specifier.version, (
+                f"Conflicting exact pins for {name}: {pins[name]} and {specifier.version}"
+            )
+            pins[name] = specifier.version
     return pins
 
 
@@ -77,6 +81,7 @@ def test_conda_environment_covers_exact_project_pins() -> None:
     """Conda installs should retain every exact core dependency pin."""
     project = _load_toml(_REPO_ROOT / "pyproject.toml")["project"]
     project_pins = _exact_pins(project["dependencies"])
+    assert project_pins, "Expected exact project pins to compare with conda"
 
     environment_text = (_REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
     environment_specs = re.findall(
@@ -92,6 +97,18 @@ def test_conda_environment_covers_exact_project_pins() -> None:
     assert not mismatches
 
     assert "-r requirements/mace-polar.txt" in environment_specs
+
+
+def test_exact_pin_parser_handles_extras_markers_and_conda():
+    assert _exact_pins([
+        'Some_Package[extra]==1.2; python_version >= "3.11"',
+        "other=2.0", "unpinned>=1", "wildcard==1.*", "pip:", "-r addons.txt",
+    ]) == {"some-package": "1.2", "other": "2.0"}
+
+
+def test_exact_pin_parser_rejects_conflicting_duplicates():
+    with pytest.raises(AssertionError, match="Conflicting exact pins"):
+        _exact_pins(["Some_Package==1", "some-package==2"])
 
 
 def test_calculator_pin_matches_all_installation_surfaces() -> None:

--- a/tests/test_ui_apptest.py
+++ b/tests/test_ui_apptest.py
@@ -82,3 +82,49 @@ def test_chat_page_renders_with_provider_key(isolated_app, monkeypatch):
     # No wizard; chat input is present immediately.
     assert not any("Welcome" in info.value for info in at.info)
     assert len(at.chat_input) == 1
+
+
+@pytest.fixture
+def configuration_app(isolated_app):
+    """Reuse credential/path isolation while exercising the editor directly."""
+    from streamlit.testing.v1 import AppTest
+
+    return AppTest.from_string(
+        "from ui._pages.configuration import render\nrender()",
+        default_timeout=60,
+    )
+
+
+def test_configuration_save_preserves_automatic_selection(configuration_app, tmp_path):
+    import toml
+
+    at = configuration_app.run()
+    assert not at.exception
+    selector = next(s for s in at.selectbox if s.label == "Default Calculator")
+    assert selector.value is None
+    assert "default" not in at.session_state["_config_draft"]["chemistry"]["calculators"]
+    next(b for b in at.button if "Save Configuration" in b.label).click().run()
+    assert not at.exception
+    assert "default" not in toml.load(tmp_path / "config.toml")["chemistry"]["calculators"]
+
+
+def test_raw_toml_can_restore_automatic_selection(configuration_app, tmp_path):
+    import toml
+
+    at = configuration_app.run()
+    next(s for s in at.selectbox if s.label == "Default Calculator").select("mace_mp").run()
+    next(b for b in at.button if "Save Configuration" in b.label).click().run()
+    at.run()
+    assert not at.exception
+    assert toml.load(tmp_path / "config.toml")["chemistry"]["calculators"]["default"] == "mace_mp"
+    previous_nonce = at.session_state["_config_widget_nonce"]
+    at.text_area[0].set_value('[chemistry.calculators]\nfallback = "emt"\n')
+    at.button(key="update_from_toml").click().run()
+    assert not at.exception
+    assert at.session_state["_config_widget_nonce"] > previous_nonce
+    assert next(s for s in at.selectbox if s.label == "Default Calculator").value is None
+    assert "default" not in at.session_state["_config_draft"]["chemistry"]["calculators"]
+    assert at.session_state["config"]["chemistry"]["calculators"]["default"] == "mace_mp"
+    next(b for b in at.button if "Save Configuration" in b.label).click().run()
+    assert not at.exception
+    assert "default" not in toml.load(tmp_path / "config.toml")["chemistry"]["calculators"]


### PR DESCRIPTION
## Summary

Remove Git-only dependencies from published metadata so ChemGraph can be uploaded to PyPI. Keep the tested Polar and OCSR references in supplemental installation files shipped with the sdist.

Omitted calculator selections now use Polar when its add-on is installed and MACE-MP otherwise. Explicit selections remain authoritative; missing Polar dependencies produce installation guidance before loading weights. Update schema/prompt/UI defaults and installation documentation together.

Conda and Docker explicitly install Polar, keep dependency pins aligned, and validate dependencies. ARM containers use official CPU PyTorch wheels because the PyPI CUDA dependency set includes an unsupported ARM wheel; x86 retains its existing selection.

## Related issues

Release prerequisite for #227. Keeps the version bump and release runtime upgrades on that PR.

## Type of change

- [x] Bug fix
- [x] Docs
- [x] Chore / refactor / CI

## How was this tested?

- `ruff check .` and `git diff --check` passed.
- Full suite with Academy/Parsl/Globus extras: **816 passed, 21 skipped, 2 deselected**. Local loopback access was required for Academy test servers; no live LLM or HPC flags were enabled.
- Focused calculator/default/metadata/MCP/OCSR tests: **122 passed, 1 skipped, 2 deselected**.
- Wheel and sdist build, `twine check`, and the new built-metadata direct-URL check passed.
- Fresh wheel imports, `chemgraph --help`, and `pip check` passed. Installing the pinned Polar add-on then switched the default to Polar without downloading weights.
- Both Dockerfiles built successfully on Linux ARM64, including calculator imports and final `pip check`.
- Complete OCSR add-on installation in Linux ARM64 passed `pip check`, torchvision import, and discovery of all four specialists without loading checkpoints. CPU images use the documented CPU index for matching torchvision wheels.
- Full OCSR installation is unavailable on this macOS ARM/Python 3.12 host because `pyonmttok` has no matching wheel; this is documented.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] Focused on publishable packaging and consistent installation defaults
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added regression coverage and publication checks
- [x] Updated installation and calculator documentation
