### PR TITLE
fix: append only unsaved session messages per graph thread

### DIFF
--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -274,6 +274,7 @@ class ChemGraph:
 
         # Track whether session has been registered in the memory store
         self._session_created: bool = False
+        self._saved_message_keys: dict[str, set[tuple]] = {}
         self._session_title: Optional[str] = None
 
         try:
@@ -740,16 +741,20 @@ class ChemGraph:
         self._session_created = True
         logger.info(f"Created session {self.uuid}: {self._session_title}")
 
-    def _save_messages_to_store(self, last_state: dict, query: str) -> None:
-        """Extract messages from workflow state and persist to session store."""
+    def _save_messages_to_store(
+        self, last_state: dict, query: str, *, thread_id: str = "1"
+    ) -> None:
+        """Append only unsaved messages from this thread's accumulated state."""
         if self.session_store is None or not self._session_created:
             return
 
         try:
+            saved_keys = self._saved_message_keys.setdefault(str(thread_id), set())
+            pending_keys = set()
             messages_to_save = []
             state_messages = last_state.get("messages", [])
 
-            for msg in state_messages:
+            for position, msg in enumerate(state_messages):
                 role = None
                 content = ""
                 tool_name = None
@@ -783,6 +788,20 @@ class ChemGraph:
                     content = str(content)
 
                 if role and content:
