### PR TITLE
fix: preserve MACE inputs and complete source archive tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,29 @@ jobs:
         chemgraph --help
         python -m pip check
 
+    - name: Test extracted source distribution
+      run: |
+        sdist_root="$RUNNER_TEMP/chemgraph-sdist"
+        mkdir -p "$sdist_root"
+        tar -xzf dist/chemgraph-*.tar.gz -C "$sdist_root" --strip-components=1
+        cd "$sdist_root"
+        export PYTHONPATH="$sdist_root/src"
+        export PYTHONNOUSERSITE=1
+        python - <<'PY'
+        from pathlib import Path
+        import chemgraph
+        import ui
+        source = Path("src").resolve()
+        for package in (chemgraph, ui):
+            assert Path(package.__file__).resolve().is_relative_to(source)
+        PY
+        python -m pytest -q \
+          tests/test_package_metadata.py \
+          tests/test_mace_defaults.py \
+          tests/test_ase_failures.py \
+          tests/test_mcp.py::test_run_ase_energy_simple \
+          tests/test_mcp.py::test_run_ase_thermo_simple
+
   # Exercises the distributed/HPC feature set: the Academy multi-agent module
   # and the parsl / globus-compute execution backends. These tests use mocks and
   # local subprocesses (no real HPC cluster, Globus endpoint, or LLM), so they

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include requirements/mace-polar.txt
 include requirements/ocsr-models.txt
 include config.toml environment.yml Dockerfile Dockerfile.arm
 include scripts/check_distribution_metadata.py
+include tests/water.xyz
+include tests/conftest.py

--- a/docs/calculators.md
+++ b/docs/calculators.md
@@ -49,6 +49,11 @@ ChemGraph uses MACE-Polar (`mace_polar`, `polar-1-m`) if the `graph-longrange`
 add-on is installed; otherwise it uses MACE-MP (`mace_mp`, reported as
 `medium-mpa-0`). Explicit calculator selections are preserved.
 
+When a MACE configuration omits `calculator_type` but supplies nonzero `charge`,
+`multiplicity` other than 1, or a nonzero `external_field`, ChemGraph selects
+Polar so those inputs reach the calculator. If the Polar add-on is missing, the
+calculation returns installation guidance before loading weights.
+
 Starting with v0.7.0, install Polar from the root of the matching source checkout
 or extracted source distribution (the directory containing `pyproject.toml`):
 

--- a/scripts/check_distribution_metadata.py
+++ b/scripts/check_distribution_metadata.py
@@ -10,7 +10,7 @@ from packaging.requirements import Requirement
 
 
 def check_distribution(path: Path) -> None:
-    """Check built metadata, including extras, and the sdist add-on files."""
+    """Check built metadata, including extras, and sdist support files."""
     if path.suffix == ".whl":
         with zipfile.ZipFile(path) as archive:
             names = [n for n in archive.namelist() if n.endswith(".dist-info/METADATA")]
@@ -24,9 +24,12 @@ def check_distribution(path: Path) -> None:
             if len(roots) != 1:
                 raise ValueError(f"{path}: expected exactly one root PKG-INFO file")
             root = roots[0].split("/")[0]
-            for filename in ("mace-polar.txt", "ocsr-models.txt"):
-                if f"{root}/requirements/{filename}" not in names:
-                    raise ValueError(f"{path}: missing requirements/{filename}")
+            for filename in (
+                "requirements/mace-polar.txt", "requirements/ocsr-models.txt",
+                "tests/water.xyz", "tests/conftest.py",
+            ):
+                if f"{root}/{filename}" not in names:
+                    raise ValueError(f"{path}: missing {filename}")
             with archive.extractfile(roots[0]) as source:
                 metadata = source.read()
     else:

--- a/src/chemgraph/schemas/calculators/mace_calc.py
+++ b/src/chemgraph/schemas/calculators/mace_calc.py
@@ -8,8 +8,8 @@ import tempfile
 import threading
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal, Optional, Union
-from pydantic import BaseModel, Field
+from typing import Literal, Optional, Self, Union
+from pydantic import BaseModel, Field, model_validator
 import torch
 
 from chemgraph.utils import calculator_defaults
@@ -125,6 +125,8 @@ class MaceCalc(BaseModel):
     calculator_type : str, optional
         Type of calculator to use: 'mace_polar', 'mace_mp', 'mace_off', or
         'mace_anicc'. Defaults to Polar when its add-on is installed, else MACE-MP.
+        Non-default charge, multiplicity, or external field requires Polar when
+        the calculator type is omitted.
     model : str or Path, optional
         Name or path to the model file. If None, uses default model for selected calculator type.
     device : str, optional
@@ -156,7 +158,9 @@ class MaceCalc(BaseModel):
         default_factory=get_default_mace_calculator_type,
         json_schema_extra=_calculator_type_schema,
         description="Type of calculator. Defaults to 'mace_polar' when the "
-        "graph-longrange add-on is installed, otherwise 'mace_mp'. Other options "
+        "graph-longrange add-on is installed, otherwise 'mace_mp'. When the type "
+        "is omitted, nonzero charge, multiplicity other than 1, or a nonzero "
+        "external field requires 'mace_polar'. Other options "
         "are 'mace_off' and 'mace_anicc'. MACE-Polar supports "
         "energies, forces, and molecular dipole moments.",
     )
@@ -207,6 +211,17 @@ class MaceCalc(BaseModel):
         default=21.167088422553647,  # Equivalent to 40.0 * units.Bohr,
         description="Cutoff radius in Bohr for D3 dispersion corrections (only for 'mace_mp').",
     )
