### PR TITLE
fix: correct thermochemistry and preserve ASE mode diagnostics

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,11 +105,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies (academy + execution backends)
+    - name: Install dependencies (tests + academy + execution backends)
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[academy,parsl,globus_compute]"
+        pip install -e ".[test,academy,parsl,globus_compute]"
         python -m pip check
+
+    - name: Verify QuickJS is installed
+      run: python -c "import quickjs"
 
     - name: Run academy + backend tests
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,10 @@ RUN CFLAGS="-O2 -fno-tree-vectorize" \
     python -m pip install --no-cache-dir --no-binary=tblite \
     . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0"
 
-# Validate calculator runtimes at build time after package install.
-RUN which nwchem && python -c "from tblite.ase import TBLite; import graph_longrange" && \
+# Use the validated ASE version after all other Python package installs.
+RUN python -m pip install --no-cache-dir "ase==3.29.0" && \
+    which nwchem && \
+    python -c "import ase; from tblite.ase import TBLite; import graph_longrange; print(f'ASE {ase.__version__}')" && \
     python -m pip check
 
 # Allow git commands in bind-mounted repo paths inside the container.

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -38,8 +38,10 @@ RUN CFLAGS="-O2 -fno-tree-vectorize" \
     python -m pip install --no-cache-dir --no-binary=tblite \
     . jupyterlab -r requirements/mace-polar.txt "tblite==0.4.0"
 
-# Validate calculator runtimes at build time after package install.
-RUN which nwchem && python -c "from tblite.ase import TBLite; import graph_longrange" && \
+# Use the validated ASE version after all other Python package installs.
+RUN python -m pip install --no-cache-dir "ase==3.29.0" && \
+    which nwchem && \
+    python -c "import ase; from tblite.ase import TBLite; import graph_longrange; print(f'ASE {ase.__version__}')" && \
     python -m pip check
 
 RUN git config --system --add safe.directory /app

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -36,6 +36,13 @@ Calculator-backed tools cover operations such as:
 Support depends on the selected calculator. A valid property for one engine may
 not exist for another.
 
+Ideal-gas thermochemistry uses the requested temperature and pressure. Enthalpy
+and Gibbs energy are reported in eV; entropy is reported in eV/K with a separate
+`entropy_unit` field. HTML reports also support kJ/(mol K) and kcal/(mol K) for
+entropy. Single atoms include translational and electronic-spin contributions
+without running finite-difference vibrations. Calculator multiplicity determines
+the electronic-spin contribution.
+
 ## EMT for setup checks
 
 EMT is lightweight and requires no download, making it a useful plumbing test.

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -46,10 +46,12 @@ results without this field, and reject other declared entropy units. The shared
 to kJ/(mol K) or kcal/(mol K) for the corresponding molar energy selection.
 
 ChemGraph requires ASE >= 3.29.0. For `thermo`, the complete complex spectrum is
-passed to `IdealGasThermo(vib_selection="highest", ignore_imag_modes=True)`.
-ASE selects the expected number of modes by squared energy, then removes any
-remaining imaginary or zero-energy modes. ChemGraph does not apply an additional
-frequency cutoff or convert imaginary frequencies to real ones.
+passed to `IdealGasThermo(vib_selection="highest", ignore_imag_modes=False)`.
+These are ASE's defaults: select the expected number of modes by signed squared
+energy, then reject any remaining imaginary modes. Zero-energy modes are not
+automatically removed; if they yield non-finite thermochemistry, the calculation
+returns a failure. ChemGraph does not apply an additional check of the complete
+spectrum, impose a frequency cutoff, or convert imaginary frequencies to real ones.
 
 Reported thermochemistry frequencies, CSV entries, and trajectories match the
 energies ASE actually used. `vibrational_frequencies.mode_indices` contains their
@@ -60,9 +62,11 @@ spectrum with used/excluded labels. Standalone `vib` and `ir` output is unchange
 
 Thermochemistry metadata records `ase_version`, `vib_selection`,
 `ignore_imag_modes`, `n_imag`, `raw_imaginary_mode_count`, and `warnings`.
-`n_imag` is ASE's cleanup count **after selection**, including zero-energy modes;
-it is not the number of imaginary modes in the complete input. Selection may
-already have excluded imaginary modes even when `n_imag` is zero. Successful
+`n_imag` is zero for successful calculations under this policy. Legacy results
+with `ignore_imag_modes=True` may record modes removed **after selection**,
+including zero-energy modes; HTML reports continue to support that metadata.
+`n_imag` is not the number of imaginary modes in the complete input. Selection
+may already have excluded imaginary modes even when `n_imag` is zero. Successful
 thermochemistry with excluded modes does not establish structural stability.
 The raw imaginary-mode count is diagnostic and does not itself trigger a
 warning. Warnings contain messages emitted by ASE and identify calculations

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -45,6 +45,31 @@ results without this field, and reject other declared entropy units. The shared
 **Units** selector converts energy and entropy together; entropy labels change
 to kJ/(mol K) or kcal/(mol K) for the corresponding molar energy selection.
 
+ChemGraph requires ASE >= 3.29.0. For `thermo`, the complete complex spectrum is
+passed to `IdealGasThermo(vib_selection="highest", ignore_imag_modes=True)`.
+ASE selects the expected number of modes by squared energy, then removes any
+remaining imaginary or zero-energy modes. ChemGraph does not apply an additional
+frequency cutoff or convert imaginary frequencies to real ones.
+
+Reported thermochemistry frequencies, CSV entries, and trajectories match the
+energies ASE actually used. `vibrational_frequencies.mode_indices` contains their
+original zero-based ASE indices; `all_modes` preserves every input mode as
+`mode_index`, `energy` (meV), and `frequency` (cm-1), with an `i` suffix for
+imaginary values. HTML displays mode numbers starting at 1 and includes the full
+spectrum with used/excluded labels. Standalone `vib` and `ir` output is unchanged.
+
+Thermochemistry metadata records `ase_version`, `vib_selection`,
+`ignore_imag_modes`, `n_imag`, `raw_imaginary_mode_count`, and `warnings`.
+`n_imag` is ASE's cleanup count **after selection**, including zero-energy modes;
+it is not the number of imaginary modes in the complete input. Selection may
+already have excluded imaginary modes even when `n_imag` is zero. Successful
+thermochemistry with excluded modes does not establish structural stability.
+Warnings identify imaginary input modes and calculations with no vibrational
+contribution. If ASE raises or returns non-finite thermodynamic values, ChemGraph
+returns a failure with `results_file` pointing to the completed structure,
+potential energy, convergence state, and full spectrum; the JSON records
+`success=false` and the error, with no thermochemistry values.
+
 Single atoms skip finite-difference vibrations for `thermo`, `vib`, and `ir`.
 Atomic thermochemistry includes translation and uses the calculator's reported
 multiplicity for the electronic-spin contribution. If no multiplicity is

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -36,12 +36,23 @@ Calculator-backed tools cover operations such as:
 Support depends on the selected calculator. A valid property for one engine may
 not exist for another.
 
-Ideal-gas thermochemistry uses the requested temperature and pressure. Enthalpy
-and Gibbs energy are reported in eV; entropy is reported in eV/K with a separate
-`entropy_unit` field. HTML reports also support kJ/(mol K) and kcal/(mol K) for
-entropy. Single atoms include translational and electronic-spin contributions
-without running finite-difference vibrations. Calculator multiplicity determines
-the electronic-spin contribution.
+Ideal-gas thermochemistry uses the requested temperature and pressure (defaults:
+298.15 K and 101325 Pa). ASE single and ensemble inputs also interpret a null
+temperature as 298.15 K; supplied temperatures must be finite and positive.
+Enthalpy and Gibbs energy are reported in eV; entropy is reported in eV/K with a
+separate `entropy_unit` field. HTML reports accept eV/K entropy, including legacy
+results without this field, and reject other declared entropy units. The shared
+**Units** selector converts energy and entropy together; entropy labels change
+to kJ/(mol K) or kcal/(mol K) for the corresponding molar energy selection.
+
+Single atoms skip finite-difference vibrations for `thermo`, `vib`, and `ir`.
+Atomic thermochemistry includes translation and uses the calculator's reported
+multiplicity for the electronic-spin contribution. If no multiplicity is
+reported, ChemGraph logs a warning and assumes a singlet, omitting the
+electronic-spin entropy of open-shell species. This does not infer ground-state
+multiplicities or add spin dependence to a calculator's potential energy.
+Rotational symmetry analysis expects an isolated, unwrapped molecule; periodic
+images are not reconstructed.
 
 ## EMT for setup checks
 

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -64,9 +64,11 @@ Thermochemistry metadata records `ase_version`, `vib_selection`,
 it is not the number of imaginary modes in the complete input. Selection may
 already have excluded imaginary modes even when `n_imag` is zero. Successful
 thermochemistry with excluded modes does not establish structural stability.
-Warnings identify imaginary input modes and calculations with no vibrational
-contribution. If ASE raises or returns non-finite thermodynamic values, ChemGraph
-returns a failure with `results_file` pointing to the completed structure,
+The raw imaginary-mode count is diagnostic and does not itself trigger a
+warning. Warnings contain messages emitted by ASE and identify calculations
+with no vibrational contribution. If ASE raises or returns non-finite
+thermodynamic values, ChemGraph returns a failure with `results_file` pointing
+to the completed structure,
 potential energy, convergence state, and full spectrum; the JSON records
 `success=false` and the error, with no thermochemistry values.
 

--- a/docs/docker_support.md
+++ b/docs/docker_support.md
@@ -4,6 +4,10 @@ The ChemGraph image can run JupyterLab, Streamlit, the CLI, or the general MCP
 server. It includes the source-tree entry points plus NWChem and TBLite support
 configured by the repository Dockerfile.
 
+Both Docker variants install the validated ASE version, 3.29.0, after the other
+Python packages and print its version during build validation. Rebuild existing
+images to pick up this change.
+
 ## Streamlit
 
 Set the credential in your host environment, then pass it by name:

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - tblite=0.4.0
   - nwchem
   - pip:
-    - ase==3.25.0
+    - ase==3.29.0
     - rdkit==2025.3.3
     - langgraph==1.2.9
     - langgraph-checkpoint==4.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,10 @@ dependencies = [
     ]
 
 [project.optional-dependencies]
+test = [
+    "quickjs==1.19.4",
+]
+
 # Optical Chemical Structure Recognition: read a structure diagram, get a SMILES.
 #
 # DECIMER and shared support packages are installable from PyPI. The three Git-only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "numpy==2.2.6",
     "numexpr==2.11.0",
     "pytest==9.0.3",
-    "ase",
+    "ase>=3.29.0",
     "rdkit",
     "pymatgen",
     "mace-torch>=0.3.16",

--- a/src/chemgraph/prompt/multi_agent_prompt.py
+++ b/src/chemgraph/prompt/multi_agent_prompt.py
@@ -21,16 +21,16 @@ You do NOT execute tools yourself. For any question involving computed propertie
   1. Each subtask must correspond to calculating a property **of a single molecule only** (e.g., energy, enthalpy, geometry optimization).
   2. Do NOT generate subtasks that involve combining or comparing results between molecules (e.g., reaction enthalpy, binding energy).
   3. Each subtask must be independent — no task should depend on the result of another.
-  4. Include all relevant simulation parameters from the user's input (temperature, pressure, calculator, etc.) in each task prompt.
+  4. Include all relevant simulation parameters from the user's input (temperature, pressure, calculator, etc.) in each task prompt. Preserve supplied values and do not invent missing values.
+  5. Let executors determine which omitted parameters have tool-defined defaults and validate supplied values against their tool schemas.
 
 **PHASE 1b: Ask Human for Clarification**
-- **Trigger:** The user query is missing critical information needed to generate tasks, or is ambiguous.
+- **Trigger:** An executor identifies a missing required input with no tool-defined default, or the task or supplied values are ambiguous or invalid.
 - **Action:** Set `next_step` to `"ask_human"` and provide a `clarification` string with a clear question.
 - **When to ask:**
-  1. Required simulation parameters are missing (e.g., no calculator specified, no temperature for thermochemistry, no molecule identified).
+  1. An executor identifies a missing required input with no default in its tool schema.
   2. The query is vague or could be interpreted in multiple ways (e.g., "calculate properties of water" — which properties?).
   3. An executor task failed and you need the user to decide how to proceed (e.g., retry with different parameters, use a different method, or skip).
-- **Never guess or assume defaults** for critical parameters — always ask the human when in doubt.
 
 **PHASE 2: Review Results (Subsequent invocations)**
 - **Trigger:** You see executor results or human clarification responses in the conversation history.
@@ -84,13 +84,12 @@ Return ONLY this JSON object. Do not wrap it in markdown fences. Do not include 
 
 _ASK_HUMAN_PLANNER_BLOCK = """\
 **PHASE 1b: Ask Human for Clarification**
-- **Trigger:** The user query is missing critical information needed to generate tasks, or is ambiguous.
+- **Trigger:** An executor identifies a missing required input with no tool-defined default, or the task or supplied values are ambiguous or invalid.
 - **Action:** Set `next_step` to `"ask_human"` and provide a `clarification` string with a clear question.
 - **When to ask:**
-  1. Required simulation parameters are missing (e.g., no calculator specified, no temperature for thermochemistry, no molecule identified).
+  1. An executor identifies a missing required input with no default in its tool schema.
   2. The query is vague or could be interpreted in multiple ways (e.g., "calculate properties of water" — which properties?).
   3. An executor task failed and you need the user to decide how to proceed (e.g., retry with different parameters, use a different method, or skip).
-- **Never guess or assume defaults** for critical parameters — always ask the human when in doubt.
 
 """
 
@@ -167,12 +166,12 @@ Instructions:
 
 2. **Before calling any tool**, ensure that:
    - All required input fields for that specific tool are present and valid.
-   - You do **not assume default values**. You must explicitly extract each value.
-   - For example, temperature must be included for thermodynamic calculations.
+   - Omit unspecified parameters that have defaults in the tool schema and let the tool apply them.
+   - Preserve user-supplied values. Do not invent defaults or replace invalid supplied values with defaults.
 
 3. **You must use tool calls to generate any molecular data**:
    - **Never fabricate SMILES strings, coordinates, thermodynamic properties, or energies**.
-   - If inputs are missing, halt and state what is needed.
+   - If a required input is missing and has no default in the tool schema, or a supplied value is ambiguous or invalid, halt and state what is needed.
 
 4. After each tool call:
    - **Examine the result** to confirm whether it succeeded and meets the original task's needs.

--- a/src/chemgraph/prompt/single_agent_prompt.py
+++ b/src/chemgraph/prompt/single_agent_prompt.py
@@ -4,7 +4,7 @@ from chemgraph.schemas.agent_response import ResponseFormatter
 
 _ASK_HUMAN_PROMPT_BLOCK = """\
 7. **Use the `ask_human` tool** in the following situations instead of guessing or failing silently:
-   - Required inputs are missing or ambiguous (e.g., molecule name, calculator type, temperature, pressure, basis set, or simulation method is not specified).
+   - A required input is missing and the selected tool's schema provides no default, or a user-supplied value is ambiguous or invalid.
    - You need confirmation before running a computationally expensive simulation (e.g., geometry optimization with a high-level calculator, large vibrational analysis).
    - A previous tool call failed and you need the user to decide how to proceed (e.g., retry with different parameters, use a different calculator, or skip the step).
    - The query is vague or could be interpreted in multiple ways.
@@ -15,7 +15,7 @@ single_agent_prompt = f"""You are an expert in computational chemistry, using ad
 
 Instructions:
 1. Extract all relevant inputs from the user's query, such as SMILES strings, molecule names, methods, software, properties, and conditions.
-2. If a tool is needed, call it using the correct schema.
+2. If a tool is needed, call it using the correct schema. Use defaults declared by the selected tool's schema for omitted parameters. Preserve user-supplied values and never invent defaults.
 3. Base all responses strictly on actual tool outputs—never fabricate results, coordinates or SMILES string.
 4. Review previous tool outputs. If they indicate failure, retry the tool with adjusted inputs if possible.
 5. Use available simulation data directly. If data is missing, clearly state that a tool call is required.

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -489,8 +489,9 @@ class ASEOutputSchema(BaseModel):
     thermochemistry: dict = Field(
         default={}, description=(
             "Thermochemistry energies in eV and entropy in eV/K, with ASE version, "
-            "mode-selection policy, cleanup counts, and warnings. ASE n_imag counts "
-            "modes removed after selection, including zero-energy modes."
+            "mode-selection policy, cleanup counts, and warnings. ASE rejects "
+            "imaginary modes remaining after highest selection; n_imag is zero "
+            "on success. Legacy results may record removed modes in n_imag."
         )
     )
     success: bool = Field(

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -466,7 +466,9 @@ class ASEOutputSchema(BaseModel):
         default={},
         description="Infrared spectrum related data.",
     )
-    thermochemistry: dict = Field(default={}, description="Thermochemistry data in eV.")
+    thermochemistry: dict = Field(
+        default={}, description="Thermochemistry energies in eV and entropy in eV/K."
+    )
     success: bool = Field(
         default=False, description="Indicates if the simulation finished correctly."
     )

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -294,8 +294,8 @@ class ASEInputSchema(BaseModel):
         Force convergence criterion in eV/Å. Optimization stops when all force components fall below this threshold.
     steps : int
         Maximum number of steps for geometry optimization.
-    temperature : Optional[float]
-        Temperature in Kelvin, required for thermochemical calculations (e.g., when using 'thermo' as the driver).
+    temperature : float
+        Positive temperature in Kelvin for thermochemistry; omitted or null values use 298.15 K.
     pressure : float
         Pressure in Pascal (Pa), used in thermochemistry calculations (default is 1 atm).
     """
@@ -327,14 +327,22 @@ class ASEInputSchema(BaseModel):
         default=1000,
         description="Maximum number of optimization steps. Internally 'vib', 'thermo' and 'ir' run geometry optimization before performing their respective calculations.",
     )
-    temperature: Optional[float] = Field(
-        default=None,
-        description="Temperature for thermochemistry calculations in Kelvin (K).",
+    temperature: float = Field(
+        default=298.15,
+        gt=0,
+        allow_inf_nan=False,
+        description="Temperature for thermochemistry in Kelvin (K), finite and greater than zero. Omitted or null values use 298.15 K.",
     )
     pressure: float = Field(
         default=101325.0,
         description="Pressure for thermochemistry calculations in Pascal (Pa).",
     )
+
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _default_temperature(cls, value: Any) -> Any:
+        """Treat explicit null like an omitted temperature."""
+        return cls.model_fields["temperature"].default if value is None else value
 
     @model_validator(mode="before")
     @classmethod
@@ -401,14 +409,22 @@ class ase_input_schema_ensemble(BaseModel):
         default=1000,
         description="Maximum number of optimization steps. Internally 'vib', 'thermo' and 'ir' run geometry optimization before performing their respective calculations.",
     )
-    temperature: Optional[float] = Field(
-        default=None,
-        description="Temperature for thermochemistry calculations in Kelvin (K).",
+    temperature: float = Field(
+        default=298.15,
+        gt=0,
+        allow_inf_nan=False,
+        description="Temperature for thermochemistry in Kelvin (K), finite and greater than zero. Omitted or null values use 298.15 K.",
     )
     pressure: float = Field(
         default=101325.0,
         description="Pressure for thermochemistry calculations in Pascal (Pa).",
     )
+
+    @field_validator("temperature", mode="before")
+    @classmethod
+    def _default_temperature(cls, value: Any) -> Any:
+        """Treat explicit null like an omitted temperature."""
+        return cls.model_fields["temperature"].default if value is None else value
 
     @model_validator(mode="before")
     @classmethod

--- a/src/chemgraph/schemas/ase_input.py
+++ b/src/chemgraph/schemas/ase_input.py
@@ -476,14 +476,22 @@ class ASEOutputSchema(BaseModel):
     )
     vibrational_frequencies: dict = Field(
         default={},
-        description="Vibrational frequencies (in cm-1) and energies (in eV).",
+        description=(
+            "Vibrational frequencies in cm-1 and energies in meV. Thermochemistry "
+            "results include the original zero-based mode_indices used by ASE "
+            "and all_modes, the complete input spectrum including excluded modes."
+        ),
     )
     ir_data: dict = Field(
         default={},
         description="Infrared spectrum related data.",
     )
     thermochemistry: dict = Field(
-        default={}, description="Thermochemistry energies in eV and entropy in eV/K."
+        default={}, description=(
+            "Thermochemistry energies in eV and entropy in eV/K, with ASE version, "
+            "mode-selection policy, cleanup counts, and warnings. ASE n_imag counts "
+            "modes removed after selection, including zero-energy modes."
+        )
     )
     success: bool = Field(
         default=False, description="Indicates if the simulation finished correctly."

--- a/src/chemgraph/schemas/calculators/orca_calc.py
+++ b/src/chemgraph/schemas/calculators/orca_calc.py
@@ -42,7 +42,9 @@ class OrcaCalc(BaseModel):
     )
     charge: int = Field(default=0, description="Total charge of the system.")
     multiplicity: int = Field(
-        default=1, description="Total multiplicity of the system."
+        default=1,
+        ge=1,
+        description="Spin multiplicity (2S+1): 1=singlet, 2=doublet, etc.",
     )
     orcasimpleinput: str = Field(
         default="B3LYP def2-TZVP",

--- a/src/chemgraph/schemas/calculators/tblite_calc.py
+++ b/src/chemgraph/schemas/calculators/tblite_calc.py
@@ -59,7 +59,9 @@ class TBLiteCalc(BaseModel):
     )
     charge: Optional[float] = Field(default=None, description="Total charge of the system")
     multiplicity: Optional[int] = Field(
-        default=None, description="Total multiplicity of the system"
+        default=None,
+        ge=1,
+        description="Spin multiplicity (2S+1): 1=singlet, 2=doublet, etc.",
     )
     accuracy: float = Field(
         default=1.0, description="Numerical accuracy of the calculation"

--- a/src/chemgraph/schemas/mace_parsl_schema.py
+++ b/src/chemgraph/schemas/mace_parsl_schema.py
@@ -164,7 +164,7 @@ class mace_output_schema(BaseModel):
     )
     thermochemistry: dict = Field(
         default={},
-        description="Thermochemistry data in eV.",
+        description="Thermochemistry energies in eV and entropy in eV/K.",
     )
     error: str = Field(
         default="",

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -248,7 +248,10 @@ def _vibrational_mode_indices(atomsdata: AtomsData, total_modes: int) -> list[in
 
 
 def get_symmetry_number(atomsdata: AtomsData) -> int:
-    """Return the rotational symmetry number using Pymatgen.
+    """Return the rotational symmetry number of an isolated molecule.
+
+    Coordinates must describe an unwrapped molecule; periodic images are
+    not reconstructed for point-group analysis.
 
     Parameters
     ----------
@@ -258,6 +261,9 @@ def get_symmetry_number(atomsdata: AtomsData) -> int:
     -------
     int
     """