+                    message_id = (
+                        msg.get("id") if isinstance(msg, dict)
+                        else getattr(msg, "id", None)
+                    )
+                    # Graph IDs survive snapshot copies. Without an ID, retain
+                    # identical text at different transcript positions.
+                    key = (
+                        ("id", message_id)
+                        if isinstance(message_id, str) and message_id
+                        else ("position", position, role, content, tool_name)
+                    )
+                    if key in saved_keys or key in pending_keys:
+                        continue
+                    pending_keys.add(key)
                     messages_to_save.append(
                         SessionMessage(
                             role=role,
@@ -796,6 +815,8 @@ class ChemGraph:
                 messages=messages_to_save,
                 title=self._session_title,
             )
+            # The store commits atomically. Keep failed writes eligible for retry.
+            saved_keys.update(pending_keys)
             logger.info(
                 f"Saved {len(messages_to_save)} messages to session {self.uuid}"
             )
@@ -1081,7 +1102,7 @@ class ChemGraph:
                 raise RuntimeError("Workflow produced no states.")
 
             # Save messages to persistent session store
-            self._save_messages_to_store(last_state, query)
+            self._save_messages_to_store(last_state, query, thread_id=thread_id)
 
             messages = _state_messages(last_state)
             executed_tools = _executed_tool_names(messages)

--- a/src/ui/_pages/main_interface.py
+++ b/src/ui/_pages/main_interface.py
@@ -2213,7 +2213,9 @@ def _handle_query_submission(
 
             # Save messages to persistent session store (best-effort)
             try:
-                agent._save_messages_to_store(last_state, trimmed_query)
+                agent._save_messages_to_store(
+                    last_state, trimmed_query, thread_id=cfg["configurable"]["thread_id"]
+                )
             except Exception:
                 pass
 

--- a/tests/test_agent_session.py
+++ b/tests/test_agent_session.py
@@ -21,6 +21,9 @@ from chemgraph.agent.llm_agent import ChemGraph
 from chemgraph.agent.turn import TurnResult, serialize_state
 from chemgraph.memory.store import SessionStore
 from chemgraph.models.endpoints import PreparedModel
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import END, START, MessagesState, StateGraph
 
 
 # ------------------------------------------------------------------
@@ -108,6 +111,96 @@ def _make_agent(clean_env, mock_agent_patches, tmp_db, **kwargs):
     defaults.update(kwargs)
     agent = ChemGraph(**defaults)
     return agent
+
+
+@pytest.fixture
+def cumulative_agent(clean_env, mock_agent_patches, tmp_db):
+    """Use a compiled graph with its real message reducer and a hermetic LLM."""
+    agent = _make_agent(clean_env, mock_agent_patches, tmp_db)
+    model = FakeListChatModel(responses=["Repeated answer"])
+    builder = StateGraph(MessagesState)
+    builder.add_node("reply", lambda state: {"messages": [model.invoke(state["messages"])]})
+    builder.add_edge(START, "reply")
+    builder.add_edge("reply", END)
+    agent.workflow = builder.compile(checkpointer=InMemorySaver())
+    return agent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("config", [None, {"thread_id": 7}, {"configurable": {"thread_id": "7"}}])
+async def test_cumulative_turns_are_saved_once(cumulative_agent, config):
+    agent = cumulative_agent
+    for turn in range(1, 4):
+        await agent.run("Repeated question", config=config)
+        session = agent.session_store.get_session(agent.uuid)
+        assert len(session.messages) == 2 * turn
+        assert session.query_count == turn
+    thread_id = "1" if config is None else "7"
+    state = agent.workflow.get_state({"configurable": {"thread_id": thread_id}}).values
+    agent._save_messages_to_store(state, "Repeated question", thread_id=thread_id)
+    assert len(agent.session_store.get_session(agent.uuid).messages) == 6
+
+
+@pytest.mark.asyncio
+async def test_cumulative_history_survives_alternating_threads(cumulative_agent):
+    agent = cumulative_agent
+    for count, thread_id in enumerate(["a", "b", "a", "b"], start=1):
+        await agent.run("Repeated question", config={"thread_id": thread_id})
+        session = agent.session_store.get_session(agent.uuid)
+        assert len(session.messages) == count * 2
+        assert session.query_count == count
+
+
+@pytest.mark.asyncio
+async def test_failed_save_retries_all_unsaved_history(cumulative_agent, monkeypatch):
+    agent = cumulative_agent
+    save = agent.session_store.save_messages
+    monkeypatch.setattr(agent.session_store, "save_messages", Mock(side_effect=RuntimeError("DB unavailable")))
+    await agent.run("First question")
+    assert agent.session_store.get_session(agent.uuid).messages == []
+    monkeypatch.setattr(agent.session_store, "save_messages", save)
+    await agent.run("Second question")
+    session = agent.session_store.get_session(agent.uuid)
+    assert len(session.messages) == 4
+    assert session.query_count == 2
+    state = agent.workflow.get_state({"configurable": {"thread_id": "1"}}).values
+    agent._save_messages_to_store(state, "Second question")
+    assert len(agent.session_store.get_session(agent.uuid).messages) == 4
+
+
+@pytest.mark.parametrize("with_ids", [False, True])
+def test_snapshot_identity_is_scoped_to_normalized_thread(cumulative_agent, with_ids):
+    agent = cumulative_agent
+    agent._ensure_session("Repeated question")
+    messages = [
+        {"type": "human", "content": "Repeated question"},
+        {"type": "tool", "name": "read", "content": [{"type": "text", "text": "same"}]},
+        {"type": "human", "content": "Repeated question"},
+    ]
+    if with_ids:
+        for index, msg in enumerate(messages):
+            msg["id"] = str(index)
+    for thread_id in (7, "7", "other", "other"):
+        # Copies model successive deserialized snapshots, not object identity.
+        agent._save_messages_to_store(
+            {"messages": [dict(msg) for msg in messages]}, "Repeated question", thread_id=thread_id
+        )
+    if with_ids:
+        agent._save_messages_to_store(
+            {"messages": messages[1:] + messages[:1]}, "Repeated question", thread_id="7"
+        )
+    session = agent.session_store.get_session(agent.uuid)
+    assert len(session.messages) == 6
+    assert session.query_count == 4
+    assert [message.content for message in session.messages] == ["Repeated question", "same", "Repeated question"] * 2
+
+
+def test_idless_snapshot_tracks_payload_changes(cumulative_agent):
+    agent = cumulative_agent
+    agent._ensure_session("Question")
+    for text in ("original", "updated", "updated"):
+        agent._save_messages_to_store({"messages": [{"type": "ai", "content": text}]}, "Question")
+    assert [message.content for message in agent.session_store.get_session(agent.uuid).messages] == ["original", "updated"]
 
 
 # ------------------------------------------------------------------

--- a/tests/test_ui_main_interface.py
+++ b/tests/test_ui_main_interface.py
@@ -1,10 +1,30 @@
 from contextlib import nullcontext
 import os
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from chemgraph.models.supported_models import supported_argo_models
 from ui._pages import main_interface as main_ui
 from ui.message_utils import extract_molecular_structure, normalize_latex_delimiters
+
+
+def test_query_submission_saves_with_the_normalized_thread_id(monkeypatch, tmp_path):
+    agent = MagicMock(log_dir=str(tmp_path), recursion_limit=20)
+    agent.workflow.get_state.return_value.values = {"messages": []}
+    fake_st = MagicMock()
+    fake_st.session_state = _SessionState(agent=agent, conversation_history=[])
+    snapshot = {"messages": [{"type": "human", "content": "question"}]}
+    monkeypatch.setattr(main_ui, "st", fake_st)
+    monkeypatch.setattr(main_ui, "_activate_turn_dir", lambda *args: str(tmp_path))
+    monkeypatch.setattr(main_ui, "persist_uploads", lambda *args: [])
+    monkeypatch.setattr(main_ui, "_stream_workflow", lambda *args: None)
+    monkeypatch.setattr(main_ui, "_poll_and_display", lambda *args: ("done", snapshot))
+    monkeypatch.setattr(main_ui, "_save_exchange_to_store", lambda *args: None)
+    monkeypatch.setattr(main_ui.artifact_utils, "append_manifest_entry", lambda *args, **kwargs: None)
+
+    main_ui._handle_query_submission(" question ", 42, {"ok": True}, None)
+
+    agent._save_messages_to_store.assert_called_once_with(snapshot, "question", thread_id="42")
 
 
 class _SessionState(dict):


### PR DESCRIPTION
## Summary

After each ordinary agent turn, the compiled graph returns the accumulated transcript. Appending that entire snapshot stored six messages and three queries after only two turns. Track successfully saved message identities per normalized thread and append only new messages, so two turns store four messages and two queries.

Use graph IDs when available and transcript position plus normalized payload otherwise. Retain repeated text and separate thread histories, retry failed writes, and pass the UI submission's actual thread ID. Preserve SessionStore's append API and the durable main-agent path; historical rows are not rewritten.

## Related issues

Release prerequisite for #227.

## Type of change

- [x] Bug fix

## How was this tested?

- `ruff check .` and `git diff --check` passed.
- Full suite with Academy/Parsl/Globus extras: **809 passed, 21 skipped, 2 deselected**, using temporary storage and loopback access for local test servers.
- Focused session/UI/memory/durable-agent suite: **127 passed**.
- New regressions use a compiled LangGraph with a fake LLM and temporary SQLite: cumulative turns, repeated text, identical snapshots, normalized/alternating threads, ID-based identity, failed-write retry, and the UI caller.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] Focused on future ordinary-agent session writes
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added regression coverage
- [x] No database migration or historical cleanup