+
+    @model_validator(mode="after")
+    def _preserve_physical_inputs(self) -> Self:
+        requires_polar = (
+            self.charge != 0
+            or self.multiplicity != 1
+            or any(self.external_field)
+        )
+        if "calculator_type" not in self.model_fields_set and requires_polar:
+            self.calculator_type = "mace_polar"
+        return self
 
     def get_model_name_for_output(self) -> Optional[Union[str, Path]]:
         """Return the model identifier to record in simulation output.

--- a/tests/test_ase_failures.py
+++ b/tests/test_ase_failures.py
@@ -31,13 +31,18 @@ def params(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("entrypoint", ["core", "langchain", "mcp"])
-async def test_missing_polar_returns_install_guidance(params, monkeypatch, tmp_path, entrypoint):
+@pytest.mark.parametrize("inputs", [
+    {"calculator_type": "mace_polar"}, {"charge": 1},
+    {"multiplicity": 2}, {"external_field": (0.1, 0, 0)},
+])
+async def test_missing_polar_returns_install_guidance(params, monkeypatch, tmp_path, entrypoint, inputs):
     import mace.calculators
 
     monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: False)
     loader = Mock(side_effect=AssertionError("must not download model weights"))
     monkeypatch.setattr(mace.calculators, "mace_polar", loader)
-    params.calculator = MaceCalc(calculator_type="mace_polar")
+    monkeypatch.setattr(mace.calculators, "mace_mp", loader)
+    params.calculator = MaceCalc(**inputs)
     if entrypoint == "core":
         result = ase_core.run_ase_core(params)
     elif entrypoint == "langchain":
@@ -51,6 +56,22 @@ async def test_missing_polar_returns_install_guidance(params, monkeypatch, tmp_p
     assert "requirements/mace-polar.txt" in result["message"]
     loader.assert_not_called()
     assert not (tmp_path / "result.json").exists()
+
+
+def test_inferred_polar_forwards_and_records_physical_inputs(params, monkeypatch, tmp_path):
+    engine = EMT()
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: True)
+    monkeypatch.setattr(MaceCalc, "get_calculator", lambda self: engine)
+    params.calculator = MaceCalc(charge=1, multiplicity=2, external_field=(0.1, 0, 0))
+    result = ase_core.run_ase_core(params)
+    assert result["status"] == "success", result
+    assert engine.atoms.info == {"charge": 1, "spin": 2, "external_field": [0.1, 0, 0]}
+    recorded = json.loads((tmp_path / "result.json").read_text())["simulation_input"]["calculator"]
+    assert recorded["calculator_type"] == "mace_polar"
+    assert recorded["model"] == "polar-1-m"
+    assert recorded["charge"] == 1
+    assert recorded["multiplicity"] == 2
+    assert recorded["external_field"] == [0.1, 0, 0]
 
 
 @pytest.mark.parametrize("driver", ["dipole", "ir"])

--- a/tests/test_mace_defaults.py
+++ b/tests/test_mace_defaults.py
@@ -73,7 +73,10 @@ def test_explicit_mace_selection_and_ui_configuration_are_preserved(monkeypatch,
     monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: polar)
     assert mace_calc.MaceCalc().calculator_type == ("mace_polar" if polar else "mace_mp")
     for variant in ("mace_polar", "mace_mp", "mace_off", "mace_anicc"):
-        calc = mace_calc.MaceCalc(calculator_type=variant, model="/models/custom.model")
+        calc = mace_calc.MaceCalc(
+            calculator_type=variant, model="/models/custom.model",
+            charge=1, multiplicity=2, external_field=(0.1, 0, 0),
+        )
         assert calc.calculator_type == variant
         assert calc.get_model_name_for_output() == "/models/custom.model"
     config = tmp_path / "explicit.toml"
@@ -155,3 +158,32 @@ assert resolve_default_calculator(get_default_config()) in {"mace_mp", "mace_pol
 assert "torch" not in sys.modules
 '''
     subprocess.run([sys.executable, "-c", source, str(path)], check=True, capture_output=True)
+
+
+@pytest.mark.parametrize("polar", [False, True])
+@pytest.mark.parametrize("inputs", [
+    {"charge": 1}, {"charge": -1}, {"multiplicity": 2},
+    {"external_field": (0, 0.1, 0)},
+    {"charge": "1"}, {"multiplicity": "2"},
+    {"external_field": ["0", "0", "-0.1"]},
+])
+def test_automatic_selection_preserves_physical_inputs(monkeypatch, polar, inputs):
+    from chemgraph.schemas.ase_input import ASEInputSchema
+
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: polar)
+    calc = mace_calc.MaceCalc(**inputs)
+    assert calc.calculator_type == "mace_polar"
+    assert calc.get_model_name_for_output() == "polar-1-m"
+    assert mace_calc.MaceCalc.model_validate(calc.model_dump()) == calc
+    params = ASEInputSchema(input_structure_file="water.xyz", calculator=calc, driver="energy")
+    assert ASEInputSchema.model_validate(params.model_dump()).calculator == calc
+
+
+@pytest.mark.parametrize("inputs", [
+    {},
+    {"charge": 0, "multiplicity": 1, "external_field": (0, 0, 0)},
+    {"charge": "0", "multiplicity": "1", "external_field": ["0", "0", "0"]},
+])
+def test_default_physical_inputs_allow_automatic_mp(monkeypatch, inputs):
+    monkeypatch.setattr(calculator_defaults, "mace_polar_available", lambda: False)
+    assert mace_calc.MaceCalc(**inputs).calculator_type == "mace_mp"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -152,6 +152,25 @@ def test_supplemental_dependency_pins():
         assert [line for line in lines if line and not line.startswith("#")] == pins
 
 
+def _write_test_distribution(path, requirement, missing=None):
+    metadata = f"Metadata-Version: 2.4\nRequires-Dist: {requirement}\n".encode()
+    if path.suffix == ".whl":
+        with zipfile.ZipFile(path, "w") as archive:
+            archive.writestr("chemgraph-0.6.0.dist-info/METADATA", metadata)
+    else:
+        with tarfile.open(path, "w:gz") as archive:
+            for name, data in {
+                "PKG-INFO": metadata, "requirements/mace-polar.txt": b"",
+                "requirements/ocsr-models.txt": b"",
+                "tests/water.xyz": b"", "tests/conftest.py": b"",
+            }.items():
+                if name == missing:
+                    continue
+                member = tarfile.TarInfo(f"chemgraph-0.6.0/{name}")
+                member.size = len(data)
+                archive.addfile(member, io.BytesIO(data))
+
+
 @pytest.mark.parametrize("kind", ["whl", "tar.gz"])
 @pytest.mark.parametrize("requirement", [
     "numpy>=2", "engine @ https://example.org/engine.whl",
@@ -162,21 +181,23 @@ def test_built_metadata_rejects_urls_including_extras(tmp_path, kind, requiremen
         "check_distribution"
     ]
     path = tmp_path / f"chemgraph-0.6.0.{kind}"
-    metadata = f"Metadata-Version: 2.4\nRequires-Dist: {requirement}\n".encode()
-    if kind == "whl":
-        with zipfile.ZipFile(path, "w") as archive:
-            archive.writestr("chemgraph-0.6.0.dist-info/METADATA", metadata)
-    else:
-        with tarfile.open(path, "w:gz") as archive:
-            for name, data in {
-                "PKG-INFO": metadata, "requirements/mace-polar.txt": b"",
-                "requirements/ocsr-models.txt": b"",
-            }.items():
-                member = tarfile.TarInfo(f"chemgraph-0.6.0/{name}")
-                member.size = len(data)
-                archive.addfile(member, io.BytesIO(data))
+    _write_test_distribution(path, requirement)
     if Requirement(requirement).url:
         with pytest.raises(ValueError, match="direct-URL dependency"):
             check(path)
     else:
+        check(path)
+
+
+@pytest.mark.parametrize("missing", [
+    "requirements/mace-polar.txt", "requirements/ocsr-models.txt",
+    "tests/water.xyz", "tests/conftest.py",
+])
+def test_sdist_requires_support_files(tmp_path, missing):
+    check = runpy.run_path(str(_REPO_ROOT / "scripts/check_distribution_metadata.py"))[
+        "check_distribution"
+    ]
+    path = tmp_path / "chemgraph-0.6.0.tar.gz"
+    _write_test_distribution(path, "numpy>=2", missing=missing)
+    with pytest.raises(ValueError, match=f"missing {re.escape(missing)}"):
         check(path)


### PR DESCRIPTION
## Summary

- Preserve physical inputs when selecting a MACE calculator automatically. For example, without the Polar add-on, `MaceCalc(charge=1)` now selects Polar and reports installation guidance before loading weights, instead of running MACE-MP with the charge ignored. Explicit calculator selections retain their existing behavior.
- Include `tests/water.xyz` and `tests/conftest.py` in the source archive. Check their presence in distribution validation and run the packaged regression tests from an extracted archive in the Python 3.11–3.13 CI matrix.

## Related issues

Follow-up to #231.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs
- [x] Chore / refactor / CI

## How was this tested?

- `ruff check .`: passed.
- `pytest tests/ -k "not tblite"`: 880 passed, 21 skipped, 2 deselected, using the existing environment with Academy and execution-backend extras.
- Fresh wheel/sdist builds, distribution metadata checks, and `twine check`: passed.
- Executed the new CI archive-test step locally against the freshly built sdist: 73 passed, including both MCP energy/thermochemistry tests. Verified imports resolve inside the extracted source directory.
- Regression coverage includes independent charge/spin/field inputs, parsed values, serialization, preserved explicit choices, installation failures across all three tool entrypoints, and metadata forwarding through a stub calculator. No model downloads or live-service tests were used.

## Checklist

- [x] Branched off the latest `main` and targets `main`
- [x] PR is focused on the two remaining default-selection and packaging fixes from #231
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added/updated tests for the change
- [x] Updated calculator documentation