+    if len(atomsdata.numbers) == 1:
+        return 1
+
     from pymatgen.symmetry.analyzer import PointGroupAnalyzer
     from ase import Atoms
     from pymatgen.io.ase import AseAtomsAdaptor
@@ -749,6 +755,7 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
         thermo_data: dict = {}
         vib_data: dict = {}
         ir_data: dict = {}
+        ir_plot_path: Optional[str] = None
 
         # --------------------------------------------------------------
         # Vibrational / thermo / IR analysis
@@ -761,17 +768,37 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 "frequencies": [],
                 "frequency_unit": "cm-1",
             }
-        if driver in {"vib", "thermo", "ir"} and not (
-            driver == "thermo" and len(atoms) == 1
-        ):
-            logger.info("Starting vibrational analysis (driver=%s)", driver)
-            from ase.vibrations import Vibrations
-            from ase import units
-
-            ir_plot_path: Optional[str] = None
             mol_stem = (
                 Path(input_structure_file).stem if input_structure_file else "mol"
             )
+            # Remove previous modes even when this run has no vibrations.
+            freq_file = Path(_resolve_path(f"frequencies_{mol_stem}.csv"))
+            freq_file.unlink(missing_ok=True)
+            traj_dest_dir = _resolve_path("")
+            stale_traj_pattern = (
+                glob.escape(_resolve_path(f"{mol_stem}_vib.")) + "*.traj"
+            )
+            for stale_traj_file in glob.glob(stale_traj_pattern):
+                os.unlink(stale_traj_file)
+
+            if driver == "ir":
+                ir_data = {
+                    "spectrum_frequencies": [],
+                    "spectrum_frequencies_units": "cm-1",
+                    "spectrum_intensities": [],
+                    "spectrum_intensities_units": "D/Å^2 amu^-1",
+                }
+                for name in (
+                    f"ir_spectrum_{mol_stem}.png",
+                    f"ir_spectrum_{mol_stem}.csv",
+                    f"ir_peaks_{mol_stem}.csv",
+                ):
+                    Path(_resolve_path(name)).unlink(missing_ok=True)
+
+        if driver in {"vib", "thermo", "ir"} and len(atoms) > 1:
+            logger.info("Starting vibrational analysis (driver=%s)", driver)
+            from ase.vibrations import Vibrations
+            from ase import units
 
             with tempfile.TemporaryDirectory(
                 prefix=f"chemgraph_vib_{mol_stem}_"
@@ -798,10 +825,6 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                     vib_data["frequencies"].append(f"{freq_cm1}{suffix}")
 
                 # Write frequencies CSV
-                freq_file_path = _resolve_path(f"frequencies_{mol_stem}.csv")
-                freq_file = Path(freq_file_path)
-                if freq_file.exists():
-                    freq_file.unlink()
                 with freq_file.open("w", encoding="utf-8") as f:
                     for mode_index, freq in zip(
                         mode_indices, vib_data["frequencies"]
@@ -814,14 +837,8 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                         n=mode_index, kT=units.kB * 300, nimages=30
                     )
 
-                traj_dest_dir = _resolve_path("")
                 if traj_dest_dir:
                     os.makedirs(traj_dest_dir, exist_ok=True)
-                stale_traj_pattern = os.path.join(
-                    traj_dest_dir, f"{mol_stem}_vib.*.traj"
-                )
-                for stale_traj_file in glob.glob(stale_traj_pattern):
-                    os.unlink(stale_traj_file)
                 for mode_index in mode_indices:
                     traj_file = os.path.join(tmpdir, f"vib.{mode_index}.traj")
                     dest_name = f"{mol_stem}_{Path(traj_file).name}"
@@ -840,11 +857,6 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
 
                     matplotlib.use("Agg")
                     import matplotlib.pyplot as plt
-
-                    ir_data["spectrum_frequencies"] = []
-                    ir_data["spectrum_frequencies_units"] = "cm-1"
-                    ir_data["spectrum_intensities"] = []
-                    ir_data["spectrum_intensities_units"] = "D/Å^2 amu^-1"
 
                     ir_name = os.path.join(tmpdir, "ir")
                     ir = Infrared(atoms, name=ir_name)
@@ -916,7 +928,15 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 symmetrynumber = get_symmetry_number(final_structure)
 
             # IdealGasThermo expects total spin S; calculators expose 2S+1.
-            multiplicity = getattr(calc_model, "get_multiplicity", lambda: None)() or 1
+            multiplicity = getattr(calc_model, "get_multiplicity", lambda: None)()
+            if multiplicity is None:
+                logger.warning(
+                    "%s does not report spin multiplicity; assuming a singlet "
+                    "(multiplicity=1) for thermochemistry. Electronic-spin entropy "
+                    "is omitted for open-shell species.",
+                    type(calc_model).__name__,
+                )
+                multiplicity = 1
             thermo = IdealGasThermo(
                 vib_energies=all_energies,
                 potentialenergy=potential_energy,
@@ -925,14 +945,12 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 symmetrynumber=symmetrynumber,
                 spin=(multiplicity - 1) / 2.0,
             )
+            enthalpy = float(thermo.get_enthalpy(temperature, verbose=False))
+            entropy = float(thermo.get_entropy(temperature, pressure, verbose=False))
             thermo_data = {
-                "enthalpy": float(thermo.get_enthalpy(temperature=temperature)),
-                "entropy": float(
-                    thermo.get_entropy(temperature=temperature, pressure=pressure)
-                ),
-                "gibbs_free_energy": float(
-                    thermo.get_gibbs_energy(temperature=temperature, pressure=pressure)
-                ),
+                "enthalpy": enthalpy,
+                "entropy": entropy,
+                "gibbs_free_energy": enthalpy - temperature * entropy,
                 "unit": "eV",
                 "entropy_unit": "eV/K",
             }
@@ -1006,6 +1024,12 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 ),
             }
         elif driver == "ir":
+            artifact_message = (
+                f"IR plot saved to {os.path.abspath(ir_plot_path)}. "
+                "Normal modes saved as individual .traj files"
+                if ir_plot_path
+                else "Single atoms have no vibrational modes or IR spectrum."
+            )
             return {
                 "status": "success",
                 **energy_metadata,
@@ -1013,8 +1037,7 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 "message": (
                     "Infrared computed and returned. "
                     f"Full results (structure, vibrations, thermochemistry and metadata) saved to {abs_output}. "
-                    f"IR plot saved to {os.path.abspath(ir_plot_path) if ir_plot_path else 'N/A'}. "
-                    "Normal modes saved as individual .traj files"
+                    f"{artifact_message}"
                 ),
             }
 

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import tempfile
 import time
+import warnings
 from pathlib import Path
 from typing import List, Optional
 
@@ -245,6 +246,110 @@ def _vibrational_mode_indices(atomsdata: AtomsData, total_modes: int) -> list[in
 
     num_nonvibrational = 5 if is_linear_molecule(atomsdata) else 6
     return list(range(num_nonvibrational, total_modes))
+
+
+def _vibrational_mode_record(mode_index: int, energy: complex) -> dict:
+    """Format an original ASE mode without hiding small imaginary energies."""
+    from ase import units
+
+    value = energy.imag if energy.imag != 0 else energy.real
+    suffix = "i" if energy.imag != 0 else ""
+    return {
+        "mode_index": mode_index,
+        "energy": f"{1e3 * value}{suffix}",
+        "frequency": f"{value / units.invcm}{suffix}",
+    }
+
+
+def _calculate_thermochemistry(
+    atoms,
+    final_structure,
+    all_energies,
+    potential_energy,
+    calc_model,
+    temperature,
+    pressure,
+) -> tuple[dict, list[int]]:
+    """Let ASE select/clean modes and map its retained energies to ASE indices."""
+    import ase
+    from ase.thermochemistry import IdealGasThermo
+
+    expected_modes = 0 if len(atoms) == 1 else 3 * len(atoms)
+    if len(all_energies) != expected_modes:
+        raise ValueError(
+            f"Expected {expected_modes} input modes, got {len(all_energies)}."
+        )
+    if len(atoms) == 1:
+        geometry, symmetrynumber = "monatomic", 1
+    else:
+        geometry = "linear" if is_linear_molecule(final_structure) else "nonlinear"
+        symmetrynumber = get_symmetry_number(final_structure)
+
+    # IdealGasThermo expects total spin S; calculators expose 2S+1.
+    multiplicity = getattr(calc_model, "get_multiplicity", lambda: None)()
+    if multiplicity is None:
+        logger.warning(
+            "%s does not report spin multiplicity; assuming a singlet "
+            "(multiplicity=1) for thermochemistry. Electronic-spin entropy "
+            "is omitted for open-shell species.",
+            type(calc_model).__name__,
+        )
+        multiplicity = 1
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", UserWarning)
+        thermo = IdealGasThermo(
+            vib_energies=all_energies,
+            potentialenergy=potential_energy,
+            atoms=atoms,
+            geometry=geometry,
+            symmetrynumber=symmetrynumber,
+            spin=(multiplicity - 1) / 2.0,
+            vib_selection="highest",
+            ignore_imag_modes=True,
+        )
+        retained_energies = thermo.vib_energies
+        enthalpy = float(thermo.get_enthalpy(temperature, verbose=False))
+        entropy = float(thermo.get_entropy(temperature, pressure, verbose=False))
+    gibbs_free_energy = enthalpy - temperature * entropy
+    if not np.all(np.isfinite([enthalpy, entropy, gibbs_free_energy])):
+        raise ValueError("ASE returned non-finite thermochemistry values.")
+
+    # ASE sorts stably and keeps the last modes. Match equal energies from
+    # the end so degenerate modes at the selection boundary keep their IDs.
+    indices_by_energy: dict[float, list[int]] = {}
+    for index, energy in enumerate(all_energies):
+        indices_by_energy.setdefault(float(np.real(energy)), []).append(index)
+    mode_indices = [
+        indices_by_energy[float(energy)].pop() for energy in reversed(retained_energies)
+    ][::-1]
+
+    notes = [str(warning.message) for warning in caught]
+    raw_imaginary_count = int(np.count_nonzero(np.iscomplex(all_energies)))
+    if raw_imaginary_count:
+        notes.append(
+            f"The input spectrum contains {raw_imaginary_count} imaginary modes. "
+            "These thermochemistry values do not establish structural stability; "
+            "inspect the complete spectrum."
+        )
+    if len(atoms) > 1 and not mode_indices:
+        notes.append("No vibrational modes contributed to thermochemistry.")
+    for note in notes:
+        logger.warning(note)
+
+    return {
+        "enthalpy": enthalpy,
+        "entropy": entropy,
+        "gibbs_free_energy": gibbs_free_energy,
+        "unit": "eV",
+        "entropy_unit": "eV/K",
+        "ase_version": ase.__version__,
+        "vib_selection": "highest",
+        "ignore_imag_modes": True,
+        "n_imag": int(thermo.n_imag),
+        "raw_imaginary_mode_count": raw_imaginary_count,
+        "warnings": notes,
+    }, mode_indices
 
 
 def get_symmetry_number(atomsdata: AtomsData) -> int:
@@ -489,7 +594,7 @@ def _energy_result_metadata(
     converged: Optional[bool] = None,
     optimization_steps: Optional[int] = None,
 ) -> dict:
-    """Build consistent energy metadata for a successful tool result."""
+    """Build consistent metadata for a completed energy calculation."""
     result = {
         "driver": driver,
         "potential_energy": potential_energy,
@@ -497,7 +602,7 @@ def _energy_result_metadata(
         "results_file": os.path.abspath(results_file),
     }
     if converged is not None:
-        result["converged"] = converged
+        result["converged"] = bool(converged)
     if optimization_steps is not None:
         result["optimization_steps"] = optimization_steps
     return result
@@ -753,6 +858,7 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
             pbc=atoms.pbc,
         )
         thermo_data: dict = {}
+        thermo_error: Optional[Exception] = None
         vib_data: dict = {}
         ir_data: dict = {}
         ir_plot_path: Optional[str] = None
@@ -810,9 +916,27 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 logger.info("Vibrational analysis complete")
 
                 all_energies = vib.get_energies()
-                mode_indices = _vibrational_mode_indices(
-                    final_structure, len(all_energies)
-                )
+                if driver == "thermo":
+                    vib_data.update(
+                        mode_indices=[],
+                        all_modes=[
+                            _vibrational_mode_record(i, e)
+                            for i, e in enumerate(all_energies)
+                        ],
+                    )
+                    try:
+                        thermo_data, mode_indices = _calculate_thermochemistry(
+                            atoms, final_structure, all_energies, potential_energy,
+                            calc_model, temperature, pressure,
+                        )
+                        vib_data["mode_indices"] = mode_indices
+                    except Exception as exc:
+                        logger.exception("Thermochemistry failed; preserving vibration results")
+                        thermo_error, mode_indices = exc, []
+                else:
+                    mode_indices = _vibrational_mode_indices(
+                        final_structure, len(all_energies)
+                    )
 
                 for mode_index in mode_indices:
                     e = all_energies[mode_index]
@@ -916,44 +1040,16 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                     )
 
         # ---- Thermochemistry ----
-        if driver == "thermo":
-            from ase.thermochemistry import IdealGasThermo
-
-            logger.info("Computing thermochemistry (T=%s K, P=%s Pa)", temperature, pressure)
-            if len(atoms) == 1:
-                geometry, symmetrynumber = "monatomic", 1
-            else:
-                linear = is_linear_molecule(final_structure)
-                geometry = "linear" if linear else "nonlinear"
-                symmetrynumber = get_symmetry_number(final_structure)
-
-            # IdealGasThermo expects total spin S; calculators expose 2S+1.
-            multiplicity = getattr(calc_model, "get_multiplicity", lambda: None)()
-            if multiplicity is None:
-                logger.warning(
-                    "%s does not report spin multiplicity; assuming a singlet "
-                    "(multiplicity=1) for thermochemistry. Electronic-spin entropy "
-                    "is omitted for open-shell species.",
-                    type(calc_model).__name__,
+        if driver == "thermo" and len(atoms) == 1:
+            vib_data.update(mode_indices=[], all_modes=[])
+            try:
+                thermo_data, _ = _calculate_thermochemistry(
+                    atoms, final_structure, [], potential_energy, calc_model,
+                    temperature, pressure,
                 )
-                multiplicity = 1
-            thermo = IdealGasThermo(
-                vib_energies=all_energies,
-                potentialenergy=potential_energy,
-                atoms=atoms,
-                geometry=geometry,
-                symmetrynumber=symmetrynumber,
-                spin=(multiplicity - 1) / 2.0,
-            )
-            enthalpy = float(thermo.get_enthalpy(temperature, verbose=False))
-            entropy = float(thermo.get_entropy(temperature, pressure, verbose=False))
-            thermo_data = {
-                "enthalpy": enthalpy,
-                "entropy": entropy,
-                "gibbs_free_energy": enthalpy - temperature * entropy,
-                "unit": "eV",
-                "entropy_unit": "eV/K",
-            }
+            except Exception as exc:
+                logger.exception("Thermochemistry failed; preserving atomic results")
+                thermo_error = exc
 
         # ---- serialise full output ----
         end_time = time.time()
@@ -967,7 +1063,8 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
             simulation_input=simulation_input,
             vibrational_frequencies=vib_data,
             thermochemistry=thermo_data,
-            success=True,
+            success=thermo_error is None,
+            error=str(thermo_error) if thermo_error is not None else "",
             ir_data=ir_data,
             potential_energy=potential_energy,
             single_point_energy=potential_energy,
@@ -985,6 +1082,16 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
             converged=converged,
             optimization_steps=optimization_steps,
         )
+        if thermo_error is not None:
+            return {
+                "status": "failure",
+                "error_type": type(thermo_error).__name__,
+                "message": (
+                    f"Thermochemistry failed: {thermo_error}. "
+                    f"Completed structure, energy, and vibration results saved to {abs_output}"
+                ),
+                **energy_metadata,
+            }
         if driver == "opt":
             if converged:
                 message = f"Geometry optimization converged. Results saved to {abs_output}"

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -734,7 +734,7 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
     atoms.info.update(system_info)
     atoms.calc = calc
 
-    if driver == "ir":
+    if driver == "ir" and len(atoms) > 1:
         # Infrared calls this ASE method at every displacement. Check it before
         # optimization and vibrations; a result-only fallback cannot support IR.
         from ase.calculators.calculator import PropertyNotImplementedError

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -876,15 +876,16 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
             mol_stem = (
                 Path(input_structure_file).stem if input_structure_file else "mol"
             )
-            # Remove previous modes even when this run has no vibrations.
             freq_file = Path(_resolve_path(f"frequencies_{mol_stem}.csv"))
-            freq_file.unlink(missing_ok=True)
             traj_dest_dir = _resolve_path("")
             stale_traj_pattern = (
                 glob.escape(_resolve_path(f"{mol_stem}_vib.")) + "*.traj"
             )
-            for stale_traj_file in glob.glob(stale_traj_pattern):
-                os.unlink(stale_traj_file)
+            if len(atoms) == 1:
+                # Single atoms have no replacement vibration artifacts.
+                freq_file.unlink(missing_ok=True)
+                for stale_traj_file in glob.glob(stale_traj_pattern):
+                    os.unlink(stale_traj_file)
 
             if driver == "ir":
                 ir_data = {
@@ -893,12 +894,13 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                     "spectrum_intensities": [],
                     "spectrum_intensities_units": "D/Å^2 amu^-1",
                 }
-                for name in (
-                    f"ir_spectrum_{mol_stem}.png",
-                    f"ir_spectrum_{mol_stem}.csv",
-                    f"ir_peaks_{mol_stem}.csv",
-                ):
-                    Path(_resolve_path(name)).unlink(missing_ok=True)
+                if len(atoms) == 1:
+                    for name in (
+                        f"ir_spectrum_{mol_stem}.png",
+                        f"ir_spectrum_{mol_stem}.csv",
+                        f"ir_peaks_{mol_stem}.csv",
+                    ):
+                        Path(_resolve_path(name)).unlink(missing_ok=True)
 
         if driver in {"vib", "thermo", "ir"} and len(atoms) > 1:
             logger.info("Starting vibrational analysis (driver=%s)", driver)
@@ -962,6 +964,9 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
 
                 if traj_dest_dir:
                     os.makedirs(traj_dest_dir, exist_ok=True)
+                # Keep previous modes until all replacements have been written.
+                for stale_traj_file in glob.glob(stale_traj_pattern):
+                    os.unlink(stale_traj_file)
                 for mode_index in mode_indices:
                     traj_file = os.path.join(tmpdir, f"vib.{mode_index}.traj")
                     dest_name = f"{mol_stem}_{Path(traj_file).name}"

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -269,7 +269,9 @@ def get_symmetry_number(atomsdata: AtomsData) -> int:
         pbc=atomsdata.pbc,
     )
     aaa = AseAtomsAdaptor()
-    molecule = aaa.get_molecule(atoms)
+    # Rotational symmetry depends on geometry, not the calculator's electronic
+    # state. Reconstructed Atoms lack magnetic moments for radical species.
+    molecule = aaa.get_molecule(atoms, charge_spin_check=False)
     pga = PointGroupAnalyzer(molecule)
     return pga.get_rotational_symmetry_number()
 
@@ -751,7 +753,17 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
         # --------------------------------------------------------------
         # Vibrational / thermo / IR analysis
         # --------------------------------------------------------------
+        all_energies = []
         if driver in {"vib", "thermo", "ir"}:
+            vib_data = {
+                "energies": [],
+                "energy_unit": "meV",
+                "frequencies": [],
+                "frequency_unit": "cm-1",
+            }
+        if driver in {"vib", "thermo", "ir"} and not (
+            driver == "thermo" and len(atoms) == 1
+        ):
             logger.info("Starting vibrational analysis (driver=%s)", driver)
             from ase.vibrations import Vibrations
             from ase import units
@@ -769,13 +781,6 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                 vib.clean()
                 vib.run()
                 logger.info("Vibrational analysis complete")
-
-                vib_data = {
-                    "energies": [],
-                    "energy_unit": "meV",
-                    "frequencies": [],
-                    "frequency_unit": "cm-1",
-                }
 
                 all_energies = vib.get_energies()
                 mode_indices = _vibrational_mode_indices(
@@ -898,55 +903,39 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
                         f"Normal modes saved as individual .traj files with prefix {mol_stem}_"
                     )
 
-                # ---- Thermochemistry ----
-                if driver == "thermo":
-                    logger.info("Computing thermochemistry (T=%s K, P=%s Pa)", temperature, pressure)
-                    if len(atoms) == 1:
-                        thermo_data = {
-                            "enthalpy": potential_energy,
-                            "entropy": 0.0,
-                            "gibbs_free_energy": potential_energy,
-                            "unit": "eV",
-                        }
-                    else:
-                        from ase.thermochemistry import IdealGasThermo
+        # ---- Thermochemistry ----
+        if driver == "thermo":
+            from ase.thermochemistry import IdealGasThermo
 
-                        linear = is_linear_molecule(final_structure)
-                        geometry = "linear" if linear else "nonlinear"
-                        symmetrynumber = get_symmetry_number(final_structure)
+            logger.info("Computing thermochemistry (T=%s K, P=%s Pa)", temperature, pressure)
+            if len(atoms) == 1:
+                geometry, symmetrynumber = "monatomic", 1
+            else:
+                linear = is_linear_molecule(final_structure)
+                geometry = "linear" if linear else "nonlinear"
+                symmetrynumber = get_symmetry_number(final_structure)
 
-                        # IdealGasThermo expects total spin S; calculators expose
-                        # multiplicity (2S+1) via get_multiplicity() when supported.
-                        multiplicity = (
-                            getattr(calc_model, "get_multiplicity", lambda: None)()
-                            or 1
-                        )
-                        spin_S = (multiplicity - 1) / 2.0
-
-                        thermo = IdealGasThermo(
-                            vib_energies=all_energies,
-                            potentialenergy=potential_energy,
-                            atoms=atoms,
-                            geometry=geometry,
-                            symmetrynumber=symmetrynumber,
-                            spin=spin_S,
-                        )
-                        thermo_data = {
-                            "enthalpy": float(
-                                thermo.get_enthalpy(temperature=temperature)
-                            ),
-                            "entropy": float(
-                                thermo.get_entropy(
-                                    temperature=temperature, pressure=pressure
-                                )
-                            ),
-                            "gibbs_free_energy": float(
-                                thermo.get_gibbs_energy(
-                                    temperature=temperature, pressure=pressure
-                                )
-                            ),
-                            "unit": "eV",
-                        }
+            # IdealGasThermo expects total spin S; calculators expose 2S+1.
+            multiplicity = getattr(calc_model, "get_multiplicity", lambda: None)() or 1
+            thermo = IdealGasThermo(
+                vib_energies=all_energies,
+                potentialenergy=potential_energy,
+                atoms=atoms,
+                geometry=geometry,
+                symmetrynumber=symmetrynumber,
+                spin=(multiplicity - 1) / 2.0,
+            )
+            thermo_data = {
+                "enthalpy": float(thermo.get_enthalpy(temperature=temperature)),
+                "entropy": float(
+                    thermo.get_entropy(temperature=temperature, pressure=pressure)
+                ),
+                "gibbs_free_energy": float(
+                    thermo.get_gibbs_energy(temperature=temperature, pressure=pressure)
+                ),
+                "unit": "eV",
+                "entropy_unit": "eV/K",
+            }
 
         # ---- serialise full output ----
         end_time = time.time()

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -270,7 +270,7 @@ def _calculate_thermochemistry(
     temperature,
     pressure,
 ) -> tuple[dict, list[int]]:
-    """Compute thermochemistry using ASE's mode selection and cleanup.
+    """Compute thermochemistry using ASE's mode selection and validation.
 
     Return thermochemistry values and metadata with original retained mode
     indices. Preserve ASE warnings and warn when no vibrations contribute.
@@ -311,7 +311,7 @@ def _calculate_thermochemistry(
             symmetrynumber=symmetrynumber,
             spin=(multiplicity - 1) / 2.0,
             vib_selection="highest",
-            ignore_imag_modes=True,
+            ignore_imag_modes=False,
         )
         retained_energies = thermo.vib_energies
         enthalpy = float(thermo.get_enthalpy(temperature, verbose=False))
@@ -344,7 +344,7 @@ def _calculate_thermochemistry(
         "entropy_unit": "eV/K",
         "ase_version": ase.__version__,
         "vib_selection": "highest",
-        "ignore_imag_modes": True,
+        "ignore_imag_modes": False,
         "n_imag": int(thermo.n_imag),
         "raw_imaginary_mode_count": raw_imaginary_count,
         "warnings": notes,

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -215,11 +215,11 @@ def is_linear_molecule(atomsdata: AtomsData, tol: float = 1e-3) -> bool:
 
 
 def _vibrational_mode_indices(atomsdata: AtomsData, total_modes: int) -> list[int]:
-    """Return ASE mode indices corresponding to molecular vibrations.
+    """Return mode indices for standalone vibration and IR reporting.
 
-    ASE returns all ``3N`` normal modes in ascending order.  The leading
-    translational and rotational modes are excluded from reported vibration
-    data: five modes for a linear molecule and six for a nonlinear molecule.
+    Skip the first five modes for linear molecules and six for nonlinear
+    molecules. This positional rule does not identify individual mode
+    character. Thermochemistry instead reports the modes retained by ASE.
 
     Parameters
     ----------
@@ -249,7 +249,7 @@ def _vibrational_mode_indices(atomsdata: AtomsData, total_modes: int) -> list[in
 
 
 def _vibrational_mode_record(mode_index: int, energy: complex) -> dict:
-    """Format an original ASE mode without hiding small imaginary energies."""
+    """Format an ASE mode in meV and cm-1, marking imaginary values with i."""
     from ase import units
 
     value = energy.imag if energy.imag != 0 else energy.real
@@ -270,7 +270,12 @@ def _calculate_thermochemistry(
     temperature,
     pressure,
 ) -> tuple[dict, list[int]]:
-    """Let ASE select/clean modes and map its retained energies to ASE indices."""
+    """Compute thermochemistry using ASE's mode selection and cleanup.
+
+    Return thermochemistry values and metadata with original retained mode
+    indices. Preserve ASE warnings and warn when no vibrations contribute.
+    Record raw imaginary-mode counts as diagnostics.
+    """
     import ase
     from ase.thermochemistry import IdealGasThermo
 
@@ -326,12 +331,6 @@ def _calculate_thermochemistry(
 
     notes = [str(warning.message) for warning in caught]
     raw_imaginary_count = int(np.count_nonzero(np.iscomplex(all_energies)))
-    if raw_imaginary_count:
-        notes.append(
-            f"The input spectrum contains {raw_imaginary_count} imaginary modes. "
-            "These thermochemistry values do not establish structural stability; "
-            "inspect the complete spectrum."
-        )
     if len(atoms) > 1 and not mode_indices:
         notes.append("No vibrational modes contributed to thermochemistry.")
     for note in notes:

--- a/src/chemgraph/tools/ase_core.py
+++ b/src/chemgraph/tools/ase_core.py
@@ -1087,12 +1087,25 @@ def _run_ase_core(params: ASEInputSchema) -> dict:
             optimization_steps=optimization_steps,
         )
         if thermo_error is not None:
+            if len(atoms) == 1:
+                artifact_message = (
+                    "Completed structure and potential energy are saved in the "
+                    f"results JSON: {abs_output}. Single atoms have no vibrational "
+                    "modes; no frequency CSV or mode trajectories were exported."
+                )
+            else:
+                artifact_message = (
+                    "Completed structure, potential energy, and the full input "
+                    f"vibrational spectrum are saved in the results JSON: {abs_output}. "
+                    "The selected-mode frequency CSV is empty; "
+                    "no selected-mode trajectories were exported."
+                )
             return {
                 "status": "failure",
                 "error_type": type(thermo_error).__name__,
                 "message": (
                     f"Thermochemistry failed: {thermo_error}. "
-                    f"Completed structure, energy, and vibration results saved to {abs_output}"
+                    f"{artifact_message}"
                 ),
                 **energy_metadata,
             }

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -621,17 +621,18 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         if "enthalpy" in ase_output.thermochemistry:
             enthalpy_ev = ase_output.thermochemistry['enthalpy']
             thermo_info.append(
-                f'<div><strong>Enthalpy:</strong> <span class="energy-value" data-ev="{enthalpy_ev}">{enthalpy_ev:.6f}</span></div>'
+                f'<div><strong>Enthalpy:</strong> <span class="energy-value" data-ev="{enthalpy_ev}">{enthalpy_ev:.6f}</span> <span class="energy-unit">eV</span></div>'
             )
         if "entropy" in ase_output.thermochemistry:
-            entropy_ev = ase_output.thermochemistry['entropy']
+            # Current and legacy ASE results express entropy in eV/K.
+            entropy_ev_k = ase_output.thermochemistry['entropy']
             thermo_info.append(
-                f'<div><strong>Entropy:</strong> <span class="energy-value" data-ev="{entropy_ev}">{entropy_ev:.6f}</span></div>'
+                f'<div><strong>Entropy:</strong> <span class="entropy-value" data-ev-k="{entropy_ev_k}">{entropy_ev_k:.6f}</span> <span class="entropy-unit">eV/K</span></div>'
             )
         if "gibbs_free_energy" in ase_output.thermochemistry:
             gibbs_ev = ase_output.thermochemistry['gibbs_free_energy']
             thermo_info.append(
-                f'<div><strong>Gibbs Free Energy:</strong> <span class="energy-value" data-ev="{gibbs_ev}">{gibbs_ev:.6f}</span></div>'
+                f'<div><strong>Gibbs Free Energy:</strong> <span class="energy-value" data-ev="{gibbs_ev}">{gibbs_ev:.6f}</span> <span class="energy-unit">eV</span></div>'
             )
 
         if thermo_info:
@@ -643,7 +644,7 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                     <button onclick="toggleEnergyUnit('kjmol')" data-unit="kjmol">kJ/mol</button>
                     <button onclick="toggleEnergyUnit('kcalmol')" data-unit="kcalmol">kcal/mol</button>
                 </div>
-                <strong>Thermochemistry Values</strong> (<span class="energy-unit">eV</span>):<br>
+                <strong>Thermochemistry Values</strong>:<br>
                 {"".join(thermo_info)}
             </li>""")
         else:
@@ -790,6 +791,15 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                 document.querySelectorAll('.energy-unit').forEach(label => {
                     label.textContent = unit === 'ev' ? 'eV' : 
                                      unit === 'kjmol' ? 'kJ/mol' : 'kcal/mol';
+                });
+                document.querySelectorAll('.entropy-unit').forEach(label => {
+                    label.textContent = unit === 'ev' ? 'eV/K' :
+                                     unit === 'kjmol' ? 'kJ/(mol K)' : 'kcal/(mol K)';
+                });
+                document.querySelectorAll('.entropy-value').forEach(cell => {
+                    const factor = unit === 'ev' ? 1 :
+                                   unit === 'kjmol' ? EV_TO_KJMOL : EV_TO_KCALMOL;
+                    cell.textContent = (parseFloat(cell.dataset.evK) * factor).toFixed(6);
                 });
                 
                 // Convert all energy values

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -658,8 +658,9 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                 f"<div>ASE {escape(str(metadata['ase_version']))}; "
                 f"mode selection: {escape(str(metadata['vib_selection']))}; "
                 f"ignore_imag_modes: {escape(str(metadata['ignore_imag_modes']))}.</div>"
-                f"<div>Imaginary modes in the complete input: {metadata['raw_imaginary_mode_count']}. "
-                f"ASE cleanup removed {metadata['n_imag']} non-positive modes "
+                "<div>Imaginary modes in the complete input: "
+                f"{escape(str(metadata['raw_imaginary_mode_count']))}. "
+                f"ASE cleanup removed {escape(str(metadata['n_imag']))} non-positive modes "
                 "(imaginary or zero energy) after selection.</div>"
             )
             for warning in metadata.get("warnings", []):

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -341,7 +341,7 @@ def generate_html(
     Returns
     -------
     str
-        Path to the generated HTML file
+        Absolute path to the generated HTML file, or an ``Error:`` message.
     """
     # run_ase and the coordinate writers emit relative paths into
     # CHEMGRAPH_LOG_DIR via _resolve_path; resolve bare names to match so a
@@ -356,14 +356,14 @@ def generate_html(
     # Validate results_json_path exists
     if not os.path.isfile(results_json_path):
         return (
-            f"Results JSON file not found: {results_json_path}. "
+            f"Error: Results JSON file not found: {results_json_path}. "
             "Please provide a valid path to the JSON file produced by the run_ase tool."
         )
 
     # Validate xyz_path exists (if provided)
     if xyz_path is not None and not os.path.isfile(xyz_path):
         return (
-            f"XYZ file not found: {xyz_path}. "
+            f"Error: XYZ file not found: {xyz_path}. "
             "Please provide a valid path to an XYZ file."
         )
 
@@ -373,7 +373,7 @@ def generate_html(
             data = json.load(f)
     except json.JSONDecodeError as e:
         return (
-            f"Failed to parse JSON from {results_json_path}: {e}. "
+            f"Error: Failed to parse JSON from {results_json_path}: {e}. "
             "The file may be corrupted or not valid JSON."
         )
 
@@ -382,7 +382,7 @@ def generate_html(
         ase_output = ASEOutputSchema(**data)
     except Exception as e:
         return (
-            f"Failed to validate results data from {results_json_path}: {e}. "
+            f"Error: Failed to validate results data from {results_json_path}: {e}. "
             "The JSON file may not contain valid ASE output data."
         )
 
@@ -393,7 +393,7 @@ def generate_html(
     else:
         if ase_output.final_structure is None:
             return (
-                "No XYZ file provided and no final_structure found in the results JSON. "
+                "Error: No XYZ file provided and no final_structure found in the results JSON. "
                 "Please provide an xyz_path or ensure the simulation results include a final structure."
             )
 
@@ -414,7 +414,7 @@ def generate_html(
     output_dir = os.path.dirname(os.path.abspath(output_path))
     if not os.path.isdir(output_dir):
         return (
-            f"Output directory does not exist: {output_dir}. "
+            f"Error: Output directory does not exist: {output_dir}. "
             "Please provide a valid output path."
         )
 
@@ -431,7 +431,7 @@ def generate_html(
         print(f"✅ HTML viewer created: {output_path}")
         return str(os.path.abspath(output_path))
     except Exception as e:
-        return f"Failed to generate HTML report: {e}"
+        return f"Error: Failed to generate HTML report: {e}"
 
 
 def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) -> str:
@@ -530,7 +530,18 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
 
         frequencies = ase_output.vibrational_frequencies["frequencies"]
         ase_selected = "all_modes" in ase_output.vibrational_frequencies
-        selected_indices = ase_output.vibrational_frequencies.get("mode_indices", [])
+        selected_indices = ase_output.vibrational_frequencies.get("mode_indices")
+        has_mode_mapping = (
+            ase_selected
+            and isinstance(selected_indices, list)
+            and len(selected_indices) == len(frequencies)
+            and all(type(index) is int and index >= 0 for index in selected_indices)
+            and len(set(selected_indices)) == len(selected_indices)
+            and set(selected_indices).issubset(
+                mode["mode_index"]
+                for mode in ase_output.vibrational_frequencies["all_modes"]
+            )
+        )
         includes_nonvibrational_modes = len(frequencies) == 3 * num_atoms
         num_vibrational_modes = max(3 * num_atoms - trans_rot_modes, 0)
 
@@ -566,7 +577,9 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
             row_class = (
                 "trans-rot-mode" if is_nonvibrational else "vibrational-mode"
             )
-            display_index = selected_indices[i - 1] + 1 if ase_selected else i
+            display_index = i
+            if ase_selected:
+                display_index = selected_indices[i - 1] + 1 if has_mode_mapping else "Unknown"
 
             freq_table += f"""
                     <tr class="{row_class}">
@@ -586,15 +599,25 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         if ase_selected:
             mode_note = (
                 f"{len(frequencies)} of {num_vibrational_modes} expected vibrational "
-                "modes contributed to thermochemistry. Mode numbers refer to the "
-                "original ASE spectrum (displayed starting at 1). "
-                "Excluded modes are not necessarily translations or rotations."
+                "modes contributed to thermochemistry. "
             )
+            if has_mode_mapping:
+                mode_note += (
+                    "Mode numbers refer to the original ASE spectrum (displayed starting at 1). "
+                    "Excluded modes are not necessarily translations or rotations."
+                )
+            else:
+                mode_note += (
+                    "Original mode mapping is unavailable or inconsistent. Selected mode "
+                    "numbers and usage in the complete spectrum are shown as Unknown."
+                )
             raw_rows = []
             for mode in ase_output.vibrational_frequencies["all_modes"]:
-                disposition = (
-                    "Used" if mode["mode_index"] in selected_indices else "Excluded"
-                )
+                disposition = "Unknown"
+                if has_mode_mapping:
+                    disposition = (
+                        "Used" if mode["mode_index"] in selected_indices else "Excluded"
+                    )
                 raw_rows.append(
                     f"<tr><td>{mode['mode_index'] + 1}</td>"
                     f"<td>{escape(str(mode['frequency']))}</td>"
@@ -652,22 +675,45 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
     # Thermochemistry Values
     if ase_output.thermochemistry:
         thermo_info = []
-        if "ase_version" in ase_output.thermochemistry:
-            metadata = ase_output.thermochemistry
+        metadata = ase_output.thermochemistry
+        settings = []
+        for key, label in (
+            ("ase_version", "ASE "),
+            ("vib_selection", "mode selection: "),
+            ("ignore_imag_modes", "ignore_imag_modes: "),
+        ):
+            if metadata.get(key) is not None:
+                settings.append(f"{label}{escape(str(metadata[key]))}")
+        if settings:
+            thermo_info.append(f"<div>{'; '.join(settings)}.</div>")
+        if metadata.get("raw_imaginary_mode_count") is not None:
             thermo_info.append(
-                f"<div>ASE {escape(str(metadata['ase_version']))}; "
-                f"mode selection: {escape(str(metadata['vib_selection']))}; "
-                f"ignore_imag_modes: {escape(str(metadata['ignore_imag_modes']))}.</div>"
                 "<div>Imaginary modes in the complete input: "
-                f"{escape(str(metadata['raw_imaginary_mode_count']))}. "
-                f"ASE cleanup removed {escape(str(metadata['n_imag']))} non-positive modes "
+                f"{escape(str(metadata['raw_imaginary_mode_count']))}.</div>"
+            )
+        policy = metadata.get("ignore_imag_modes")
+        if policy is False:
+            thermo_info.append(
+                "<div>Imaginary modes remaining after selection cause an error; "
+                "zero-energy modes are not removed.</div>"
+            )
+        if policy is True:
+            cleanup = "ASE cleanup removes"
+            if metadata.get("n_imag") is not None:
+                cleanup = f"ASE cleanup removed {escape(str(metadata['n_imag']))}"
+            thermo_info.append(
+                f"<div>{cleanup} non-positive modes "
                 "(imaginary or zero energy) after selection.</div>"
             )
-            for warning in metadata.get("warnings", []):
-                thermo_info.append(
-                    "<div role='note' class='thermo-warning'>"
-                    f"<strong>Warning:</strong> {escape(str(warning))}</div>"
-                )
+        elif metadata.get("n_imag") is not None:
+            thermo_info.append(
+                f"<div>ASE n_imag: {escape(str(metadata['n_imag']))}.</div>"
+            )
+        for warning in metadata.get("warnings") or []:
+            thermo_info.append(
+                "<div role='note' class='thermo-warning'>"
+                f"<strong>Warning:</strong> {escape(str(warning))}</div>"
+            )
 
         # Add data attributes for conversion with labels
         if "enthalpy" in ase_output.thermochemistry:

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -168,7 +168,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
         .unit-toggle button:hover:not(.active) {{
             background: #e9ecef;
         }}
-        .energy-value {{
+        .energy-value, .entropy-value {{
             display: inline-block;
             min-width: 100px;
         }}
@@ -493,7 +493,7 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         calc_results.append(f"""
         <li class='regular-item'>
             <div class="unit-toggle">
-                <span>Energy Unit:</span>
+                <span>Units:</span>
                 <button onclick="toggleEnergyUnit('ev')" class="active" data-unit="ev">eV</button>
                 <button onclick="toggleEnergyUnit('kjmol')" data-unit="kjmol">kJ/mol</button>
                 <button onclick="toggleEnergyUnit('kcalmol')" data-unit="kcalmol">kcal/mol</button>
@@ -624,7 +624,13 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                 f'<div><strong>Enthalpy:</strong> <span class="energy-value" data-ev="{enthalpy_ev}">{enthalpy_ev:.6f}</span> <span class="energy-unit">eV</span></div>'
             )
         if "entropy" in ase_output.thermochemistry:
-            # Current and legacy ASE results express entropy in eV/K.
+            entropy_unit = ase_output.thermochemistry.get("entropy_unit", "eV/K")
+            if entropy_unit != "eV/K":
+                raise ValueError(
+                    f"Unsupported entropy_unit {entropy_unit!r}; expected 'eV/K'. "
+                    "Convert entropy to eV/K before generating a report."
+                )
+            # Legacy ASE results also express entropy in eV/K.
             entropy_ev_k = ase_output.thermochemistry['entropy']
             thermo_info.append(
                 f'<div><strong>Entropy:</strong> <span class="entropy-value" data-ev-k="{entropy_ev_k}">{entropy_ev_k:.6f}</span> <span class="entropy-unit">eV/K</span></div>'
@@ -639,7 +645,7 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
             calc_results.append(f"""
             <li class='regular-item'>
                 <div class="unit-toggle">
-                    <span>Energy Unit:</span>
+                    <span>Units:</span>
                     <button onclick="toggleEnergyUnit('ev')" class="active" data-unit="ev">eV</button>
                     <button onclick="toggleEnergyUnit('kjmol')" data-unit="kjmol">kJ/mol</button>
                     <button onclick="toggleEnergyUnit('kcalmol')" data-unit="kcalmol">kcal/mol</button>
@@ -799,7 +805,8 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                 document.querySelectorAll('.entropy-value').forEach(cell => {
                     const factor = unit === 'ev' ? 1 :
                                    unit === 'kjmol' ? EV_TO_KJMOL : EV_TO_KCALMOL;
-                    cell.textContent = (parseFloat(cell.dataset.evK) * factor).toFixed(6);
+                    const precision = unit === 'ev' ? 6 : 4;
+                    cell.textContent = (parseFloat(cell.dataset.evK) * factor).toFixed(precision);
                 });
                 
                 // Convert all energy values

--- a/src/chemgraph/tools/report_tools.py
+++ b/src/chemgraph/tools/report_tools.py
@@ -1,6 +1,7 @@
 import os
 import json
 import base64
+from html import escape
 from typing import Optional
 from langchain_core.tools import tool
 
@@ -528,6 +529,8 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
             trans_rot_modes = 5 if is_linear else 6
 
         frequencies = ase_output.vibrational_frequencies["frequencies"]
+        ase_selected = "all_modes" in ase_output.vibrational_frequencies
+        selected_indices = ase_output.vibrational_frequencies.get("mode_indices", [])
         includes_nonvibrational_modes = len(frequencies) == 3 * num_atoms
         num_vibrational_modes = max(3 * num_atoms - trans_rot_modes, 0)
 
@@ -555,7 +558,7 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
             1,
         ):
             is_nonvibrational = (
-                includes_nonvibrational_modes and i <= trans_rot_modes
+                not ase_selected and includes_nonvibrational_modes and i <= trans_rot_modes
             )
             mode_type = (
                 "Translation/Rotation" if is_nonvibrational else "Vibrational"
@@ -563,10 +566,11 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
             row_class = (
                 "trans-rot-mode" if is_nonvibrational else "vibrational-mode"
             )
+            display_index = selected_indices[i - 1] + 1 if ase_selected else i
 
             freq_table += f"""
                     <tr class="{row_class}">
-                        <td>{i}</td>
+                        <td>{display_index}</td>
                         <td>{freq}</td>
                         <td>{energy}</td>
                         <td>{mode_type}</td>
@@ -579,7 +583,33 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
         </div>
         """
 
-        if includes_nonvibrational_modes:
+        if ase_selected:
+            mode_note = (
+                f"{len(frequencies)} of {num_vibrational_modes} expected vibrational "
+                "modes contributed to thermochemistry. Mode numbers refer to the "
+                "original ASE spectrum (displayed starting at 1). "
+                "Excluded modes are not necessarily translations or rotations."
+            )
+            raw_rows = []
+            for mode in ase_output.vibrational_frequencies["all_modes"]:
+                disposition = (
+                    "Used" if mode["mode_index"] in selected_indices else "Excluded"
+                )
+                raw_rows.append(
+                    f"<tr><td>{mode['mode_index'] + 1}</td>"
+                    f"<td>{escape(str(mode['frequency']))}</td>"
+                    f"<td>{escape(str(mode['energy']))}</td>"
+                    f"<td>{disposition}</td></tr>"
+                )
+            freq_table += (
+                "<details><summary>Complete input spectrum</summary>"
+                "<div class='table-container'><table><thead><tr>"
+                f"<th>Mode #</th><th>Frequency ({escape(freq_unit)})</th>"
+                f"<th>Energy ({escape(energy_unit)})</th><th>Thermochemistry</th>"
+                "</tr></thead><tbody>" + "".join(raw_rows)
+                + "</tbody></table></div></details>"
+            )
+        elif includes_nonvibrational_modes:
             mode_note = (
                 f"This legacy result includes the first {trans_rot_modes} "
                 "translation/rotation modes."
@@ -590,10 +620,16 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
                 "from the reported frequencies."
             )
 
+        breakdown = (
+            f"Expected: {num_vibrational_modes} vibrational modes; "
+            f"used: {len(frequencies)}"
+            if ase_selected else
+            f"{trans_rot_modes} translation/rotation modes + {num_vibrational_modes} vibrational modes"
+        )
         mode_explanation = f"""
         <div class="mode-explanation">
             <p><strong>Molecule Type:</strong> {molecule_type}</p>
-            <p><strong>Mode Breakdown:</strong> {trans_rot_modes} translation/rotation modes + {num_vibrational_modes} vibrational modes</p>
+            <p><strong>Mode Breakdown:</strong> {breakdown}</p>
             <p><em>Note: {mode_note}</em></p>
         </div>
         """
@@ -616,6 +652,21 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
     # Thermochemistry Values
     if ase_output.thermochemistry:
         thermo_info = []
+        if "ase_version" in ase_output.thermochemistry:
+            metadata = ase_output.thermochemistry
+            thermo_info.append(
+                f"<div>ASE {escape(str(metadata['ase_version']))}; "
+                f"mode selection: {escape(str(metadata['vib_selection']))}; "
+                f"ignore_imag_modes: {escape(str(metadata['ignore_imag_modes']))}.</div>"
+                f"<div>Imaginary modes in the complete input: {metadata['raw_imaginary_mode_count']}. "
+                f"ASE cleanup removed {metadata['n_imag']} non-positive modes "
+                "(imaginary or zero energy) after selection.</div>"
+            )
+            for warning in metadata.get("warnings", []):
+                thermo_info.append(
+                    "<div role='note' class='thermo-warning'>"
+                    f"<strong>Warning:</strong> {escape(str(warning))}</div>"
+                )
 
         # Add data attributes for conversion with labels
         if "enthalpy" in ase_output.thermochemistry:
@@ -673,7 +724,7 @@ def add_additional_info_to_html(html_content: str, ase_output: ASEOutputSchema) 
     # Error Information
     if ase_output.error:
         calc_results.append(
-            f"<li class='regular-item'><strong>Error:</strong> <span style='color: #dc3545;'>{ase_output.error}</span></li>"
+            f"<li class='regular-item'><strong>Error:</strong> <span style='color: #dc3545;'>{escape(ase_output.error)}</span></li>"
         )
 
     # Join all results with proper spacing

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -10,6 +10,35 @@ from chemgraph.schemas.calculators.orca_calc import OrcaCalc
 from ase import Atoms
 
 
+@pytest.mark.parametrize("schema", [TBLiteCalc, OrcaCalc], ids=["tight-binding", "orca"])
+@pytest.mark.parametrize("multiplicity", [0, -1])
+def test_calculator_multiplicity_rejects_nonpositive_values(schema, multiplicity):
+    with pytest.raises(ValidationError, match="multiplicity"):
+        schema(multiplicity=multiplicity)
+
+
+@pytest.mark.parametrize("schema", [TBLiteCalc, OrcaCalc], ids=["tight-binding", "orca"])
+@pytest.mark.parametrize("multiplicity", [1, 2, 3])
+def test_calculator_multiplicity_preserves_valid_values(schema, multiplicity):
+    calc = schema(multiplicity=multiplicity)
+    assert calc.multiplicity == multiplicity
+    assert calc.get_multiplicity() == multiplicity
+
+
+@pytest.mark.parametrize(
+    "schema, inputs, expected",
+    [
+        pytest.param(TBLiteCalc, {}, None, id="tight-binding-default"),
+        pytest.param(TBLiteCalc, {"multiplicity": None}, None, id="tight-binding-null"),
+        pytest.param(OrcaCalc, {}, 1, id="orca-default"),
+    ],
+)
+def test_calculator_multiplicity_preserves_defaults(schema, inputs, expected):
+    calc = schema(**inputs)
+    assert calc.multiplicity == expected
+    assert calc.get_multiplicity() == expected
+
+
 @pytest.mark.skipif(
     importlib.util.find_spec("tblite") is None, reason="TBLite not installed"
 )

--- a/tests/test_human_interrupt.py
+++ b/tests/test_human_interrupt.py
@@ -358,6 +358,32 @@ def test_get_single_agent_prompt_strips_ask_human():
     assert len(prompt_without) < len(prompt_with)
     # The default prompt should match the supervised version
     assert prompt_with == single_agent_prompt
+    for prompt in (prompt_with, prompt_without):
+        assert "Use defaults declared by the selected tool's schema" in prompt
+        assert "Preserve user-supplied values and never invent defaults" in prompt
+
+
+def test_get_planner_prompt_keeps_default_delegation_without_ask_human():
+    """Removing human routing must preserve delegation of schema defaults."""
+    from chemgraph.prompt.multi_agent_prompt import (
+        get_planner_prompt,
+        planner_prompt,
+        planner_prompt_json,
+    )
+
+    prompt_with = get_planner_prompt(human_supervised=True)
+    prompt_without = get_planner_prompt(human_supervised=False)
+
+    assert prompt_with == planner_prompt == planner_prompt_json
+    assert "ask_human" in prompt_with
+    assert "ask_human" not in prompt_without
+    assert "PHASE 1b" not in prompt_without
+    assert "When asking the human for clarification" not in prompt_without
+    assert len(prompt_without) < len(prompt_with)
+    for prompt in (prompt_with, prompt_without):
+        assert "Let executors determine which omitted parameters have tool-defined defaults" in prompt
+        assert "Preserve supplied values and do not invent missing values" in prompt
+        assert "no temperature for thermochemistry" not in prompt
 
 
 def test_multi_agent_graph_includes_human_review(monkeypatch):

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,5 @@
 import json
+import re
 import pytest
 from pathlib import Path
 import tempfile
@@ -164,6 +165,25 @@ def test_generate_html_labels_energy_by_driver(
 
     content = report_html.read_text(encoding="utf-8")
     assert expected_label in content
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_report_distinguishes_entropy_units(tmp_path, legacy):
+    output = json.loads(json.dumps(sample_ase_output))
+    if not legacy:
+        output["thermochemistry"]["entropy_unit"] = "eV/K"
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(output))
+    generate_html.invoke({"results_json_path": str(source), "output_path": str(report)})
+    content = report.read_text()
+    entropy_row = re.search(r'<div><strong>Entropy:</strong>.*?</div>', content).group()
+    assert 'class="entropy-unit">eV/K</span>' in entropy_row
+    assert 'class="entropy-value"' in entropy_row
+    assert 'data-ev-k="0.001957587821789186"' in entropy_row
+    assert 'class="energy-value"' not in entropy_row
+    for name in ("Enthalpy", "Gibbs Free Energy"):
+        row = re.search(rf'<div><strong>{name}:</strong>.*?</div>', content).group()
+        assert 'class="energy-unit">eV</span>' in row
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -159,14 +159,14 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
         energies=[all_modes[i]["energy"] for i in indices],
         frequencies=[all_modes[i]["frequency"] for i in indices],
     )
-    note = "Inspect <input> imaginary modes; stability is not established."
+    note = "ASE diagnostic: <input>"
     output["thermochemistry"].update(
         ase_version="3.29.0",
         vib_selection="highest",
         ignore_imag_modes=True,
         n_imag=0 if case == "selection-only" else 1,
         raw_imaginary_mode_count=4,
-        warnings=[note],
+        warnings=[] if case == "selection-only" else [note],
     )
     if case == "all-removed":
         output["thermochemistry"]["warnings"].append(
@@ -200,12 +200,14 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
     else:
         assert "ASE 3.29.0" in content
         assert "Imaginary modes in the complete input: 4" in content
-        assert "Inspect &lt;input&gt; imaginary modes" in content
         assert (
             "non-positive modes (imaginary or zero energy) after selection" in content
         )
     if case == "selection-only":
         assert "ASE cleanup removed 0" in content
+        assert "<strong>Warning:</strong>" not in content
+    elif case != "failure":
+        assert "ASE diagnostic: &lt;input&gt;" in content
     if case == "all-removed":
         assert "No vibrational modes contributed to thermochemistry." in content
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -215,6 +215,51 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
         assert "No vibrational modes contributed to thermochemistry." in content
 
 
+@pytest.mark.parametrize("field", ["raw_imaginary_mode_count", "n_imag"])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '<img id="thermo-count-payload" src=x onerror="window.reportProbe=1">',
+        '<script id="thermo-count-payload">window.reportProbe=1</script>',
+    ],
+    ids=["image-handler", "script"],
+)
+def test_report_renders_thermochemistry_counts_as_text(tmp_path, field, payload):
+    class ReportParser(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.element_ids = []
+            self.text_parts = []
+
+        def handle_starttag(self, tag, attrs):
+            self.element_ids.append(dict(attrs).get("id"))
+
+        def handle_data(self, data):
+            self.text_parts.append(data)
+
+    output = json.loads(json.dumps(sample_ase_output))
+    output["thermochemistry"].update(
+        ase_version="3.29.0",
+        vib_selection="highest",
+        ignore_imag_modes=False,
+        n_imag=0,
+        raw_imaginary_mode_count=4,
+        warnings=[],
+    )
+    output["thermochemistry"][field] = payload
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(output), encoding="utf-8")
+    result = generate_html.invoke(
+        {"results_json_path": str(source), "output_path": str(report)}
+    )
+    assert result == str(report.resolve())
+    parser = ReportParser()
+    parser.feed(report.read_text(encoding="utf-8"))
+    parser.close()
+    assert "thermo-count-payload" not in parser.element_ids
+    assert payload in "".join(parser.text_parts)
+
+
 @pytest.mark.parametrize(
     ("driver", "legacy_energy", "expected_label"),
     [

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -160,10 +160,11 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
         frequencies=[all_modes[i]["frequency"] for i in indices],
     )
     note = "ASE diagnostic: <input>"
+    # Cleanup cases retain coverage for older results that ignored imaginary modes.
     output["thermochemistry"].update(
         ase_version="3.29.0",
         vib_selection="highest",
-        ignore_imag_modes=True,
+        ignore_imag_modes=case != "selection-only",
         n_imag=0 if case == "selection-only" else 1,
         raw_imaginary_mode_count=4,
         warnings=[] if case == "selection-only" else [note],
@@ -204,9 +205,11 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
             "non-positive modes (imaginary or zero energy) after selection" in content
         )
     if case == "selection-only":
+        assert "ignore_imag_modes: False" in content
         assert "ASE cleanup removed 0" in content
         assert "<strong>Warning:</strong>" not in content
     elif case != "failure":
+        assert "ignore_imag_modes: True" in content
         assert "ASE diagnostic: &lt;input&gt;" in content
     if case == "all-removed":
         assert "No vibrational modes contributed to thermochemistry." in content

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -6,6 +6,8 @@ import tempfile
 import shutil
 from datetime import datetime
 from html.parser import HTMLParser
+from langchain_core.messages import AIMessage, ToolMessage
+from chemgraph.graphs.single_agent import route_after_report_tools, route_report_tools
 from chemgraph.schemas.ase_input import ASEOutputSchema
 from chemgraph.tools.report_tools import generate_html
 
@@ -101,6 +103,32 @@ def create_xyz_content_from_final_structure(final_structure):
 def sample_ase_output_schema():
     """Create a valid ASEOutputSchema object from the sample data."""
     return ASEOutputSchema(**sample_ase_output)
+
+
+@pytest.fixture
+def ase_selected_output():
+    output = json.loads(json.dumps(sample_ase_output))
+    vibrations = output["vibrational_frequencies"]
+    vibrations["all_modes"] = [
+        {"mode_index": i, "frequency": frequency, "energy": energy}
+        for i, (frequency, energy) in enumerate(
+            zip(vibrations["frequencies"], vibrations["energies"])
+        )
+    ]
+    vibrations.update(
+        mode_indices=[6, 7, 8],
+        frequencies=vibrations["frequencies"][-3:],
+        energies=vibrations["energies"][-3:],
+    )
+    output["thermochemistry"].update(
+        ase_version="3.29.0",
+        vib_selection="highest",
+        ignore_imag_modes=False,
+        n_imag=0,
+        raw_imaginary_mode_count=4,
+        warnings=["ASE diagnostic: <input>"],
+    )
+    return output
 
 
 def test_generate_html_distinguishes_filtered_and_legacy_modes(tmp_path):
@@ -201,20 +229,130 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
     else:
         assert "ASE 3.29.0" in content
         assert "Imaginary modes in the complete input: 4" in content
-        assert (
-            "non-positive modes (imaginary or zero energy) after selection" in content
-        )
     if case == "selection-only":
         assert "ignore_imag_modes: False" in content
-        assert "ASE cleanup removed 0" in content
+        assert "Imaginary modes remaining after selection cause an error" in content
+        assert "zero-energy modes are not removed" in content
+        assert "ASE n_imag: 0" in content
+        assert "ASE cleanup" not in content
         assert "<strong>Warning:</strong>" not in content
     elif case != "failure":
         assert "ignore_imag_modes: True" in content
+        assert (
+            "ASE cleanup removed 1 non-positive modes "
+            "(imaginary or zero energy) after selection" in content
+        )
         assert "ASE diagnostic: &lt;input&gt;" in content
     if case == "all-removed":
         assert "No vibrational modes contributed to thermochemistry." in content
 
 
+@pytest.mark.parametrize(
+    ("field", "label"),
+    [
+        ("ase_version", "ASE 3.29.0"),
+        ("vib_selection", "mode selection:"),
+        ("ignore_imag_modes", "ignore_imag_modes:"),
+        ("raw_imaginary_mode_count", "Imaginary modes in the complete input:"),
+        ("n_imag", "ASE n_imag:"),
+        ("warnings", "ASE diagnostic:"),
+    ],
+)
+@pytest.mark.parametrize("missing", [True, False], ids=["missing", "null"])
+def test_report_tolerates_incomplete_metadata(
+    tmp_path, ase_selected_output, field, label, missing
+):
+    metadata = ase_selected_output["thermochemistry"]
+    if missing:
+        metadata.pop(field)
+    else:
+        metadata[field] = None
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(ase_selected_output))
+    result = generate_html.invoke(
+        {"results_json_path": str(source), "output_path": str(report)}
+    )
+    assert result == str(report.resolve())
+    content = report.read_text()
+    assert label not in content
+    assert "Enthalpy:" in content
+    assert "Complete input spectrum" in content
+    if field != "warnings":
+        assert "ASE diagnostic: &lt;input&gt;" in content
+    if field == "ignore_imag_modes":
+        assert "ASE cleanup" not in content
+        assert "Imaginary modes remaining after selection cause an error" not in content
+        assert "ASE n_imag: 0" in content
+
+
+@pytest.mark.parametrize(
+    "indices",
+    [
+        "missing", None, [], [6, 7], [6, 7, 8, 8], [6, 7, 99], [6, 7, 7],
+        ["6", 7, 8], [True, 7, 8], [-1, 7, 8],
+    ],
+    ids=[
+        "missing", "null", "empty", "short", "long", "outside-spectrum", "duplicate",
+        "string-index", "boolean-index", "negative-index",
+    ],
+)
+def test_report_preserves_modes_without_valid_mapping(
+    tmp_path, ase_selected_output, indices
+):
+    vibrations = ase_selected_output["vibrational_frequencies"]
+    if indices == "missing":
+        vibrations.pop("mode_indices")
+    else:
+        vibrations["mode_indices"] = indices
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(ase_selected_output))
+    result = generate_html.invoke(
+        {"results_json_path": str(source), "output_path": str(report)}
+    )
+    assert result == str(report.resolve())
+    content = report.read_text()
+    assert "Original mode mapping is unavailable or inconsistent" in content
+    assert "Complete input spectrum" in content
+    assert "3 of 3 expected vibrational modes contributed" in content
+    assert "<td>Used</td>" not in content
+    assert "<td>Excluded</td>" not in content
+    assert content.count("<td>Unknown</td>") == 12
+    selected_rows = re.findall(
+        r'<tr class="vibrational-mode">\s*<td>Unknown</td>\s*<td>(.*?)</td>\s*<td>(.*?)</td>',
+        content,
+    )
+    assert selected_rows == list(zip(vibrations["frequencies"], vibrations["energies"]))
+    for mode in vibrations["all_modes"]:
+        assert f"<td>{mode['frequency']}</td><td>{mode['energy']}</td>" in content
+
+
+@pytest.mark.parametrize("n_imag", [0, 2, None])
+def test_report_describes_legacy_cleanup_with_optional_count(
+    tmp_path, ase_selected_output, n_imag
+):
+    metadata = ase_selected_output["thermochemistry"]
+    metadata["ignore_imag_modes"] = True
+    if n_imag is None:
+        metadata.pop("n_imag")
+    else:
+        metadata["n_imag"] = n_imag
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(ase_selected_output))
+    result = generate_html.invoke(
+        {"results_json_path": str(source), "output_path": str(report)}
+    )
+    assert result == str(report.resolve())
+    content = report.read_text()
+    assert "Imaginary modes in the complete input: 4" in content
+    assert "Imaginary modes remaining after selection cause an error" not in content
+    if n_imag is None:
+        assert "ASE cleanup removes non-positive modes" in content
+        assert "ASE cleanup removed" not in content
+    else:
+        assert f"ASE cleanup removed {n_imag} non-positive modes" in content
+
+
+@pytest.mark.parametrize("policy", [True, False, None])
 @pytest.mark.parametrize("field", ["raw_imaginary_mode_count", "n_imag"])
 @pytest.mark.parametrize(
     "payload",
@@ -224,7 +362,7 @@ def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
     ],
     ids=["image-handler", "script"],
 )
-def test_report_renders_thermochemistry_counts_as_text(tmp_path, field, payload):
+def test_report_renders_thermochemistry_counts_as_text(tmp_path, policy, field, payload):
     class ReportParser(HTMLParser):
         def __init__(self):
             super().__init__()
@@ -241,7 +379,7 @@ def test_report_renders_thermochemistry_counts_as_text(tmp_path, field, payload)
     output["thermochemistry"].update(
         ase_version="3.29.0",
         vib_selection="highest",
-        ignore_imag_modes=False,
+        ignore_imag_modes=policy,
         n_imag=0,
         raw_imaginary_mode_count=4,
         warnings=[],
@@ -328,12 +466,69 @@ def test_report_rejects_unsupported_entropy_units(tmp_path, unit):
     result = generate_html.invoke(
         {"results_json_path": str(source), "output_path": str(report)}
     )
+    assert result.startswith("Error:")
     assert "Unsupported entropy_unit" in result
     assert "expected 'eV/K'" in result
     assert not report.exists()
     report.write_text("previous report")
     generate_html.invoke({"results_json_path": str(source), "output_path": str(report)})
     assert report.read_text() == "previous report"
+
+
+@pytest.mark.parametrize(
+    ("case", "error"),
+    [
+        ("success", None),
+        ("missing-results", "Results JSON file not found"),
+        ("missing-xyz", "XYZ file not found"),
+        ("invalid-json", "Failed to parse JSON"),
+        ("invalid-schema", "Failed to validate results data"),
+        ("missing-structure", "Failed to validate results data"),
+        ("missing-output-directory", "Output directory does not exist"),
+        ("unsupported-entropy-unit", "Unsupported entropy_unit"),
+        ("write-error", "Failed to generate HTML report"),
+    ],
+)
+def test_report_result_controls_routing(tmp_path, ase_selected_output, case, error):
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    args = {"results_json_path": str(source), "output_path": str(report)}
+    if case == "missing-results":
+        args["results_json_path"] = str(tmp_path / "missing.json")
+    elif case == "missing-xyz":
+        args["xyz_path"] = str(tmp_path / "missing.xyz")
+    elif case == "missing-structure":
+        ase_selected_output["final_structure"] = None
+    elif case == "missing-output-directory":
+        args["output_path"] = str(tmp_path / "missing" / "report.html")
+    elif case == "unsupported-entropy-unit":
+        ase_selected_output["thermochemistry"]["entropy_unit"] = "J/(mol K)"
+    source.write_text(json.dumps(ase_selected_output))
+    if case == "invalid-json":
+        source.write_text("{")
+    elif case == "invalid-schema":
+        source.write_text("{}")
+    if case == "write-error":
+        report.mkdir()
+    else:
+        report.write_text("previous report")
+
+    result = generate_html.invoke(args)
+    if error is None:
+        assert result == str(report.resolve())
+        assert "Calculation Results" in report.read_text()
+    else:
+        assert result.startswith("Error:")
+        assert error in result
+        if report.is_file():
+            assert report.read_text() == "previous report"
+    messages = [ToolMessage(content=result, name="generate_html", tool_call_id="call_1")]
+    assert route_after_report_tools({"messages": messages}) == ("retry" if error else "done")
+    messages.append(
+        AIMessage(content="", tool_calls=[{
+            "name": "generate_html", "args": args, "id": "call_2", "type": "tool_call",
+        }])
+    )
+    assert route_report_tools({"messages": messages}) == ("tools" if error else "done")
 
 
 @pytest.mark.parametrize("script_tag", ["script", "SCRIPT", "ScRiPt"])

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -137,6 +137,79 @@ def test_generate_html_distinguishes_filtered_and_legacy_modes(tmp_path):
     assert "This legacy result includes the first 6" in legacy_content
 
 
+@pytest.mark.parametrize("case", ["selection-only", "cleanup", "all-removed", "failure"])
+def test_report_shows_ase_retained_modes_and_complete_spectrum(tmp_path, case):
+    output = json.loads(json.dumps(sample_ase_output))
+    vibrations = output["vibrational_frequencies"]
+    all_modes = [
+        {"mode_index": i, "frequency": frequency, "energy": energy}
+        for i, (frequency, energy) in enumerate(
+            zip(
+                vibrations["frequencies"],
+                vibrations["energies"],
+            )
+        )
+    ]
+    indices = [6, 7, 8] if case == "selection-only" else [7, 8]
+    if case in {"all-removed", "failure"}:
+        indices = []
+    vibrations.update(
+        mode_indices=indices,
+        all_modes=all_modes,
+        energies=[all_modes[i]["energy"] for i in indices],
+        frequencies=[all_modes[i]["frequency"] for i in indices],
+    )
+    note = "Inspect <input> imaginary modes; stability is not established."
+    output["thermochemistry"].update(
+        ase_version="3.29.0",
+        vib_selection="highest",
+        ignore_imag_modes=True,
+        n_imag=0 if case == "selection-only" else 1,
+        raw_imaginary_mode_count=4,
+        warnings=[note],
+    )
+    if case == "all-removed":
+        output["thermochemistry"]["warnings"].append(
+            "No vibrational modes contributed to thermochemistry."
+        )
+    if case == "failure":
+        output.update(
+            success=False,
+            error="Thermochemistry failed for <input>",
+            thermochemistry={},
+        )
+    results_json, report_html = tmp_path / "result.json", tmp_path / "report.html"
+    results_json.write_text(json.dumps(output), encoding="utf-8")
+    generate_html.invoke(
+        {"results_json_path": str(results_json), "output_path": str(report_html)}
+    )
+    content = report_html.read_text(encoding="utf-8")
+    assert f"{len(indices)} of 3 expected vibrational modes contributed" in content
+    assert "Complete input spectrum" in content
+    assert content.count("<td>Used</td>") == len(indices)
+    assert content.count("<td>Excluded</td>") == 9 - len(indices)
+    assert "<td>Translation/Rotation</td>" not in content
+    assert "Excluded modes are not necessarily translations or rotations" in content
+    for mode in all_modes:
+        assert mode["frequency"] in content
+    for i in indices:
+        assert re.search(rf'<tr class="vibrational-mode">\s*<td>{i + 1}</td>', content)
+    if case == "failure":
+        assert "Thermochemistry failed for &lt;input&gt;" in content
+        assert "Final Potential Energy" in content
+    else:
+        assert "ASE 3.29.0" in content
+        assert "Imaginary modes in the complete input: 4" in content
+        assert "Inspect &lt;input&gt; imaginary modes" in content
+        assert (
+            "non-positive modes (imaginary or zero energy) after selection" in content
+        )
+    if case == "selection-only":
+        assert "ASE cleanup removed 0" in content
+    if case == "all-removed":
+        assert "No vibrational modes contributed to thermochemistry." in content
+
+
 @pytest.mark.parametrize(
     ("driver", "legacy_energy", "expected_label"),
     [

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -168,8 +168,11 @@ def test_generate_html_labels_energy_by_driver(
 
 
 @pytest.mark.parametrize("legacy", [False, True])
-def test_report_distinguishes_entropy_units(tmp_path, legacy):
+@pytest.mark.parametrize("entropy_only", [False, True])
+def test_report_distinguishes_entropy_units(tmp_path, legacy, entropy_only):
     output = json.loads(json.dumps(sample_ase_output))
+    if entropy_only:
+        output["thermochemistry"] = {"entropy": output["thermochemistry"]["entropy"]}
     if not legacy:
         output["thermochemistry"]["entropy_unit"] = "eV/K"
     source, report = tmp_path / "result.json", tmp_path / "report.html"
@@ -181,9 +184,101 @@ def test_report_distinguishes_entropy_units(tmp_path, legacy):
     assert 'class="entropy-value"' in entropy_row
     assert 'data-ev-k="0.001957587821789186"' in entropy_row
     assert 'class="energy-value"' not in entropy_row
+    assert '<span>Units:</span>' in content
+    assert 'Energy Unit:' not in content
+    if entropy_only:
+        assert '<strong>Enthalpy:</strong>' not in content
+        assert '<strong>Gibbs Free Energy:</strong>' not in content
+        return
     for name in ("Enthalpy", "Gibbs Free Energy"):
         row = re.search(rf'<div><strong>{name}:</strong>.*?</div>', content).group()
         assert 'class="energy-unit">eV</span>' in row
+
+
+@pytest.mark.parametrize("unit", ["J/(mol K)", "kJ/(mol K)", "kcal/(mol K)", None, ""])
+def test_report_rejects_unsupported_entropy_units(tmp_path, unit):
+    output = json.loads(json.dumps(sample_ase_output))
+    output["thermochemistry"]["entropy_unit"] = unit
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(output))
+    result = generate_html.invoke(
+        {"results_json_path": str(source), "output_path": str(report)}
+    )
+    assert "Unsupported entropy_unit" in result
+    assert "expected 'eV/K'" in result
+    assert not report.exists()
+    report.write_text("previous report")
+    generate_html.invoke({"results_json_path": str(source), "output_path": str(report)})
+    assert report.read_text() == "previous report"
+
+
+def test_report_unit_conversion_javascript(tmp_path):
+    """Execute the generated converter, with only its DOM dependencies stubbed."""
+    quickjs = pytest.importorskip("quickjs")
+    source, report = tmp_path / "result.json", tmp_path / "report.html"
+    source.write_text(json.dumps(sample_ase_output))
+    generate_html.invoke({"results_json_path": str(source), "output_path": str(report)})
+    content = report.read_text()
+    elements = {}
+    for kind, attrs, value in re.findall(
+        r'<span class="((?:energy|entropy)-(?:value|unit))"([^>]*)>(.*?)</span>',
+        content,
+    ):
+        dataset = {}
+        for attr, key in [("data-ev", "ev"), ("data-ev-k", "evK")]:
+            match = re.search(rf'{attr}="([^"]*)"', attrs)
+            if match:
+                dataset[key] = match.group(1)
+        elements.setdefault(f".{kind}", []).append(
+            {"dataset": dataset, "textContent": value}
+        )
+    runtime = quickjs.Context()
+    runtime.eval("const elements = " + json.dumps(elements))
+    runtime.eval("""
+        Object.values(elements).flat().forEach(cell => {
+            cell.parentElement = {querySelector: () => ({textContent: ''})};
+        });
+        const document = {
+            querySelectorAll: selector => elements[selector] || [],
+            addEventListener: () => {},
+        };
+    """)
+    script = next(
+        script
+        for script in re.findall(r'<script>(.*?)</script>', content, re.S)
+        if 'function toggleEnergyUnit' in script
+    )
+    runtime.eval(script)
+    thermo = sample_ase_output["thermochemistry"]
+    energy_values = [
+        round(sample_ase_output["potential_energy"], 6),
+        thermo["enthalpy"],
+        thermo["gibbs_free_energy"],
+    ]
+    conversions = {
+        "ev": (1, "eV", "eV/K", 6, 6),
+        "kjmol": (96.485, "kJ/mol", "kJ/(mol K)", 2, 4),
+        "kcalmol": (23.061, "kcal/mol", "kcal/(mol K)", 2, 4),
+    }
+    for unit in ["ev", "kjmol", "kcalmol", "ev", "kcalmol", "kjmol", "ev"]:
+        runtime.eval(f"toggleEnergyUnit('{unit}')")
+        actual = json.loads(runtime.eval("JSON.stringify(elements)"))
+        factor, energy_unit, entropy_unit, energy_digits, entropy_digits = conversions[
+            unit
+        ]
+        assert [cell["textContent"] for cell in actual[".energy-value"]] == [
+            f"{value * factor:.{energy_digits}f}" for value in energy_values
+        ]
+        assert (
+            actual[".entropy-value"][0]["textContent"]
+            == f"{thermo['entropy'] * factor:.{entropy_digits}f}"
+        )
+        assert all(
+            cell["textContent"] == energy_unit for cell in actual[".energy-unit"]
+        )
+        assert all(
+            cell["textContent"] == entropy_unit for cell in actual[".entropy-unit"]
+        )
 
 
 @pytest.fixture(scope="session")
@@ -269,7 +364,7 @@ def test_generate_html_with_xyz(test_output_dir, sample_ase_output_schema):
         assert "Entropy" in html_content
         assert "Gibbs Free Energy" in html_content
         assert "Thermochemistry Values" in html_content
-        assert "Energy Unit" in html_content
+        assert "<span>Units:</span>" in html_content
         assert "eV" in html_content
         assert "kJ/mol" in html_content
         assert "kcal/mol" in html_content
@@ -342,7 +437,7 @@ def test_generate_html_without_xyz(test_output_dir, sample_ase_output_schema):
         assert "Entropy" in html_content
         assert "Gibbs Free Energy" in html_content
         assert "Thermochemistry Values" in html_content
-        assert "Energy Unit" in html_content
+        assert "<span>Units:</span>" in html_content
         assert "eV" in html_content
         assert "kJ/mol" in html_content
         assert "kcal/mol" in html_content

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import tempfile
 import shutil
 from datetime import datetime
+from html.parser import HTMLParser
 from chemgraph.schemas.ase_input import ASEOutputSchema
 from chemgraph.tools.report_tools import generate_html
 
@@ -212,13 +213,36 @@ def test_report_rejects_unsupported_entropy_units(tmp_path, unit):
     assert report.read_text() == "previous report"
 
 
-def test_report_unit_conversion_javascript(tmp_path):
+@pytest.mark.parametrize("script_tag", ["script", "SCRIPT", "ScRiPt"])
+def test_report_unit_conversion_javascript(tmp_path, script_tag):
     """Execute the generated converter, with only its DOM dependencies stubbed."""
     quickjs = pytest.importorskip("quickjs")
+
+    class ScriptParser(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.scripts = []
+            self.parts = None
+
+        def handle_starttag(self, tag, attrs):
+            if tag == "script":
+                self.parts = []
+
+        def handle_data(self, data):
+            if self.parts is not None:
+                self.parts.append(data)
+
+        def handle_endtag(self, tag):
+            if tag == "script" and self.parts is not None:
+                self.scripts.append("".join(self.parts))
+                self.parts = None
+
     source, report = tmp_path / "result.json", tmp_path / "report.html"
     source.write_text(json.dumps(sample_ase_output))
     generate_html.invoke({"results_json_path": str(source), "output_path": str(report)})
     content = report.read_text()
+    content = content.replace("<script>", f'<{script_tag} type="text/javascript">')
+    content = content.replace("</script>", f"</{script_tag}>")
     elements = {}
     for kind, attrs, value in re.findall(
         r'<span class="((?:energy|entropy)-(?:value|unit))"([^>]*)>(.*?)</span>',
@@ -243,10 +267,11 @@ def test_report_unit_conversion_javascript(tmp_path):
             addEventListener: () => {},
         };
     """)
+    parser = ScriptParser()
+    parser.feed(content)
+    parser.close()
     script = next(
-        script
-        for script in re.findall(r'<script>(.*?)</script>', content, re.S)
-        if 'function toggleEnergyUnit' in script
+        script for script in parser.scripts if 'function toggleEnergyUnit' in script
     )
     runtime.eval(script)
     thermo = sample_ase_output["thermochemistry"]

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -1,0 +1,136 @@
+"""Scientific regressions using EMT and controlled molecular vibrations."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from ase import Atoms, units
+from ase.calculators.calculator import Calculator, all_changes
+from ase.calculators.emt import EMT
+from ase.io import write
+from ase.thermochemistry import IdealGasThermo
+import ase.vibrations
+
+from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.atomsdata import AtomsData
+from chemgraph.schemas.calculators.emt_calc import EMTCalc
+from chemgraph.schemas.calculators.mace_calc import MaceCalc
+from chemgraph.tools.ase_core import get_symmetry_number, run_ase_core
+
+
+def _run_thermo(tmp_path, monkeypatch, atoms, calculator, temperature, pressure):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    input_path, output_path = tmp_path / "input.xyz", tmp_path / "result.json"
+    write(input_path, atoms)
+    params = ASEInputSchema(
+        input_structure_file=str(input_path), output_results_file=str(output_path),
+        calculator=calculator, driver="thermo", temperature=temperature, pressure=pressure,
+    )
+    result = run_ase_core(params)
+    assert result["status"] == "success", result
+    output = json.loads(output_path.read_text())
+    assert result["result"]["thermochemistry"] == output["thermochemistry"]
+    assert output["thermochemistry"]["unit"] == "eV"
+    assert output["thermochemistry"]["entropy_unit"] == "eV/K"
+    return output
+
+
+def _assert_reference(actual, reference, temperature, pressure):
+    assert actual["enthalpy"] == pytest.approx(reference.get_enthalpy(temperature))
+    assert actual["entropy"] == pytest.approx(reference.get_entropy(temperature, pressure))
+    assert actual["gibbs_free_energy"] == pytest.approx(reference.get_gibbs_energy(temperature, pressure))
+
+
+@pytest.mark.parametrize("temperature,pressure", [(250, 101325), (500, 101325), (500, 202650)])
+@pytest.mark.parametrize("multiplicity", [1, 2, 3])
+def test_monatomic_thermo_matches_ase_without_vibrations(
+    tmp_path, monkeypatch, temperature, pressure, multiplicity,
+):
+    vibrations = Mock(side_effect=AssertionError("an atom has no vibrational modes"))
+    monkeypatch.setattr(ase.vibrations, "Vibrations", vibrations)
+    monkeypatch.setattr(EMTCalc, "get_multiplicity", lambda self: multiplicity, raising=False)
+    atoms = Atoms("Cu", positions=[[0, 0, 0]])
+    atoms.calc = EMT()
+    potential_energy = atoms.get_potential_energy()
+    output = _run_thermo(tmp_path, monkeypatch, atoms, EMTCalc(), temperature, pressure)
+    reference = IdealGasThermo(
+        vib_energies=[], potentialenergy=potential_energy, atoms=atoms,
+        geometry="monatomic", symmetrynumber=1, spin=(multiplicity - 1) / 2,
+    )
+    _assert_reference(output["thermochemistry"], reference, temperature, pressure)
+    assert output["thermochemistry"]["enthalpy"] == pytest.approx(
+        potential_energy + 2.5 * units.kB * temperature
+    )
+    assert output["thermochemistry"]["entropy"] > 0
+    assert output["vibrational_frequencies"] == {
+        "energies": [], "energy_unit": "meV", "frequencies": [], "frequency_unit": "cm-1",
+    }
+    vibrations.assert_not_called()
+    assert not list(tmp_path.glob("*.traj"))
+
+
+_MOLECULES = [
+    ("OH", [[0, 0, 0], [0, 0, 0.97]], 1, 2, "linear"),
+    ("NO", [[0, 0, 0], [0, 0, 1.15]], 1, 2, "linear"),
+    ("H2", [[0, 0, 0], [0, 0, 0.74]], 2, 1, "linear"),
+    ("OH2", [[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]], 2, 1, "nonlinear"),
+]
+
+
+@pytest.mark.parametrize("symbols,positions,symmetry,multiplicity,geometry", _MOLECULES)
+def test_geometric_symmetry_including_radicals(symbols, positions, symmetry, multiplicity, geometry):
+    atoms = Atoms(symbols, positions=positions)
+    assert get_symmetry_number(AtomsData(numbers=atoms.numbers, positions=positions)) == symmetry
+
+
+@pytest.mark.parametrize("symbols,positions,symmetry,multiplicity,geometry", _MOLECULES)
+def test_molecular_thermo_retains_spin_and_vibrations(
+    tmp_path, monkeypatch, symbols, positions, symmetry, multiplicity, geometry,
+):
+    atoms = Atoms(symbols, positions=positions)
+    energies = np.zeros(3 * len(atoms))
+    mode_count = 1 if geometry == "linear" else 3
+    energies[-mode_count:] = np.arange(1, mode_count + 1) * 0.2
+
+    class ConstantCalculator(Calculator):
+        implemented_properties = ["energy", "forces"]
+
+        def calculate(self, atoms=None, properties=("energy",), system_changes=all_changes):
+            super().calculate(atoms, properties, system_changes)
+            self.results = {"energy": -1.0, "forces": np.zeros((len(atoms), 3))}
+
+    calculator = ConstantCalculator()
+    monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: calculator)
+    vibration_runs = []
+
+    class ControlledVibrations:
+        def __init__(self, atoms, name):
+            self.atoms, self.name = atoms, name
+
+        def clean(self):
+            pass
+
+        def run(self):
+            vibration_runs.append(self.atoms)
+
+        def get_energies(self):
+            return energies
+
+        def write_mode(self, n, **kwargs):
+            write(Path(f"{self.name}.{n}.traj"), self.atoms)
+
+    monkeypatch.setattr(ase.vibrations, "Vibrations", ControlledVibrations)
+    config = MaceCalc(calculator_type="mace_polar", multiplicity=multiplicity, charge=0)
+    output = _run_thermo(tmp_path, monkeypatch, atoms, config, 300, 101325)
+    reference = IdealGasThermo(
+        vib_energies=energies, potentialenergy=-1.0, atoms=atoms, geometry=geometry,
+        symmetrynumber=symmetry, spin=(multiplicity - 1) / 2,
+    )
+    _assert_reference(output["thermochemistry"], reference, 300, 101325)
+    assert len(vibration_runs) == 1
+    assert len(output["vibrational_frequencies"]["energies"]) == mode_count
+    assert calculator.atoms.info["charge"] == 0
+    assert calculator.atoms.info["spin"] == multiplicity
+    assert output["simulation_input"]["calculator"]["multiplicity"] == multiplicity

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 from ase import Atoms, units
 from ase.calculators.calculator import Calculator, all_changes
 from ase.calculators.emt import EMT
@@ -13,20 +14,25 @@ from ase.io import write
 from ase.thermochemistry import IdealGasThermo
 import ase.vibrations
 
-from chemgraph.schemas.ase_input import ASEInputSchema
+from chemgraph.schemas.ase_input import ASEInputSchema, ase_input_schema_ensemble
 from chemgraph.schemas.atomsdata import AtomsData
 from chemgraph.schemas.calculators.emt_calc import EMTCalc
 from chemgraph.schemas.calculators.mace_calc import MaceCalc
+from chemgraph.schemas.calculators.nwchem_calc import NWChemCalc
+from chemgraph.tools import ase_core
 from chemgraph.tools.ase_core import get_symmetry_number, run_ase_core
 
 
-def _run_thermo(tmp_path, monkeypatch, atoms, calculator, temperature, pressure):
+def _run_thermo(tmp_path, monkeypatch, atoms, calculator, **conditions):
     monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
     input_path, output_path = tmp_path / "input.xyz", tmp_path / "result.json"
     write(input_path, atoms)
     params = ASEInputSchema(
-        input_structure_file=str(input_path), output_results_file=str(output_path),
-        calculator=calculator, driver="thermo", temperature=temperature, pressure=pressure,
+        input_structure_file=str(input_path),
+        output_results_file=str(output_path),
+        calculator=calculator,
+        driver="thermo",
+        **conditions,
     )
     result = run_ase_core(params)
     assert result["status"] == "success", result
@@ -38,26 +44,109 @@ def _run_thermo(tmp_path, monkeypatch, atoms, calculator, temperature, pressure)
 
 
 def _assert_reference(actual, reference, temperature, pressure):
-    assert actual["enthalpy"] == pytest.approx(reference.get_enthalpy(temperature))
-    assert actual["entropy"] == pytest.approx(reference.get_entropy(temperature, pressure))
-    assert actual["gibbs_free_energy"] == pytest.approx(reference.get_gibbs_energy(temperature, pressure))
+    assert actual["enthalpy"] == pytest.approx(
+        reference.get_enthalpy(temperature, verbose=False)
+    )
+    assert actual["entropy"] == pytest.approx(
+        reference.get_entropy(temperature, pressure, verbose=False)
+    )
+    assert actual["gibbs_free_energy"] == pytest.approx(
+        reference.get_gibbs_energy(temperature, pressure, verbose=False)
+    )
 
 
-@pytest.mark.parametrize("temperature,pressure", [(250, 101325), (500, 101325), (500, 202650)])
+@pytest.mark.parametrize("schema", [ASEInputSchema, ase_input_schema_ensemble])
+@pytest.mark.parametrize(
+    "conditions,expected",
+    [({}, 298.15), ({"temperature": None}, 298.15), ({"temperature": 500}, 500)],
+)
+def test_temperature_defaults_and_serialization(schema, conditions, expected):
+    source = {"input_structure_file": "input.xyz"} if schema is ASEInputSchema else {}
+    params = schema(calculator=EMTCalc(), driver="thermo", **source, **conditions)
+    assert params.temperature == expected
+    assert params.model_dump()["temperature"] == expected
+    assert schema.model_json_schema()["properties"]["temperature"]["default"] == 298.15
+
+
+@pytest.mark.parametrize("schema", [ASEInputSchema, ase_input_schema_ensemble])
+@pytest.mark.parametrize(
+    "temperature", [0, -1, float("nan"), float("inf"), -float("inf")]
+)
+def test_invalid_temperature_rejected(schema, temperature):
+    source = {"input_structure_file": "input.xyz"} if schema is ASEInputSchema else {}
+    with pytest.raises(ValidationError, match="temperature"):
+        schema(calculator=EMTCalc(), driver="thermo", temperature=temperature, **source)
+
+
+@pytest.mark.parametrize("conditions", [{}, {"temperature": None}])
+@pytest.mark.parametrize("calc_model", [EMTCalc(), NWChemCalc()])
+def test_atomic_default_temperature_and_singlet_warning(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    caplog,
+    conditions,
+    calc_model,
+):
+    atoms = Atoms("Cu", positions=[[0, 0, 0]])
+    atoms.calc = EMT()
+    # Exercise both an absent accessor and an accessor returning None without
+    # starting an external engine or adding methods to a real calculator schema.
+    monkeypatch.setattr(
+        ase_core, "load_calculator", lambda config: (EMT(), {}, calc_model)
+    )
+    output = _run_thermo(tmp_path, monkeypatch, atoms, EMTCalc(), **conditions)
+    assert output["simulation_input"]["temperature"] == 298.15
+    assert capsys.readouterr().out == ""
+    assert "assuming a singlet" in caplog.text
+    reference = IdealGasThermo(
+        vib_energies=[],
+        potentialenergy=atoms.get_potential_energy(),
+        atoms=atoms,
+        geometry="monatomic",
+        symmetrynumber=1,
+        spin=0,
+    )
+    _assert_reference(output["thermochemistry"], reference, 298.15, 101325)
+
+
+@pytest.mark.parametrize(
+    "temperature,pressure", [(250, 101325), (500, 101325), (500, 202650)]
+)
 @pytest.mark.parametrize("multiplicity", [1, 2, 3])
 def test_monatomic_thermo_matches_ase_without_vibrations(
-    tmp_path, monkeypatch, temperature, pressure, multiplicity,
+    tmp_path,
+    monkeypatch,
+    capsys,
+    caplog,
+    temperature,
+    pressure,
+    multiplicity,
 ):
     vibrations = Mock(side_effect=AssertionError("an atom has no vibrational modes"))
     monkeypatch.setattr(ase.vibrations, "Vibrations", vibrations)
-    monkeypatch.setattr(EMTCalc, "get_multiplicity", lambda self: multiplicity, raising=False)
+    monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: EMT())
     atoms = Atoms("Cu", positions=[[0, 0, 0]])
     atoms.calc = EMT()
     potential_energy = atoms.get_potential_energy()
-    output = _run_thermo(tmp_path, monkeypatch, atoms, EMTCalc(), temperature, pressure)
+    config = MaceCalc(calculator_type="mace_polar", multiplicity=multiplicity)
+    output = _run_thermo(
+        tmp_path,
+        monkeypatch,
+        atoms,
+        config,
+        temperature=temperature,
+        pressure=pressure,
+    )
+    assert capsys.readouterr().out == ""
+    assert "assuming a singlet" not in caplog.text
     reference = IdealGasThermo(
-        vib_energies=[], potentialenergy=potential_energy, atoms=atoms,
-        geometry="monatomic", symmetrynumber=1, spin=(multiplicity - 1) / 2,
+        vib_energies=[],
+        potentialenergy=potential_energy,
+        atoms=atoms,
+        geometry="monatomic",
+        symmetrynumber=1,
+        spin=(multiplicity - 1) / 2,
     )
     _assert_reference(output["thermochemistry"], reference, temperature, pressure)
     assert output["thermochemistry"]["enthalpy"] == pytest.approx(
@@ -65,10 +154,84 @@ def test_monatomic_thermo_matches_ase_without_vibrations(
     )
     assert output["thermochemistry"]["entropy"] > 0
     assert output["vibrational_frequencies"] == {
-        "energies": [], "energy_unit": "meV", "frequencies": [], "frequency_unit": "cm-1",
+        "energies": [],
+        "energy_unit": "meV",
+        "frequencies": [],
+        "frequency_unit": "cm-1",
     }
     vibrations.assert_not_called()
     assert not list(tmp_path.glob("*.traj"))
+    assert not list(tmp_path.glob("frequencies_*.csv"))
+
+
+@pytest.mark.parametrize("driver", ["thermo", "vib", "ir"])
+@pytest.mark.parametrize("stem", ["input", "input[1]"])
+def test_atomic_drivers_skip_displacements_and_clean_artifacts(
+    tmp_path,
+    monkeypatch,
+    driver,
+    stem,
+):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    vibrations, infrared = Mock(), Mock()
+    monkeypatch.setattr(ase.vibrations, "Vibrations", vibrations)
+    monkeypatch.setattr(ase.vibrations, "Infrared", infrared)
+    stale = [f"frequencies_{stem}.csv", f"{stem}_vib.5.traj"]
+    ir_files = [
+        f"ir_spectrum_{stem}.png",
+        f"ir_spectrum_{stem}.csv",
+        f"ir_peaks_{stem}.csv",
+    ]
+    unrelated = [
+        "frequencies_other.csv",
+        "other_vib.5.traj",
+        "ir_spectrum_other.csv",
+        "input1_vib.5.traj",
+    ]
+    for name in stale + ir_files + unrelated:
+        (tmp_path / name).write_text("previous calculation")
+    write(tmp_path / f"{stem}.xyz", Atoms("Cu", positions=[[0, 0, 0]]))
+    result = run_ase_core(
+        ASEInputSchema(
+            input_structure_file=str(tmp_path / f"{stem}.xyz"),
+            output_results_file="result.json",
+            calculator=EMTCalc(),
+            driver=driver,
+        )
+    )
+    assert result["status"] == "success", result
+    output = json.loads((tmp_path / "result.json").read_text())
+    assert output["vibrational_frequencies"] == {
+        "energies": [],
+        "energy_unit": "meV",
+        "frequencies": [],
+        "frequency_unit": "cm-1",
+    }
+    vibrations.assert_not_called()
+    infrared.assert_not_called()
+    assert all(not (tmp_path / name).exists() for name in stale)
+    assert all(
+        (tmp_path / name).read_text() == "previous calculation" for name in unrelated
+    )
+    if driver == "ir":
+        assert (
+            "Single atoms have no vibrational modes or IR spectrum" in result["message"]
+        )
+        assert "saved as individual .traj files" not in result["message"]
+        assert all(not (tmp_path / name).exists() for name in ir_files)
+        assert output["ir_data"] == {
+            "spectrum_frequencies": [],
+            "spectrum_frequencies_units": "cm-1",
+            "spectrum_intensities": [],
+            "spectrum_intensities_units": "D/Å^2 amu^-1",
+        }
+    else:
+        assert all((tmp_path / name).exists() for name in ir_files)
+
+
+@pytest.mark.parametrize("number", [1, 8, 29])
+def test_atomic_symmetry_is_one(number):
+    assert get_symmetry_number(AtomsData(numbers=[number], positions=[[0, 0, 0]])) == 1
 
 
 _MOLECULES = [
@@ -76,28 +239,43 @@ _MOLECULES = [
     ("NO", [[0, 0, 0], [0, 0, 1.15]], 1, 2, "linear"),
     ("H2", [[0, 0, 0], [0, 0, 0.74]], 2, 1, "linear"),
     ("OH2", [[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]], 2, 1, "nonlinear"),
+    ("CO2", [[0, 0, 0], [0, 0, 1.16], [0, 0, -1.16]], 2, 1, "linear"),
 ]
 
 
 @pytest.mark.parametrize("symbols,positions,symmetry,multiplicity,geometry", _MOLECULES)
-def test_geometric_symmetry_including_radicals(symbols, positions, symmetry, multiplicity, geometry):
+def test_geometric_symmetry_including_radicals(
+    symbols, positions, symmetry, multiplicity, geometry
+):
     atoms = Atoms(symbols, positions=positions)
-    assert get_symmetry_number(AtomsData(numbers=atoms.numbers, positions=positions)) == symmetry
+    assert (
+        get_symmetry_number(AtomsData(numbers=atoms.numbers, positions=positions))
+        == symmetry
+    )
 
 
 @pytest.mark.parametrize("symbols,positions,symmetry,multiplicity,geometry", _MOLECULES)
 def test_molecular_thermo_retains_spin_and_vibrations(
-    tmp_path, monkeypatch, symbols, positions, symmetry, multiplicity, geometry,
+    tmp_path,
+    monkeypatch,
+    capsys,
+    symbols,
+    positions,
+    symmetry,
+    multiplicity,
+    geometry,
 ):
     atoms = Atoms(symbols, positions=positions)
-    energies = np.zeros(3 * len(atoms))
-    mode_count = 1 if geometry == "linear" else 3
+    energies = np.full(3 * len(atoms), 1e-7j, dtype=complex)
+    mode_count = 3 * len(atoms) - (5 if geometry == "linear" else 6)
     energies[-mode_count:] = np.arange(1, mode_count + 1) * 0.2
 
     class ConstantCalculator(Calculator):
         implemented_properties = ["energy", "forces"]
 
-        def calculate(self, atoms=None, properties=("energy",), system_changes=all_changes):
+        def calculate(
+            self, atoms=None, properties=("energy",), system_changes=all_changes
+        ):
             super().calculate(atoms, properties, system_changes)
             self.results = {"energy": -1.0, "forces": np.zeros((len(atoms), 3))}
 
@@ -123,10 +301,20 @@ def test_molecular_thermo_retains_spin_and_vibrations(
 
     monkeypatch.setattr(ase.vibrations, "Vibrations", ControlledVibrations)
     config = MaceCalc(calculator_type="mace_polar", multiplicity=multiplicity, charge=0)
-    output = _run_thermo(tmp_path, monkeypatch, atoms, config, 300, 101325)
+    output = _run_thermo(
+        tmp_path, monkeypatch, atoms, config, temperature=300, pressure=101325
+    )
+    stdout = capsys.readouterr().out
+    assert "Enthalpy components" not in stdout
+    assert "Entropy components" not in stdout
+    assert "Free energy components" not in stdout
     reference = IdealGasThermo(
-        vib_energies=energies, potentialenergy=-1.0, atoms=atoms, geometry=geometry,
-        symmetrynumber=symmetry, spin=(multiplicity - 1) / 2,
+        vib_energies=energies[-mode_count:].real,
+        potentialenergy=-1.0,
+        atoms=atoms,
+        geometry=geometry,
+        symmetrynumber=symmetry,
+        spin=(multiplicity - 1) / 2,
     )
     _assert_reference(output["thermochemistry"], reference, 300, 101325)
     assert len(vibration_runs) == 1

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -375,6 +375,7 @@ def test_molecular_thermo_retains_spin_and_vibrations(
 def test_thermo_reports_exactly_the_modes_used_by_ase(
     tmp_path,
     monkeypatch,
+    caplog,
     energies,
     expected_indices,
     cleanup_count,
@@ -434,15 +435,17 @@ def test_thermo_reports_exactly_the_modes_used_by_ase(
     assert thermo["vib_selection"] == "highest"
     assert thermo["ignore_imag_modes"] is True
     assert thermo["ase_version"] == ase.__version__
-    if thermo["raw_imaginary_mode_count"]:
-        assert any(
-            "do not establish structural stability" in note
-            for note in thermo["warnings"]
-        )
+    expected_warnings = []
+    if cleanup_count:
+        expected_warnings.append(f"{cleanup_count} imag modes removed")
     if not expected_indices:
-        assert (
-            "No vibrational modes contributed to thermochemistry." in thermo["warnings"]
+        expected_warnings.append(
+            "No vibrational modes contributed to thermochemistry."
         )
+    assert thermo["warnings"] == expected_warnings
+    assert "The input spectrum contains" not in caplog.text
+    for note in expected_warnings:
+        assert note in caplog.text
     rows = (tmp_path / "frequencies_input.csv").read_text(encoding="utf-8").splitlines()
     assert rows == [
         f"input_vib.{i}.traj,{frequency}"

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -25,13 +25,17 @@ from chemgraph.tools.ase_core import get_symmetry_number, run_ase_core
 
 def _controlled_spectrum(monkeypatch, energies):
     class ConstantCalculator(Calculator):
-        implemented_properties = ["energy", "forces"]
+        implemented_properties = ["energy", "forces", "dipole"]
 
         def calculate(
             self, atoms=None, properties=("energy",), system_changes=all_changes
         ):
             super().calculate(atoms, properties, system_changes)
-            self.results = {"energy": -1.0, "forces": np.zeros((len(atoms), 3))}
+            self.results = {
+                "energy": -1.0,
+                "forces": np.zeros((len(atoms), 3)),
+                "dipole": np.zeros(3),
+            }
 
     calculator = ConstantCalculator()
     monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: calculator)
@@ -274,6 +278,11 @@ def test_atomic_drivers_skip_displacements_and_clean_artifacts(
 
 @pytest.fixture
 def water_vibration_artifacts(tmp_path, monkeypatch):
+    class DipoleEMT(EMT):
+        def get_dipole_moment(self, atoms=None):
+            return np.zeros(3)
+
+    monkeypatch.setattr(EMTCalc, "get_calculator", lambda self: DipoleEMT())
     monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
     write(
         tmp_path / "water.xyz",
@@ -290,7 +299,7 @@ def water_vibration_artifacts(tmp_path, monkeypatch):
     paths = [tmp_path / "frequencies_water.csv"] + [
         tmp_path / f"water_vib.{i}.traj" for i in (6, 7, 8)
     ]
-    # EMT has no dipole implementation; seed prior IR outputs separately.
+    # Seed prior IR outputs separately from the initial vibration-only run.
     for name in (
         "ir_spectrum_water.png", "ir_spectrum_water.csv", "ir_peaks_water.csv",
     ):

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -1,7 +1,6 @@
 """Scientific regressions using EMT and controlled molecular vibrations."""
 
 import json
-import warnings
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -77,6 +76,8 @@ def _run_thermo(tmp_path, monkeypatch, atoms, calculator, **conditions):
     assert result["result"]["thermochemistry"] == output["thermochemistry"]
     assert output["thermochemistry"]["unit"] == "eV"
     assert output["thermochemistry"]["entropy_unit"] == "eV/K"
+    assert output["thermochemistry"]["ignore_imag_modes"] is False
+    assert output["thermochemistry"]["n_imag"] == 0
     return output
 
 
@@ -338,7 +339,7 @@ def test_molecular_thermo_retains_spin_and_vibrations(
 
 
 @pytest.mark.parametrize(
-    "energies,expected_indices,cleanup_count",
+    "energies,expected_indices",
     [
         pytest.param(
             [
@@ -356,20 +357,10 @@ def test_molecular_thermo_retains_spin_and_vibrations(
                 0.0352987,
             ],
             [6, 7, 8, 9, 10, 11],
-            0,
             id="recorded-cu4",
         ),
-        pytest.param(
-            [0.09j, 0.08j, 0.07j, 0.06j, 0.05j, 0.04j, 0.03j, 0.02, 0.03],
-            [7, 8],
-            1,
-            id="remaining-imaginary",
-        ),
-        pytest.param([0.01j] * 9, [], 3, id="all-imaginary"),
-        pytest.param([0.01j] * 6 + [0, 0.02, 0.03], [7, 8], 1, id="selected-zero"),
-        pytest.param([0.01] * 7 + [0.02, 0.03], [6, 7, 8], 0, id="boundary-duplicates"),
-        pytest.param([0.03, 0.01, 0.02] + [0.001] * 6, [1, 2, 0], 0, id="unordered"),
-        pytest.param([0.0] * 9, [], 3, id="all-zero"),
+        pytest.param([0.01] * 7 + [0.02, 0.03], [6, 7, 8], id="boundary-duplicates"),
+        pytest.param([0.03, 0.01, 0.02] + [0.001] * 6, [1, 2, 0], id="unordered"),
     ],
 )
 def test_thermo_reports_exactly_the_modes_used_by_ase(
@@ -378,7 +369,6 @@ def test_thermo_reports_exactly_the_modes_used_by_ase(
     caplog,
     energies,
     expected_indices,
-    cleanup_count,
 ):
     _controlled_spectrum(monkeypatch, energies)
     atoms = (
@@ -392,23 +382,21 @@ def test_thermo_reports_exactly_the_modes_used_by_ase(
         atoms,
         MaceCalc(calculator_type="mace_polar", multiplicity=1),
     )
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        reference = IdealGasThermo(
-            vib_energies=energies,
-            geometry="nonlinear",
-            atoms=atoms,
-            potentialenergy=-1.0,
-            spin=0,
-            symmetrynumber=get_symmetry_number(
-                AtomsData(
-                    numbers=atoms.numbers,
-                    positions=atoms.positions,
-                )
-            ),
-            vib_selection="highest",
-            ignore_imag_modes=True,
-        )
+    reference = IdealGasThermo(
+        vib_energies=energies,
+        geometry="nonlinear",
+        atoms=atoms,
+        potentialenergy=-1.0,
+        spin=0,
+        symmetrynumber=get_symmetry_number(
+            AtomsData(
+                numbers=atoms.numbers,
+                positions=atoms.positions,
+            )
+        ),
+        vib_selection="highest",
+        ignore_imag_modes=False,
+    )
     thermo, vibration = output["thermochemistry"], output["vibrational_frequencies"]
     _assert_reference(thermo, reference, 298.15, 101325)
     assert vibration["mode_indices"] == expected_indices
@@ -428,24 +416,13 @@ def test_thermo_reports_exactly_the_modes_used_by_ase(
         assert float(record["energy"].removesuffix("i")) / 1e3 == pytest.approx(
             magnitude
         )
-    assert thermo["n_imag"] == cleanup_count
     assert thermo["raw_imaginary_mode_count"] == np.count_nonzero(
         np.iscomplex(energies)
     )
     assert thermo["vib_selection"] == "highest"
-    assert thermo["ignore_imag_modes"] is True
     assert thermo["ase_version"] == ase.__version__
-    expected_warnings = []
-    if cleanup_count:
-        expected_warnings.append(f"{cleanup_count} imag modes removed")
-    if not expected_indices:
-        expected_warnings.append(
-            "No vibrational modes contributed to thermochemistry."
-        )
-    assert thermo["warnings"] == expected_warnings
+    assert thermo["warnings"] == []
     assert "The input spectrum contains" not in caplog.text
-    for note in expected_warnings:
-        assert note in caplog.text
     rows = (tmp_path / "frequencies_input.csv").read_text(encoding="utf-8").splitlines()
     assert rows == [
         f"input_vib.{i}.traj,{frequency}"
@@ -458,10 +435,24 @@ def test_thermo_reports_exactly_the_modes_used_by_ase(
         assert read(tmp_path / f"input_vib.{index}.traj").info["mode_index"] == index
 
 
-@pytest.mark.parametrize("failure", ["constructor", "entropy", "nonfinite"])
+@pytest.mark.parametrize(
+    "failure",
+    [
+        "constructor", "entropy", "nonfinite", "remaining-imaginary",
+        "all-imaginary", "selected-zero", "all-zero",
+    ],
+)
 def test_thermo_failure_preserves_completed_results(tmp_path, monkeypatch, failure):
     monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
-    _controlled_spectrum(monkeypatch, [0.01j] * 6 + [0.02, 0.03, 0.04])
+    energies = {
+        "remaining-imaginary": [
+            0.09j, 0.08j, 0.07j, 0.06j, 0.05j, 0.04j, 0.03j, 0.02, 0.03,
+        ],
+        "all-imaginary": [0.01j] * 9,
+        "selected-zero": [0.01j] * 6 + [0, 0.02, 0.03],
+        "all-zero": [0.0] * 9,
+    }.get(failure, [0.01j] * 6 + [0.02, 0.03, 0.04])
+    _controlled_spectrum(monkeypatch, energies)
     if failure == "constructor":
         monkeypatch.setattr(
             "ase.thermochemistry.IdealGasThermo",
@@ -473,10 +464,16 @@ def test_thermo_failure_preserves_completed_results(tmp_path, monkeypatch, failu
             "get_entropy",
             Mock(side_effect=ValueError("thermo unavailable")),
         )
-    else:
+    elif failure == "nonfinite":
         monkeypatch.setattr(
             IdealGasThermo, "get_entropy", Mock(return_value=float("nan"))
         )
+    if failure in {"constructor", "entropy"}:
+        expected_error = "thermo unavailable"
+    elif failure in {"remaining-imaginary", "all-imaginary"}:
+        expected_error = "Imaginary vibrational energies are present."
+    else:
+        expected_error = "ASE returned non-finite thermochemistry values."
     atoms = Atoms("OH2", positions=[[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]])
     write(tmp_path / "input.xyz", atoms)
     result = run_ase_core(
@@ -489,16 +486,22 @@ def test_thermo_failure_preserves_completed_results(tmp_path, monkeypatch, failu
     )
     assert result["status"] == "failure"
     assert result["error_type"] == "ValueError"
+    assert expected_error in result["message"]
+    assert "result" not in result
     assert result["converged"] is True
     assert result["potential_energy"] == -1.0
     assert result["results_file"] == str(tmp_path / "result.json")
     json.dumps(result)  # The failure payload must also work over MCP/ensemble JSON.
     output = json.loads(Path(result["results_file"]).read_text(encoding="utf-8"))
     assert output["success"] is False
-    assert output["error"]
+    assert output["error"] == expected_error
     assert output["thermochemistry"] == {}
     assert output["final_structure"]["numbers"] == atoms.numbers.tolist()
     assert output["potential_energy"] == -1.0
     assert len(output["vibrational_frequencies"]["all_modes"]) == 9
+    assert [
+        complex(mode["energy"].replace("i", "j")) / 1e3
+        for mode in output["vibrational_frequencies"]["all_modes"]
+    ] == pytest.approx(energies)
     assert output["vibrational_frequencies"]["mode_indices"] == []
     assert read(tmp_path / "input_opt.traj").get_potential_energy() == -1.0

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -645,6 +645,10 @@ def test_thermo_failure_preserves_completed_results(tmp_path, monkeypatch, failu
     assert result["converged"] is True
     assert result["potential_energy"] == -1.0
     assert result["results_file"] == str(tmp_path / "result.json")
+    assert f"results JSON: {result['results_file']}" in result["message"]
+    assert "full input vibrational spectrum" in result["message"]
+    assert "selected-mode frequency CSV is empty" in result["message"]
+    assert "no selected-mode trajectories were exported" in result["message"]
     json.dumps(result)  # The failure payload must also work over MCP/ensemble JSON.
     output = json.loads(Path(result["results_file"]).read_text(encoding="utf-8"))
     assert output["success"] is False
@@ -658,4 +662,47 @@ def test_thermo_failure_preserves_completed_results(tmp_path, monkeypatch, failu
         for mode in output["vibrational_frequencies"]["all_modes"]
     ] == pytest.approx(energies)
     assert output["vibrational_frequencies"]["mode_indices"] == []
+    assert (tmp_path / "frequencies_input.csv").read_text(encoding="utf-8") == ""
+    assert not list(tmp_path.glob("input_vib.*.traj"))
     assert read(tmp_path / "input_opt.traj").get_potential_energy() == -1.0
+
+
+def test_atomic_thermo_failure_describes_absent_vibration_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        "ase.thermochemistry.IdealGasThermo",
+        Mock(side_effect=ValueError("thermo unavailable")),
+    )
+    atoms = Atoms("Cu", positions=[[0, 0, 0]])
+    atoms.calc = EMT()
+    expected_energy = atoms.get_potential_energy()
+    write(tmp_path / "input.xyz", atoms)
+    result = run_ase_core(
+        ASEInputSchema(
+            input_structure_file="input.xyz",
+            output_results_file="result.json",
+            calculator=EMTCalc(),
+            driver="thermo",
+        )
+    )
+    assert result["status"] == "failure"
+    assert result["error_type"] == "ValueError"
+    assert result["message"].startswith("Thermochemistry failed: thermo unavailable.")
+    assert result["results_file"] == str(tmp_path / "result.json")
+    assert f"results JSON: {result['results_file']}" in result["message"]
+    assert "Single atoms have no vibrational modes" in result["message"]
+    assert "no frequency CSV or mode trajectories were exported" in result["message"]
+    assert "full input vibrational spectrum" not in result["message"]
+    assert result["potential_energy"] == pytest.approx(expected_energy)
+    assert "result" not in result
+    json.dumps(result)
+    output = json.loads(Path(result["results_file"]).read_text(encoding="utf-8"))
+    assert output["success"] is False
+    assert output["error"] == "thermo unavailable"
+    assert output["thermochemistry"] == {}
+    assert output["final_structure"]["numbers"] == atoms.numbers.tolist()
+    assert output["potential_energy"] == pytest.approx(expected_energy)
+    assert output["vibrational_frequencies"]["all_modes"] == []
+    assert output["vibrational_frequencies"]["mode_indices"] == []
+    assert not list(tmp_path.glob("frequencies_*.csv"))
+    assert not list(tmp_path.glob("input_vib.*.traj"))

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -36,7 +36,7 @@ def _run_thermo(tmp_path, monkeypatch, atoms, calculator, **conditions):
     )
     result = run_ase_core(params)
     assert result["status"] == "success", result
-    output = json.loads(output_path.read_text())
+    output = json.loads(output_path.read_text(encoding="utf-8"))
     assert result["result"]["thermochemistry"] == output["thermochemistry"]
     assert output["thermochemistry"]["unit"] == "eV"
     assert output["thermochemistry"]["entropy_unit"] == "eV/K"
@@ -200,7 +200,7 @@ def test_atomic_drivers_skip_displacements_and_clean_artifacts(
         )
     )
     assert result["status"] == "success", result
-    output = json.loads((tmp_path / "result.json").read_text())
+    output = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
     assert output["vibrational_frequencies"] == {
         "energies": [],
         "energy_unit": "meV",

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -272,6 +272,151 @@ def test_atomic_drivers_skip_displacements_and_clean_artifacts(
         assert all((tmp_path / name).exists() for name in ir_files)
 
 
+@pytest.fixture
+def water_vibration_artifacts(tmp_path, monkeypatch):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    write(
+        tmp_path / "water.xyz",
+        Atoms("OH2", positions=[[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]]),
+    )
+    params = ASEInputSchema(
+        input_structure_file="water.xyz",
+        output_results_file="result.json",
+        calculator=EMTCalc(),
+        driver="vib",
+    )
+    result = run_ase_core(params)
+    assert result["status"] == "success", result
+    paths = [tmp_path / "frequencies_water.csv"] + [
+        tmp_path / f"water_vib.{i}.traj" for i in (6, 7, 8)
+    ]
+    # EMT has no dipole implementation; seed prior IR outputs separately.
+    for name in (
+        "ir_spectrum_water.png", "ir_spectrum_water.csv", "ir_peaks_water.csv",
+    ):
+        path = tmp_path / name
+        path.write_bytes(b"previous IR calculation")
+        paths.append(path)
+    return params, {path: path.read_bytes() for path in paths}
+
+
+@pytest.mark.parametrize("driver", ["vib", "thermo", "ir"])
+def test_displacement_failure_preserves_previous_artifacts(
+    monkeypatch, water_vibration_artifacts, driver,
+):
+    params, artifacts = water_vibration_artifacts
+    original_run = ase.vibrations.Vibrations.run
+    evaluations = 0
+
+    def fail_during_displacements(vib):
+        original_calculate = vib.atoms.calc.calculate
+
+        def calculate(*args, **kwargs):
+            nonlocal evaluations
+            evaluations += 1
+            if evaluations > 10:
+                raise RuntimeError("SCF did not converge")
+            return original_calculate(*args, **kwargs)
+
+        monkeypatch.setattr(vib.atoms.calc, "calculate", calculate)
+        return original_run(vib)
+
+    monkeypatch.setattr(ase.vibrations.Vibrations, "run", fail_during_displacements)
+    result = run_ase_core(params.model_copy(update={"driver": driver}))
+    assert result["status"] == "failure", result
+    assert result["message"] == "SCF did not converge"
+    assert evaluations == 11
+    assert all(path.exists() for path in artifacts)
+    assert {path: path.read_bytes() for path in artifacts} == artifacts
+
+
+def test_mode_write_failure_preserves_previous_trajectories(
+    monkeypatch, water_vibration_artifacts,
+):
+    params, artifacts = water_vibration_artifacts
+    trajectories = {path: data for path, data in artifacts.items() if path.suffix == ".traj"}
+    original_write_mode = ase.vibrations.Vibrations.write_mode
+    written_modes = []
+
+    def fail_after_first_mode(vib, n, **kwargs):
+        if written_modes:
+            raise RuntimeError("mode write failed")
+        original_write_mode(vib, n=n, **kwargs)
+        written_modes.append(n)
+
+    monkeypatch.setattr(ase.vibrations.Vibrations, "write_mode", fail_after_first_mode)
+    result = run_ase_core(params)
+    assert result["status"] == "failure", result
+    assert result["message"] == "mode write failed"
+    assert written_modes == [6]
+    assert all(path.exists() for path in trajectories)
+    assert {path: path.read_bytes() for path in trajectories} == trajectories
+
+
+def test_ir_failure_preserves_previous_ir_artifacts(
+    monkeypatch, water_vibration_artifacts,
+):
+    params, artifacts = water_vibration_artifacts
+    ir_artifacts = {path: data for path, data in artifacts.items() if path.name.startswith("ir_")}
+    infrared_run = Mock(side_effect=RuntimeError("IR calculation failed"))
+    monkeypatch.setattr(ase.vibrations.Infrared, "run", infrared_run)
+    result = run_ase_core(params.model_copy(update={"driver": "ir"}))
+    assert result["status"] == "failure", result
+    assert result["message"] == "IR calculation failed"
+    infrared_run.assert_called_once()
+    assert all(path.exists() for path in ir_artifacts)
+    assert {path: path.read_bytes() for path in ir_artifacts} == ir_artifacts
+
+
+@pytest.mark.parametrize("driver", ["vib", "thermo", "ir"])
+@pytest.mark.parametrize("stem", ["water", "water[1]"])
+def test_molecular_rerun_replaces_artifacts_and_removes_obsolete_modes(
+    tmp_path, monkeypatch, driver, stem,
+):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    energies = [0.001] * 6 + [0.02, 0.03, 0.04]
+    _controlled_spectrum(monkeypatch, energies)
+    if driver == "ir":
+        infrared = Mock()
+        infrared.get_spectrum.return_value = ([500, 1000], [0.2, 0.1])
+        infrared.get_energies.return_value = np.asarray(energies, dtype=complex)
+        infrared.intensities = np.arange(9, dtype=float)
+        monkeypatch.setattr(ase.vibrations, "Infrared", Mock(return_value=infrared))
+    write(
+        tmp_path / f"{stem}.xyz",
+        Atoms("OH2", positions=[[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]]),
+    )
+    replacements = [f"frequencies_{stem}.csv"] + [
+        f"{stem}_vib.{i}.traj" for i in (6, 7, 8)
+    ]
+    if driver == "ir":
+        replacements += [
+            f"ir_spectrum_{stem}.png", f"ir_spectrum_{stem}.csv", f"ir_peaks_{stem}.csv",
+        ]
+    obsolete = f"{stem}_vib.5.traj"
+    unrelated = ["other_vib.5.traj", "water1_vib.5.traj", "frequencies_other.csv"]
+    for name in replacements + [obsolete] + unrelated:
+        (tmp_path / name).write_bytes(b"previous calculation")
+    result = run_ase_core(
+        ASEInputSchema(
+            input_structure_file=f"{stem}.xyz",
+            output_results_file="result.json",
+            calculator=MaceCalc(calculator_type="mace_polar", multiplicity=1),
+            driver=driver,
+        )
+    )
+    assert result["status"] == "success", result
+    assert not (tmp_path / obsolete).exists()
+    assert all((tmp_path / name).read_bytes() != b"previous calculation" for name in replacements)
+    assert all((tmp_path / name).read_bytes() == b"previous calculation" for name in unrelated)
+    rows = (tmp_path / f"frequencies_{stem}.csv").read_text().splitlines()
+    assert [row.split(",")[0] for row in rows] == [
+        f"{stem}_vib.{i}.traj" for i in (6, 7, 8)
+    ]
+    for index in (6, 7, 8):
+        assert read(tmp_path / f"{stem}_vib.{index}.traj").info["mode_index"] == index
+
+
 @pytest.mark.parametrize("number", [1, 8, 29])
 def test_atomic_symmetry_is_one(number):
     assert get_symmetry_number(AtomsData(numbers=[number], positions=[[0, 0, 0]])) == 1

--- a/tests/test_thermochemistry.py
+++ b/tests/test_thermochemistry.py
@@ -1,6 +1,7 @@
 """Scientific regressions using EMT and controlled molecular vibrations."""
 
 import json
+import warnings
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -10,7 +11,7 @@ from pydantic import ValidationError
 from ase import Atoms, units
 from ase.calculators.calculator import Calculator, all_changes
 from ase.calculators.emt import EMT
-from ase.io import write
+from ase.io import read, write
 from ase.thermochemistry import IdealGasThermo
 import ase.vibrations
 
@@ -21,6 +22,42 @@ from chemgraph.schemas.calculators.mace_calc import MaceCalc
 from chemgraph.schemas.calculators.nwchem_calc import NWChemCalc
 from chemgraph.tools import ase_core
 from chemgraph.tools.ase_core import get_symmetry_number, run_ase_core
+
+
+def _controlled_spectrum(monkeypatch, energies):
+    class ConstantCalculator(Calculator):
+        implemented_properties = ["energy", "forces"]
+
+        def calculate(
+            self, atoms=None, properties=("energy",), system_changes=all_changes
+        ):
+            super().calculate(atoms, properties, system_changes)
+            self.results = {"energy": -1.0, "forces": np.zeros((len(atoms), 3))}
+
+    calculator = ConstantCalculator()
+    monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: calculator)
+    vibration_runs = []
+
+    class ControlledVibrations:
+        def __init__(self, atoms, name):
+            self.atoms, self.name = atoms, name
+
+        def clean(self):
+            pass
+
+        def run(self):
+            vibration_runs.append(self.atoms)
+
+        def get_energies(self):
+            return np.asarray(energies, dtype=complex)
+
+        def write_mode(self, n, **kwargs):
+            frame = self.atoms.copy()
+            frame.info["mode_index"] = n
+            write(Path(f"{self.name}.{n}.traj"), frame)
+
+    monkeypatch.setattr(ase.vibrations, "Vibrations", ControlledVibrations)
+    return calculator, vibration_runs
 
 
 def _run_thermo(tmp_path, monkeypatch, atoms, calculator, **conditions):
@@ -158,6 +195,8 @@ def test_monatomic_thermo_matches_ase_without_vibrations(
         "energy_unit": "meV",
         "frequencies": [],
         "frequency_unit": "cm-1",
+        "mode_indices": [],
+        "all_modes": [],
     }
     vibrations.assert_not_called()
     assert not list(tmp_path.glob("*.traj"))
@@ -201,12 +240,15 @@ def test_atomic_drivers_skip_displacements_and_clean_artifacts(
     )
     assert result["status"] == "success", result
     output = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
-    assert output["vibrational_frequencies"] == {
+    expected_vibrations = {
         "energies": [],
         "energy_unit": "meV",
         "frequencies": [],
         "frequency_unit": "cm-1",
     }
+    if driver == "thermo":
+        expected_vibrations.update(mode_indices=[], all_modes=[])
+    assert output["vibrational_frequencies"] == expected_vibrations
     vibrations.assert_not_called()
     infrared.assert_not_called()
     assert all(not (tmp_path / name).exists() for name in stale)
@@ -270,36 +312,7 @@ def test_molecular_thermo_retains_spin_and_vibrations(
     mode_count = 3 * len(atoms) - (5 if geometry == "linear" else 6)
     energies[-mode_count:] = np.arange(1, mode_count + 1) * 0.2
 
-    class ConstantCalculator(Calculator):
-        implemented_properties = ["energy", "forces"]
-
-        def calculate(
-            self, atoms=None, properties=("energy",), system_changes=all_changes
-        ):
-            super().calculate(atoms, properties, system_changes)
-            self.results = {"energy": -1.0, "forces": np.zeros((len(atoms), 3))}
-
-    calculator = ConstantCalculator()
-    monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: calculator)
-    vibration_runs = []
-
-    class ControlledVibrations:
-        def __init__(self, atoms, name):
-            self.atoms, self.name = atoms, name
-
-        def clean(self):
-            pass
-
-        def run(self):
-            vibration_runs.append(self.atoms)
-
-        def get_energies(self):
-            return energies
-
-        def write_mode(self, n, **kwargs):
-            write(Path(f"{self.name}.{n}.traj"), self.atoms)
-
-    monkeypatch.setattr(ase.vibrations, "Vibrations", ControlledVibrations)
+    calculator, vibration_runs = _controlled_spectrum(monkeypatch, energies)
     config = MaceCalc(calculator_type="mace_polar", multiplicity=multiplicity, charge=0)
     output = _run_thermo(
         tmp_path, monkeypatch, atoms, config, temperature=300, pressure=101325
@@ -322,3 +335,167 @@ def test_molecular_thermo_retains_spin_and_vibrations(
     assert calculator.atoms.info["charge"] == 0
     assert calculator.atoms.info["spin"] == multiplicity
     assert output["simulation_input"]["calculator"]["multiplicity"] == multiplicity
+
+
+@pytest.mark.parametrize(
+    "energies,expected_indices,cleanup_count",
+    [
+        pytest.param(
+            [
+                0.00748031j,
+                0.00398170j,
+                3.96854e-8j,
+                3.96839e-8j,
+                3.12353e-10j,
+                8.62908e-5,
+                9.16070e-5,
+                9.16070e-5,
+                0.0234627,
+                0.0297504,
+                0.0297504,
+                0.0352987,
+            ],
+            [6, 7, 8, 9, 10, 11],
+            0,
+            id="recorded-cu4",
+        ),
+        pytest.param(
+            [0.09j, 0.08j, 0.07j, 0.06j, 0.05j, 0.04j, 0.03j, 0.02, 0.03],
+            [7, 8],
+            1,
+            id="remaining-imaginary",
+        ),
+        pytest.param([0.01j] * 9, [], 3, id="all-imaginary"),
+        pytest.param([0.01j] * 6 + [0, 0.02, 0.03], [7, 8], 1, id="selected-zero"),
+        pytest.param([0.01] * 7 + [0.02, 0.03], [6, 7, 8], 0, id="boundary-duplicates"),
+        pytest.param([0.03, 0.01, 0.02] + [0.001] * 6, [1, 2, 0], 0, id="unordered"),
+        pytest.param([0.0] * 9, [], 3, id="all-zero"),
+    ],
+)
+def test_thermo_reports_exactly_the_modes_used_by_ase(
+    tmp_path,
+    monkeypatch,
+    energies,
+    expected_indices,
+    cleanup_count,
+):
+    _controlled_spectrum(monkeypatch, energies)
+    atoms = (
+        Atoms("Cu4", positions=[[0, 0, 0], [2.3, 0, 0], [2.3, 2.3, 0], [0, 2.3, 0]])
+        if len(energies) == 12
+        else Atoms("OH2", positions=[[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]])
+    )
+    output = _run_thermo(
+        tmp_path,
+        monkeypatch,
+        atoms,
+        MaceCalc(calculator_type="mace_polar", multiplicity=1),
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        reference = IdealGasThermo(
+            vib_energies=energies,
+            geometry="nonlinear",
+            atoms=atoms,
+            potentialenergy=-1.0,
+            spin=0,
+            symmetrynumber=get_symmetry_number(
+                AtomsData(
+                    numbers=atoms.numbers,
+                    positions=atoms.positions,
+                )
+            ),
+            vib_selection="highest",
+            ignore_imag_modes=True,
+        )
+    thermo, vibration = output["thermochemistry"], output["vibrational_frequencies"]
+    _assert_reference(thermo, reference, 298.15, 101325)
+    assert vibration["mode_indices"] == expected_indices
+    assert np.array(vibration["energies"], dtype=float) / 1e3 == pytest.approx(
+        reference.vib_energies
+    )
+    assert np.array(
+        vibration["frequencies"], dtype=float
+    ) * units.invcm == pytest.approx(reference.vib_energies)
+    assert len(vibration["all_modes"]) == len(energies)
+    for i, (original, record) in enumerate(zip(energies, vibration["all_modes"])):
+        assert record["mode_index"] == i
+        assert record["energy"].endswith("i") == bool(np.iscomplex(original))
+        magnitude = (
+            complex(original).imag if np.iscomplex(original) else float(original)
+        )
+        assert float(record["energy"].removesuffix("i")) / 1e3 == pytest.approx(
+            magnitude
+        )
+    assert thermo["n_imag"] == cleanup_count
+    assert thermo["raw_imaginary_mode_count"] == np.count_nonzero(
+        np.iscomplex(energies)
+    )
+    assert thermo["vib_selection"] == "highest"
+    assert thermo["ignore_imag_modes"] is True
+    assert thermo["ase_version"] == ase.__version__
+    if thermo["raw_imaginary_mode_count"]:
+        assert any(
+            "do not establish structural stability" in note
+            for note in thermo["warnings"]
+        )
+    if not expected_indices:
+        assert (
+            "No vibrational modes contributed to thermochemistry." in thermo["warnings"]
+        )
+    rows = (tmp_path / "frequencies_input.csv").read_text(encoding="utf-8").splitlines()
+    assert rows == [
+        f"input_vib.{i}.traj,{frequency}"
+        for i, frequency in zip(expected_indices, vibration["frequencies"])
+    ]
+    assert {path.name for path in tmp_path.glob("input_vib.*.traj")} == {
+        f"input_vib.{i}.traj" for i in expected_indices
+    }
+    for index in expected_indices:
+        assert read(tmp_path / f"input_vib.{index}.traj").info["mode_index"] == index
+
+
+@pytest.mark.parametrize("failure", ["constructor", "entropy", "nonfinite"])
+def test_thermo_failure_preserves_completed_results(tmp_path, monkeypatch, failure):
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    _controlled_spectrum(monkeypatch, [0.01j] * 6 + [0.02, 0.03, 0.04])
+    if failure == "constructor":
+        monkeypatch.setattr(
+            "ase.thermochemistry.IdealGasThermo",
+            Mock(side_effect=ValueError("thermo unavailable")),
+        )
+    elif failure == "entropy":
+        monkeypatch.setattr(
+            IdealGasThermo,
+            "get_entropy",
+            Mock(side_effect=ValueError("thermo unavailable")),
+        )
+    else:
+        monkeypatch.setattr(
+            IdealGasThermo, "get_entropy", Mock(return_value=float("nan"))
+        )
+    atoms = Atoms("OH2", positions=[[0, 0, 0], [0.76, 0, 0.59], [-0.76, 0, 0.59]])
+    write(tmp_path / "input.xyz", atoms)
+    result = run_ase_core(
+        ASEInputSchema(
+            input_structure_file="input.xyz",
+            output_results_file="result.json",
+            calculator=MaceCalc(calculator_type="mace_polar", multiplicity=1),
+            driver="thermo",
+        )
+    )
+    assert result["status"] == "failure"
+    assert result["error_type"] == "ValueError"
+    assert result["converged"] is True
+    assert result["potential_energy"] == -1.0
+    assert result["results_file"] == str(tmp_path / "result.json")
+    json.dumps(result)  # The failure payload must also work over MCP/ensemble JSON.
+    output = json.loads(Path(result["results_file"]).read_text(encoding="utf-8"))
+    assert output["success"] is False
+    assert output["error"]
+    assert output["thermochemistry"] == {}
+    assert output["final_structure"]["numbers"] == atoms.numbers.tolist()
+    assert output["potential_energy"] == -1.0
+    assert len(output["vibrational_frequencies"]["all_modes"]) == 9
+    assert output["vibrational_frequencies"]["mode_indices"] == []
+    assert read(tmp_path / "input_opt.traj").get_potential_energy() == -1.0


### PR DESCRIPTION
## Summary

Monatomic thermochemistry previously returned zero entropy and set enthalpy/Gibbs energy equal to potential energy at every temperature and pressure. Compute the atomic contributions with ASE IdealGasThermo and skip atomic displacement calculations. Geometric symmetry detection permits radicals without changing the calculator's electronic state.

Molecular thermochemistry now uses ASE 3.29's explicit `vib_selection="highest", ignore_imag_modes=False` policy on the complete complex spectrum. Reported frequencies, CSV entries, and mode trajectories follow ASE's retained energies, including correct indices for degenerate modes. Preserve the complete input spectrum, selection/cleanup metadata, and warnings in JSON and HTML. If thermochemistry fails or returns non-finite values, save the completed structure, energy, convergence state, and spectrum and return the result-file path. Failure messages distinguish the saved JSON from empty selected-mode exports and explain that single atoms have no vibrational artifacts.

Require ASE >= 3.29.0 and use 3.29.0 in the maintained environment and both Docker variants. Normalize omitted/null ASE input temperatures to 298.15 K, clean stale atomic artifacts, and validate/display entropy units independently of energy units.

Reject nonpositive TBLite/ORCA spin multiplicities during input validation while preserving existing defaults. Keep the report JavaScript conversion tests and install QuickJS from the optional `test` extra in Ubuntu CI jobs, with an explicit import check.

HTML reports tolerate missing thermochemistry diagnostics and unavailable mode mappings while keeping the structure, energy, and spectra visible. Show unknown mode mappings explicitly, describe the recorded imaginary-mode policy accurately, and keep unsupported entropy units as errors. Handled report failures return `Error:` messages so the agent retries instead of treating a missing report as success.

Single-agent and executor prompts use defaults declared by the selected tool schema, preserve user-supplied values, and avoid inventing defaults. The planner delegates schema validation and default handling to executors. This guidance remains available when human supervision is disabled.

## Scientific behavior and compatibility

- ASE selects the expected number of modes by signed squared energy, then rejects any imaginary modes remaining after selection. Zero-energy modes are retained; non-finite thermochemistry values cause a failure. Selection may exclude imaginary modes before validation, so successful thermochemistry does not establish structural stability. The complete spectrum remains available in JSON and HTML.
- `n_imag` is zero on successful current calculations. Legacy results using `ignore_imag_modes=True` may record modes removed after selection, including zero-energy modes. `raw_imaginary_mode_count` separately records imaginary input modes and does not itself trigger a warning. Preserve ASE warnings and warn when no vibrational modes contribute.
- On molecular thermochemistry failure, the complete input spectrum remains in JSON under `vibrational_frequencies.all_modes`; selected frequencies and mode indices are empty, the selected-mode CSV has no rows, and no selected-mode trajectories are exported.
- Temperature normalization applies to ASE single and ensemble inputs. Validation changes to the legacy `run_mace` wrappers are deferred to a separate PR; MACE calculations through the ASE interface use the ASE input schema.
- Existing energy/entropy fields and units are preserved. New mode indices are zero-based; HTML displays original mode numbers starting at 1. Legacy reports remain supported.
- Standalone vibration and IR selection is unchanged. Missing calculator multiplicity still warns and assumes a singlet; automatic ground-state spin inference remains outside this change.
- Ideal-gas thermochemistry expects isolated, nonperiodic molecules with unwrapped coordinates. Periodic inputs are rejected; periodic molecule reconstruction is outside this change.

## Related issues

Closes #141. Release prerequisite for #227.

## Type of change

- [x] Bug fix
- [x] Docs
- [x] Dependency / Docker update

## How was this tested?

- `ruff check .` and `git diff --check` passed.
- Core test gate at `caf189473`: `pytest tests/ -k "not tblite"` — **995 passed, 21 skipped, 2 deselected**, run locally with ASE 3.29.0, QuickJS 1.19.4, and Academy/Parsl/Globus extras.
- Thermochemistry/report regressions pass in the full suite above, including all three QuickJS JavaScript conversion cases. Ubuntu `test-extras` jobs for Python 3.11/3.12 now install the `test` extra and verify the QuickJS import before pytest; the results above are local verification, not a claim of completed CI.
- Recomputed thermochemistry from the saved methane 500 K spectrum: `n_imag=0`, `raw_imaginary_mode_count=3`, `warnings=[]`; retained mode indices and H/S/G match the saved result (absolute tolerance 1e-12).
- Controlled complex spectra cover recorded Cu4/EMT energies, duplicate energies at the selection boundary, and nontrivial mode ordering. Verify H/S/G and retained spectra against ASE, and verify exact CSV/trajectory indices. Selected imaginary modes (including all-imaginary inputs) and zero energies that produce non-finite values exercise the failure path.
- Constructor, entropy, and non-finite-result failures preserve completed output and a JSON-serializable failure response. Failure-message regressions verify that molecular spectra survive in JSON with empty selected-mode CSVs and no selected-mode trajectories, while atomic failures preserve structure and energy without claiming a vibrational spectrum.
- Thirteen schema-only regression cases cover rejection of zero/negative multiplicities, preservation of valid values, and unchanged TBLite/ORCA defaults.
- Report tests cover missing/null diagnostic metadata, absent or inconsistent mode mappings, full spectra, warnings, partial failures, current and legacy imaginary-mode policies, HTML escaping, unsupported entropy units, preservation of existing reports after validation errors, and actual conversion JavaScript executed locally with QuickJS.
- Actual successful and failed report-tool outputs exercise both routing functions, verifying completion after success and retry after failure.
- Prompt regression tests verify that schema-default guidance and planner delegation survive removal of human-routing instructions, including the legacy planner-prompt alias.
- Molecular rerun tests verify preservation of prior artifacts during displacement failures, prior trajectories during mode-write failures, and prior IR artifacts during IR-calculation failures.
- Single-atom IR skips dipole validation because no vibrational modes are calculated; molecular IR still requires a dipole-capable calculator. Both behaviors are covered by the passing suite.
- Both Dockerfiles passed shell and embedded-Python syntax checks after rebasing onto main. The final validation block pins ASE 3.29.0 and preserves main's NWChem/TBLite/graph-longrange checks and `python -m pip check`. **Docker image builds were not run because the local Docker daemon is unavailable.**

## Checklist

- [x] Targets main; no direct or force push to main
- [x] Ruff and the core test gate pass
- [x] Added hermetic scientific and result-preservation regressions
- [x] Updated schema descriptions, calculator documentation, and Docker documentation
