### PR TITLE
Add React chemistry UI with shared institutional LLM support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,11 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+frontend/node_modules/
+frontend/dist/
+frontend/test-results/
+web_data/
+.cg*/
 .venv/
 venv/
 env/

--- a/.github/workflows/dependency_tests.yml
+++ b/.github/workflows/dependency_tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        install_extras: [core, calculators, uma, ui, parsl, xanes, rag]
+        install_extras: [core, calculators, uma, ui, web, parsl, xanes, rag]
 
     steps:
     - uses: actions/checkout@v4
@@ -83,6 +83,7 @@ jobs:
             'calculators': ['tblite'],
             'uma': ['fairchem.core', 'e3nn'],
             'ui': ['streamlit', 'py3Dmol', 'plotly'],
+            'web': ['fastapi', 'uvicorn', 'chemgraph.api.app'],
             'parsl': ['parsl'],
             'xanes': ['parsl'],
             'rag': [

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   web:
     runs-on: ubuntu-latest

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -1,0 +1,57 @@
+name: React UI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install web dependencies
+        run: |
+          python -m pip install -e '.[web]' ruff
+          npm ci --prefix frontend
+          cd frontend
+          npx playwright install --with-deps chromium
+      - name: Validate API and frontend
+        run: |
+          ruff check .
+          pytest tests/test_web_foundation.py tests/test_web_api.py tests/test_web_worker.py -q
+          npm test --prefix frontend
+          npm run build --prefix frontend
+          docker compose -f compose.web.yml config --quiet
+      - name: Exercise the browser workflow
+        env:
+          CHEMGRAPH_WEB_DEV_USER: ci-demo
+          CHEMGRAPH_WEB_DEMO: 'true'
+          CHEMGRAPH_WEB_DATA_DIR: /tmp/chemgraph-web-ci
+        run: |
+          python -m chemgraph.api > /tmp/chemgraph-api.log 2>&1 &
+          api_pid=$!
+          npm run dev --prefix frontend > /tmp/chemgraph-frontend.log 2>&1 &
+          frontend_pid=$!
+          trap 'kill "$api_pid" "$frontend_pid" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 60); do
+            if curl -fsS http://localhost:8000/healthz && curl -fsS http://localhost:8080/ > /dev/null; then break; fi
+            sleep 1
+          done
+          npm run test:e2e --prefix frontend
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: web-ui-failure-details
+          path: |
+            frontend/test-results/
+            /tmp/chemgraph-api.log
+            /tmp/chemgraph-frontend.log

--- a/.github/workflows/web-ui.yml
+++ b/.github/workflows/web-ui.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Validate API and frontend
         run: |
           ruff check .
-          pytest tests/test_web_foundation.py tests/test_web_api.py tests/test_web_worker.py -q
+          pytest tests/test_web_*.py -q
           npm test --prefix frontend
           npm run build --prefix frontend
           docker compose -f compose.web.yml config --quiet
+          docker compose -f compose.web.test.yml config --quiet
+          kubectl kustomize k8s/web > /tmp/chemgraph-web-manifests.yaml
       - name: Exercise the browser workflow
         env:
           CHEMGRAPH_WEB_DEV_USER: ci-demo
@@ -42,14 +44,47 @@ jobs:
         run: |
           python -m chemgraph.api > /tmp/chemgraph-api.log 2>&1 &
           api_pid=$!
-          npm run dev --prefix frontend > /tmp/chemgraph-frontend.log 2>&1 &
+          node frontend/node_modules/vite/bin/vite.js frontend --host 127.0.0.1 > /tmp/chemgraph-frontend.log 2>&1 &
           frontend_pid=$!
-          trap 'kill "$api_pid" "$frontend_pid" 2>/dev/null || true' EXIT
+          trap 'kill "$api_pid" "$frontend_pid" 2>/dev/null || true; wait "$api_pid" "$frontend_pid" 2>/dev/null || true' EXIT
           for _ in $(seq 1 60); do
             if curl -fsS http://localhost:8000/healthz && curl -fsS http://localhost:8080/ > /dev/null; then break; fi
             sleep 1
           done
           npm run test:e2e --prefix frontend
+      - name: Exercise real graphs in the development frontend
+        env:
+          CHEMGRAPH_WEB_DEV_USER: ci-test
+          CHEMGRAPH_WEB_DEMO: 'false'
+          CHEMGRAPH_WEB_DATA_DIR: /tmp/chemgraph-web-real-ci
+          CHEMGRAPH_WEB_PROVIDERS: '{"Lab":{"model":"test-model","base_url":"http://127.0.0.1:9999/v1"},"Unavailable":{"model":"test-model","base_url":"http://127.0.0.1:9999/v1","api_key_env":"CHEMGRAPH_TEST_MISSING"},"Auth failure":{"model":"fail-401","base_url":"http://127.0.0.1:9999/v1"}}'
+          WEB_TEST_REAL: 'true'
+        run: |
+          python tests/web_model_server.py > /tmp/chemgraph-model.log 2>&1 &
+          model_pid=$!
+          python -m chemgraph.api > /tmp/chemgraph-api.log 2>&1 &
+          api_pid=$!
+          node frontend/node_modules/vite/bin/vite.js frontend --host 127.0.0.1 > /tmp/chemgraph-frontend.log 2>&1 &
+          frontend_pid=$!
+          trap 'kill "$api_pid" "$frontend_pid" "$model_pid" 2>/dev/null || true; wait "$api_pid" "$frontend_pid" "$model_pid" 2>/dev/null || true' EXIT
+          for _ in $(seq 1 60); do
+            if curl -fsS http://localhost:8000/healthz && curl -fsS http://localhost:8080/ > /dev/null; then break; fi
+            sleep 1
+          done
+          npm run test:e2e --prefix frontend
+      - name: Exercise real graphs through the built proxy
+        env:
+          WEB_TEST_REAL: 'true'
+          WEB_TEST_URL: http://localhost:8082
+        run: |
+          docker compose -p chemgraph-web-test -f compose.web.test.yml build
+          docker compose -p chemgraph-web-test -f compose.web.test.yml up -d --wait
+          npm run test:e2e --prefix frontend
+      - name: Collect container logs and stop the test deployment
+        if: always()
+        run: |
+          docker compose -p chemgraph-web-test -f compose.web.test.yml logs --no-color > /tmp/chemgraph-web-containers.log
+          docker compose -p chemgraph-web-test -f compose.web.test.yml down --volumes
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
@@ -58,3 +93,5 @@ jobs:
             frontend/test-results/
             /tmp/chemgraph-api.log
             /tmp/chemgraph-frontend.log
+            /tmp/chemgraph-model.log
+            /tmp/chemgraph-web-containers.log

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ test_outputs/
 *ir/
 
 .venv
+web_data/
+frontend/node_modules/
+frontend/test-results/
+frontend/playwright-report/
+frontend/*.tsbuildinfo
 combine*
 
 # OpenCode (user-local config; copy from opencode.example.jsonc)

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,21 @@
+# Reuse the maintained chemistry runtime. Override with an immutable digest for rollout.
+ARG CHEMGRAPH_BASE_IMAGE=ghcr.io/argonne-lcf/chemgraph:latest
+FROM ${CHEMGRAPH_BASE_IMAGE}
+
+USER root
+WORKDIR /app
+COPY pyproject.toml README.md LICENSE /app/
+COPY src /app/src
+# Older images contain the superseded package and an unused Python browser
+# renderer whose websocket pin conflicts with current model-provider clients.
+RUN python -m pip uninstall -y chemgraphagent chemgraph pyppeteer && \
+    python -m pip install --no-cache-dir '.[web]' && \
+    python -m pip check && \
+    useradd --create-home --uid 10001 chemgraph-web && \
+    mkdir -p /data && chown chemgraph-web:chemgraph-web /data
+USER 10001:10001
+ENV CHEMGRAPH_WEB_DATA_DIR=/data PYTHONUNBUFFERED=1
+EXPOSE 8000
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=3)"
+CMD ["python", "-m", "chemgraph.api", "--host", "0.0.0.0", "--port", "8000"]

--- a/compose.web.test.yml
+++ b/compose.web.test.yml
@@ -1,0 +1,37 @@
+# Isolated integration deployment. Never use this development identity in production.
+services:
+  model:
+    image: chemgraph-web-api:test
+    command: ["python", "/test/web_model_server.py", "--host", "0.0.0.0"]
+    volumes: ["./tests/web_model_server.py:/test/web_model_server.py:ro"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9999/healthz')"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+  web-api:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    image: chemgraph-web-api:test
+    init: true
+    environment:
+      CHEMGRAPH_WEB_DEV_USER: integration-test
+      CHEMGRAPH_WEB_DEMO: "false"
+      CHEMGRAPH_WEB_PUBLIC_ORIGIN: http://localhost:${CHEMGRAPH_TEST_PORT:-8082}
+      CHEMGRAPH_WEB_PROVIDERS_FILE: /etc/chemgraph/providers.toml
+    volumes:
+      - test-data:/data
+      - ./tests/web-providers.test.toml:/etc/chemgraph/providers.toml:ro
+    depends_on:
+      model:
+        condition: service_healthy
+  web:
+    build: ./frontend
+    image: chemgraph-web:test
+    ports: ["127.0.0.1:${CHEMGRAPH_TEST_PORT:-8082}:8080"]
+    depends_on:
+      web-api:
+        condition: service_healthy
+volumes:
+  test-data:

--- a/compose.web.yml
+++ b/compose.web.yml
@@ -13,7 +13,8 @@ services:
       CHEMGRAPH_WEB_PUBLIC_ORIGIN: ${CHEMGRAPH_WEB_PUBLIC_ORIGIN:-http://localhost:8080}
       CHEMGRAPH_WEB_DEV_USER: ${CHEMGRAPH_WEB_DEV_USER:-}
       CHEMGRAPH_WEB_DEMO: ${CHEMGRAPH_WEB_DEMO:-false}
-      CHEMGRAPH_WEB_PROVIDERS: ${CHEMGRAPH_WEB_PROVIDERS:-{}}
+      CHEMGRAPH_WEB_PROVIDERS:
+      CHEMGRAPH_WEB_PROVIDERS_FILE: /etc/chemgraph/providers.toml
       CHEMGRAPH_WEB_CALCULATORS: ${CHEMGRAPH_WEB_CALCULATORS:-["emt"]}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
@@ -22,9 +23,24 @@ services:
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       ARGO_USER: ${ARGO_USER:-}
       ALCF_ACCESS_TOKEN: ${ALCF_ACCESS_TOKEN:-}
+      VLLM_API_KEY: ${VLLM_API_KEY:-}
+      CHEMGRAPH_WEB_MAX_WORKERS: ${CHEMGRAPH_WEB_MAX_WORKERS:-2}
+      CHEMGRAPH_WEB_MAX_QUEUED: ${CHEMGRAPH_WEB_MAX_QUEUED:-20}
+      CHEMGRAPH_WEB_MAX_USER_RUNS: ${CHEMGRAPH_WEB_MAX_USER_RUNS:-2}
+      CHEMGRAPH_WEB_RUN_TIMEOUT: ${CHEMGRAPH_WEB_RUN_TIMEOUT:-3600}
+      CHEMGRAPH_WEB_CLARIFICATION_TIMEOUT: ${CHEMGRAPH_WEB_CLARIFICATION_TIMEOUT:-900}
+      CHEMGRAPH_WEB_PROVIDER_TIMEOUT: ${CHEMGRAPH_WEB_PROVIDER_TIMEOUT:-120}
+      CHEMGRAPH_WEB_USER_STORAGE_LIMIT: ${CHEMGRAPH_WEB_USER_STORAGE_LIMIT:-1073741824}
+      CHEMGRAPH_WEB_RETENTION_DAYS: ${CHEMGRAPH_WEB_RETENTION_DAYS:-30}
     volumes:
       - web-data:/data
       - web-model-cache:/home/chemgraph-web/.cache
+      - type: bind
+        source: ${CHEMGRAPH_WEB_PROVIDERS_HOST_FILE:-./web-providers.example.toml}
+        target: /etc/chemgraph/providers.toml
+        read_only: true
+        bind:
+          create_host_path: false
     security_opt: ["no-new-privileges:true"]
     cap_drop: ["ALL"]
     stop_grace_period: 15s

--- a/compose.web.yml
+++ b/compose.web.yml
@@ -1,0 +1,42 @@
+# Local-only pilot. For a shared service, set DEV_USER empty and place the
+# frontend behind the institution's authenticating gateway (see docs).
+services:
+  web-api:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+      args:
+        CHEMGRAPH_BASE_IMAGE: ${CHEMGRAPH_BASE_IMAGE:-ghcr.io/argonne-lcf/chemgraph:latest}
+    image: chemgraph-web-api:local
+    init: true
+    environment:
+      CHEMGRAPH_WEB_PUBLIC_ORIGIN: ${CHEMGRAPH_WEB_PUBLIC_ORIGIN:-http://localhost:8080}
+      CHEMGRAPH_WEB_DEV_USER: ${CHEMGRAPH_WEB_DEV_USER:-}
+      CHEMGRAPH_WEB_DEMO: ${CHEMGRAPH_WEB_DEMO:-false}
+      CHEMGRAPH_WEB_PROVIDERS: ${CHEMGRAPH_WEB_PROVIDERS:-{}}
+      CHEMGRAPH_WEB_CALCULATORS: ${CHEMGRAPH_WEB_CALCULATORS:-["emt"]}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      ARGO_USER: ${ARGO_USER:-}
+      ALCF_ACCESS_TOKEN: ${ALCF_ACCESS_TOKEN:-}
+    volumes:
+      - web-data:/data
+      - web-model-cache:/home/chemgraph-web/.cache
+    security_opt: ["no-new-privileges:true"]
+    cap_drop: ["ALL"]
+    stop_grace_period: 15s
+    restart: unless-stopped
+  web:
+    build: ./frontend
+    image: chemgraph-web:local
+    ports: ["127.0.0.1:8080:8080"]
+    depends_on:
+      web-api:
+        condition: service_healthy
+    restart: unless-stopped
+volumes:
+  web-data:
+  web-model-cache:

--- a/docs/react_web_interface.md
+++ b/docs/react_web_interface.md
@@ -1,0 +1,188 @@
+# React interface (internal pilot)
+
+ChemGraph's React interface runs as a separate frontend and Python API. It
+provides chat, administrator-approved model selection, single-/multi-agent
+workflows, structure/data attachments, live tool progress, follow-up questions,
+saved conversations, 3D structures, trajectory playback, and artifact downloads.
+The existing Streamlit interface and `chemgraph ui` command remain available.
+
+## Run a local demo with Docker Compose
+
+From a source checkout:
+
+```bash
+CHEMGRAPH_WEB_DEV_USER=local-demo CHEMGRAPH_WEB_DEMO=true \
+  docker compose -f compose.web.yml up --build -d
+```
+
+Open <http://localhost:8080>. The demo runs a real, small copper-dimer EMT
+optimization without model credentials. Include `confirm` in a message to
+exercise a follow-up question. Demo execution always uses this fixed example;
+it does not interpret the requested chemistry or simulate uploaded structures.
+
+The frontend is bound to loopback. The API has no published host port. Data is
+stored in the `web-data` named volume; stopping/recreating the containers keeps
+it. `docker compose -f compose.web.yml down` stops the deployment without
+deleting its volumes. Do not use `down --volumes` to preserve conversations.
+
+The API image extends the maintained ChemGraph runtime and installs the current
+checkout. Set `CHEMGRAPH_BASE_IMAGE` to an approved immutable image digest for
+your deployment; the base must provide this checkout's core Python dependencies.
+The frontend image contains static assets and Nginx, with no Python runtime.
+
+## Develop without Docker
+
+The API runtime supports Linux and macOS. Production packaging targets Linux.
+Use Python 3.11+ and Node.js 22.12+:
+
+```bash
+python -m pip install -e '.[web]'
+CHEMGRAPH_WEB_DEV_USER=local-demo CHEMGRAPH_WEB_DEMO=true \
+  python -m chemgraph.api
+```
+
+In a second terminal:
+
+```bash
+cd frontend
+npm ci
+npm run dev
+```
+
+Open <http://localhost:8080>; Vite proxies `/api/` to port 8000. Keep the browser
+origin consistent with `CHEMGRAPH_WEB_PUBLIC_ORIGIN` (default
+`http://localhost:8080`), including hostname and port. For example, opening
+`127.0.0.1` instead requires setting that origin on the API.
+
+## Connect approved models
+
+Administrators set `CHEMGRAPH_WEB_PROVIDERS` to a JSON object whose keys are the
+model labels shown to users. A definition accepts `model`, optional `base_url`,
+optional `api_key_env`, and optional `argo_user`. Keys and endpoint definitions
+stay on the server. Example non-secret configuration:
+
+```json
+{
+  "OpenAI · GPT-4o mini": {
+    "model": "gpt-4o-mini",
+    "api_key_env": "OPENAI_API_KEY"
+  },
+  "Lab endpoint": {
+    "model": "lab-model",
+    "base_url": "https://inference.example.org/v1",
+    "api_key_env": "LAB_MODEL_API_KEY"
+  }
+}
+```
+
+Supply the referenced environment variables through your secret manager. Add
+custom credential variables to the Compose/Kubernetes API environment as needed.
+Disable `CHEMGRAPH_WEB_DEMO` to use approved providers. A missing explicitly
+configured credential produces a service-unavailable error before queueing work.
+Each conversation keeps the model/workflow chosen at creation; start a new
+conversation to change them. Removing a model disables new runs in its old
+conversations while retaining their history.
+
+## Deploy behind institutional SSO
+
+For a shared service, **unset `CHEMGRAPH_WEB_DEV_USER` and disable demo mode**.
+The development user bypasses gateway authentication and is for private local
+testing only. Route both `/` and `/api/` through the same authenticated origin.
+
+The gateway must remove any client-supplied `X-Auth-Request-User` header and
+insert the verified, stable user identifier after login. If your gateway uses
+a different header, configure `CHEMGRAPH_WEB_IDENTITY_HEADER`. Use a stable
+subject identifier; changing the identity makes its existing conversations
+unavailable to that user. The API hashes it for ownership checks.
+
+Set `CHEMGRAPH_WEB_PUBLIC_ORIGIN` to the exact HTTPS origin. API mutations require
+that `Origin` header; browser `fetch` supplies it. Scripts must include it too.
+Restrict network access to the frontend to the gateway and API access to the
+frontend. Header-based identity is valid only within this trusted boundary.
+The supplied Nginx proxy disables buffering for SSE and does not execute HTML
+reports in the application origin; artifact downloads use attachment responses.
+
+For Kubernetes, customize the templates in `k8s/web/` before applying:
+
+1. Build/tag/push the two images into your registry and set their image digests.
+2. Set the hostname, public origin, TLS secret, provider definitions, and
+   credential secret references.
+3. Replace the ingress external-auth URLs and configure the authenticated
+   identity header. Match the gateway namespace in the frontend NetworkPolicy.
+4. Choose a persistent volume/storage class with reliable POSIX file locking
+   for SQLite (a block-backed volume rather than an NFS share). Verify that the
+   cluster network plugin enforces the supplied NetworkPolicies.
+5. Inspect `kubectl kustomize k8s/web`, then apply it in your pilot namespace:
+
+```bash
+kubectl apply -k k8s/web -n YOUR_NAMESPACE
+```
+
+The API uses **one replica and one Uvicorn process**, with a `Recreate` rollout
+strategy. An exclusive lock prevents two API processes from sharing its data
+directory. Its `/healthz` probe checks storage and scheduler health. The static
+frontend is independently deployable. Existing Streamlit/MCP deployments are
+not changed by these manifests.
+
+## Execution, storage, and limits
+
+The API stores HTTP resources and replayable events in `web.db`. A separate
+`SessionStore` database retains each conversation's agent context. Files live
+under session/run directories. These stores are separate from Streamlit's
+existing sessions; automatic import is not part of the pilot.
+
+Workers run in separate processes to isolate environment variables and avoid
+blocking HTTP requests. The web tool set excludes Python/shell execution,
+arbitrary model-file loading, and arbitrary filesystem paths. Tool reads stay
+inside their conversation; new outputs stay inside the current run. The pilot
+allows EMT by default. `CHEMGRAPH_WEB_CALCULATORS` can enable `mace_mp`,
+`mace_off`, or `mace_polar` (JSON array); provision those foundation models and
+their dependencies on the server. Only their default model selections are
+exposed. This remains an internal pilot, not a sandbox for untrusted code.
+
+| Setting | Default | Meaning |
+| --- | --- | --- |
+| `CHEMGRAPH_WEB_DATA_DIR` | `web_data` (`/data` in Docker) | Persistent data root |
+| `CHEMGRAPH_WEB_MAX_WORKERS` | `2` | Maximum simultaneous worker processes |
+| `CHEMGRAPH_WEB_RUN_TIMEOUT` | `3600` | Seconds per worker, including time waiting for human input |
+| `CHEMGRAPH_WEB_UPLOAD_LIMIT` | `26214400` | Maximum bytes per attachment; align proxy limits if changed |
+
+Only one unfinished run is allowed in each conversation. Other conversations
+queue while workers are occupied. Each message accepts up to ten XYZ, PDB, CIF,
+TRAJ, JSON, CSV, or TXT attachments. Structure previews are limited to 500 frames,
+20,000 atoms/frame, and 25 MiB of XYZ; larger artifacts can still be downloaded.
+
+Refreshing or closing a browser does not stop work. Reopening its conversation
+reconnects to status and events without resubmitting the calculation. A backend
+restart retains finished history and files but marks unfinished/paused runs as
+interrupted. Retrying is explicit and starts a new run. Completed conversations
+continue with the existing stored-context summary mechanism, not restoration
+of a prior live graph checkpoint. Save/back up the data volume between upgrades.
+
+## HTTP interface and tests
+
+The authenticated API schema is at `/api/v1/openapi.json`. Endpoints cover
+capabilities, sessions, binary uploads, run submission/status, human responses,
+SSE events, and artifacts. Submissions include a UUID `request_id` for retry
+deduplication. Human responses reference the pending `question_id`. Artifact IDs
+are opaque; the API never accepts a server path as a download target. SSE
+supports `Last-Event-ID` and `after` replay cursors. This release streams tool and
+workflow progress rather than individual model tokens.
+
+```bash
+ruff check .
+pytest tests/ -k 'not tblite'
+cd frontend
+npm test
+npm run build
+```
+
+With the local demo running, `npm run test:e2e` tests attachments, follow-up
+questions, refresh/reconnect, artifact downloads, WebGL structure rendering,
+trajectory controls, and mobile panels. Install the Playwright Chromium runtime
+for CI, or set `WEB_TEST_BROWSER=chrome` to use an installed Chrome browser.
+Set `WEB_TEST_URL` when testing a different frontend origin.
+
+Personal provider login, advanced IR exploration, arbitrary Python workflows,
+durable recovery of unfinished graphs, and horizontal API scaling remain in
+future work. The pilot does not change the existing Streamlit feature set.

--- a/docs/react_web_interface.md
+++ b/docs/react_web_interface.md
@@ -1,10 +1,16 @@
-# React interface (internal pilot)
+# React interface for institutional users
 
 ChemGraph's React interface runs as a separate frontend and Python API. It
 provides chat, administrator-approved model selection, single-/multi-agent
 workflows, structure/data attachments, live tool progress, follow-up questions,
 saved conversations, 3D structures, trajectory playback, and artifact downloads.
 The existing Streamlit interface and `chemgraph ui` command remain available.
+
+The first production deployment is for internal users behind institutional SSO,
+using shared administrator-managed Argo or ALCF credentials. SSO controls data
+ownership; all users' provider calls use the configured shared account. Per-user
+provider identities and token management are future work. Hosted endpoints do
+not require another container.
 
 ## Run a local demo with Docker Compose
 
@@ -56,32 +62,68 @@ origin consistent with `CHEMGRAPH_WEB_PUBLIC_ORIGIN` (default
 
 ## Connect approved models
 
-Administrators set `CHEMGRAPH_WEB_PROVIDERS` to a JSON object whose keys are the
-model labels shown to users. A definition accepts `model`, optional `base_url`,
-optional `api_key_env`, and optional `argo_user`. Keys and endpoint definitions
-stay on the server. Example non-secret configuration:
+Copy `web-providers.example.toml` and select approved models:
 
-```json
-{
-  "OpenAI · GPT-4o mini": {
-    "model": "gpt-4o-mini",
-    "api_key_env": "OPENAI_API_KEY"
-  },
-  "Lab endpoint": {
-    "model": "lab-model",
-    "base_url": "https://inference.example.org/v1",
-    "api_key_env": "LAB_MODEL_API_KEY"
-  }
-}
+```toml
+[providers.Argo]
+model = "argo:gpt-4o"
+# Uses the shared ARGO_USER environment value.
+
+[providers.ALCF]
+model = "alcf:meta-llama/Llama-3.3-70B-Instruct"
+api_key_env = "ALCF_ACCESS_TOKEN"
 ```
 
-Supply the referenced environment variables through your secret manager. Add
-custom credential variables to the Compose/Kubernetes API environment as needed.
-Disable `CHEMGRAPH_WEB_DEMO` to use approved providers. A missing explicitly
-configured credential produces a service-unavailable error before queueing work.
-Each conversation keeps the model/workflow chosen at creation; start a new
-conversation to change them. Removing a model disables new runs in its old
-conversations while retaining their history.
+For a local Python API, set `CHEMGRAPH_WEB_PROVIDERS_FILE` to the file path. For
+Compose, set `CHEMGRAPH_WEB_PROVIDERS_HOST_FILE` to the host file path; Compose
+mounts it read-only at `/etc/chemgraph/providers.toml` and sets the API's selector.
+The example file is mounted by default. Keep demo disabled for real LLM runs.
+
+The existing `CHEMGRAPH_WEB_PROVIDERS` JSON object remains supported. When set,
+it completely replaces the file's list, without reading the file. An empty
+string is invalid; `{}` deliberately disables all models. Compose leaves this
+variable absent unless supplied. Unknown fields and literal API-key fields are
+rejected. URLs cannot contain embedded credentials, query strings, or fragments.
+
+Argo resolves `argo_user` first, then `ARGO_USER`. A real shared identity must be
+configured; the web service does not use the generic `chemgraph` identity.
+ALCF uses `api_key_env` if supplied, otherwise `ALCF_ACCESS_TOKEN`. A missing
+explicit override never falls back to another variable. Other hosted providers
+retain their provider-specific credential variables. Custom OpenAI-compatible
+routes use an explicit variable, `VLLM_API_KEY`, or a no-auth placeholder; they
+never inherit `OPENAI_API_KEY`. Subscription authentication is unavailable here.
+
+Supply credentials through deployment secrets or the API environment. Compose
+forwards `ARGO_USER`, `ALCF_ACCESS_TOKEN`, and the documented hosted-provider
+variables; add any custom `api_key_env` variable to the API service's environment
+in a local Compose override. Host environment variables are not automatically
+available inside containers. Never put credentials in frontend/Vite variables.
+
+Validate without starting workers, creating application storage, prompting, or
+contacting a provider:
+
+```bash
+python -m chemgraph.api --check-config
+# Or validate the exact container environment and mounted file:
+docker compose -f compose.web.yml run --rm --no-deps web-api python -m chemgraph.api --check-config
+```
+
+Exit codes: `0` means every configured model has its required configuration;
+`1` means missing credentials or no models; `2` means invalid configuration.
+Malformed configuration stops startup. Missing credentials leave the API and
+history available, with the affected model disabled. "Configured" does not
+mean that connectivity or credential validity has been verified.
+
+File edits and environment-based credential rotation require an API restart.
+Conversations retain a non-secret fingerprint of their model and endpoint.
+Changing either, removing a model, or disabling demo makes affected conversations
+read-only. Credential rotation does not change the fingerprint. Conversations
+created by the earlier pilot without a fingerprint also become read-only.
+Their history remains readable to their original owner. Development-user
+history is not reassigned to an SSO identity during cutover.
+Upgraded conversations receive a full retention window starting at migration,
+because the earlier schema did not record activity. Previously exposed internal
+graph-state download IDs are revoked; chemistry outputs remain available.
 
 ## Deploy behind institutional SSO
 
@@ -105,10 +147,17 @@ reports in the application origin; artifact downloads use attachment responses.
 For Kubernetes, customize the templates in `k8s/web/` before applying:
 
 1. Build/tag/push the two images into your registry and set their image digests.
-2. Set the hostname, public origin, TLS secret, provider definitions, and
-   credential secret references.
+2. Set the hostname, public origin, and TLS secret. Edit `k8s/web/providers.toml`;
+   Kustomize generates a ConfigMap and mounts it read-only. Supply the
+   `argo-user` and/or `alcf-access-token` keys in `chemgraph-secrets` for the
+   enabled providers. Missing keys leave those providers unavailable.
 3. Replace the ingress external-auth URLs and configure the authenticated
    identity header. Match the gateway namespace in the frontend NetworkPolicy.
+   Use an institution-supported controller: the included ingress-nginx
+   annotations illustrate the authentication contract, but upstream
+   [ingress-nginx was retired in March 2026](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+   and is not a new deployment default.
+   Translate those settings to the gateway supported by your institution.
 4. Choose a persistent volume/storage class with reliable POSIX file locking
    for SQLite (a block-backed volume rather than an NFS share). Verify that the
    cluster network plugin enforces the supplied NetworkPolicies.
@@ -146,28 +195,92 @@ exposed. This remains an internal pilot, not a sandbox for untrusted code.
 | `CHEMGRAPH_WEB_MAX_WORKERS` | `2` | Maximum simultaneous worker processes |
 | `CHEMGRAPH_WEB_RUN_TIMEOUT` | `3600` | Seconds per worker, including time waiting for human input |
 | `CHEMGRAPH_WEB_UPLOAD_LIMIT` | `26214400` | Maximum bytes per attachment; align proxy limits if changed |
+| `CHEMGRAPH_WEB_PROVIDER_TIMEOUT` | `120` | Timeout in seconds per provider request |
+| `CHEMGRAPH_WEB_MAX_QUEUED` | `20` | Maximum queued runs across users |
+| `CHEMGRAPH_WEB_MAX_USER_RUNS` | `2` | Maximum unfinished runs per user |
+| `CHEMGRAPH_WEB_CLARIFICATION_TIMEOUT` | `900` | Maximum seconds awaiting a clarification response |
+| `CHEMGRAPH_WEB_USER_STORAGE_LIMIT` | `1073741824` | Per-user workspace, memory, diagnostics, and transcript byte budget |
+| `CHEMGRAPH_WEB_RETENTION_DAYS` | `30` | Retention after the last write activity of inactive conversations |
+| `CHEMGRAPH_WEB_CONTEXT_LIMIT` | `16000` | Maximum characters of prior context sent on a follow-up |
 
 Only one unfinished run is allowed in each conversation. Other conversations
 queue while workers are occupied. Each message accepts up to ten XYZ, PDB, CIF,
 TRAJ, JSON, CSV, or TXT attachments. Structure previews are limited to 500 frames,
 20,000 atoms/frame, and 25 MiB of XYZ; larger artifacts can still be downloaded.
+The approved reader handles those structure and text formats; text content sent
+to the model is capped at 50,000 characters. Only one worker executes per user,
+including clarification waits. Other users can use the remaining worker slots.
+
+The UI can cancel queued, running, or waiting runs. A running cancellation stays
+in `cancelling` until the worker is stopped; then it becomes `cancelled` and
+releases capacity. Whole-run retries are never automatic. Existing SDK retries
+and graph parse/task retries remain; a request timeout can therefore consume
+more than one attempt, bounded by the worker timeout. The default graph allows
+one parse retry and multi-agent execution allows up to two task attempts.
+
+Uploads reserve space before writing. Chemistry tools check storage around their
+work and the supervisor interrupts workers that exceed the budget. This is an
+application quota, not a filesystem hard limit; a tool can briefly exceed it
+between checks. Provision filesystem/container limits and monitor total volume
+usage, including shared model caches and SQLite/WAL overhead. Hourly retention
+cleanup removes inactive conversations and their artifacts, diagnostics, and
+agent memory; active runs and in-progress uploads are excluded.
 
 Refreshing or closing a browser does not stop work. Reopening its conversation
 reconnects to status and events without resubmitting the calculation. A backend
 restart retains finished history and files but marks unfinished/paused runs as
 interrupted. Retrying is explicit and starts a new run. Completed conversations
 continue with the existing stored-context summary mechanism, not restoration
-of a prior live graph checkpoint. Save/back up the data volume between upgrades.
+of a prior live graph checkpoint. Context uses a bounded tail and the stored
+user messages do not include recursively injected summaries. Explicit retries
+retain the original attachments. Internal graph-state JSON is stored separately
+and is never registered as a chemistry download.
+
+## Release and operations
+
+Before opening access, verify the actual gateway: unauthenticated requests and
+forged identity headers cannot reach user data, two test users cannot access
+each other's sessions/downloads, direct API access is blocked, TLS is valid,
+and SSE reconnect works after browser refresh and SSO renewal. These are site
+acceptance checks; local tests cannot verify an institution's SSO configuration.
+
+Run the optional provider smoke test from the deployed API environment for
+every enabled provider before release and after endpoint or credential changes.
+Mount a copy of the test directory into a temporary container if it is not in
+the image. It performs a real, small EMT calculation through the selected LLM:
+
+```bash
+pytest tests/test_web_integration.py::test_enabled_live_providers_smoke --run-llm -q
+```
+
+Normal CI does not enable this flag. A present ALCF token can still be expired;
+rotate it through the institution's approved process and restart the API.
+There is no browser credential entry and no automatic token refresh in v1.
+Shared-account usage, attribution, and quotas should be approved by the site.
+
+Monitor `/healthz`, provider error codes and run IDs, queue age, interrupted runs,
+and storage usage. Keep provider exception logs access-restricted. For backup,
+stop the API and copy/snapshot the entire data volume, including `web.db`, its
+WAL files if present, session files, diagnostics, and memory databases. Restore
+the complete snapshot into an empty volume with the API stopped. Upgrade after
+a backup; configuration/schema changes are startup-only. Rollback restores both
+the previous image and its matching data snapshot. Restarted runs are interrupted
+and require an explicit retry; one API replica and `Recreate` rollouts remain.
 
 ## HTTP interface and tests
 
 The authenticated API schema is at `/api/v1/openapi.json`. Endpoints cover
 capabilities, sessions, binary uploads, run submission/status, human responses,
-SSE events, and artifacts. Submissions include a UUID `request_id` for retry
+SSE events, cancellation, and artifacts. Submissions include a UUID `request_id` for retry
 deduplication. Human responses reference the pending `question_id`. Artifact IDs
 are opaque; the API never accepts a server path as a download target. SSE
 supports `Last-Event-ID` and `after` replay cursors. This release streams tool and
 workflow progress rather than individual model tokens.
+`capabilities.models` remains a label list; `model_status` adds configuration
+readiness and safe reasons. Session details include readiness for that specific
+conversation. Definitive API rejections include `submission_rejected: true`;
+transport failures or unclassified proxy errors retain the same request ID for
+an uncertain submission. Cancel with `POST /api/v1/runs/{id}/cancel`.
 
 ```bash
 ruff check .
@@ -182,6 +295,21 @@ questions, refresh/reconnect, artifact downloads, WebGL structure rendering,
 trajectory controls, and mobile panels. Install the Playwright Chromium runtime
 for CI, or set `WEB_TEST_BROWSER=chrome` to use an installed Chrome browser.
 Set `WEB_TEST_URL` when testing a different frontend origin.
+
+The deterministic non-demo endpoint lives only in `tests/web_model_server.py`.
+`compose.web.test.yml` builds an isolated API, frontend, and test model endpoint;
+it mounts test configuration rather than deployment secrets:
+
+```bash
+docker compose -p chemgraph-web-test -f compose.web.test.yml up --build -d --wait
+cd frontend
+WEB_TEST_REAL=true WEB_TEST_URL=http://localhost:8082 npm run test:e2e
+```
+
+Stop this test deployment from the repository root with
+`docker compose -p chemgraph-web-test -f compose.web.test.yml down --volumes`.
+Its volumes contain only disposable test data. Browser CI runs demo mode and
+real graphs in Vite, then repeats the real workflow through the built Nginx proxy.
 
 Personal provider login, advanced IR exploration, arbitrary Python workflows,
 durable recovery of unfinished graphs, and horizontal API scaling remain in

--- a/docs/streamlit_web_interface.md
+++ b/docs/streamlit_web_interface.md
@@ -1,5 +1,9 @@
 # Streamlit interface
 
+A separately deployed [React interface](react_web_interface.md) is also
+available as an internal pilot. Streamlit continues to support the full
+configuration and visualization interface described here.
+
 The web interface provides model/workflow selection, chat, molecular
 visualization, saved sessions, and access to run artifacts.
 

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+test-results
+playwright-report
+*.tsbuildinfo

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+COPY . .
+RUN npm run build
+
+FROM nginx:1.28-alpine
+ENV API_UPSTREAM=web-api:8000
+COPY nginx.conf /etc/nginx/templates/default.conf.template
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 8080
+HEALTHCHECK --interval=15s --timeout=3s CMD wget -q -O /dev/null http://127.0.0.1:8080/healthz || exit 1

--- a/frontend/e2e/workspace.spec.ts
+++ b/frontend/e2e/workspace.spec.ts
@@ -4,6 +4,8 @@ const real = process.env.WEB_TEST_REAL === "true";
 const resultText = real
   ? "Calculation complete."
   : "Demo calculation complete.";
+// Spawned workers import the chemistry stack before producing their first event.
+const runWait = { timeout: 30000 };
 
 test("upload, clarify, reconnect, inspect a structure and replay a trajectory", async ({
   page,
@@ -31,7 +33,7 @@ test("upload, clarify, reconnect, inspect a structure and replay a trajectory", 
     .getByRole("textbox", { name: "Message", exact: true })
     .fill("Confirm optimization of the attached copper dimer");
   await page.getByRole("button", { name: "Send message" }).click();
-  await expect(page.getByText("A quick clarification")).toBeVisible();
+  await expect(page.getByText("A quick clarification")).toBeVisible(runWait);
   const sessionURL = page.url();
   await page.reload();
   await expect(page.getByText("A quick clarification")).toBeVisible();
@@ -39,7 +41,7 @@ test("upload, clarify, reconnect, inspect a structure and replay a trajectory", 
     .getByRole("textbox", { name: "Response to agent" })
     .fill("Yes, continue");
   await page.getByRole("button", { name: "Send response" }).click();
-  await expect(page.getByText(resultText, { exact: false })).toBeVisible();
+  await expect(page.getByText(resultText, { exact: false })).toBeVisible(runWait);
   await expect(page.locator(".molecule-canvas canvas")).toBeVisible();
   const selector = page.getByLabel("Structure or trajectory");
   const trajectory = await selector
@@ -91,14 +93,14 @@ test("real multi-agent results, unavailable models, and provider errors", async 
   await page.getByRole("button", { name: "Send message" }).click();
   await expect(
     page.getByText("Calculation complete.", { exact: false }),
-  ).toBeVisible();
+  ).toBeVisible(runWait);
   await page
     .getByRole("textbox", { name: "Message", exact: true })
     .fill("Follow-up: recall our work");
   await page.getByRole("button", { name: "Send message" }).click();
   await expect(
     page.getByText("Previous context retained", { exact: false }),
-  ).toBeVisible();
+  ).toBeVisible(runWait);
   await page.getByRole("button", { name: "New conversation" }).click();
   await page.getByLabel("Model").selectOption("Auth failure");
   await page
@@ -109,7 +111,7 @@ test("real multi-agent results, unavailable models, and provider errors", async 
     page.getByText("The provider rejected the shared credentials.", {
       exact: false,
     }),
-  ).toBeVisible();
+  ).toBeVisible(runWait);
   await expect(page.getByText("PRIVATE_PROVIDER_RESPONSE_MARKER")).toHaveCount(
     0,
   );

--- a/frontend/e2e/workspace.spec.ts
+++ b/frontend/e2e/workspace.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "@playwright/test";
+
+test("upload, clarify, reconnect, inspect a structure and replay a trajectory", async ({
+  page,
+}, testInfo) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await page.goto("/");
+  await expect(page.getByText("Local demo workspace")).toBeVisible();
+  await page.screenshot({
+    path: testInfo.outputPath("workspace.png"),
+    fullPage: true,
+  });
+  await page
+    .getByLabel("Attach structure or data files")
+    .setInputFiles({
+      name: "copper.xyz",
+      mimeType: "text/plain",
+      buffer: Buffer.from("2\nCopper dimer\nCu 0 0 0\nCu 0 0 2.5\n"),
+    });
+  await page
+    .getByRole("textbox", { name: "Message", exact: true })
+    .fill("Confirm optimization of the attached copper dimer");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText("A quick clarification")).toBeVisible();
+  const sessionURL = page.url();
+  await page.reload();
+  await expect(page.getByText("A quick clarification")).toBeVisible();
+  await page
+    .getByRole("textbox", { name: "Response to agent" })
+    .fill("Yes, continue");
+  await page.getByRole("button", { name: "Send response" }).click();
+  await expect(
+    page.getByText("Demo calculation complete.", { exact: false }),
+  ).toBeVisible();
+  await expect(page.locator(".molecule-canvas canvas")).toBeVisible();
+  const selector = page.getByLabel("Structure or trajectory");
+  const trajectory = await selector
+    .locator("option")
+    .filter({ hasText: "copper_opt.traj" })
+    .getAttribute("value");
+  await selector.selectOption(trajectory!);
+  await expect(
+    page.getByRole("button", { name: "Play trajectory" }),
+  ).toBeEnabled();
+  await page.getByRole("button", { name: "Play trajectory" }).click();
+  await expect(
+    page.getByRole("button", { name: "Pause trajectory" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Pause trajectory" }).click();
+  const downloadPromise = page.waitForEvent("download");
+  await page.locator(".artifact").filter({ hasText: "copper.xyz" }).click();
+  expect((await downloadPromise).suggestedFilename()).toBe("copper.xyz");
+  await page.screenshot({
+    path: testInfo.outputPath("results.png"),
+    fullPage: true,
+  });
+  await page.getByRole("button", { name: "New conversation" }).click();
+  await page.goto(sessionURL);
+  await expect(
+    page.getByText("Demo calculation complete.", { exact: false }),
+  ).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test("small screens keep the composer reachable and panels toggle without overflow", async ({
+  page,
+}, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/");
+  await expect(
+    page.getByRole("textbox", { name: "Message", exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close results" })).toHaveCount(
+    0,
+  );
+  await page.getByRole("button", { name: "Open conversations" }).click();
+  await expect(
+    page.getByRole("button", { name: "New conversation" }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Close conversations" }).click();
+  await page.getByRole("button", { name: "Results", exact: true }).click();
+  await page.getByRole("button", { name: "Close results" }).click();
+  expect(
+    await page.evaluate(
+      () => document.documentElement.scrollWidth <= window.innerWidth,
+    ),
+  ).toBe(true);
+  await page.screenshot({
+    path: testInfo.outputPath("mobile.png"),
+    fullPage: true,
+  });
+});

--- a/frontend/e2e/workspace.spec.ts
+++ b/frontend/e2e/workspace.spec.ts
@@ -1,23 +1,32 @@
 import { expect, test } from "@playwright/test";
 
+const real = process.env.WEB_TEST_REAL === "true";
+const resultText = real
+  ? "Calculation complete."
+  : "Demo calculation complete.";
+
 test("upload, clarify, reconnect, inspect a structure and replay a trajectory", async ({
   page,
 }, testInfo) => {
   const errors: string[] = [];
   page.on("pageerror", (error) => errors.push(error.message));
   await page.goto("/");
-  await expect(page.getByText("Local demo workspace")).toBeVisible();
+  await expect(
+    page.getByText(
+      real
+        ? "Configured; connectivity has not been verified."
+        : "Local demo workspace",
+    ),
+  ).toBeVisible();
   await page.screenshot({
     path: testInfo.outputPath("workspace.png"),
     fullPage: true,
   });
-  await page
-    .getByLabel("Attach structure or data files")
-    .setInputFiles({
-      name: "copper.xyz",
-      mimeType: "text/plain",
-      buffer: Buffer.from("2\nCopper dimer\nCu 0 0 0\nCu 0 0 2.5\n"),
-    });
+  await page.getByLabel("Attach structure or data files").setInputFiles({
+    name: "copper.xyz",
+    mimeType: "text/plain",
+    buffer: Buffer.from("2\nCopper dimer\nCu 0 0 0\nCu 0 0 2.5\n"),
+  });
   await page
     .getByRole("textbox", { name: "Message", exact: true })
     .fill("Confirm optimization of the attached copper dimer");
@@ -30,9 +39,7 @@ test("upload, clarify, reconnect, inspect a structure and replay a trajectory", 
     .getByRole("textbox", { name: "Response to agent" })
     .fill("Yes, continue");
   await page.getByRole("button", { name: "Send response" }).click();
-  await expect(
-    page.getByText("Demo calculation complete.", { exact: false }),
-  ).toBeVisible();
+  await expect(page.getByText(resultText, { exact: false })).toBeVisible();
   await expect(page.locator(".molecule-canvas canvas")).toBeVisible();
   const selector = page.getByLabel("Structure or trajectory");
   const trajectory = await selector
@@ -49,18 +56,65 @@ test("upload, clarify, reconnect, inspect a structure and replay a trajectory", 
   ).toBeVisible();
   await page.getByRole("button", { name: "Pause trajectory" }).click();
   const downloadPromise = page.waitForEvent("download");
-  await page.locator(".artifact").filter({ hasText: "copper.xyz" }).click();
-  expect((await downloadPromise).suggestedFilename()).toBe("copper.xyz");
+  const downloadName = real ? "copper-result.json" : "copper.xyz";
+  await page.locator(".artifact").filter({ hasText: downloadName }).click();
+  expect((await downloadPromise).suggestedFilename()).toBe(downloadName);
   await page.screenshot({
     path: testInfo.outputPath("results.png"),
     fullPage: true,
   });
   await page.getByRole("button", { name: "New conversation" }).click();
   await page.goto(sessionURL);
-  await expect(
-    page.getByText("Demo calculation complete.", { exact: false }),
-  ).toBeVisible();
+  await expect(page.getByText(resultText, { exact: false })).toBeVisible();
   expect(errors).toEqual([]);
+});
+
+test("real multi-agent results, unavailable models, and provider errors", async ({
+  page,
+}) => {
+  test.skip(!real, "Requires the deterministic non-demo endpoint");
+  await page.goto("/");
+  await expect(
+    page.getByRole("option", { name: "Unavailable (unavailable)" }),
+  ).toHaveJSProperty("disabled", true);
+  await page.getByLabel("Workflow").selectOption("multi_agent");
+  await page
+    .getByLabel("Attach structure or data files")
+    .setInputFiles({
+      name: "copper.xyz",
+      mimeType: "text/plain",
+      buffer: Buffer.from("2\nCopper\nCu 0 0 0\nCu 0 0 2.5\n"),
+    });
+  await page
+    .getByRole("textbox", { name: "Message", exact: true })
+    .fill("Optimize the attached copper with EMT");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(
+    page.getByText("Calculation complete.", { exact: false }),
+  ).toBeVisible();
+  await page
+    .getByRole("textbox", { name: "Message", exact: true })
+    .fill("Follow-up: recall our work");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(
+    page.getByText("Previous context retained", { exact: false }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "New conversation" }).click();
+  await page.getByLabel("Model").selectOption("Auth failure");
+  await page
+    .getByRole("textbox", { name: "Message", exact: true })
+    .fill("Test authentication failure");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(
+    page.getByText("The provider rejected the shared credentials.", {
+      exact: false,
+    }),
+  ).toBeVisible();
+  await expect(page.getByText("PRIVATE_PROVIDER_RESPONSE_MARKER")).toHaveCount(
+    0,
+  );
+  await page.getByRole("button", { name: "New conversation" }).click();
+  await expect(page.getByLabel("Model")).toBeEnabled();
 });
 
 test("small screens keep the composer reachable and panels toggle without overflow", async ({

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="ChemGraph — a workspace for computational chemistry."
+    />
+    <title>ChemGraph · Chemistry workspace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,23 @@
+server {
+    listen 8080;
+    server_name _;
+    root /usr/share/nginx/html;
+    client_max_body_size 25m;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy same-origin always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; worker-src 'self' blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'" always;
+    location = /healthz { access_log off; return 200 'ok'; }
+    location /api/ {
+        # The institutional gateway MUST strip user-supplied identity headers
+        # and insert its verified identity before requests reach this service.
+        proxy_pass http://${API_UPSTREAM};
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 90s;
+    }
+    location /assets/ { expires 1y; try_files $uri =404; }
+    location / { expires -1; try_files $uri /index.html; }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,4948 @@
+{
+  "name": "chemgraph-web",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chemgraph-web",
+      "version": "0.0.0",
+      "dependencies": {
+        "3dmol": "2.5.5",
+        "katex": "0.16.22",
+        "lucide-react": "0.577.0",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
+        "react-markdown": "10.1.0",
+        "rehype-katex": "7.0.1",
+        "remark-gfm": "4.0.1",
+        "remark-math": "6.0.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.58.2",
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/react": "16.3.2",
+        "@types/node": "22.19.0",
+        "@types/react": "19.2.0",
+        "@types/react-dom": "19.2.0",
+        "@vitejs/plugin-react": "5.1.0",
+        "jsdom": "28.0.0",
+        "typescript": "5.9.3",
+        "vite": "7.3.1",
+        "vitest": "4.0.18"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.13.tgz",
+      "integrity": "sha512-i9ZylF5QNhmNfPA9l0vHAWK4kPrbIp6g9lKgaiIFsIBz2F/WNB7OLrzlNNcCOm+h42bkaSD2v1PG+IBPHhc3ZA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.43",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.43.tgz",
+      "integrity": "sha512-5Uxg7fQUCmfhax7FJke2+8B6cqgeUJUD9o2uXIKXhD+mG0mL6NObmVoi9wXEU1tY89mZKgAYA6fTbftx3q2ZPQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.63.1.tgz",
+      "integrity": "sha512-UZ8sUxPTiHWYX9QNdJedb1kDZSpS1t/VPWBWGSgqHNi9w3Cu6IXvu2mzbhiTiPvtrqgTQJ+zqiAq2iPIPilpaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.63.1.tgz",
+      "integrity": "sha512-cQ4nFQABN5cDvDpbvJ7bMStCpnaVxynZrRMfUJYgxcIk9Sh54FIO1vtfkg0B69REjER77ioZ/ov+eAApx/KmLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.63.1.tgz",
+      "integrity": "sha512-FQNqd1lRy/0QhDk3xeRIkSBiCpXCiDnZO3YLVdcDKN1UBiKToNftCzcXYNLshmPDUMlu2TdeS8tGcsU6f3YF1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.63.1.tgz",
+      "integrity": "sha512-pvD16V939D3CloK0+qikpGaxiPrDUXTe7Y5cWOMkMSy7m1cawa8EGy/kXYi/G/cKAC4HDAbSnzCIk1WmsoOKXg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.63.1.tgz",
+      "integrity": "sha512-pcFGeL2345VwdTnJhA6zLbew+YgWB0qBG2+dMtXjCicf6+rm6kO6cOoh5VnTe0ZMrMRgRyuHmCJxZWrIdzYuOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.63.1.tgz",
+      "integrity": "sha512-mRJlqSRulVzcKq/LKA6ICSIc3K/l4fzlVn/gePn2nXIHy8seRi5z/eeRE0d/XMBxcMldiXtQTSpRj0tkkC3g8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.63.1.tgz",
+      "integrity": "sha512-YDUNvVM85TI3g/1OpnqKP1h4NeW/j64DfWMf+G3M809xNk1bJSnpFp4sh83NpmVE5DXnkh8ULor4LTVZKoYLHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.63.1.tgz",
+      "integrity": "sha512-7Mcn71p9ZuQFAj+h+dhQXy/yeLePRS2yKRnmW1DijA9thKO5qap0GNOIQK4yQ6iP3SU0Mrb/yWo8h8vgRba8lw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.63.1.tgz",
+      "integrity": "sha512-4YiLQTX6U4CSl0L9cluep9A9W6UmTfqBDc2/CH6wlu54pl4E7Jn3cOD8oxzvBDEGk/JMKgJ47C8g+radF7mwvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.63.1.tgz",
+      "integrity": "sha512-2ra8F7w8OquwZN9z2/fKFnli69wa8PLwaVzRMIPGb13ByMJwC28Fbp8YcVGoUhlYMTt7j5j9bNgpysrN2UM+vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.63.1.tgz",
+      "integrity": "sha512-Sy20ncyhjmBP0Ml+UvQbimjlk6VFgjW5uNP+qqwHB00mTE8Bl2C1TuHTlRwK2YoXeZbee5lP2XevBWVkAQAtSQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.63.1.tgz",
+      "integrity": "sha512-noITLp8oNjYliPnGWmLyelIHwULGqbHloQHGw1rtxbWhTuWooRpnZarZQJ1y9EUC4szuCusCc+HEpUtxpIwYvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.63.1.tgz",
+      "integrity": "sha512-hlxxXd+F1mWiAcaFR7Sv9ZQT6m6UfI8+Vy/kFJzztq2pDMU/0wZ9sish0iszNZvsQDo8Gc0i5yuFEOz5dDf6fA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.63.1.tgz",
+      "integrity": "sha512-EF7OpqQTQ/BvGqLzUi4rEHuagCV9MugAUXSHemwPW5vxZ75RR+jxO/2j95Ph2dalMpFHSVECjRoioHZgA9zOYA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.63.1.tgz",
+      "integrity": "sha512-wQO3JesW9PRkwlabQ27y7sPfVOOTLRG73I4F2UYHG5PXun3J9U3y+b7ezVKSYbsvSKGQ1k1cq8Qlun4C9kLt3w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.63.1.tgz",
+      "integrity": "sha512-ouAGwhO6wHRXdnOVCOsB0tRFkA7nhNB2Nwax6oECXN0YiN8EYUTBAOudADOB1PI+yDL61TeNx/u7MVCzksNbkQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.63.1.tgz",
+      "integrity": "sha512-q2R38Sn+1J8RxhfJ+T54wSWmyKXWec+9jgDfqO2AtArEqHO5R2aeayp5H5OYLr5UYDVGsVaZPEFUooMhYCdz5A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-gfI5T24WLLuFfSKw7Go/zDXjAAV0fny0swTaDv+WjK7vqcw4cRhFfdsyKL1n+ukI+ooBxn3bVQnyrn06WpI50w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.63.1.tgz",
+      "integrity": "sha512-4h6XqthmB4Hspji84wvgk+ElodTsGj+dbZqHJHHtKxj4mYq0ANSEEPX9ys3moJueqsRjwpaJYH7874Itwnj2ow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.63.1.tgz",
+      "integrity": "sha512-dlfCOa87o1VAYegLQ9EKilx2JCeRofiyPGhTCmqnuXZ6bMPiycO1rq1+sKoulAp7pGLIsTIw+1x5R+zgh5LhhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.63.1.tgz",
+      "integrity": "sha512-cjkLbOlfcm3QGhMM1J5zaZjsw1GggbN6rw9UTSSRrPrR1KkcXnN7Uq9rPw34xImQ9VOY9GN+6u2Zj80B9ptkcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.63.1.tgz",
+      "integrity": "sha512-Li1KdUnWGE4N3e1F/B4RTB1ms+nG4WBgjByO46pkeBVX/2UBsY53xf5vK9WygVmnH3RwncIST7lkSdLSY6P9lg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.63.1.tgz",
+      "integrity": "sha512-t4ZYOSoLTgwhuFMrmTMLx/+i1DQVK7HYqMc6kY46EApwi8X0nIVphzdNoThU3xt6n+N5urG1/gxBdCaKDLavfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.63.1.tgz",
+      "integrity": "sha512-RgroPfMmKlD1RzSDxvwgcPiy2HNQKoYV7OmwIXDsk73uKW5t6B/V8KIy27SMv/FNXFo/oSBtWc9J0X7t91ezZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.63.1.tgz",
+      "integrity": "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.0.tgz",
+      "integrity": "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.0.tgz",
+      "integrity": "sha512-4LuWrg7EKWgQaMJfnN+wcmbAW+VSsCmqGohftWjuct47bv8uE4n/nPpq4XjJPsxgq00GGG5J8dvBczp8uxScew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.4",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.43",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/3dmol": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/3dmol/-/3dmol-2.5.5.tgz",
+      "integrity": "sha512-kqNHouGqq3YfW58174tdERvm0XYTmP0tavQKOqIw1ouc2OJ7epkXEFrtEkVXV0clBZT2Ze2xHRC/qxX0u0qCdw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "iobuffer": "^5.0.0",
+        "netcdfjs": "^3.0.0",
+        "pako": "^2.1.0",
+        "upng-js": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=16.16.0",
+        "npm": ">=8.11"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.22",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.22.tgz",
+      "integrity": "sha512-pWc4w51fBFd7mav43/zKRC+RI6f4yfzQoVlfvE8dECePyfkn1bzLp01Fj0QACcyCZyFhiEMyD2qScfKRWgWibA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.1.0.tgz",
+      "integrity": "sha512-fX1Onk0tdVPC7obPWB5EbJ1z7NVhLq4m2xZLq2YXBkxzMXIGRpNMU88n0EPgWseKl12J7zXs7qrDxPK4sRs2fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.427",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.427.tgz",
+      "integrity": "sha512-n14zb3FdsChZ2BNobqNHAJMcP3ifFv4paox2LvCrfVAQcqGiSURgbJl+PfMpHVCNFkStnNc+RRVtPBTVW5PDgw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.1.0.tgz",
+      "integrity": "sha512-kxL7msIffSuh9aaFAMD7rxAIuTRMAHMeBtgHW2yUdWw732ZNh4MehkF2gdjvtdmikkaIP9bFDDJOPlsvm7avrA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-html/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.0.0.tgz",
+      "integrity": "sha512-KDYJgZ6T2TKdU8yBfYueq5EPG/EylMsBvCaenWMJb2OXmjgczzwveRCoJ+Hgj1lXPDyasvrgneSn4GBuR1hYyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^5.3.7",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.20.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.22",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.22.tgz",
+      "integrity": "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.2.tgz",
+      "integrity": "sha512-pRzm4kDTu0MjlmBkxmS9yYhw60nncfcEwu9NNdPFSQEFXS95ZKyIIyTSHu/o3ReBUrLKYEq+7YaXCRn/bPB4MA==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.19",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.19.tgz",
+      "integrity": "sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/netcdfjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/netcdfjs/-/netcdfjs-3.0.0.tgz",
+      "integrity": "sha512-LOvT8KkC308qtpUkcBPiCMBtii7ZQCN6LxcVheWgyUeZ6DQWcpSRFV9dcVXLj/2eHZ/bre9tV5HTH4Sf93vrFw==",
+      "license": "MIT",
+      "dependencies": {
+        "iobuffer": "^5.3.2"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.55",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.55.tgz",
+      "integrity": "sha512-mIrE/Cw9y+9Au6dS5vDKDhQza9YvG6w+ZrS6X+ZzA7yFW/soAeaups4Qzn1bL6g5FVy8WtP79+0j82oPIbqRjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.2.1.tgz",
+      "integrity": "sha512-XrsrhT5sybtKI6wakr2SPOlGZWWYbUXZ7a0jT8/QOeAPau+1X/bSegNe5YR75oJmEZQbKningirmGOEJCIk61Q==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.18",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.63.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.63.1.tgz",
+      "integrity": "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.63.1",
+        "@rollup/rollup-android-arm64": "4.63.1",
+        "@rollup/rollup-darwin-arm64": "4.63.1",
+        "@rollup/rollup-darwin-x64": "4.63.1",
+        "@rollup/rollup-freebsd-arm64": "4.63.1",
+        "@rollup/rollup-freebsd-x64": "4.63.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.63.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.63.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.63.1",
+        "@rollup/rollup-linux-arm64-musl": "4.63.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.63.1",
+        "@rollup/rollup-linux-loong64-musl": "4.63.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.63.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.63.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.63.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.63.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-gnu": "4.63.1",
+        "@rollup/rollup-linux-x64-musl": "4.63.1",
+        "@rollup/rollup-openbsd-x64": "4.63.1",
+        "@rollup/rollup-openharmony-arm64": "4.63.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.63.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.63.1",
+        "@rollup/rollup-win32-x64-gnu": "4.63.1",
+        "@rollup/rollup-win32-x64-msvc": "4.63.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.12.tgz",
+      "integrity": "sha512-WylhSDKVeYnWXL3a+vKTaOxjnOeEGw938hImY8zoRWJjRRK/Jp1K+IihBzIONpUmW4e3WmXT6q5FW6vlESVZCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.12"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.12.tgz",
+      "integrity": "sha512-nYNzS2WRf4QJmjzFFgAxLOBjyBxAGRbCy9PVBPaglcYyYajh40VBn+v5Ngr96ZMc7oM0+aCJdtQnNejvdBnXMQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.3.tgz",
+      "integrity": "sha512-pJ2sYawQS0R/WI928Gj5GlPhTGzbMelq0+4INtSYNDV9ErKJcX6xjGWkoG/VnB3dpUm00zALaqkrUD77pO5TDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/upng-js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/upng-js/-/upng-js-2.1.0.tgz",
+      "integrity": "sha512-d3xzZzpMP64YkjP5pr8gNyvBt7dLk/uGI67EctzDuVp4lCZyVMo0aJO6l/VDlgbInJYDY6cnClLoBp29eKWI6g==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
+    "node_modules/upng-js/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "chemgraph-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "tsc -b && vite build",
+    "test": "vitest run",
+    "test:e2e": "playwright test"
+  },
+  "dependencies": {
+    "3dmol": "2.5.5",
+    "katex": "0.16.22",
+    "lucide-react": "0.577.0",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "react-markdown": "10.1.0",
+    "rehype-katex": "7.0.1",
+    "remark-gfm": "4.0.1",
+    "remark-math": "6.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.58.2",
+    "@testing-library/jest-dom": "6.9.1",
+    "@testing-library/react": "16.3.2",
+    "@types/node": "22.19.0",
+    "@types/react": "19.2.0",
+    "@types/react-dom": "19.2.0",
+    "@vitejs/plugin-react": "5.1.0",
+    "jsdom": "28.0.0",
+    "typescript": "5.9.3",
+    "vite": "7.3.1",
+    "vitest": "4.0.18"
+  }
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60000,
+  workers: 1,
+  retries: 0,
+  use: {
+    baseURL: process.env.WEB_TEST_URL || "http://localhost:8080",
+    channel: process.env.WEB_TEST_BROWSER || undefined,
+    viewport: { width: 1440, height: 1000 },
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    launchOptions: {
+      args: [
+        "--enable-webgl",
+        "--use-gl=angle",
+        "--use-angle=swiftshader",
+        "--enable-unsafe-swiftshader",
+      ],
+    },
+  },
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,0 +1,106 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import App from "./App";
+
+vi.mock("./MoleculeViewer", () => ({ default: () => <div>Viewer</div> }));
+const caps = {
+  user: "alice",
+  models: ["Lab model"],
+  workflows: ["single_agent", "multi_agent"],
+  calculators: ["emt"],
+  upload_limit: 25000000,
+  demo: false,
+};
+const session = {
+  id: "session-a",
+  title: "Copper",
+  model: "Lab model",
+  workflow: "single_agent",
+  runs: [],
+};
+const response = (value: unknown) =>
+  new Response(JSON.stringify(value), {
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeEach(() => {
+  window.history.replaceState(null, "", "/");
+});
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+test("restored conversations retain their model and workflow", async () => {
+  window.history.replaceState(null, "", "/?session=session-a");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (path: string) =>
+      response(
+        path.endsWith("/capabilities")
+          ? caps
+          : path.endsWith("/sessions")
+            ? [session]
+            : session,
+      ),
+    ),
+  );
+  render(<App />);
+  await waitFor(() =>
+    expect(screen.getByLabelText("Model")).toHaveValue("Lab model"),
+  );
+  expect(screen.getByLabelText("Model")).toBeDisabled();
+  expect(screen.getByLabelText("Workflow")).toBeDisabled();
+  fireEvent.click(screen.getByRole("button", { name: "New conversation" }));
+  expect(screen.getByLabelText("Model")).toBeEnabled();
+});
+
+test("uncertain submissions retry the same request ID and upload only once", async () => {
+  const submissions: string[] = [];
+  let uploads = 0;
+  const fetch = vi.fn(async (path: string, init?: RequestInit) => {
+    if (path.endsWith("/capabilities")) return response(caps);
+    if (path.endsWith("/uploads?filename=copper.xyz")) {
+      uploads++;
+      return response({
+        id: "file-a",
+        name: "copper.xyz",
+        url: "/file",
+        preview_url: null,
+      });
+    }
+    if (path.endsWith("/runs")) {
+      submissions.push(String(init?.body));
+      if (submissions.length === 1) throw new Error("Connection lost");
+      return response({ id: "run-a" });
+    }
+    if (path.endsWith("/sessions"))
+      return response(init?.method === "POST" ? session : []);
+    return response(session);
+  });
+  vi.stubGlobal("fetch", fetch);
+  render(<App />);
+  await screen.findByText("alice");
+  fireEvent.change(screen.getByLabelText("Message"), {
+    target: { value: "Optimize copper" },
+  });
+  fireEvent.change(screen.getByLabelText("Attach structure or data files"), {
+    target: { files: [new File(["2\n\nCu 0 0 0\nCu 0 0 2.5"], "copper.xyz")] },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+  await screen.findByRole("alert");
+  expect(
+    screen.getByRole("button", { name: "New conversation" }),
+  ).toBeDisabled();
+  fireEvent.click(screen.getByRole("button", { name: "Retry send" }));
+  await waitFor(() => expect(submissions).toHaveLength(2));
+  expect(submissions[0]).toEqual(submissions[1]);
+  expect(uploads).toBe(1);
+  await waitFor(() => expect(screen.getByLabelText("Message")).toHaveValue(""));
+});

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -104,3 +104,127 @@ test("uncertain submissions retry the same request ID and upload only once", asy
   expect(uploads).toBe(1);
   await waitFor(() => expect(screen.getByLabelText("Message")).toHaveValue(""));
 });
+
+test("unavailable models are disabled and the first configured model is selected", async () => {
+  const readiness = {
+    ...caps,
+    models: ["Missing", "Lab model"],
+    model_status: {
+      Missing: {
+        configured: false,
+        code: "missing_credentials",
+        message: "Credentials are missing.",
+      },
+      "Lab model": {
+        configured: true,
+        code: "configured",
+        message: "Configured; connectivity has not been verified.",
+      },
+    },
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (path: string) =>
+      response(path.endsWith("/capabilities") ? readiness : []),
+    ),
+  );
+  render(<App />);
+  await waitFor(() =>
+    expect(screen.getByLabelText("Model")).toHaveValue("Lab model"),
+  );
+  expect(
+    screen.getByRole("option", { name: "Missing (unavailable)" }),
+  ).toBeDisabled();
+  expect(
+    screen.getByText("Configured; connectivity has not been verified."),
+  ).toBeVisible();
+});
+
+test("a rejected provider request preserves attachments and allows recovery", async () => {
+  const submissions: string[] = [];
+  let uploads = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (path: string, init?: RequestInit) => {
+      if (path.endsWith("/capabilities")) return response(caps);
+      if (path.includes("/uploads?")) {
+        uploads++;
+        return response({
+          id: "file-a",
+          name: "copper.xyz",
+          url: "/file",
+          preview_url: null,
+        });
+      }
+      if (path.endsWith("/runs")) {
+        submissions.push(String(init?.body));
+        if (submissions.length === 1)
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: "missing_credentials",
+                message: "Provider unavailable",
+                submission_rejected: true,
+              },
+            }),
+            { status: 503, headers: { "Content-Type": "application/json" } },
+          );
+        return response({ id: "run-a" });
+      }
+      if (path.endsWith("/sessions"))
+        return response(init?.method === "POST" ? session : [session]);
+      return response(session);
+    }),
+  );
+  render(<App />);
+  await screen.findByText("alice");
+  fireEvent.change(screen.getByLabelText("Message"), {
+    target: { value: "Optimize copper" },
+  });
+  fireEvent.change(screen.getByLabelText("Attach structure or data files"), {
+    target: { files: [new File(["Cu"], "copper.xyz")] },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+  await screen.findByText("Provider unavailable");
+  expect(
+    screen.getByRole("button", { name: "New conversation" }),
+  ).toBeEnabled();
+  expect(screen.getByLabelText("Message")).toBeEnabled();
+  fireEvent.click(screen.getByRole("button", { name: "Send message" }));
+  await waitFor(() => expect(submissions).toHaveLength(2));
+  expect(uploads).toBe(1);
+  expect(JSON.parse(submissions[1]).attachments).toEqual(["file-a"]);
+  expect(JSON.parse(submissions[0]).request_id).not.toEqual(
+    JSON.parse(submissions[1]).request_id,
+  );
+});
+
+test("archived conversations stay readable and cannot submit", async () => {
+  window.history.replaceState(null, "", "/?session=session-a");
+  const archived = {
+    ...session,
+    model_status: {
+      configured: false,
+      code: "model_changed",
+      message: "Start a new conversation.",
+    },
+  };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (path: string) =>
+      response(
+        path.endsWith("/capabilities")
+          ? caps
+          : path.endsWith("/sessions")
+            ? [session]
+            : archived,
+      ),
+    ),
+  );
+  render(<App />);
+  await screen.findByText("Start a new conversation.");
+  expect(screen.getByLabelText("Message")).toBeDisabled();
+  expect(
+    screen.getByRole("button", { name: "New conversation" }),
+  ).toBeEnabled();
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,8 @@ const statusLabel: Record<string, string> = {
   completed: "Complete",
   failed: "Failed",
   interrupted: "Interrupted",
+  cancelling: "Stopping",
+  cancelled: "Cancelled",
 };
 type Submission = {
   sessionId: string;
@@ -72,6 +74,7 @@ export default function App() {
   const [workflow, setWorkflow] = useState("single_agent");
   const [draft, setDraft] = useState("");
   const [files, setFiles] = useState<File[]>([]);
+  const [savedAttachments, setSavedAttachments] = useState<Artifact[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [revision, setRevision] = useState(0);
@@ -86,6 +89,12 @@ export default function App() {
   const endOfChat = useRef<HTMLDivElement>(null);
   const activeRun = detail?.runs.find((run) => !terminal(run.status));
   const waiting = activeRun?.status === "waiting_for_input";
+  const selectedModel = detail?.model || model;
+  const modelStatus =
+    detail?.model_status || capabilities?.model_status?.[selectedModel];
+  const unavailable = modelStatus
+    ? !modelStatus.configured
+    : !capabilities?.models.includes(selectedModel);
   const artifacts = detail?.runs.flatMap((run) => run.artifacts) || [];
   const structures = artifacts.filter((artifact) => artifact.preview_url);
   const currentArtifact =
@@ -100,13 +109,42 @@ export default function App() {
     ])
       .then(([caps, list]) => {
         setCapabilities(caps);
-        setModel(caps.models[0] || "");
+        setModel(
+          caps.models.find(
+            (label) => caps.model_status?.[label]?.configured !== false,
+          ) || "",
+        );
         setSessions(list);
       })
       .catch((error) => {
         if (!controller.signal.aborted) setError(error.message);
       });
     return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const refresh = () => {
+      void api<Capabilities>("/capabilities")
+        .then((caps) => {
+          setCapabilities(caps);
+          setModel((previous) =>
+            caps.models.includes(previous) &&
+            caps.model_status?.[previous]?.configured !== false
+              ? previous
+              : caps.models.find(
+                  (label) => caps.model_status?.[label]?.configured !== false,
+                ) || "",
+          );
+          setRevision((value) => value + 1);
+        })
+        .catch((error) => setError(error.message));
+    };
+    const timer = window.setInterval(refresh, 30000);
+    window.addEventListener("focus", refresh);
+    return () => {
+      window.clearInterval(timer);
+      window.removeEventListener("focus", refresh);
+    };
   }, []);
 
   useEffect(() => {
@@ -170,6 +208,7 @@ export default function App() {
     setDetail(null);
     setDraft("");
     setFiles([]);
+    setSavedAttachments([]);
     setError("");
     setArtifactId(null);
     setSidebar(false);
@@ -178,7 +217,13 @@ export default function App() {
 
   async function send(event: React.FormEvent) {
     event.preventDefault();
-    if (busy || (!draft.trim() && !pending) || (!model && !selected)) return;
+    if (
+      busy ||
+      (!draft.trim() && !pending) ||
+      (!model && !selected) ||
+      (!waiting && (unavailable || !!activeRun) && !pending)
+    )
+      return;
     setBusy(true);
     setError("");
     try {
@@ -204,7 +249,7 @@ export default function App() {
           setSelected(sessionId);
           setDetail({ ...session, runs: [] });
         }
-        const attachments: string[] = [];
+        const attachments: string[] = savedAttachments.map((file) => file.id);
         for (const file of files) {
           if (file.size > (capabilities?.upload_limit || 0))
             throw new Error(`${file.name} exceeds the upload limit.`);
@@ -217,6 +262,8 @@ export default function App() {
             },
           );
           attachments.push(artifact.id);
+          setSavedAttachments((previous) => [...previous, artifact]);
+          setFiles((previous) => previous.filter((item) => item !== file));
         }
         submission = {
           sessionId,
@@ -231,6 +278,7 @@ export default function App() {
       setPending(null);
       setDraft("");
       setFiles([]);
+      setSavedAttachments([]);
       setRevision((value) => value + 1);
       setSessions(await api<Session[]>("/sessions"));
     } catch (error) {
@@ -239,11 +287,14 @@ export default function App() {
       );
       if (
         error instanceof ApiError &&
-        error.status >= 400 &&
-        error.status < 500
+        (error.submissionRejected ||
+          (error.status >= 400 && error.status < 500))
       ) {
         setPending(null);
         setRevision((value) => value + 1);
+        void api<Capabilities>("/capabilities")
+          .then(setCapabilities)
+          .catch(() => {});
       }
     } finally {
       setBusy(false);
@@ -360,8 +411,17 @@ export default function App() {
               onChange={(event) => setModel(event.target.value)}
             >
               {(capabilities?.models || []).map((value) => (
-                <option key={value} value={value}>
+                <option
+                  key={value}
+                  value={value}
+                  disabled={
+                    capabilities?.model_status?.[value]?.configured === false
+                  }
+                >
                   {value}
+                  {capabilities?.model_status?.[value]?.configured === false
+                    ? " (unavailable)"
+                    : ""}
                 </option>
               ))}
               {detail && !capabilities?.models.includes(detail.model) && (
@@ -473,6 +533,28 @@ export default function App() {
                   {run.final_text && <RichText>{run.final_text}</RichText>}
                   {run.id === activeRun?.id && (
                     <div className="run-progress" aria-live="polite">
+                      <button
+                        disabled={busy || run.status === "cancelling"}
+                        onClick={async () => {
+                          setBusy(true);
+                          try {
+                            await api(`/runs/${run.id}/cancel`, post({}));
+                            setRevision((value) => value + 1);
+                          } catch (error) {
+                            setError(
+                              error instanceof Error
+                                ? error.message
+                                : "Unable to cancel this run.",
+                            );
+                          } finally {
+                            setBusy(false);
+                          }
+                        }}
+                      >
+                        {run.status === "cancelling"
+                          ? "Stopping…"
+                          : "Cancel run"}
+                      </button>
                       {progress
                         .filter((item) => item.tool)
                         .slice(-6)
@@ -522,6 +604,8 @@ export default function App() {
                       <button
                         onClick={() => {
                           setDraft(run.query);
+                          setFiles([]);
+                          setSavedAttachments(run.attachments);
                           setError("");
                         }}
                       >
@@ -563,10 +647,22 @@ export default function App() {
               </button>
             </div>
           )}
-          {capabilities && !capabilities.models.length && (
-            <div className="error-banner">
-              No model providers are configured. Ask your administrator to
-              enable a provider.
+          {capabilities &&
+            !capabilities.models.some(
+              (label) =>
+                capabilities.model_status?.[label]?.configured !== false,
+            ) && (
+              <div className="error-banner">
+                No model providers are ready. Ask your administrator to
+                configure a provider and its credentials.
+              </div>
+            )}
+          {modelStatus && (
+            <div
+              className={unavailable ? "error-banner" : "settings-note"}
+              role={unavailable ? "status" : undefined}
+            >
+              {modelStatus.message}
             </div>
           )}
           {selected && (
@@ -579,8 +675,26 @@ export default function App() {
             className={`composer ${waiting ? "needs-response" : ""}`}
             onSubmit={send}
           >
-            {!!files.length && (
+            {!!(files.length + savedAttachments.length) && (
               <div className="attachment-chips">
+                {savedAttachments.map((file) => (
+                  <span key={file.id}>
+                    <Paperclip size={13} />
+                    {file.name}
+                    <button
+                      type="button"
+                      disabled={busy || !!pending}
+                      aria-label={`Remove ${file.name}`}
+                      onClick={() =>
+                        setSavedAttachments((previous) =>
+                          previous.filter((item) => item.id !== file.id),
+                        )
+                      }
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
                 {files.map((file, index) => (
                   <span key={`${file.name}-${index}`}>
                     <Paperclip size={13} />
@@ -610,6 +724,7 @@ export default function App() {
               disabled={
                 busy ||
                 !!pending ||
+                (unavailable && !waiting) ||
                 (!!activeRun && !waiting) ||
                 answered === activeRun?.question_id
               }
@@ -640,7 +755,7 @@ export default function App() {
                       ...files,
                       ...Array.from(event.target.files || []),
                     ];
-                    if (next.length > 10)
+                    if (next.length + savedAttachments.length > 10)
                       setError("Attach up to 10 files per message.");
                     else setFiles(next);
                     event.target.value = "";
@@ -649,7 +764,7 @@ export default function App() {
                 <button
                   type="button"
                   className="attach-button"
-                  disabled={busy || !!activeRun || !!pending}
+                  disabled={busy || !!activeRun || !!pending || unavailable}
                   onClick={() => uploadInput.current?.click()}
                 >
                   <Paperclip size={17} />
@@ -668,6 +783,7 @@ export default function App() {
                 }
                 disabled={
                   busy ||
+                  (unavailable && !waiting && !pending) ||
                   (!draft.trim() && !pending) ||
                   !capabilities?.models.length ||
                   (!!activeRun && !waiting && !pending) ||

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,772 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ArrowDownToLine,
+  ArrowUp,
+  Atom,
+  Check,
+  ChevronRight,
+  FlaskConical,
+  LoaderCircle,
+  Menu,
+  MessageSquare,
+  Paperclip,
+  Plus,
+  SlidersHorizontal,
+  Sparkles,
+  X,
+} from "lucide-react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+import {
+  api,
+  ApiError,
+  post,
+  terminal,
+  type Artifact,
+  type Capabilities,
+  type Run,
+  type Session,
+  type SessionDetail,
+} from "./api";
+import MoleculeViewer from "./MoleculeViewer";
+
+const workflowLabel = (value: string) =>
+  value === "multi_agent" ? "Multi-agent" : "Single agent";
+const statusLabel: Record<string, string> = {
+  queued: "Queued",
+  running: "Working",
+  waiting_for_input: "Needs your response",
+  completed: "Complete",
+  failed: "Failed",
+  interrupted: "Interrupted",
+};
+type Submission = {
+  sessionId: string;
+  body: { query: string; attachments: string[]; request_id: string };
+};
+type Progress = { id: string; kind: string; tool?: string };
+
+function RichText({ children }: { children: string }) {
+  return (
+    <div className="markdown">
+      <Markdown
+        remarkPlugins={[remarkGfm, remarkMath]}
+        rehypePlugins={[rehypeKatex]}
+      >
+        {children}
+      </Markdown>
+    </div>
+  );
+}
+
+export default function App() {
+  const [capabilities, setCapabilities] = useState<Capabilities | null>(null);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [selected, setSelected] = useState<string | null>(() =>
+    new URLSearchParams(window.location.search).get("session"),
+  );
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [model, setModel] = useState("");
+  const [workflow, setWorkflow] = useState("single_agent");
+  const [draft, setDraft] = useState("");
+  const [files, setFiles] = useState<File[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [revision, setRevision] = useState(0);
+  const [progress, setProgress] = useState<Progress[]>([]);
+  const [connected, setConnected] = useState(true);
+  const [sidebar, setSidebar] = useState(false);
+  const [resultsOpen, setResultsOpen] = useState(() => window.innerWidth > 950);
+  const [artifactId, setArtifactId] = useState<string | null>(null);
+  const [answered, setAnswered] = useState<string | null>(null);
+  const [pending, setPending] = useState<Submission | null>(null);
+  const uploadInput = useRef<HTMLInputElement>(null);
+  const endOfChat = useRef<HTMLDivElement>(null);
+  const activeRun = detail?.runs.find((run) => !terminal(run.status));
+  const waiting = activeRun?.status === "waiting_for_input";
+  const artifacts = detail?.runs.flatMap((run) => run.artifacts) || [];
+  const structures = artifacts.filter((artifact) => artifact.preview_url);
+  const currentArtifact =
+    structures.find((artifact) => artifact.id === artifactId) ||
+    structures[structures.length - 1];
+
+  useEffect(() => {
+    const controller = new AbortController();
+    Promise.all([
+      api<Capabilities>("/capabilities", { signal: controller.signal }),
+      api<Session[]>("/sessions", { signal: controller.signal }),
+    ])
+      .then(([caps, list]) => {
+        setCapabilities(caps);
+        setModel(caps.models[0] || "");
+        setSessions(list);
+      })
+      .catch((error) => {
+        if (!controller.signal.aborted) setError(error.message);
+      });
+    return () => controller.abort();
+  }, []);
+
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    if (selected) url.searchParams.set("session", selected);
+    else url.searchParams.delete("session");
+    window.history.replaceState(null, "", url);
+    if (!selected) {
+      setDetail(null);
+      return;
+    }
+    const controller = new AbortController();
+    api<SessionDetail>(`/sessions/${selected}`, { signal: controller.signal })
+      .then(setDetail)
+      .catch((error) => {
+        if (!controller.signal.aborted) setError(error.message);
+      });
+    return () => controller.abort();
+  }, [selected, revision]);
+
+  useEffect(() => {
+    if (!activeRun) return;
+    setProgress([]);
+    setConnected(true);
+    const stream = new EventSource(`/api/v1/runs/${activeRun.id}/events`);
+    stream.onopen = () => setConnected(true);
+    stream.onerror = () => {
+      setConnected(false);
+      setRevision((value) => value + 1);
+    };
+    stream.addEventListener("progress", (event) => {
+      const message = event as MessageEvent;
+      const data = JSON.parse(message.data);
+      setProgress((previous) =>
+        previous.some((item) => item.id === message.lastEventId)
+          ? previous
+          : [...previous.slice(-99), { id: message.lastEventId, ...data }],
+      );
+    });
+    stream.addEventListener("status", () => setRevision((value) => value + 1));
+    stream.addEventListener("human_response", () =>
+      setRevision((value) => value + 1),
+    );
+    stream.addEventListener("end", () => {
+      stream.close();
+      setRevision((value) => value + 1);
+      void api<Session[]>("/sessions")
+        .then(setSessions)
+        .catch((error) => setError(error.message));
+    });
+    return () => stream.close();
+  }, [activeRun?.id]);
+
+  useEffect(() => {
+    endOfChat.current?.scrollIntoView?.({ behavior: "smooth", block: "end" });
+  }, [detail?.runs.length, activeRun?.status]);
+
+  function chooseSession(id: string | null) {
+    if (busy || pending) return;
+    setSelected(id);
+    setDetail(null);
+    setDraft("");
+    setFiles([]);
+    setError("");
+    setArtifactId(null);
+    setSidebar(false);
+    setAnswered(null);
+  }
+
+  async function send(event: React.FormEvent) {
+    event.preventDefault();
+    if (busy || (!draft.trim() && !pending) || (!model && !selected)) return;
+    setBusy(true);
+    setError("");
+    try {
+      if (waiting && activeRun?.question_id) {
+        await api(
+          `/runs/${activeRun.id}/response`,
+          post({ question_id: activeRun.question_id, answer: draft }),
+        );
+        setAnswered(activeRun.question_id);
+        setDraft("");
+        setRevision((value) => value + 1);
+        return;
+      }
+      let submission = pending;
+      if (!submission) {
+        let sessionId = selected;
+        if (!sessionId) {
+          const session = await api<Session>(
+            "/sessions",
+            post({ model, workflow }),
+          );
+          sessionId = session.id;
+          setSelected(sessionId);
+          setDetail({ ...session, runs: [] });
+        }
+        const attachments: string[] = [];
+        for (const file of files) {
+          if (file.size > (capabilities?.upload_limit || 0))
+            throw new Error(`${file.name} exceeds the upload limit.`);
+          const artifact = await api<Artifact>(
+            `/sessions/${sessionId}/uploads?filename=${encodeURIComponent(file.name)}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/octet-stream" },
+              body: file,
+            },
+          );
+          attachments.push(artifact.id);
+        }
+        submission = {
+          sessionId,
+          body: { query: draft, attachments, request_id: crypto.randomUUID() },
+        };
+        setPending(submission);
+      }
+      await api<Run>(
+        `/sessions/${submission.sessionId}/runs`,
+        post(submission.body),
+      );
+      setPending(null);
+      setDraft("");
+      setFiles([]);
+      setRevision((value) => value + 1);
+      setSessions(await api<Session[]>("/sessions"));
+    } catch (error) {
+      setError(
+        error instanceof Error ? error.message : "Unable to send the request.",
+      );
+      if (
+        error instanceof ApiError &&
+        error.status >= 400 &&
+        error.status < 500
+      ) {
+        setPending(null);
+        setRevision((value) => value + 1);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={`workspace ${resultsOpen ? "" : "results-hidden"}`}>
+      <aside className={`sidebar ${sidebar ? "open" : ""}`}>
+        <a
+          className="brand"
+          href="/"
+          onClick={(event) => {
+            event.preventDefault();
+            chooseSession(null);
+          }}
+        >
+          <span className="brand-icon">
+            <Atom size={24} />
+          </span>
+          <span>
+            ChemGraph<small>CHEMISTRY WORKSPACE</small>
+          </span>
+        </a>
+        <button
+          className="new-chat"
+          disabled={busy || !!pending}
+          onClick={() => chooseSession(null)}
+        >
+          <Plus size={18} /> New conversation
+        </button>
+        <div className="section-label">
+          YOUR CONVERSATIONS <span>{sessions.length}</span>
+        </div>
+        <nav className="session-list" aria-label="Conversations">
+          {sessions.map((session) => (
+            <button
+              key={session.id}
+              className={`session ${selected === session.id ? "selected" : ""}`}
+              disabled={busy || !!pending}
+              onClick={() => chooseSession(session.id)}
+            >
+              <MessageSquare size={16} />
+              <span>{session.title}</span>
+            </button>
+          ))}
+          {!sessions.length && (
+            <p className="quiet sidebar-empty">
+              Your conversations will appear here.
+            </p>
+          )}
+        </nav>
+        <div className="sidebar-bottom">
+          <div className="availability">
+            <span className="dot" />
+            {capabilities?.demo
+              ? "Local demo workspace"
+              : "Institution workspace"}
+          </div>
+          <div className="profile">
+            <span className="avatar">
+              {capabilities?.user.slice(0, 2).toUpperCase() || "CG"}
+            </span>
+            <span>
+              {capabilities?.user || "Connecting…"}
+              <small>
+                {capabilities?.calculators.join(", ").toUpperCase() ||
+                  "Computational chemistry"}
+              </small>
+            </span>
+          </div>
+        </div>
+      </aside>
+      {sidebar && (
+        <button
+          className="sidebar-scrim"
+          aria-label="Close conversations"
+          onClick={() => setSidebar(false)}
+        />
+      )}
+      <main className="main-panel">
+        <header className="workspace-header">
+          <button
+            className="icon-button mobile-menu"
+            aria-label="Open conversations"
+            onClick={() => setSidebar(true)}
+          >
+            <Menu size={20} />
+          </button>
+          <div className="breadcrumb">
+            Workspace <ChevronRight size={14} />
+            <strong>{detail?.title || "New conversation"}</strong>
+          </div>
+          <button
+            className={`results-toggle ${resultsOpen ? "active" : ""}`}
+            aria-expanded={resultsOpen}
+            onClick={() => setResultsOpen(!resultsOpen)}
+          >
+            <FlaskConical size={16} />
+            Results
+          </button>
+        </header>
+        <div className="chat-settings">
+          <div>
+            <SlidersHorizontal size={15} />
+            <span>Run settings</span>
+          </div>
+          <label>
+            Model
+            <select
+              aria-label="Model"
+              value={detail?.model || model}
+              disabled={!!selected || busy}
+              onChange={(event) => setModel(event.target.value)}
+            >
+              {(capabilities?.models || []).map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+              {detail && !capabilities?.models.includes(detail.model) && (
+                <option value={detail.model}>{detail.model}</option>
+              )}
+            </select>
+          </label>
+          <label>
+            Workflow
+            <select
+              aria-label="Workflow"
+              value={detail?.workflow || workflow}
+              disabled={!!selected || busy}
+              onChange={(event) => setWorkflow(event.target.value)}
+            >
+              {(capabilities?.workflows || ["single_agent", "multi_agent"]).map(
+                (value) => (
+                  <option key={value} value={value}>
+                    {workflowLabel(value)}
+                  </option>
+                ),
+              )}
+            </select>
+          </label>
+        </div>
+        <div className="chat-scroll">
+          {!detail?.runs.length && (
+            <section className="welcome">
+              <div className="welcome-mark">
+                <FlaskConical size={32} strokeWidth={1.4} />
+              </div>
+              <div className="eyebrow">FROM QUESTION TO CALCULATION</div>
+              <h1>
+                Explore your next
+                <br />
+                <span>molecular question.</span>
+              </h1>
+              <p>
+                Build structures, run simulations, and explore the results.
+                <br />
+                Start with a question or attach a structure.
+              </p>
+              <div className="suggestions">
+                {[
+                  [
+                    "Optimize a structure",
+                    capabilities?.demo
+                      ? "Optimize a copper dimer with EMT"
+                      : "Build a water molecule from SMILES O and optimize its geometry.",
+                  ],
+                  [
+                    "Compare molecules",
+                    "Compare the optimized structures of water and methanol.",
+                  ],
+                  [
+                    "Explore an attachment",
+                    "Describe the attached structure and suggest a suitable calculation.",
+                  ],
+                ].map(([title, query]) => (
+                  <button key={title} onClick={() => setDraft(query)}>
+                    <Sparkles size={16} />
+                    <span>{title}</span>
+                    <ChevronRight size={15} />
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+          {detail?.runs.map((run) => (
+            <article className="exchange" key={run.id}>
+              <div className="user-message">
+                <div className="message-label">YOU</div>
+                <p>{run.query}</p>
+                {run.attachments.length > 0 && (
+                  <div className="attachment-chips">
+                    {run.attachments.map((file) => (
+                      <a key={file.id} href={file.url}>
+                        <Paperclip size={13} />
+                        {file.name}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="assistant-message">
+                <span className="assistant-avatar">
+                  <Atom size={20} />
+                </span>
+                <div className="assistant-body">
+                  <div className="assistant-heading">
+                    <strong>ChemGraph</strong>
+                    <span className={`status-badge ${run.status}`}>
+                      {!terminal(run.status) ? (
+                        <LoaderCircle className="spin" size={12} />
+                      ) : run.status === "completed" ? (
+                        <Check size={12} />
+                      ) : null}
+                      {statusLabel[run.status]}
+                    </span>
+                  </div>
+                  {run.responses.map((response, index) => (
+                    <div className="follow-up-history" key={index}>
+                      <RichText>{response.question}</RichText>
+                      <p>
+                        <strong>Your response:</strong> {response.answer}
+                      </p>
+                    </div>
+                  ))}
+                  {run.final_text && <RichText>{run.final_text}</RichText>}
+                  {run.id === activeRun?.id && (
+                    <div className="run-progress" aria-live="polite">
+                      {progress
+                        .filter((item) => item.tool)
+                        .slice(-6)
+                        .map((item) => (
+                          <div key={item.id}>
+                            {item.kind.endsWith("finished") ? (
+                              <Check size={13} />
+                            ) : (
+                              <span className="progress-dot" />
+                            )}
+                            <span>
+                              {item.tool?.replaceAll("_", " ")}
+                              {item.kind.endsWith("failed") ? " — failed" : ""}
+                            </span>
+                          </div>
+                        ))}
+                      {!progress.length && (
+                        <p>
+                          {run.status === "queued"
+                            ? "Your calculation is queued."
+                            : "Preparing the calculation…"}
+                        </p>
+                      )}
+                      {!connected && (
+                        <p>
+                          Connection interrupted. Reconnecting to your
+                          calculation…
+                        </p>
+                      )}
+                    </div>
+                  )}
+                  {run.question && (
+                    <div className="question">
+                      <strong>A quick clarification</strong>
+                      <RichText>{run.question}</RichText>
+                      <small>
+                        {answered === run.question_id
+                          ? "Response sent. Waiting for the agent…"
+                          : "Reply in the message box below to continue."}
+                      </small>
+                    </div>
+                  )}
+                  {run.error && (
+                    <div className="run-error">
+                      <p>{run.error}</p>
+                      <small>Run {run.id}</small>
+                      <button
+                        onClick={() => {
+                          setDraft(run.query);
+                          setError("");
+                        }}
+                      >
+                        Use this question again
+                      </button>
+                    </div>
+                  )}
+                  {!!run.artifacts.length && (
+                    <button
+                      className="inline-results"
+                      onClick={() => {
+                        setResultsOpen(true);
+                        setArtifactId(
+                          run.artifacts.find((a) => a.preview_url)?.id || null,
+                        );
+                      }}
+                    >
+                      <FlaskConical size={14} />
+                      {run.artifacts.length} result files
+                      <ChevronRight size={14} />
+                    </button>
+                  )}
+                </div>
+              </div>
+            </article>
+          ))}
+          <div ref={endOfChat} />
+        </div>
+        <div className="composer-area">
+          {error && (
+            <div role="alert" className="error-banner">
+              <span>{error}</span>
+              <button
+                className="icon-button"
+                aria-label="Dismiss error"
+                onClick={() => setError("")}
+              >
+                <X size={15} />
+              </button>
+            </div>
+          )}
+          {capabilities && !capabilities.models.length && (
+            <div className="error-banner">
+              No model providers are configured. Ask your administrator to
+              enable a provider.
+            </div>
+          )}
+          {selected && (
+            <div className="settings-note">
+              Model and workflow stay with this conversation. Start a new
+              conversation to change them.
+            </div>
+          )}
+          <form
+            className={`composer ${waiting ? "needs-response" : ""}`}
+            onSubmit={send}
+          >
+            {!!files.length && (
+              <div className="attachment-chips">
+                {files.map((file, index) => (
+                  <span key={`${file.name}-${index}`}>
+                    <Paperclip size={13} />
+                    {file.name}
+                    <button
+                      type="button"
+                      disabled={busy || !!pending}
+                      aria-label={`Remove ${file.name}`}
+                      onClick={() =>
+                        setFiles(files.filter((_, i) => i !== index))
+                      }
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+            <textarea
+              aria-label={waiting ? "Response to agent" : "Message"}
+              placeholder={
+                waiting
+                  ? "Reply to continue the calculation…"
+                  : "Ask a chemistry question…"
+              }
+              value={draft}
+              disabled={
+                busy ||
+                !!pending ||
+                (!!activeRun && !waiting) ||
+                answered === activeRun?.question_id
+              }
+              onChange={(event) => setDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (
+                  event.key === "Enter" &&
+                  !event.shiftKey &&
+                  !event.nativeEvent.isComposing
+                ) {
+                  event.preventDefault();
+                  event.currentTarget.form?.requestSubmit();
+                }
+              }}
+              rows={2}
+            />
+            <div className="composer-toolbar">
+              <div>
+                <input
+                  ref={uploadInput}
+                  type="file"
+                  multiple
+                  accept=".xyz,.pdb,.cif,.traj,.json,.csv,.txt"
+                  aria-label="Attach structure or data files"
+                  hidden
+                  onChange={(event) => {
+                    const next = [
+                      ...files,
+                      ...Array.from(event.target.files || []),
+                    ];
+                    if (next.length > 10)
+                      setError("Attach up to 10 files per message.");
+                    else setFiles(next);
+                    event.target.value = "";
+                  }}
+                />
+                <button
+                  type="button"
+                  className="attach-button"
+                  disabled={busy || !!activeRun || !!pending}
+                  onClick={() => uploadInput.current?.click()}
+                >
+                  <Paperclip size={17} />
+                  <span>Attach files</span>
+                </button>
+              </div>
+              <button
+                className="send-button"
+                type="submit"
+                aria-label={
+                  pending
+                    ? "Retry send"
+                    : waiting
+                      ? "Send response"
+                      : "Send message"
+                }
+                disabled={
+                  busy ||
+                  (!draft.trim() && !pending) ||
+                  !capabilities?.models.length ||
+                  (!!activeRun && !waiting && !pending) ||
+                  answered === activeRun?.question_id
+                }
+              >
+                {busy ? (
+                  <LoaderCircle className="spin" size={18} />
+                ) : pending ? (
+                  "Retry send"
+                ) : (
+                  <ArrowUp size={20} />
+                )}
+              </button>
+            </div>
+          </form>
+          <div className="composer-footnote">
+            {capabilities?.demo
+              ? "Demo mode · Real EMT calculation · No model credentials required"
+              : "Review simulation settings and results before using them in your research."}
+          </div>
+        </div>
+      </main>
+      {resultsOpen && (
+        <aside className="results-panel">
+          <div className="results-heading">
+            <div>
+              <FlaskConical size={18} />
+              <h2>Results</h2>
+            </div>
+            <button
+              className="icon-button"
+              aria-label="Close results"
+              onClick={() => setResultsOpen(false)}
+            >
+              <X size={17} />
+            </button>
+          </div>
+          {currentArtifact ? (
+            <>
+              <div className="result-label">MOLECULAR VIEWER</div>
+              <select
+                className="structure-select"
+                aria-label="Structure or trajectory"
+                value={currentArtifact.id}
+                onChange={(event) => setArtifactId(event.target.value)}
+              >
+                {structures.map((artifact) => (
+                  <option key={artifact.id} value={artifact.id}>
+                    {artifact.name} · Run {artifact.run_id?.slice(0, 6)}
+                  </option>
+                ))}
+              </select>
+              <MoleculeViewer artifact={currentArtifact} />
+            </>
+          ) : (
+            <div className="empty-results">
+              <div className="empty-molecule">
+                <Atom size={52} strokeWidth={1} />
+              </div>
+              <h3>A closer look, right here.</h3>
+              <p>
+                Molecular structures and trajectories will appear as your
+                calculations finish.
+              </p>
+            </div>
+          )}
+          <div className="artifacts-heading">
+            <span className="result-label">ARTIFACTS</span>
+            <span>{artifacts.length}</span>
+          </div>
+          <div className="artifact-list">
+            {artifacts.map((artifact) => (
+              <a className="artifact" href={artifact.url} key={artifact.id}>
+                <span className="file-icon">
+                  {artifact.name.split(".").pop()?.toUpperCase()}
+                </span>
+                <span>
+                  <strong>{artifact.name}</strong>
+                  <small>
+                    {Math.max(1, Math.round(artifact.size / 1024))} KB · Run{" "}
+                    {artifact.run_id?.slice(0, 6)}
+                  </small>
+                </span>
+                <ArrowDownToLine size={15} />
+              </a>
+            ))}
+            {!artifacts.length && (
+              <p className="quiet">
+                Downloadable files are saved with each calculation.
+              </p>
+            )}
+          </div>
+          <div className="results-note">
+            <Check size={14} />
+            <span>Results stay attached to their conversation.</span>
+          </div>
+        </aside>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/MoleculeViewer.tsx
+++ b/frontend/src/MoleculeViewer.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from "react";
+import { Pause, Play, RotateCcw } from "lucide-react";
+import type { GLViewer } from "3dmol";
+import type { Artifact } from "./api";
+
+export default function MoleculeViewer({ artifact }: { artifact: Artifact }) {
+  const element = useRef<HTMLDivElement>(null);
+  const viewer = useRef<GLViewer | null>(null);
+  const [error, setError] = useState("");
+  const [ready, setReady] = useState(false);
+  const [playing, setPlaying] = useState(false);
+  const [frames, setFrames] = useState(1);
+  const [frame, setFrame] = useState(0);
+  useEffect(() => {
+    const controller = new AbortController();
+    let disposed = false;
+    let instance: GLViewer | null = null;
+    const resize = new ResizeObserver(() => {
+      instance?.resize();
+      instance?.render();
+    });
+    setReady(false);
+    setError("");
+    setPlaying(false);
+    setFrame(0);
+    Promise.all([
+      import("3dmol"),
+      fetch(artifact.preview_url!, { signal: controller.signal }).then(
+        async (response) => {
+          if (!response.ok)
+            throw new Error(
+              "This structure could not be previewed. Download the original file below.",
+            );
+          return response.text();
+        },
+      ),
+    ])
+      .then(([mol, xyz]) => {
+        if (disposed || !element.current) return;
+        instance = mol.createViewer(element.current, {
+          backgroundColor: "#f4f7fa",
+          antialias: true,
+        });
+        viewer.current = instance;
+        instance.addModelsAsFrames(xyz, "xyz");
+        instance.setStyle(
+          {},
+          { stick: { radius: 0.13 }, sphere: { scale: 0.28 } },
+        );
+        instance.zoomTo();
+        instance.rotate(45, "y");
+        instance.rotate(15, "x");
+        instance.render();
+        setFrames(instance.getNumFrames());
+        setReady(true);
+        resize.observe(element.current);
+      })
+      .catch((error) => {
+        if (!disposed)
+          setError(
+            error instanceof Error ? error.message : "Viewer unavailable.",
+          );
+      });
+    return () => {
+      disposed = true;
+      controller.abort();
+      resize.disconnect();
+      instance?.stopAnimate();
+      instance?.clear();
+      viewer.current = null;
+      if (element.current) element.current.replaceChildren();
+    };
+  }, [artifact.id, artifact.preview_url]);
+  const play = () => {
+    if (playing) viewer.current?.stopAnimate();
+    else viewer.current?.animate({ loop: "forward", interval: 120 });
+    setPlaying(!playing);
+  };
+  return (
+    <div className="viewer-card">
+      <div
+        ref={element}
+        className="molecule-canvas"
+        role="img"
+        aria-label={`3D molecular structure: ${artifact.name}`}
+      />
+      {!ready && (
+        <div className="viewer-message" role="status">
+          {error || "Loading molecular structure…"}
+        </div>
+      )}
+      <div className="viewer-controls">
+        <span>
+          {frames > 1
+            ? `${frames} trajectory frames`
+            : "Drag to rotate · Scroll to zoom"}
+        </span>
+        {frames > 1 && (
+          <button
+            className="icon-button"
+            disabled={!ready}
+            onClick={play}
+            aria-label={playing ? "Pause trajectory" : "Play trajectory"}
+          >
+            {playing ? <Pause size={16} /> : <Play size={16} />}
+          </button>
+        )}
+        <button
+          className="icon-button"
+          disabled={!ready}
+          aria-label="Reset molecular view"
+          onClick={() => {
+            viewer.current?.zoomTo();
+            viewer.current?.render();
+          }}
+        >
+          <RotateCcw size={16} />
+        </button>
+      </div>
+      {frames > 1 && (
+        <input
+          className="frame-slider"
+          type="range"
+          min={0}
+          max={frames - 1}
+          value={frame}
+          aria-label="Trajectory frame"
+          onChange={(event) => {
+            const value = Number(event.target.value);
+            setFrame(value);
+            setPlaying(false);
+            viewer.current?.stopAnimate();
+            void viewer.current
+              ?.setFrame(value)
+              .then(() => viewer.current?.render());
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/api.test.ts
+++ b/frontend/src/api.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { api, ApiError } from "./api";
+
+afterEach(() => vi.unstubAllGlobals());
+
+test("an SSO login redirect gives a useful sign-in error", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response("<html>Sign in</html>", {
+          headers: { "Content-Type": "text/html" },
+        }),
+    ),
+  );
+  await expect(api("/sessions")).rejects.toMatchObject({
+    status: 401,
+    message: expect.stringContaining("sign-in may have expired"),
+  });
+});
+
+test("structured API errors preserve the server message and status", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { message: "Conversation already has an unfinished run." },
+          }),
+          { status: 409, headers: { "Content-Type": "application/json" } },
+        ),
+    ),
+  );
+  await expect(api("/sessions/id/runs")).rejects.toBeInstanceOf(ApiError);
+  await expect(api("/sessions/id/runs")).rejects.toMatchObject({
+    status: 409,
+    message: "Conversation already has an unfinished run.",
+  });
+});

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -17,10 +17,16 @@ export interface Session {
 export interface Capabilities {
   user: string;
   models: string[];
+  model_status?: Record<string, ModelStatus>;
   workflows: string[];
   calculators: string[];
   upload_limit: number;
   demo: boolean;
+}
+export interface ModelStatus {
+  configured: boolean;
+  code: string;
+  message: string;
 }
 export interface Run {
   id: string;
@@ -29,6 +35,7 @@ export interface Run {
   status: string;
   final_text: string;
   error: string | null;
+  error_code?: string | null;
   question_id: string | null;
   question: string | null;
   artifacts: Artifact[];
@@ -37,14 +44,16 @@ export interface Run {
 }
 export interface SessionDetail extends Session {
   runs: Run[];
+  model_status?: ModelStatus;
 }
 export const terminal = (status: string) =>
-  ["completed", "failed", "interrupted"].includes(status);
+  ["completed", "failed", "interrupted", "cancelled"].includes(status);
 
 export class ApiError extends Error {
   constructor(
     message: string,
     public status: number,
+    public submissionRejected = false,
   ) {
     super(message);
   }
@@ -65,6 +74,7 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
     throw new ApiError(
       body?.error?.message || `Request failed (${response.status}).`,
       response.status,
+      body?.error?.submission_rejected === true,
     );
   }
   return response.json();

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,76 @@
+export interface Artifact {
+  id: string;
+  name: string;
+  kind: string;
+  size: number;
+  url: string;
+  preview_url: string | null;
+  run_id: string | null;
+}
+export interface Session {
+  id: string;
+  title: string;
+  model: string;
+  workflow: string;
+  created?: string;
+}
+export interface Capabilities {
+  user: string;
+  models: string[];
+  workflows: string[];
+  calculators: string[];
+  upload_limit: number;
+  demo: boolean;
+}
+export interface Run {
+  id: string;
+  session_id: string;
+  query: string;
+  status: string;
+  final_text: string;
+  error: string | null;
+  question_id: string | null;
+  question: string | null;
+  artifacts: Artifact[];
+  attachments: Artifact[];
+  responses: { question: string; answer: string }[];
+}
+export interface SessionDetail extends Session {
+  runs: Run[];
+}
+export const terminal = (status: string) =>
+  ["completed", "failed", "interrupted"].includes(status);
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+  ) {
+    super(message);
+  }
+}
+export async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`/api/v1${path}`, init);
+  if (
+    response.ok &&
+    !response.headers.get("Content-Type")?.includes("application/json")
+  ) {
+    throw new ApiError(
+      "Your sign-in may have expired. Refresh this page to sign in again.",
+      401,
+    );
+  }
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new ApiError(
+      body?.error?.message || `Request failed (${response.status}).`,
+      response.status,
+    );
+  }
+  return response.json();
+}
+export const post = (body: unknown): RequestInit => ({
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+import "katex/dist/katex.min.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -951,7 +951,7 @@ button:hover:not(:disabled) {
   .sidebar-scrim {
     display: block;
     position: fixed;
-    inset: 0;
+    inset: 0 0 0 260px;
     background: #0d243e66;
     z-index: 11;
   }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,1049 @@
+:root {
+  font-family:
+    Inter,
+    ui-sans-serif,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: #243546;
+  background: #fff;
+  font-synthesis: none;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.5;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+}
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+button,
+a,
+select {
+  touch-action: manipulation;
+}
+button {
+  cursor: pointer;
+}
+button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+button {
+  color: inherit;
+}
+a {
+  color: #176f83;
+  text-decoration: none;
+}
+button:focus-visible,
+a:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+input:focus-visible {
+  outline: 3px solid #23a6b2;
+  outline-offset: 3px;
+}
+button {
+  border: 0;
+}
+button:hover:not(:disabled) {
+  filter: brightness(0.97);
+}
+.workspace {
+  display: grid;
+  grid-template-columns: 244px minmax(400px, 1fr) 342px;
+  height: 100dvh;
+  overflow: hidden;
+}
+.workspace.results-hidden {
+  grid-template-columns: 244px minmax(0, 1fr);
+}
+.sidebar {
+  background: #101f30;
+  color: #c3cfda;
+  display: flex;
+  flex-direction: column;
+  padding: 30px 18px 0;
+}
+.brand {
+  display: flex;
+  gap: 11px;
+  align-items: center;
+  color: white;
+  padding: 0 10px;
+  font-size: 22px;
+  font-weight: 650;
+  letter-spacing: -0.8px;
+}
+.brand small {
+  display: block;
+  color: #8297aa;
+  font-size: 8px;
+  letter-spacing: 2.1px;
+  margin-top: 1px;
+}
+.brand-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 40px;
+  color: #75d0d0;
+}
+.new-chat {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  background: #1a394b;
+  color: #e0f6f5;
+  border: 1px solid #2a5363;
+  border-radius: 7px;
+  margin: 32px 0 30px;
+  padding: 11px 8px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.section-label {
+  display: flex;
+  justify-content: space-between;
+  color: #8295a8;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 1.6px;
+  padding: 0 10px 15px;
+}
+.section-label span {
+  letter-spacing: 0;
+}
+.session-list {
+  overflow: auto;
+  flex: 1;
+}
+.session {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  background: transparent;
+  text-align: left;
+  color: #abbccb;
+  font-size: 12px;
+  padding: 11px 10px;
+  border-radius: 6px;
+  margin-bottom: 4px;
+}
+.session.selected {
+  background: #23384a;
+  color: #effbfb;
+}
+.session svg {
+  flex-shrink: 0;
+  color: #7e9aaf;
+}
+.session span {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-empty {
+  padding: 0 10px;
+  font-size: 12px;
+}
+.sidebar-bottom {
+  margin-top: 30px;
+}
+.availability {
+  border-bottom: 1px solid #2b3b4c;
+  padding: 15px 8px;
+  color: #94aaba;
+  font-size: 10px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #70c1ad;
+}
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 19px 5px;
+  font-size: 11px;
+  overflow: hidden;
+}
+.profile > span:last-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.profile small {
+  display: block;
+  color: #839bad;
+  font-size: 9px;
+  padding-top: 2px;
+}
+.avatar {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 31px;
+  height: 31px;
+  border-radius: 50%;
+  background: #304658;
+  color: #c9e0e6;
+  font-size: 10px;
+}
+.main-panel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  height: 100dvh;
+}
+.workspace-header {
+  height: 72px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 30px;
+  border-bottom: 1px solid #edf0f2;
+  gap: 10px;
+}
+.breadcrumb {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  color: #8b98a4;
+  font-size: 11px;
+  min-width: 0;
+}
+.breadcrumb strong {
+  color: #37485a;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.results-toggle {
+  background: #f0f6f7;
+  color: #347482;
+  border-radius: 5px;
+  font-size: 11px;
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  padding: 7px 9px;
+}
+.chat-settings {
+  height: 64px;
+  display: flex;
+  align-items: center;
+  padding: 0 30px;
+  gap: 18px;
+  flex-shrink: 0;
+  border-bottom: 1px solid #f1f3f4;
+}
+.chat-settings > div {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: #7e8b98;
+  font-size: 10px;
+  margin-right: auto;
+}
+.chat-settings label {
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  font-size: 10px;
+  color: #8c98a3;
+}
+.chat-settings select {
+  background: #fff;
+  border: 1px solid #e0e6eb;
+  border-radius: 5px;
+  padding: 6px 8px;
+  max-width: 150px;
+  font-size: 11px;
+  color: #455767;
+}
+.chat-settings select:disabled {
+  opacity: 1;
+  background: #f7f9fa;
+}
+.chat-scroll {
+  overflow: auto;
+  flex: 1;
+  padding: 24px 35px;
+}
+.welcome {
+  max-width: 590px;
+  margin: clamp(20px, 6vh, 80px) auto 20px;
+  text-align: center;
+}
+.welcome-mark {
+  background: #eaf4f4;
+  color: #438b92;
+  display: grid;
+  place-items: center;
+  border-radius: 18px;
+  width: 66px;
+  height: 66px;
+  margin: 0 auto 27px;
+}
+.eyebrow {
+  font-size: 9px;
+  color: #678592;
+  letter-spacing: 2.1px;
+  font-weight: 650;
+}
+.welcome h1 {
+  font-family: Georgia, "Times New Roman", serif;
+  font-weight: 400;
+  font-size: clamp(29px, 2.5vw, 41px);
+  letter-spacing: -1.2px;
+  line-height: 1.22;
+  margin: 17px 0;
+  color: #1c3345;
+}
+.welcome h1 span {
+  color: #639095;
+}
+.welcome p {
+  color: #8997a3;
+  font-size: 12px;
+  line-height: 1.9;
+}
+.suggestions {
+  display: flex;
+  gap: 9px;
+  justify-content: center;
+  margin-top: 34px;
+}
+.suggestions button {
+  background: #fff;
+  border: 1px solid #e1e8eb;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  text-align: left;
+  padding: 12px 10px;
+  color: #566d7c;
+  font-size: 10px;
+}
+.suggestions svg:first-child {
+  color: #67999b;
+  flex-shrink: 0;
+}
+.suggestions svg:last-child {
+  color: #a2b1bc;
+}
+.composer-area {
+  padding: 12px 35px 20px;
+  max-width: 950px;
+  width: 100%;
+  margin: 0 auto;
+}
+.composer {
+  border: 1px solid #dce4e8;
+  box-shadow: 0 3px 12px #142e4610;
+  border-radius: 12px;
+  padding: 14px 16px 10px;
+  background: #fff;
+}
+.composer textarea {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  resize: none;
+  min-height: 51px;
+  color: #293d4f;
+  line-height: 1.6;
+  font-size: 12px;
+}
+.composer textarea::placeholder {
+  color: #94a1ac;
+}
+.composer-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.attach-button {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  background: transparent;
+  padding: 6px 0;
+  color: #80919f;
+  font-size: 10px;
+}
+.send-button {
+  background: #247d85;
+  color: white;
+  border-radius: 7px;
+  min-width: 32px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+}
+.composer-footnote {
+  text-align: center;
+  color: #98a3ad;
+  font-size: 9px;
+  padding-top: 10px;
+}
+.settings-note {
+  font-size: 9px;
+  color: #8795a1;
+  text-align: center;
+  margin-bottom: 8px;
+}
+.results-panel {
+  background: #fafcfd;
+  border-left: 1px solid #e8edf0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 0 21px 18px;
+}
+.results-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 72px;
+  min-height: 72px;
+  border-bottom: 1px solid #e8edf0;
+  margin: 0 -21px 23px;
+  padding: 0 21px;
+}
+.results-heading > div {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  color: #536c7b;
+}
+.results-heading h2 {
+  font-size: 12px;
+  font-weight: 600;
+}
+.icon-button {
+  background: transparent;
+  display: grid;
+  place-items: center;
+  padding: 5px;
+  color: #82939f;
+  border-radius: 4px;
+}
+.empty-results {
+  text-align: center;
+  padding: 38px 18px 37px;
+  border: 1px dashed #d9e4e8;
+  border-radius: 8px;
+  background: #f5f9fa;
+  margin-bottom: 30px;
+}
+.empty-molecule {
+  color: #a9c7cd;
+  margin-bottom: 15px;
+}
+.empty-results h3 {
+  font-size: 12px;
+  font-weight: 500;
+  color: #4e6a7c;
+  margin: 0 0 9px;
+}
+.empty-results p {
+  font-size: 11px;
+  color: #92a3ad;
+  line-height: 1.8;
+  margin: 0;
+}
+.artifacts-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 20px 0 13px;
+  color: #8fa1ad;
+  font-size: 10px;
+}
+.result-label {
+  font-size: 9px;
+  letter-spacing: 1.7px;
+  font-weight: 600;
+  color: #8a9eaa;
+}
+.artifact-list {
+  flex: 1;
+}
+.quiet {
+  font-size: 11px;
+  color: #8b9da8;
+  line-height: 1.8;
+}
+.results-note {
+  border-top: 1px solid #e3ebef;
+  padding-top: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #91a4ae;
+  font-size: 9px;
+  margin-top: 25px;
+}
+.results-note svg {
+  color: #669a8b;
+  flex-shrink: 0;
+}
+.exchange {
+  max-width: 760px;
+  margin: 0 auto 30px;
+}
+.user-message {
+  margin-left: 36px;
+  background: #f3f7f8;
+  padding: 15px 18px;
+  border-radius: 10px;
+}
+.message-label {
+  font-size: 8px;
+  letter-spacing: 1.5px;
+  color: #90a3ae;
+  font-weight: 650;
+}
+.user-message p {
+  margin: 5px 0;
+  font-size: 13px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.assistant-message {
+  display: flex;
+  gap: 13px;
+  margin-top: 23px;
+}
+.assistant-avatar {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  background: #eaf5f3;
+  color: #529596;
+  border-radius: 7px;
+  flex-shrink: 0;
+}
+.assistant-body {
+  flex: 1;
+  min-width: 0;
+}
+.assistant-heading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 0 12px;
+  font-size: 11px;
+}
+.assistant-heading strong {
+  font-weight: 600;
+}
+.status-badge {
+  font-size: 9px;
+  background: #f2f5f6;
+  color: #81929e;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 6px;
+}
+.status-badge.completed {
+  background: #edf7f2;
+  color: #548470;
+}
+.status-badge.failed,
+.status-badge.interrupted {
+  background: #fff0eb;
+  color: #a45a45;
+}
+.status-badge.waiting_for_input {
+  background: #fff6e3;
+  color: #9d7c3b;
+}
+.markdown {
+  font-size: 13px;
+  line-height: 1.85;
+  overflow-wrap: anywhere;
+}
+.markdown p:first-child {
+  margin-top: 0;
+}
+.markdown pre {
+  white-space: pre-wrap;
+  background: #edf2f5;
+  padding: 12px;
+  border-radius: 5px;
+}
+.markdown table {
+  border-collapse: collapse;
+  display: block;
+  overflow: auto;
+  max-width: 100%;
+}
+.markdown th,
+.markdown td {
+  border: 1px solid #dce5e9;
+  padding: 6px 10px;
+}
+.markdown img {
+  max-width: 100%;
+}
+.run-progress {
+  font-size: 11px;
+  color: #7a91a0;
+  margin: 10px 0;
+}
+.run-progress > div {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin: 6px 0;
+}
+.progress-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: #87a4ac;
+}
+.question {
+  background: #fff9ed;
+  border: 1px solid #ece0c6;
+  border-radius: 8px;
+  padding: 15px;
+  margin: 15px 0;
+}
+.question > strong {
+  display: block;
+  font-size: 11px;
+  color: #96763b;
+  margin-bottom: 7px;
+}
+.question small {
+  color: #a18d69;
+  font-size: 10px;
+}
+.follow-up-history {
+  border-left: 2px solid #dbe8e7;
+  padding-left: 14px;
+  color: #748894;
+  margin: 12px 0;
+  font-size: 12px;
+}
+.inline-results {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: #f0f7f7;
+  color: #4b8b8e;
+  border-radius: 5px;
+  padding: 7px 9px;
+  font-size: 10px;
+}
+.run-error {
+  background: #fff5f2;
+  color: #945f4f;
+  padding: 12px;
+  border-radius: 6px;
+  font-size: 11px;
+}
+.run-error small {
+  font-size: 9px;
+  display: block;
+  overflow-wrap: anywhere;
+}
+.run-error button {
+  background: transparent;
+  color: #945f4f;
+  text-decoration: underline;
+  font-size: 11px;
+  padding: 8px 0 0;
+}
+.error-banner {
+  background: #fff1ec;
+  color: #985241;
+  border: 1px solid #f0d9cf;
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  margin-bottom: 10px;
+}
+.attachment-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 7px 0;
+}
+.attachment-chips > span,
+.attachment-chips > a {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  border: 1px solid #dce6ea;
+  border-radius: 5px;
+  padding: 4px 6px;
+  font-size: 10px;
+  color: #6e8593;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+.attachment-chips button {
+  display: grid;
+  place-items: center;
+  background: transparent;
+  padding: 0;
+}
+.needs-response {
+  border-color: #d9b878;
+}
+.structure-select {
+  width: 100%;
+  background: white;
+  border: 1px solid #e1e8eb;
+  border-radius: 5px;
+  padding: 8px;
+  font-size: 11px;
+  color: #617d8e;
+  margin: 10px 0 12px;
+}
+.viewer-card {
+  position: relative;
+  border: 1px solid #e2e9ed;
+  border-radius: 8px;
+  overflow: hidden;
+}
+.molecule-canvas {
+  position: relative;
+  height: 265px;
+  width: 100%;
+  background: #f4f7fa;
+}
+.viewer-message {
+  position: absolute;
+  top: 100px;
+  left: 12px;
+  right: 12px;
+  text-align: center;
+  font-size: 11px;
+  color: #7a94a3;
+}
+.viewer-controls {
+  display: flex;
+  align-items: center;
+  padding: 7px 9px;
+  gap: 5px;
+  background: white;
+  color: #8c9eaa;
+  font-size: 9px;
+}
+.viewer-controls > span {
+  margin-right: auto;
+}
+.frame-slider {
+  width: calc(100% - 20px);
+  margin: 0 10px 10px;
+  accent-color: #438e96;
+}
+.artifact {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 0;
+  border-bottom: 1px solid #e8eef1;
+  color: #658192;
+}
+.artifact > span:nth-child(2) {
+  min-width: 0;
+  flex: 1;
+}
+.artifact strong {
+  display: block;
+  font-size: 11px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.artifact small {
+  font-size: 9px;
+  color: #9aadb8;
+}
+.file-icon {
+  display: grid;
+  place-items: center;
+  font-size: 8px;
+  width: 30px;
+  height: 35px;
+  border: 1px solid #d8e4e9;
+  background: white;
+  border-radius: 4px;
+  color: #829caa;
+}
+.artifact > svg {
+  color: #8aa3b1;
+  flex-shrink: 0;
+}
+.spin {
+  animation: spin 1.2s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.mobile-menu,
+.sidebar-scrim {
+  display: none;
+}
+@media (min-width: 1600px) {
+  .workspace {
+    grid-template-columns: 265px minmax(400px, 1fr) 380px;
+  }
+  .workspace.results-hidden {
+    grid-template-columns: 265px 1fr;
+  }
+  .chat-scroll {
+    padding-left: 65px;
+    padding-right: 65px;
+  }
+  .welcome {
+    margin-top: 10vh;
+  }
+  .results-panel {
+    padding-left: 25px;
+    padding-right: 25px;
+  }
+}
+@media (max-width: 1200px) {
+  .workspace {
+    grid-template-columns: 205px minmax(370px, 1fr) 280px;
+  }
+  .workspace.results-hidden {
+    grid-template-columns: 205px 1fr;
+  }
+  .sidebar {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+  .brand {
+    font-size: 19px;
+    gap: 6px;
+  }
+  .brand small {
+    font-size: 7px;
+  }
+  .workspace-header,
+  .chat-settings {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+  .chat-settings {
+    gap: 9px;
+  }
+  .chat-settings > div span {
+    display: none;
+  }
+  .chat-scroll {
+    padding: 20px;
+  }
+  .composer-area {
+    padding: 10px 20px 16px;
+  }
+  .suggestions {
+    flex-direction: column;
+    max-width: 290px;
+    margin: 24px auto 0;
+  }
+  .suggestions button {
+    padding: 11px 12px;
+  }
+  .suggestions button svg:last-child {
+    margin-left: auto;
+  }
+  .welcome {
+    margin-top: 15px;
+  }
+  .welcome h1 {
+    font-size: 32px;
+  }
+  .results-panel {
+    padding-left: 15px;
+    padding-right: 15px;
+  }
+  .results-heading {
+    margin-left: -15px;
+    margin-right: -15px;
+    padding: 0 15px;
+  }
+  .molecule-canvas {
+    height: 225px;
+  }
+}
+@media (max-width: 950px) {
+  .workspace,
+  .workspace.results-hidden {
+    grid-template-columns: 205px minmax(0, 1fr);
+  }
+  .results-panel {
+    position: fixed;
+    z-index: 5;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: 320px;
+    box-shadow: -10px 0 35px #20374617;
+  }
+  .results-panel:not(:has(.viewer-card)) {
+    box-shadow: -10px 0 35px #20374617;
+  }
+  .chat-settings {
+    gap: 15px;
+  }
+  .welcome {
+    margin-top: 45px;
+  }
+  .suggestions {
+    max-width: 340px;
+  }
+}
+@media (max-width: 680px) {
+  .workspace,
+  .workspace.results-hidden {
+    display: block;
+  }
+  .sidebar {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 260px;
+    z-index: 12;
+    transform: translateX(-100%);
+    transition: transform 0.2s;
+  }
+  .sidebar.open {
+    transform: translateX(0);
+  }
+  .sidebar-scrim {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: #0d243e66;
+    z-index: 11;
+  }
+  .mobile-menu {
+    display: grid;
+  }
+  .workspace-header {
+    height: 58px;
+    padding: 0 15px;
+  }
+  .breadcrumb {
+    flex: 1;
+    font-size: 10px;
+  }
+  .breadcrumb > strong {
+    max-width: 160px;
+  }
+  .results-toggle {
+    font-size: 10px;
+  }
+  .chat-settings {
+    height: auto;
+    min-height: 57px;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 12px 15px;
+  }
+  .chat-settings > div {
+    display: none;
+  }
+  .chat-settings label {
+    flex: 1;
+  }
+  .chat-settings select {
+    flex: 1;
+    max-width: 160px;
+  }
+  .chat-scroll {
+    padding: 18px 17px;
+  }
+  .welcome {
+    margin-top: 20px;
+  }
+  .welcome h1 {
+    font-size: 32px;
+  }
+  .welcome-mark {
+    width: 53px;
+    height: 53px;
+    border-radius: 14px;
+    margin-bottom: 20px;
+  }
+  .welcome p {
+    font-size: 11px;
+  }
+  .composer-area {
+    padding: 10px 13px 12px;
+  }
+  .composer-footnote {
+    font-size: 8px;
+  }
+  .settings-note {
+    font-size: 8px;
+  }
+  .results-panel {
+    width: min(340px, 100vw);
+    z-index: 10;
+  }
+  .user-message {
+    margin-left: 22px;
+  }
+  .assistant-message {
+    gap: 8px;
+  }
+  .message-label {
+    font-size: 8px;
+  }
+  .markdown {
+    font-size: 12px;
+  }
+  .suggestions {
+    margin-top: 22px;
+  }
+  .send-button {
+    min-width: 36px;
+    height: 36px;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "vite.config.ts", "playwright.config.ts", "e2e"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 8080,
+    strictPort: true,
+    proxy: { "/api": "http://127.0.0.1:8000" },
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test-setup.ts"],
+    exclude: ["e2e/**", "node_modules/**"],
+  },
+});

--- a/k8s/web/deployment.yaml
+++ b/k8s/web/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: chemgraph-web-data
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chemgraph-web-api
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: {app: chemgraph-web-api}
+  template:
+    metadata:
+      labels: {app: chemgraph-web-api}
+    spec:
+      terminationGracePeriodSeconds: 20
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        runAsNonRoot: true
+      containers:
+        - name: api
+          image: chemgraph-web-api:local # Replace with your built registry image/digest.
+          ports: [{containerPort: 8000}]
+          env:
+            - {name: CHEMGRAPH_WEB_DATA_DIR, value: /data}
+            - {name: CHEMGRAPH_WEB_PUBLIC_ORIGIN, value: "https://chemgraph-react.example.com"}
+            - name: CHEMGRAPH_WEB_PROVIDERS
+              value: '{"OpenAI":{"model":"gpt-4o-mini","api_key_env":"OPENAI_API_KEY"}}'
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef: {name: chemgraph-secrets, key: openai-api-key}
+          volumeMounts: [{name: data, mountPath: /data}]
+          resources:
+            requests: {cpu: "1", memory: 2Gi}
+            limits: {cpu: "4", memory: 8Gi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: [ALL]}
+          startupProbe:
+            httpGet: {path: /healthz, port: 8000}
+            periodSeconds: 5
+            failureThreshold: 30
+          readinessProbe:
+            httpGet: {path: /healthz, port: 8000}
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8000}
+            periodSeconds: 15
+      volumes:
+        - name: data
+          persistentVolumeClaim: {claimName: chemgraph-web-data}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chemgraph-web-api
+spec:
+  selector: {app: chemgraph-web-api}
+  ports: [{port: 8000, targetPort: 8000}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chemgraph-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: chemgraph-web}
+  template:
+    metadata:
+      labels: {app: chemgraph-web}
+    spec:
+      containers:
+        - name: frontend
+          image: chemgraph-web:local # Replace with your built registry image/digest.
+          ports: [{containerPort: 8080}]
+          env: [{name: API_UPSTREAM, value: "chemgraph-web-api:8000"}]
+          resources:
+            requests: {cpu: 100m, memory: 64Mi}
+            limits: {cpu: "1", memory: 256Mi}
+          readinessProbe:
+            httpGet: {path: /healthz, port: 8080}
+          livenessProbe:
+            httpGet: {path: /healthz, port: 8080}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chemgraph-web
+spec:
+  selector: {app: chemgraph-web}
+  ports: [{port: 8080, targetPort: 8080}]

--- a/k8s/web/deployment.yaml
+++ b/k8s/web/deployment.yaml
@@ -35,12 +35,16 @@ spec:
           env:
             - {name: CHEMGRAPH_WEB_DATA_DIR, value: /data}
             - {name: CHEMGRAPH_WEB_PUBLIC_ORIGIN, value: "https://chemgraph-react.example.com"}
-            - name: CHEMGRAPH_WEB_PROVIDERS
-              value: '{"OpenAI":{"model":"gpt-4o-mini","api_key_env":"OPENAI_API_KEY"}}'
-            - name: OPENAI_API_KEY
+            - {name: CHEMGRAPH_WEB_PROVIDERS_FILE, value: /etc/chemgraph/providers.toml}
+            - name: ARGO_USER
               valueFrom:
-                secretKeyRef: {name: chemgraph-secrets, key: openai-api-key}
-          volumeMounts: [{name: data, mountPath: /data}]
+                secretKeyRef: {name: chemgraph-secrets, key: argo-user, optional: true}
+            - name: ALCF_ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef: {name: chemgraph-secrets, key: alcf-access-token, optional: true}
+          volumeMounts:
+            - {name: data, mountPath: /data}
+            - {name: providers, mountPath: /etc/chemgraph, readOnly: true}
           resources:
             requests: {cpu: "1", memory: 2Gi}
             limits: {cpu: "4", memory: 8Gi}
@@ -59,6 +63,8 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim: {claimName: chemgraph-web-data}
+        - name: providers
+          configMap: {name: chemgraph-web-providers}
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/web/ingress.yaml
+++ b/k8s/web/ingress.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chemgraph-react
+  annotations:
+    # Example external-auth gateway integration; replace with institutional URLs.
+    nginx.ingress.kubernetes.io/auth-url: "https://sso.example.com/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://sso.example.com/oauth2/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Auth-Request-User"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "90"
+    nginx.ingress.kubernetes.io/proxy-body-size: "25m"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts: [chemgraph-react.example.com]
+      secretName: chemgraph-react-tls
+  rules:
+    - host: chemgraph-react.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: chemgraph-web
+                port: {number: 8080}

--- a/k8s/web/kustomization.yaml
+++ b/k8s/web/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - network-policy.yaml
+  - ingress.yaml

--- a/k8s/web/kustomization.yaml
+++ b/k8s/web/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
   - deployment.yaml
   - network-policy.yaml
   - ingress.yaml
+configMapGenerator:
+  - name: chemgraph-web-providers
+    files:
+      - providers.toml

--- a/k8s/web/network-policy.yaml
+++ b/k8s/web/network-policy.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: chemgraph-web-api
+spec:
+  podSelector:
+    matchLabels: {app: chemgraph-web-api}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels: {app: chemgraph-web}
+      ports: [{protocol: TCP, port: 8000}]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: chemgraph-web-gateway-only
+spec:
+  podSelector:
+    matchLabels: {app: chemgraph-web}
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx # Set to your trusted gateway namespace.
+      ports: [{protocol: TCP, port: 8080}]

--- a/k8s/web/providers.toml
+++ b/k8s/web/providers.toml
@@ -1,0 +1,5 @@
+# Shared credentials are injected separately through chemgraph-secrets.
+[providers.Argo]
+model = "argo:gpt-4o"
+# Add an ALCF entry using a supported model and api_key_env="ALCF_ACCESS_TOKEN".
+# See web-providers.example.toml and the operator guide.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - Calculators: calculators.md
       - Python API: python_api.md
       - Streamlit interface: streamlit_web_interface.md
+      - React interface (pilot): react_web_interface.md
       - Configuration: configuration_with_toml.md
       - Examples: example_usage.md
   - Integrations and scale:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,10 @@ dependencies = [
     ]
 
 [project.optional-dependencies]
+web = [
+    "fastapi>=0.135,<1",
+    "uvicorn>=0.30,<1",
+]
 test = [
     "quickjs==1.19.4",
 ]

--- a/src/chemgraph/agent/llm_agent.py
+++ b/src/chemgraph/agent/llm_agent.py
@@ -143,6 +143,8 @@ class ChemGraph:
         Base URL for API calls, by default None
     api_key : str, optional
         API key for authentication, by default None
+    model_timeout : float, optional
+        Timeout in seconds per provider request. Defaults to the model settings.
     reasoning_effort : str, optional
         Reasoning effort for manually verified GPT-5.6 models, which default to
         ``"none"``. Supported values are ``none``, ``low``, ``medium``,
@@ -225,6 +227,7 @@ class ChemGraph:
         on_event: Optional[EventCallback] = None,
         reasoning_effort: Optional[str] = None,
         checkpointer: BaseCheckpointSaver | None = None,
+        model_timeout: float | None = None,
     ):
         if enable_deepagent and workflow_type != "main_agent":
             raise ValueError(
@@ -289,6 +292,7 @@ class ChemGraph:
                 api_key=api_key,
                 argo_user=argo_user,
                 reasoning_effort=reasoning_effort,
+                **({"timeout_s": model_timeout} if model_timeout is not None else {}),
             )
         except Exception as e:
             logger.error(f"Exception thrown when loading {model_name}: {str(e)}")

--- a/src/chemgraph/api/__init__.py
+++ b/src/chemgraph/api/__init__.py
@@ -1,0 +1,1 @@
+"""Optional HTTP interface. Importing ChemGraph does not require FastAPI."""

--- a/src/chemgraph/api/__main__.py
+++ b/src/chemgraph/api/__main__.py
@@ -1,0 +1,20 @@
+"""Run with python -m chemgraph.api; this service uses one API process."""
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+    try:
+        import uvicorn
+        from chemgraph.api.app import create_app
+    except ImportError as exc:
+        parser.error(f"Install chemgraph[web] to run the HTTP API: {exc}")
+    uvicorn.run(create_app(), host=args.host, port=args.port, ws="none")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/chemgraph/api/__main__.py
+++ b/src/chemgraph/api/__main__.py
@@ -7,13 +7,39 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--check-config",
+        action="store_true",
+        help="Validate configuration without contacting providers or starting workers.",
+    )
     args = parser.parse_args()
+    from chemgraph.api.settings import ConfigurationError, Settings
+    from chemgraph.api.providers import model_status
+
+    try:
+        settings = Settings.from_env()
+        readiness = model_status(settings)
+    except ConfigurationError as exc:
+        parser.exit(2, f"Configuration error: {exc}\n")
+    if args.check_config:
+        import json
+
+        print(
+            json.dumps(
+                {"model_status": readiness, "connectivity_verified": False}, indent=2
+            )
+        )
+        parser.exit(
+            0
+            if readiness and all(item["configured"] for item in readiness.values())
+            else 1
+        )
     try:
         import uvicorn
         from chemgraph.api.app import create_app
     except ImportError as exc:
         parser.error(f"Install chemgraph[web] to run the HTTP API: {exc}")
-    uvicorn.run(create_app(), host=args.host, port=args.port, ws="none")
+    uvicorn.run(create_app(settings), host=args.host, port=args.port, ws="none")
 
 
 if __name__ == "__main__":

--- a/src/chemgraph/api/app.py
+++ b/src/chemgraph/api/app.py
@@ -6,9 +6,9 @@ import asyncio
 from contextlib import asynccontextmanager
 import hashlib
 import json
-import os
 from pathlib import Path, PureWindowsPath
 import sqlite3
+import time
 from uuid import UUID, uuid4
 
 from fastapi import FastAPI, HTTPException, Request
@@ -22,6 +22,7 @@ from fastapi.responses import (
 from pydantic import BaseModel, Field
 
 from chemgraph.api.settings import Settings
+from chemgraph.api.providers import model_status, provenance, session_status
 from chemgraph.api.store import Store, TERMINAL
 from chemgraph.api.worker import Supervisor
 
@@ -45,6 +46,7 @@ class HumanResponse(BaseModel):
 def create_app(settings: Settings | None = None, *, start_workers=True) -> FastAPI:
     """Application factory; worker startup can be disabled in hermetic API tests."""
     settings = settings or Settings.from_env()
+    model_status(settings)  # Invalid routes fail before creating storage/workers.
     store = Store(settings.data_dir)
     supervisor = Supervisor(store, settings)
 
@@ -71,8 +73,13 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
 
     @app.exception_handler(HTTPException)
     async def http_error(request, exc):
+        detail = (
+            exc.detail
+            if isinstance(exc.detail, dict)
+            else {"code": exc.status_code, "message": str(exc.detail)}
+        )
         return JSONResponse(
-            {"error": {"code": exc.status_code, "message": str(exc.detail)}},
+            {"error": {**detail, "submission_rejected": True}},
             status_code=exc.status_code,
         )
 
@@ -169,6 +176,7 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
                 "status",
                 "final_text",
                 "error",
+                "error_code",
                 "question_id",
                 "question",
                 "created",
@@ -208,6 +216,7 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
         return {
             "user": request.state.identity,
             "models": ["demo"] if settings.demo else list(settings.providers),
+            "model_status": model_status(settings),
             "workflows": ["single_agent", "multi_agent"],
             "calculators": settings.calculators,
             "upload_limit": settings.upload_limit,
@@ -229,15 +238,22 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
             "multi_agent",
         }:
             raise HTTPException(422, "Choose an approved model and workflow.")
+        readiness = model_status(settings)[data.model]
+        if not readiness["configured"]:
+            raise HTTPException(
+                503, {"code": readiness["code"], "message": readiness["message"]}
+            )
         session_id = str(uuid4())
         store.execute(
-            "INSERT INTO sessions(id,owner,model,workflow,title) VALUES (?,?,?,?,?)",
+            "INSERT INTO sessions(id,owner,model,workflow,title,provenance,last_activity) VALUES (?,?,?,?,?,?,?)",
             (
                 session_id,
                 request.state.owner,
                 data.model,
                 data.workflow,
                 "New conversation",
+                provenance(settings, data.model),
+                time.time(),
             ),
         )
         return {
@@ -251,6 +267,8 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
     def session_detail(session_id: str, request: Request):
         session = owned_session(request, session_id)
         session.pop("owner")
+        session["model_status"] = session_status(settings, session)
+        session.pop("provenance")
         session["runs"] = [
             run_view(r)
             for r in store.rows(
@@ -261,7 +279,12 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
 
     @app.post("/api/v1/sessions/{session_id}/uploads", status_code=201)
     async def upload(session_id: str, request: Request, filename: str):
-        owned_session(request, session_id)
+        session = owned_session(request, session_id)
+        readiness = session_status(settings, session)
+        if not readiness["configured"]:
+            raise HTTPException(
+                503, {"code": readiness["code"], "message": readiness["message"]}
+            )
         name = Path(PureWindowsPath(filename).name).name
         if not name or len(name) > 200 or any(ord(c) < 32 for c in name):
             raise HTTPException(422, "Invalid filename.")
@@ -277,22 +300,73 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
             raise HTTPException(
                 422, "Supported uploads: XYZ, PDB, CIF, TRAJ, JSON, CSV, TXT."
             )
-        path = store.session_dir(session_id) / "uploads" / str(uuid4()) / name
+        reservation = str(uuid4())
+        try:
+            expected = int(request.headers.get("content-length", settings.upload_limit))
+        except ValueError:
+            raise HTTPException(422, "Invalid content length.") from None
+        if expected < 0 or expected > settings.upload_limit:
+            raise HTTPException(413, "This file exceeds the upload limit.")
+        with store.transaction() as db:
+            if db.execute(
+                "SELECT 1 FROM runs WHERE session_id=? AND status IN ('queued','running','waiting_for_input','cancelling')",
+                (session_id,),
+            ).fetchone():
+                raise HTTPException(
+                    409, "Wait for the current run before attaching more files."
+                )
+            if (
+                store.owner_usage(request.state.owner, db) + expected
+                > settings.user_storage_limit
+            ):
+                raise HTTPException(
+                    413,
+                    {
+                        "code": "storage_limit",
+                        "message": "Your workspace storage limit has been reached.",
+                    },
+                )
+            db.execute(
+                "INSERT INTO upload_reservations VALUES (?,?,?)",
+                (reservation, session_id, expected),
+            )
+        path = store.root / "staging" / reservation
         path.parent.mkdir(parents=True, exist_ok=True)
         size = 0
         try:
             with path.open("xb") as output:
                 async for chunk in request.stream():
                     size += len(chunk)
-                    if size > settings.upload_limit:
+                    if size > min(expected, settings.upload_limit):
                         raise HTTPException(413, "This file exceeds the upload limit.")
                     output.write(chunk)
             if not size:
                 raise HTTPException(422, "The attachment is empty.")
-            file_id = store.register_file(session_id, path, "upload", name=name)
-        except BaseException:
+            target = store.session_dir(session_id) / "uploads" / reservation / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with store.transaction() as db:
+                path.replace(target)
+                file_id = str(uuid4())
+                db.execute(
+                    "INSERT INTO files VALUES (?,?,?,?,?,?,?)",
+                    (
+                        file_id,
+                        session_id,
+                        None,
+                        name,
+                        str(target.relative_to(store.root)),
+                        "upload",
+                        size,
+                    ),
+                )
+                db.execute("DELETE FROM upload_reservations WHERE id=?", (reservation,))
+                db.execute(
+                    "UPDATE sessions SET last_activity=? WHERE id=?",
+                    (time.time(), session_id),
+                )
+        finally:
             path.unlink(missing_ok=True)
-            raise
+            store.execute("DELETE FROM upload_reservations WHERE id=?", (reservation,))
         return file_view(store.one("SELECT * FROM files WHERE id=?", (file_id,)))
 
     @app.post("/api/v1/sessions/{session_id}/runs", status_code=202)
@@ -322,18 +396,74 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
                     409, "This request ID was already used for a different submission."
                 )
             return run_view(previous)
-        if not settings.demo:
-            provider = settings.providers.get(session["model"])
-            if provider is None or (
-                provider.api_key_env and not os.getenv(provider.api_key_env)
-            ):
-                raise HTTPException(
-                    503,
-                    "This model's provider is unavailable. Ask your administrator to configure it.",
-                )
+        readiness = session_status(settings, session)
+        if not readiness["configured"]:
+            raise HTTPException(
+                503, {"code": readiness["code"], "message": readiness["message"]}
+            )
         run_id = str(uuid4())
         try:
-            with store.connect() as db:
+            with store.transaction() as db:
+                # Recheck inside the transaction for concurrent retries.
+                duplicate = db.execute(
+                    "SELECT * FROM runs WHERE session_id=? AND request_id=?",
+                    (session_id, str(data.request_id)),
+                ).fetchone()
+                if duplicate:
+                    if (
+                        duplicate["query"] != data.query
+                        or json.loads(duplicate["attachments"]) != attachments
+                    ):
+                        raise HTTPException(
+                            409,
+                            "This request ID was already used for a different submission.",
+                        )
+                    return run_view(dict(duplicate))
+                if db.execute(
+                    "SELECT 1 FROM upload_reservations WHERE session_id=?",
+                    (session_id,),
+                ).fetchone():
+                    raise HTTPException(
+                        409, "Wait for attachments to finish uploading."
+                    )
+                if db.execute(
+                    "SELECT 1 FROM runs WHERE session_id=? AND status IN ('queued','running','waiting_for_input','cancelling')",
+                    (session_id,),
+                ).fetchone():
+                    raise HTTPException(
+                        409,
+                        "This conversation already has an unfinished run. Refresh its status.",
+                    )
+                queued = db.execute(
+                    "SELECT count(*) FROM runs WHERE status='queued'"
+                ).fetchone()[0]
+                owner_runs = db.execute(
+                    "SELECT count(*) FROM runs r JOIN sessions s ON s.id=r.session_id WHERE s.owner=? AND r.status IN ('queued','running','waiting_for_input','cancelling')",
+                    (request.state.owner,),
+                ).fetchone()[0]
+                if (
+                    queued >= settings.max_queued
+                    or owner_runs >= settings.max_user_runs
+                ):
+                    raise HTTPException(
+                        429,
+                        {
+                            "code": "queue_limit",
+                            "message": "The run limit has been reached. Wait for an existing run to finish.",
+                        },
+                    )
+                if (
+                    store.owner_usage(request.state.owner, db)
+                    + len(data.query.encode())
+                    > settings.user_storage_limit
+                ):
+                    raise HTTPException(
+                        413,
+                        {
+                            "code": "storage_limit",
+                            "message": "Your workspace storage limit has been reached.",
+                        },
+                    )
                 db.execute(
                     "INSERT INTO runs(id,session_id,query,request_id,attachments) VALUES (?,?,?,?,?)",
                     (
@@ -345,6 +475,14 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
                     ),
                 )
                 db.execute(
+                    "UPDATE sessions SET last_activity=? WHERE id=?",
+                    (time.time(), session_id),
+                )
+                db.execute(
+                    "INSERT INTO events(run_id,type,data) VALUES (?,?,?)",
+                    (run_id, "status", json.dumps({"status": "queued"})),
+                )
+                db.execute(
                     "UPDATE sessions SET title=? WHERE id=? AND title='New conversation'",
                     (data.query[:80], session_id),
                 )
@@ -353,7 +491,27 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
                 409,
                 "This conversation already has an unfinished run. Refresh its status.",
             ) from None
-        store.event(run_id, "status", {"status": "queued"})
+        return run_view(store.one("SELECT * FROM runs WHERE id=?", (run_id,)))
+
+    @app.post("/api/v1/runs/{run_id}/cancel", status_code=202)
+    def cancel(run_id: str, request: Request):
+        owned_run(request, run_id)
+        with store.transaction() as db:
+            row = db.execute("SELECT status FROM runs WHERE id=?", (run_id,)).fetchone()
+            if row["status"] not in TERMINAL and row["status"] != "cancelling":
+                state = "cancelled" if row["status"] == "queued" else "cancelling"
+                db.execute(
+                    "UPDATE runs SET status=?,question=NULL,question_id=NULL,error_code='cancelled',error='The run was cancelled.' WHERE id=?",
+                    (state, run_id),
+                )
+                db.execute(
+                    "INSERT INTO events(run_id,type,data) VALUES (?,?,?)",
+                    (run_id, "status", json.dumps({"status": state})),
+                )
+                db.execute(
+                    "UPDATE sessions SET last_activity=? WHERE id=(SELECT session_id FROM runs WHERE id=?)",
+                    (time.time(), run_id),
+                )
         return run_view(store.one("SELECT * FROM runs WHERE id=?", (run_id,)))
 
     @app.get("/api/v1/runs/{run_id}")
@@ -365,7 +523,7 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
         owned_run(request, run_id)
         if not data.answer.strip():
             raise HTTPException(422, "A response must not be blank.")
-        with store.connect() as db:
+        with store.transaction() as db:
             row = db.execute(
                 "SELECT question FROM runs WHERE id=?", (run_id,)
             ).fetchone()
@@ -385,6 +543,10 @@ def create_app(settings: Settings | None = None, *, start_workers=True) -> FastA
                     "human_response",
                     json.dumps({"question": row["question"], "answer": data.answer}),
                 ),
+            )
+            db.execute(
+                "UPDATE sessions SET last_activity=? WHERE id=(SELECT session_id FROM runs WHERE id=?)",
+                (time.time(), run_id),
             )
         return {"accepted": True}
 

--- a/src/chemgraph/api/app.py
+++ b/src/chemgraph/api/app.py
@@ -1,0 +1,450 @@
+"""Authenticated REST and SSE endpoints for the separately deployed React UI."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+import hashlib
+import json
+import os
+from pathlib import Path, PureWindowsPath
+import sqlite3
+from uuid import UUID, uuid4
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import (
+    FileResponse,
+    JSONResponse,
+    PlainTextResponse,
+    StreamingResponse,
+)
+from pydantic import BaseModel, Field
+
+from chemgraph.api.settings import Settings
+from chemgraph.api.store import Store, TERMINAL
+from chemgraph.api.worker import Supervisor
+
+
+class SessionInput(BaseModel):
+    model: str = Field(min_length=1, max_length=200)
+    workflow: str = "single_agent"
+
+
+class RunInput(BaseModel):
+    query: str = Field(min_length=1, max_length=20000)
+    request_id: UUID
+    attachments: list[UUID] = Field(default_factory=list, max_length=10)
+
+
+class HumanResponse(BaseModel):
+    question_id: UUID
+    answer: str = Field(min_length=1, max_length=20000)
+
+
+def create_app(settings: Settings | None = None, *, start_workers=True) -> FastAPI:
+    """Application factory; worker startup can be disabled in hermetic API tests."""
+    settings = settings or Settings.from_env()
+    store = Store(settings.data_dir)
+    supervisor = Supervisor(store, settings)
+
+    @asynccontextmanager
+    async def lifespan(app):
+        if start_workers:
+            await supervisor.start()
+        try:
+            yield
+        finally:
+            if start_workers:
+                await supervisor.stop()
+
+    app = FastAPI(
+        title="ChemGraph Web API",
+        version="1",
+        lifespan=lifespan,
+        docs_url=None,
+        redoc_url=None,
+        openapi_url=None,
+    )
+    app.state.store = store
+    app.state.settings = settings
+
+    @app.exception_handler(HTTPException)
+    async def http_error(request, exc):
+        return JSONResponse(
+            {"error": {"code": exc.status_code, "message": str(exc.detail)}},
+            status_code=exc.status_code,
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error(request, exc):
+        return JSONResponse(
+            {"error": {"code": 422, "message": "Invalid request fields."}},
+            status_code=422,
+        )
+
+    @app.middleware("http")
+    async def gateway_identity(request: Request, call_next):
+        if request.url.path == "/healthz":
+            return await call_next(request)
+        identity = (
+            settings.dev_user
+            or request.headers.get(settings.identity_header, "").strip()
+        )
+        if not identity or len(identity) > 512:
+            return JSONResponse(
+                {
+                    "error": {
+                        "code": 401,
+                        "message": "Sign in through your institution's gateway.",
+                    }
+                },
+                status_code=401,
+            )
+        request.state.owner = hashlib.sha256(identity.encode()).hexdigest()
+        request.state.identity = identity
+        if request.method not in {"GET", "HEAD", "OPTIONS"}:
+            # Browser mutations must be JSON/binary fetches from this origin.
+            if request.headers.get("Origin") != settings.public_origin.rstrip("/"):
+                return JSONResponse(
+                    {
+                        "error": {
+                            "code": 403,
+                            "message": "Request origin is not allowed.",
+                        }
+                    },
+                    status_code=403,
+                )
+        response = await call_next(request)
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        return response
+
+    def owned_session(request, session_id):
+        row = store.one(
+            "SELECT * FROM sessions WHERE id=? AND owner=?",
+            (session_id, request.state.owner),
+        )
+        if row is None:
+            raise HTTPException(404, "Conversation not found.")
+        return row
+
+    def owned_run(request, run_id):
+        row = store.one(
+            "SELECT r.* FROM runs r JOIN sessions s ON s.id=r.session_id WHERE r.id=? AND s.owner=?",
+            (run_id, request.state.owner),
+        )
+        if row is None:
+            raise HTTPException(404, "Run not found.")
+        return row
+
+    def owned_file(request, file_id):
+        row = store.one(
+            "SELECT f.* FROM files f JOIN sessions s ON s.id=f.session_id WHERE f.id=? AND s.owner=?",
+            (file_id, request.state.owner),
+        )
+        if row is None:
+            raise HTTPException(404, "Artifact not found.")
+        try:
+            path = store.file_path(row)
+        except (ValueError, FileNotFoundError):
+            raise HTTPException(404, "Artifact is no longer available.") from None
+        return row, path
+
+    def file_view(row):
+        return {key: row[key] for key in ("id", "name", "kind", "size", "run_id")} | {
+            "url": f"/api/v1/artifacts/{row['id']}/content",
+            "preview_url": f"/api/v1/artifacts/{row['id']}/structure"
+            if Path(row["name"]).suffix.lower() in {".xyz", ".pdb", ".cif", ".traj"}
+            else None,
+        }
+
+    def run_view(row):
+        data = {
+            key: row[key]
+            for key in (
+                "id",
+                "session_id",
+                "query",
+                "status",
+                "final_text",
+                "error",
+                "question_id",
+                "question",
+                "created",
+            )
+        }
+        data["artifacts"] = [
+            file_view(f)
+            for f in store.rows("SELECT * FROM files WHERE run_id=?", (row["id"],))
+        ]
+        data["attachments"] = [
+            file_view(f)
+            for file_id in json.loads(row["attachments"])
+            if (f := store.one("SELECT * FROM files WHERE id=?", (file_id,)))
+        ]
+        data["responses"] = [
+            json.loads(e["data"])
+            for e in store.rows(
+                "SELECT data FROM events WHERE run_id=? AND type='human_response' ORDER BY id",
+                (row["id"],),
+            )
+        ]
+        return data
+
+    @app.get("/healthz")
+    def health():
+        store.one("SELECT 1")
+        if start_workers and (supervisor.task is None or supervisor.task.done()):
+            raise HTTPException(503, "The run scheduler is unavailable.")
+        return {"status": "ok"}
+
+    @app.get("/api/v1/openapi.json")
+    def schema():
+        return app.openapi()
+
+    @app.get("/api/v1/capabilities")
+    def capabilities(request: Request):
+        return {
+            "user": request.state.identity,
+            "models": ["demo"] if settings.demo else list(settings.providers),
+            "workflows": ["single_agent", "multi_agent"],
+            "calculators": settings.calculators,
+            "upload_limit": settings.upload_limit,
+            "demo": settings.demo,
+        }
+
+    @app.get("/api/v1/sessions")
+    def sessions(request: Request):
+        return store.rows(
+            "SELECT id,model,workflow,title,created FROM sessions WHERE owner=? ORDER BY created DESC",
+            (request.state.owner,),
+        )
+
+    @app.post("/api/v1/sessions", status_code=201)
+    def create_session(data: SessionInput, request: Request):
+        models = {"demo"} if settings.demo else settings.providers
+        if data.model not in models or data.workflow not in {
+            "single_agent",
+            "multi_agent",
+        }:
+            raise HTTPException(422, "Choose an approved model and workflow.")
+        session_id = str(uuid4())
+        store.execute(
+            "INSERT INTO sessions(id,owner,model,workflow,title) VALUES (?,?,?,?,?)",
+            (
+                session_id,
+                request.state.owner,
+                data.model,
+                data.workflow,
+                "New conversation",
+            ),
+        )
+        return {
+            "id": session_id,
+            "model": data.model,
+            "workflow": data.workflow,
+            "title": "New conversation",
+        }
+
+    @app.get("/api/v1/sessions/{session_id}")
+    def session_detail(session_id: str, request: Request):
+        session = owned_session(request, session_id)
+        session.pop("owner")
+        session["runs"] = [
+            run_view(r)
+            for r in store.rows(
+                "SELECT * FROM runs WHERE session_id=? ORDER BY created", (session_id,)
+            )
+        ]
+        return session
+
+    @app.post("/api/v1/sessions/{session_id}/uploads", status_code=201)
+    async def upload(session_id: str, request: Request, filename: str):
+        owned_session(request, session_id)
+        name = Path(PureWindowsPath(filename).name).name
+        if not name or len(name) > 200 or any(ord(c) < 32 for c in name):
+            raise HTTPException(422, "Invalid filename.")
+        if Path(name).suffix.lower() not in {
+            ".xyz",
+            ".pdb",
+            ".cif",
+            ".traj",
+            ".json",
+            ".csv",
+            ".txt",
+        }:
+            raise HTTPException(
+                422, "Supported uploads: XYZ, PDB, CIF, TRAJ, JSON, CSV, TXT."
+            )
+        path = store.session_dir(session_id) / "uploads" / str(uuid4()) / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        size = 0
+        try:
+            with path.open("xb") as output:
+                async for chunk in request.stream():
+                    size += len(chunk)
+                    if size > settings.upload_limit:
+                        raise HTTPException(413, "This file exceeds the upload limit.")
+                    output.write(chunk)
+            if not size:
+                raise HTTPException(422, "The attachment is empty.")
+            file_id = store.register_file(session_id, path, "upload", name=name)
+        except BaseException:
+            path.unlink(missing_ok=True)
+            raise
+        return file_view(store.one("SELECT * FROM files WHERE id=?", (file_id,)))
+
+    @app.post("/api/v1/sessions/{session_id}/runs", status_code=202)
+    def submit(session_id: str, data: RunInput, request: Request):
+        session = owned_session(request, session_id)
+        if not data.query.strip():
+            raise HTTPException(
+                422, "Describe what you want to do with the attached files."
+            )
+        attachments = [str(value) for value in data.attachments]
+        for file_id in attachments:
+            if not store.one(
+                "SELECT id FROM files WHERE id=? AND session_id=? AND kind='upload'",
+                (file_id, session_id),
+            ):
+                raise HTTPException(404, "Attachment not found in this conversation.")
+        previous = store.one(
+            "SELECT * FROM runs WHERE session_id=? AND request_id=?",
+            (session_id, str(data.request_id)),
+        )
+        if previous:
+            if (
+                previous["query"] != data.query
+                or json.loads(previous["attachments"]) != attachments
+            ):
+                raise HTTPException(
+                    409, "This request ID was already used for a different submission."
+                )
+            return run_view(previous)
+        if not settings.demo:
+            provider = settings.providers.get(session["model"])
+            if provider is None or (
+                provider.api_key_env and not os.getenv(provider.api_key_env)
+            ):
+                raise HTTPException(
+                    503,
+                    "This model's provider is unavailable. Ask your administrator to configure it.",
+                )
+        run_id = str(uuid4())
+        try:
+            with store.connect() as db:
+                db.execute(
+                    "INSERT INTO runs(id,session_id,query,request_id,attachments) VALUES (?,?,?,?,?)",
+                    (
+                        run_id,
+                        session_id,
+                        data.query,
+                        str(data.request_id),
+                        json.dumps(attachments),
+                    ),
+                )
+                db.execute(
+                    "UPDATE sessions SET title=? WHERE id=? AND title='New conversation'",
+                    (data.query[:80], session_id),
+                )
+        except sqlite3.IntegrityError:
+            raise HTTPException(
+                409,
+                "This conversation already has an unfinished run. Refresh its status.",
+            ) from None
+        store.event(run_id, "status", {"status": "queued"})
+        return run_view(store.one("SELECT * FROM runs WHERE id=?", (run_id,)))
+
+    @app.get("/api/v1/runs/{run_id}")
+    def run_status(run_id: str, request: Request):
+        return run_view(owned_run(request, run_id))
+
+    @app.post("/api/v1/runs/{run_id}/response", status_code=202)
+    def respond(run_id: str, data: HumanResponse, request: Request):
+        owned_run(request, run_id)
+        if not data.answer.strip():
+            raise HTTPException(422, "A response must not be blank.")
+        with store.connect() as db:
+            row = db.execute(
+                "SELECT question FROM runs WHERE id=?", (run_id,)
+            ).fetchone()
+            changed = db.execute(
+                "UPDATE runs SET answer=? WHERE id=? AND question_id=? AND answer IS NULL AND status='waiting_for_input'",
+                (data.answer, run_id, str(data.question_id)),
+            ).rowcount
+            if not changed:
+                raise HTTPException(
+                    409,
+                    "This question has already been answered or is no longer pending.",
+                )
+            db.execute(
+                "INSERT INTO events(run_id,type,data) VALUES (?,?,?)",
+                (
+                    run_id,
+                    "human_response",
+                    json.dumps({"question": row["question"], "answer": data.answer}),
+                ),
+            )
+        return {"accepted": True}
+
+    @app.get("/api/v1/runs/{run_id}/events")
+    async def events(run_id: str, request: Request, after: int = 0):
+        owned_run(request, run_id)
+        try:
+            cursor = max(after, int(request.headers.get("Last-Event-ID", "0")), 0)
+        except ValueError:
+            raise HTTPException(422, "Invalid event cursor.") from None
+
+        async def stream():
+            nonlocal cursor
+            idle = 0
+            while not await request.is_disconnected():
+                rows = store.rows(
+                    "SELECT * FROM events WHERE run_id=? AND id>? ORDER BY id LIMIT 200",
+                    (run_id, cursor),
+                )
+                for row in rows:
+                    cursor = row["id"]
+                    yield f"id: {cursor}\nevent: {row['type']}\ndata: {row['data']}\n\n"
+                row = store.one("SELECT status FROM runs WHERE id=?", (run_id,))
+                if row["status"] in TERMINAL and len(rows) < 200:
+                    yield "event: end\ndata: {}\n\n"
+                    return
+                idle += 1
+                if idle % 30 == 0:
+                    yield ": keep-alive\n\n"
+                await asyncio.sleep(0.5)
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={"X-Accel-Buffering": "no"},
+        )
+
+    @app.get("/api/v1/artifacts/{file_id}/content")
+    def download(file_id: str, request: Request):
+        row, path = owned_file(request, file_id)
+        return FileResponse(
+            path,
+            filename=row["name"],
+            media_type="application/octet-stream",
+            headers={"Content-Security-Policy": "sandbox"},
+        )
+
+    @app.get("/api/v1/artifacts/{file_id}/structure")
+    def preview(file_id: str, request: Request):
+        from chemgraph.api.chemistry import structure_xyz
+
+        _, path = owned_file(request, file_id)
+        if path.stat().st_size > settings.upload_limit:
+            raise HTTPException(413, "This artifact is too large to preview.")
+        try:
+            return PlainTextResponse(structure_xyz(path))
+        except Exception:
+            raise HTTPException(
+                422,
+                "Unable to preview this structure. Download the original artifact instead.",
+            ) from None
+
+    return app

--- a/src/chemgraph/api/chemistry.py
+++ b/src/chemgraph/api/chemistry.py
@@ -1,0 +1,115 @@
+"""A deliberately small set of workspace-scoped chemistry tools for the web UI."""
+
+import os
+from pathlib import Path
+
+
+STRUCTURE_FORMATS = {
+    ".xyz": "extxyz",
+    ".pdb": "proteindatabank",
+    ".cif": "cif",
+    ".traj": "traj",
+}
+
+
+def workspace_path(root: Path, value: str, *, reading=False) -> str:
+    """Reuse chemistry path resolution, then enforce the session boundary."""
+    from chemgraph.tools.ase_core import _resolve_existing_path, _resolve_path
+
+    resolve = _resolve_existing_path if reading else _resolve_path
+    path = Path(resolve(value)).resolve()
+    try:
+        path.relative_to(root.resolve())
+        if not reading:
+            path.relative_to(Path(os.environ["CHEMGRAPH_LOG_DIR"]).resolve())
+    except ValueError:
+        raise ValueError(
+            "Read files from this conversation and write new files in the current run directory."
+        ) from None
+    if reading and not path.is_file():
+        raise ValueError("The requested workspace file does not exist.")
+    return str(path)
+
+
+def web_tools(workspace: Path, calculators: tuple[str, ...]):
+    """Wrap approved tools without exposing shell, Python, or model-file loading."""
+    from langchain_core.tools import tool
+    from chemgraph.schemas.ase_input import ASEInputSchema
+    from chemgraph.tools import ase_core, cheminformatics_core
+    from chemgraph.tools.cheminformatics_tools import molecule_name_to_smiles
+    from chemgraph.tools.generic_tools import calculator
+
+    @tool
+    def smiles_to_coordinate_file(
+        smiles: str, output_file: str = "molecule.xyz"
+    ) -> str:
+        """Create an XYZ structure from SMILES inside the conversation workspace."""
+        output_file = workspace_path(workspace, output_file)
+        if Path(output_file).suffix.lower() != ".xyz":
+            raise ValueError("Coordinate output must be an XYZ file.")
+        return cheminformatics_core.smiles_to_coordinate_file_core(
+            smiles, output_file=output_file
+        )
+
+    @tool
+    def run_ase(ase_input: ASEInputSchema) -> dict:
+        """Run an ASE calculation using an approved calculator and workspace files."""
+        data = ase_input.model_copy(deep=True)
+        calc = data.calculator
+        if calc.calculator_type not in calculators:
+            raise ValueError(
+                f"Choose an approved calculator: {', '.join(calculators)}."
+            )
+        # MACE accepts arbitrary model paths/URLs; web runs use only the installed
+        # foundation-model default. No user-specified serialized model is loaded.
+        if getattr(calc, "model", None) is not None:
+            raise ValueError(
+                "Web calculations use the administrator's default foundation model."
+            )
+        data.input_structure_file = workspace_path(
+            workspace, data.input_structure_file, reading=True
+        )
+        if Path(data.input_structure_file).suffix.lower() not in STRUCTURE_FORMATS:
+            raise ValueError("Use an XYZ, PDB, CIF, or TRAJ structure.")
+        data.output_results_file = workspace_path(workspace, data.output_results_file)
+        if Path(data.output_results_file).suffix.lower() != ".json":
+            raise ValueError("Simulation results must use a JSON filename.")
+        return ase_core.run_ase_core(data)
+
+    @tool
+    def extract_output_json(json_file: str) -> dict:
+        """Read simulation results from a JSON file in this conversation."""
+        path = workspace_path(workspace, json_file, reading=True)
+        if Path(path).suffix.lower() != ".json":
+            raise ValueError("Only JSON results can be read by this tool.")
+        return ase_core.extract_output_json_core(path)
+
+    return [
+        molecule_name_to_smiles,
+        smiles_to_coordinate_file,
+        run_ase,
+        extract_output_json,
+        calculator,
+    ]
+
+
+def structure_xyz(path: Path) -> str:
+    """Convert supported structures/trajectories to browser-readable XYZ frames."""
+    import io
+    from ase.io import iread, write
+
+    fmt = STRUCTURE_FORMATS.get(path.suffix.lower())
+    if fmt is None:
+        raise ValueError("This artifact is not a supported molecular structure.")
+    output = io.StringIO()
+    for index, atoms in enumerate(iread(str(path), format=fmt, index=":")):
+        if index >= 500 or len(atoms) > 20000:
+            raise ValueError(
+                "Structure preview exceeds 500 frames or 20,000 atoms; download the artifact instead."
+            )
+        write(output, atoms, format="xyz")
+        if output.tell() > 25 * 1024 * 1024:
+            raise ValueError(
+                "Structure preview is too large; download the artifact instead."
+            )
+    return output.getvalue()

--- a/src/chemgraph/api/chemistry.py
+++ b/src/chemgraph/api/chemistry.py
@@ -31,7 +31,9 @@ def workspace_path(root: Path, value: str, *, reading=False) -> str:
     return str(path)
 
 
-def web_tools(workspace: Path, calculators: tuple[str, ...]):
+def web_tools(
+    workspace: Path, calculators: tuple[str, ...], *, guard=None, publish=None
+):
     """Wrap approved tools without exposing shell, Python, or model-file loading."""
     from langchain_core.tools import tool
     from chemgraph.schemas.ase_input import ASEInputSchema
@@ -39,21 +41,29 @@ def web_tools(workspace: Path, calculators: tuple[str, ...]):
     from chemgraph.tools.cheminformatics_tools import molecule_name_to_smiles
     from chemgraph.tools.generic_tools import calculator
 
+    guard = guard or (lambda: None)
+    publish = publish or (lambda _path: None)
+
     @tool
     def smiles_to_coordinate_file(
         smiles: str, output_file: str = "molecule.xyz"
     ) -> str:
         """Create an XYZ structure from SMILES inside the conversation workspace."""
+        guard()
         output_file = workspace_path(workspace, output_file)
         if Path(output_file).suffix.lower() != ".xyz":
             raise ValueError("Coordinate output must be an XYZ file.")
-        return cheminformatics_core.smiles_to_coordinate_file_core(
+        result = cheminformatics_core.smiles_to_coordinate_file_core(
             smiles, output_file=output_file
         )
+        guard()
+        publish(output_file)
+        return result
 
     @tool
     def run_ase(ase_input: ASEInputSchema) -> dict:
         """Run an ASE calculation using an approved calculator and workspace files."""
+        guard()
         data = ase_input.model_copy(deep=True)
         calc = data.calculator
         if calc.calculator_type not in calculators:
@@ -74,7 +84,43 @@ def web_tools(workspace: Path, calculators: tuple[str, ...]):
         data.output_results_file = workspace_path(workspace, data.output_results_file)
         if Path(data.output_results_file).suffix.lower() != ".json":
             raise ValueError("Simulation results must use a JSON filename.")
-        return ase_core.run_ase_core(data)
+        result = ase_core.run_ase_core(data)
+        guard()
+        # Register only outputs owned by this chemistry operation. Internal
+        # graph diagnostics and arbitrary JSON files are never auto-published.
+        output = Path(data.output_results_file)
+        stem = Path(data.input_structure_file).stem
+        turn = Path(os.environ["CHEMGRAPH_LOG_DIR"])
+        paths = [output, output.with_name(f"{stem}_opt.traj")]
+        paths.extend(
+            turn / name
+            for name in (
+                f"frequencies_{stem}.csv",
+                f"ir_spectrum_{stem}.png",
+                f"ir_spectrum_{stem}.csv",
+                f"ir_peaks_{stem}.csv",
+            )
+        )
+        paths.extend(turn.glob(f"{stem}_vib.*.traj"))
+        for path in paths:
+            if path.is_file():
+                publish(path)
+        return result
+
+    @tool
+    def read_workspace_file(filename: str) -> str:
+        """Read an attached XYZ/PDB/CIF/TRAJ structure or JSON/CSV/TXT data file; large content is truncated."""
+        guard()
+        path = Path(workspace_path(workspace, filename, reading=True))
+        if path.suffix.lower() == ".traj":
+            return structure_xyz(path)[:50000]
+        if path.suffix.lower() not in {".xyz", ".pdb", ".cif", ".json", ".csv", ".txt"}:
+            raise ValueError("Choose a supported structure or text attachment.")
+        with path.open(encoding="utf-8") as source:
+            content = source.read(50001)
+        return content[:50000] + (
+            "\n[Content truncated]" if len(content) > 50000 else ""
+        )
 
     @tool
     def extract_output_json(json_file: str) -> dict:
@@ -90,6 +136,7 @@ def web_tools(workspace: Path, calculators: tuple[str, ...]):
         run_ase,
         extract_output_json,
         calculator,
+        read_workspace_file,
     ]
 
 

--- a/src/chemgraph/api/errors.py
+++ b/src/chemgraph/api/errors.py
@@ -1,0 +1,68 @@
+"""Safe public errors. Provider exception strings belong only in protected logs."""
+
+
+class RunStopped(Exception):
+    pass
+
+
+class StorageLimit(Exception):
+    pass
+
+
+def public_error(exc):
+    if isinstance(exc, StorageLimit):
+        return (
+            "storage_limit",
+            "Your workspace storage limit was reached. Contact your administrator.",
+        )
+    # Inspect typed status metadata, never provider response text.
+    chain = []
+    while exc is not None and id(exc) not in {id(item) for item in chain}:
+        chain.append(exc)
+        exc = exc.__cause__ or exc.__context__
+    for error in chain:
+        code = getattr(error, "status_code", None) or getattr(error, "code", None)
+        name = type(error).__name__
+        if code in {401, 403} or name in {
+            "AuthenticationError",
+            "PermissionDeniedError",
+            "Unauthenticated",
+            "PermissionDenied",
+        }:
+            return (
+                "provider_authentication",
+                "The provider rejected the shared credentials. Ask your administrator to renew them.",
+            )
+        if code == 429 or name in {
+            "RateLimitError",
+            "ResourceExhausted",
+            "TooManyRequests",
+        }:
+            return (
+                "provider_rate_limit",
+                "The provider's rate limit was reached. Wait before explicitly retrying this run.",
+            )
+        if (
+            code in {408, 504}
+            or isinstance(error, TimeoutError)
+            or "Timeout" in name
+            or name == "DeadlineExceeded"
+        ):
+            return (
+                "provider_timeout",
+                "The provider did not respond in time. You can retry this run.",
+            )
+        if isinstance(error, ConnectionError) or name in {
+            "APIConnectionError",
+            "ConnectError",
+            "NetworkError",
+            "ServiceUnavailable",
+        }:
+            return (
+                "provider_connection",
+                "The provider could not be reached. Check with your administrator or retry later.",
+            )
+    return (
+        "calculation_failed",
+        "The calculation failed. Contact your administrator with this run ID.",
+    )

--- a/src/chemgraph/api/memory.py
+++ b/src/chemgraph/api/memory.py
@@ -1,0 +1,34 @@
+"""Bounded conversation context without recursively persisting injected history."""
+
+from chemgraph.memory.store import SessionStore
+
+
+class WebSessionStore(SessionStore):
+    def __init__(self, path, original_query, context_limit):
+        super().__init__(path)
+        self.original_query = original_query
+        self.context_limit = context_limit
+
+    def build_context_summary(self, session_id):
+        # Query a bounded tail without loading an entire long-lived transcript.
+        with self._connect() as db:
+            rows = db.execute(
+                "SELECT role,substr(content,1,2000) AS content FROM messages WHERE session_id=? ORDER BY id DESC LIMIT 40",
+                (session_id,),
+            ).fetchall()
+        context = "\n".join(
+            f"{row['role']}: {row['content']}" for row in reversed(rows)
+        )
+        return context[-self.context_limit :]
+
+    def save_messages(self, session_id, messages, **kwargs):
+        # Each web turn starts a new graph; its first human message contains
+        # ephemeral history and attachment instructions. Persist the user input.
+        messages = list(messages)
+        for index, message in enumerate(messages):
+            if message.role == "human":
+                messages[index] = message.model_copy(
+                    update={"content": self.original_query}
+                )
+                break
+        return super().save_messages(session_id, messages, **kwargs)

--- a/src/chemgraph/api/providers.py
+++ b/src/chemgraph/api/providers.py
@@ -1,0 +1,133 @@
+"""Noninteractive web provider validation and shared credential resolution."""
+
+from dataclasses import dataclass
+import hashlib
+import json
+import os
+
+from chemgraph.api.settings import ConfigurationError, Provider, validate_url
+
+
+@dataclass(frozen=True)
+class SharedCredentials:
+    # Never serialize this object into API resources or worker arguments.
+    api_key: str | None = None
+    argo_user: str | None = None
+
+
+def endpoint(provider: Provider):
+    from chemgraph.models.endpoints import ModelRequest
+    from chemgraph.models.endpoints.registry import select_endpoint
+
+    try:
+        spec = select_endpoint(
+            ModelRequest(model=provider.model, base_url=provider.base_url)
+        )
+        if spec.name == "codex":
+            raise ValueError(
+                "Subscription authentication is outside the web deployment."
+            )
+        if (
+            spec.accepted_prefix
+            and not provider.model.removeprefix(spec.accepted_prefix).strip()
+        ):
+            raise ValueError("Missing model name.")
+        # Prefix routing alone does not validate Argo/ALCF catalog membership.
+        if spec.name.startswith("argo_") or spec.name == "alcf":
+            if provider.model not in spec.curated_models:
+                raise ValueError("Unsupported institutional model.")
+        url = spec.resolve_base_url(provider.model, provider.base_url)
+        if url is not None:
+            validate_url(url)
+        if spec.name.startswith("argo_") and provider.api_key_env:
+            raise ValueError("Argo uses argo_user/ARGO_USER, not an API key variable.")
+        if spec.name == "ollama" and provider.api_key_env:
+            raise ValueError("The Ollama adapter does not support API key overrides.")
+        return spec
+    except ValueError:
+        raise ConfigurationError(
+            "Invalid provider route, model, URL, or credential fields."
+        ) from None
+
+
+def credentials(provider: Provider) -> SharedCredentials:
+    """Resolve shared credentials independently of authenticated session ownership."""
+    spec = endpoint(provider)
+    if spec.name.startswith("argo_"):
+        identity = provider.argo_user or os.getenv("ARGO_USER", "").strip()
+        if not identity or any(c.isspace() for c in identity):
+            raise ValueError("missing_identity")
+        return SharedCredentials(argo_user=identity)
+    variable = provider.api_key_env or spec.credential.env_var
+    key = os.getenv(variable, "").strip() if variable else None
+    if not key and (provider.api_key_env or spec.credential.required):
+        raise ValueError("missing_credentials")
+    if spec.name == "vllm":
+        # Explicit placeholder prevents the legacy OPENAI_API_KEY fallback.
+        key = key or spec.credential.placeholder
+    return SharedCredentials(api_key=key)
+
+
+def status(provider: Provider) -> dict:
+    try:
+        credentials(provider)
+    except ConfigurationError:
+        raise
+    except ValueError as exc:
+        code = str(exc)
+        return {
+            "configured": False,
+            "code": code,
+            "message": "The shared Argo identity is missing. Contact your administrator."
+            if code == "missing_identity"
+            else "Provider credentials are missing. Contact your administrator.",
+        }
+    return {
+        "configured": True,
+        "code": "configured",
+        "message": "Configured; connectivity has not been verified.",
+    }
+
+
+def model_status(settings) -> dict:
+    if settings.demo:
+        return {
+            "demo": {
+                "configured": True,
+                "code": "demo",
+                "message": "Local demonstration; no LLM is contacted.",
+            }
+        }
+    return {label: status(provider) for label, provider in settings.providers.items()}
+
+
+def provenance(settings, label: str) -> str | None:
+    if settings.demo:
+        return "demo" if label == "demo" else None
+    if label not in settings.providers:
+        return None
+    provider = settings.providers[label]
+    spec = endpoint(provider)
+    payload = (
+        spec.name,
+        provider.model,
+        spec.resolve_base_url(provider.model, provider.base_url),
+    )
+    return hashlib.sha256(json.dumps(payload).encode()).hexdigest()
+
+
+def session_status(settings, session) -> dict:
+    available = model_status(settings).get(session["model"])
+    if available is None:
+        return {
+            "configured": False,
+            "code": "model_removed",
+            "message": "This model is no longer enabled. Start a new conversation.",
+        }
+    if session.get("provenance") != provenance(settings, session["model"]):
+        return {
+            "configured": False,
+            "code": "model_changed",
+            "message": "This conversation's model configuration changed. Start a new conversation.",
+        }
+    return available

--- a/src/chemgraph/api/settings.py
+++ b/src/chemgraph/api/settings.py
@@ -1,0 +1,58 @@
+"""Administrator-owned configuration for the web service."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class Provider(BaseModel):
+    """An approved model endpoint; secrets are read only by workers."""
+
+    model: str
+    base_url: str | None = None
+    api_key_env: str | None = None
+    argo_user: str | None = None
+
+
+class Settings(BaseModel):
+    data_dir: Path = Path("web_data")
+    public_origin: str = "http://localhost:8080"
+    identity_header: str = "X-Auth-Request-User"
+    dev_user: str | None = None
+    demo: bool = False
+    providers: dict[str, Provider] = Field(default_factory=dict)
+    calculators: tuple[str, ...] = ("emt",)
+    max_workers: int = Field(default=2, ge=1, le=32)
+    run_timeout: int = Field(default=3600, ge=10)
+    upload_limit: int = Field(default=25 * 1024 * 1024, ge=1)
+
+    @model_validator(mode="after")
+    def validate_deployment(self):
+        if self.demo and not self.dev_user:
+            raise ValueError("Demo execution requires an explicit development user.")
+        if not self.public_origin.startswith(("http://", "https://")):
+            raise ValueError("public_origin must be an HTTP(S) origin.")
+        allowed = {"emt", "mace_mp", "mace_off", "mace_polar"}
+        if not self.calculators or not set(self.calculators) <= allowed:
+            raise ValueError(
+                "Only EMT and approved MACE foundation calculators are supported."
+            )
+        return self
+
+    @classmethod
+    def from_env(cls):
+        """Read non-secret deployment settings; never expose provider definitions."""
+        values = {}
+        for field in cls.model_fields:
+            value = os.getenv(f"CHEMGRAPH_WEB_{field.upper()}")
+            if value is not None:
+                values[field] = (
+                    json.loads(value)
+                    if field in {"providers", "calculators"}
+                    else value
+                )
+        return cls(**values)

--- a/src/chemgraph/api/settings.py
+++ b/src/chemgraph/api/settings.py
@@ -5,20 +5,76 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import re
+import tomllib
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+
+class ConfigurationError(ValueError):
+    """A configuration error whose message is safe to display to an operator."""
+
+
+def validate_url(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+        valid = (
+            parsed.scheme in {"http", "https"}
+            and parsed.hostname
+            and not parsed.username
+            and not parsed.password
+            and not parsed.query
+            and not parsed.fragment
+            and not any(c.isspace() for c in value)
+        )
+        _ = parsed.port
+    except ValueError:
+        valid = False
+    if not valid:
+        raise ValueError("Use an HTTP(S) URL without credentials, query, or fragment.")
+    return value.rstrip("/")
 
 
 class Provider(BaseModel):
     """An approved model endpoint; secrets are read only by workers."""
 
-    model: str
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    model: str = Field(min_length=1, max_length=200, pattern=r"^\S+$")
     base_url: str | None = None
     api_key_env: str | None = None
     argo_user: str | None = None
 
+    @field_validator("base_url")
+    @classmethod
+    def endpoint_url(cls, value):
+        return validate_url(value) if value is not None else value
+
+    @field_validator("api_key_env")
+    @classmethod
+    def credential_variable(cls, value):
+        if value is not None and not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value):
+            raise ValueError("Use an environment variable name.")
+        return value
+
+    @field_validator("argo_user")
+    @classmethod
+    def identity(cls, value):
+        if value is not None and (not value.strip() or any(c.isspace() for c in value)):
+            raise ValueError("Use a nonblank Argo identity without whitespace.")
+        return value
+
 
 class Settings(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
     data_dir: Path = Path("web_data")
     public_origin: str = "http://localhost:8080"
     identity_header: str = "X-Auth-Request-User"
@@ -29,13 +85,31 @@ class Settings(BaseModel):
     max_workers: int = Field(default=2, ge=1, le=32)
     run_timeout: int = Field(default=3600, ge=10)
     upload_limit: int = Field(default=25 * 1024 * 1024, ge=1)
+    provider_timeout: int = Field(default=120, ge=1)
+    max_queued: int = Field(default=20, ge=1)
+    max_user_runs: int = Field(default=2, ge=1)
+    clarification_timeout: int = Field(default=900, ge=1)
+    user_storage_limit: int = Field(default=1024**3, ge=1)
+    retention_days: int = Field(default=30, ge=1)
+    context_limit: int = Field(default=16000, ge=1000)
+
+    @field_validator("providers")
+    @classmethod
+    def provider_labels(cls, value):
+        if any(
+            not label.strip() or len(label) > 200 or any(ord(c) < 32 for c in label)
+            for label in value
+        ):
+            raise ValueError("Provider labels must contain 1–200 printable characters.")
+        return value
 
     @model_validator(mode="after")
     def validate_deployment(self):
         if self.demo and not self.dev_user:
             raise ValueError("Demo execution requires an explicit development user.")
-        if not self.public_origin.startswith(("http://", "https://")):
-            raise ValueError("public_origin must be an HTTP(S) origin.")
+        self.public_origin = validate_url(self.public_origin)
+        if urlsplit(self.public_origin).path:
+            raise ValueError("public_origin must not include a path.")
         allowed = {"emt", "mace_mp", "mace_off", "mace_polar"}
         if not self.calculators or not set(self.calculators) <= allowed:
             raise ValueError(
@@ -46,13 +120,31 @@ class Settings(BaseModel):
     @classmethod
     def from_env(cls):
         """Read non-secret deployment settings; never expose provider definitions."""
-        values = {}
-        for field in cls.model_fields:
-            value = os.getenv(f"CHEMGRAPH_WEB_{field.upper()}")
-            if value is not None:
-                values[field] = (
-                    json.loads(value)
-                    if field in {"providers", "calculators"}
-                    else value
-                )
-        return cls(**values)
+        try:
+            values = {}
+            for field in cls.model_fields:
+                value = os.getenv(f"CHEMGRAPH_WEB_{field.upper()}")
+                if value is not None:
+                    values[field] = (
+                        json.loads(value)
+                        if field in {"providers", "calculators"}
+                        else value
+                    )
+            if "providers" not in values and (
+                path := os.getenv("CHEMGRAPH_WEB_PROVIDERS_FILE")
+            ):
+                with Path(path).open("rb") as source:
+                    document = tomllib.load(source)
+                if set(document) != {"providers"}:
+                    raise ConfigurationError(
+                        "The provider file must contain only a providers table."
+                    )
+                values["providers"] = document["providers"]
+            return cls(**values)
+        except (OSError, ValueError, ValidationError) as exc:
+            if isinstance(exc, ConfigurationError):
+                raise
+            # Parser/validation exception strings may contain literal secrets.
+            raise ConfigurationError(
+                "Invalid web configuration. Check field names, types, URLs, and provider file syntax/access."
+            ) from None

--- a/src/chemgraph/api/store.py
+++ b/src/chemgraph/api/store.py
@@ -1,0 +1,132 @@
+"""Persistent HTTP resources and an append-only, replayable event stream."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import json
+from pathlib import Path
+import sqlite3
+from uuid import uuid4
+
+
+TERMINAL = {"completed", "failed", "interrupted"}
+
+
+class Store:
+    def __init__(self, root: Path):
+        self.root = root.resolve()
+        self.root.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.db_path = self.root / "web.db"
+        with self.connect() as db:
+            db.executescript("""
+                CREATE TABLE IF NOT EXISTS sessions (
+                    id TEXT PRIMARY KEY, owner TEXT NOT NULL, model TEXT NOT NULL,
+                    workflow TEXT NOT NULL, title TEXT NOT NULL,
+                    created TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                );
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES sessions(id),
+                    query TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'queued',
+                    final_text TEXT NOT NULL DEFAULT '', error TEXT,
+                    question_id TEXT, question TEXT, answer TEXT,
+                    request_id TEXT NOT NULL, attachments TEXT NOT NULL DEFAULT '[]',
+                    created TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                    UNIQUE(session_id, request_id)
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS one_active_run ON runs(session_id)
+                    WHERE status IN ('queued', 'running', 'waiting_for_input');
+                CREATE TABLE IF NOT EXISTS events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id TEXT NOT NULL REFERENCES runs(id), type TEXT NOT NULL,
+                    data TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS run_events ON events(run_id, id);
+                CREATE TABLE IF NOT EXISTS files (
+                    id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES sessions(id),
+                    run_id TEXT REFERENCES runs(id), name TEXT NOT NULL,
+                    path TEXT NOT NULL, kind TEXT NOT NULL, size INTEGER NOT NULL
+                );
+            """)
+        self.db_path.chmod(0o600)
+
+    @contextmanager
+    def connect(self):
+        db = sqlite3.connect(self.db_path, timeout=30)
+        db.row_factory = sqlite3.Row
+        db.execute("PRAGMA foreign_keys=ON")
+        db.execute("PRAGMA journal_mode=WAL")
+        try:
+            with db:
+                yield db
+        finally:
+            db.close()
+
+    def rows(self, sql, args=()):
+        with self.connect() as db:
+            return [dict(row) for row in db.execute(sql, args)]
+
+    def one(self, sql, args=()):
+        rows = self.rows(sql, args)
+        return rows[0] if rows else None
+
+    def execute(self, sql, args=()):
+        with self.connect() as db:
+            return db.execute(sql, args).rowcount
+
+    def session_dir(self, session_id):
+        # IDs originate in this store, never from a filesystem path supplied by a client.
+        return self.root / "sessions" / session_id
+
+    def event(self, run_id, event_type, data):
+        self.execute(
+            "INSERT INTO events(run_id,type,data) VALUES (?,?,?)",
+            (run_id, event_type, json.dumps(data)),
+        )
+
+    def finish(self, run_id, status, *, text="", error=None):
+        with self.connect() as db:
+            changed = db.execute(
+                "UPDATE runs SET status=?, final_text=?, error=?, question_id=NULL, "
+                "question=NULL WHERE id=? AND status IN ('queued','running','waiting_for_input')",
+                (status, text, error, run_id),
+            ).rowcount
+            if changed:
+                db.execute(
+                    "INSERT INTO events(run_id,type,data) VALUES (?,?,?)",
+                    (run_id, "status", json.dumps({"status": status})),
+                )
+
+    def recover(self):
+        for row in self.rows(
+            "SELECT id FROM runs WHERE status IN ('queued','running','waiting_for_input')"
+        ):
+            self.finish(
+                row["id"],
+                "interrupted",
+                error="The server restarted. You can retry this request.",
+            )
+
+    def register_file(self, session_id, path, kind, run_id=None, name=None):
+        path = Path(path).resolve()
+        path.relative_to(self.session_dir(session_id).resolve())
+        file_id = str(uuid4())
+        self.execute(
+            "INSERT INTO files VALUES (?,?,?,?,?,?,?)",
+            (
+                file_id,
+                session_id,
+                run_id,
+                name or path.name,
+                str(path.relative_to(self.root)),
+                kind,
+                path.stat().st_size,
+            ),
+        )
+        return file_id
+
+    def file_path(self, record):
+        path = (self.root / record["path"]).resolve()
+        path.relative_to(self.session_dir(record["session_id"]).resolve())
+        if not path.is_file():
+            raise FileNotFoundError(record["id"])
+        return path

--- a/src/chemgraph/api/store.py
+++ b/src/chemgraph/api/store.py
@@ -6,10 +6,13 @@ from contextlib import contextmanager
 import json
 from pathlib import Path
 import sqlite3
+import shutil
+import time
 from uuid import uuid4
 
 
-TERMINAL = {"completed", "failed", "interrupted"}
+TERMINAL = {"completed", "failed", "interrupted", "cancelled"}
+ACTIVE = {"queued", "running", "waiting_for_input", "cancelling"}
 
 
 class Store:
@@ -46,6 +49,41 @@ class Store:
                     run_id TEXT REFERENCES runs(id), name TEXT NOT NULL,
                     path TEXT NOT NULL, kind TEXT NOT NULL, size INTEGER NOT NULL
                 );
+                CREATE TABLE IF NOT EXISTS upload_reservations (
+                    id TEXT PRIMARY KEY, session_id TEXT NOT NULL REFERENCES sessions(id),
+                    bytes INTEGER NOT NULL
+                );
+            """)
+            for table, columns in {
+                "sessions": {
+                    "provenance": "TEXT",
+                    "last_activity": "REAL NOT NULL DEFAULT 0",
+                },
+                "runs": {"error_code": "TEXT", "waiting_since": "REAL"},
+            }.items():
+                existing = {
+                    row["name"] for row in db.execute(f"PRAGMA table_info({table})")
+                }
+                for name, definition in columns.items():
+                    if name not in existing:
+                        db.execute(
+                            f"ALTER TABLE {table} ADD COLUMN {name} {definition}"
+                        )
+            # Older deployments did not record activity. Give that history a
+            # full retention window after upgrade rather than expiring it based
+            # on conversation creation, which may predate recent follow-ups.
+            db.execute(
+                "UPDATE sessions SET last_activity=? WHERE last_activity=0",
+                (time.time(),),
+            )
+            # Earlier workers published every JSON file, including agent state.
+            # Revoke those download IDs while retaining diagnostics on disk.
+            db.execute(
+                "DELETE FROM files WHERE kind!='upload' AND name GLOB 'state_thread_*.json'"
+            )
+            db.executescript("""
+                CREATE UNIQUE INDEX IF NOT EXISTS one_active_web_run_v2 ON runs(session_id)
+                    WHERE status IN ('queued','running','waiting_for_input','cancelling');
             """)
         self.db_path.chmod(0o600)
 
@@ -65,6 +103,12 @@ class Store:
         with self.connect() as db:
             return [dict(row) for row in db.execute(sql, args)]
 
+    @contextmanager
+    def transaction(self):
+        with self.connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            yield db
+
     def one(self, sql, args=()):
         rows = self.rows(sql, args)
         return rows[0] if rows else None
@@ -83,28 +127,51 @@ class Store:
             (run_id, event_type, json.dumps(data)),
         )
 
-    def finish(self, run_id, status, *, text="", error=None):
-        with self.connect() as db:
+    def finish(
+        self, run_id, status, *, text="", error=None, error_code=None, stopped=False
+    ):
+        with self.transaction() as db:
+            if stopped:
+                current = db.execute(
+                    "SELECT status FROM runs WHERE id=?", (run_id,)
+                ).fetchone()
+                if current and current["status"] == "cancelling":
+                    status, error_code, error = (
+                        "cancelled",
+                        "cancelled",
+                        "The run was cancelled.",
+                    )
             changed = db.execute(
-                "UPDATE runs SET status=?, final_text=?, error=?, question_id=NULL, "
-                "question=NULL WHERE id=? AND status IN ('queued','running','waiting_for_input')",
-                (status, text, error, run_id),
+                "UPDATE runs SET status=?, final_text=?, error=?, error_code=?, question_id=NULL, "
+                "question=NULL,waiting_since=NULL WHERE id=? AND status IN ('queued','running','waiting_for_input'"
+                + (",'cancelling'" if status == "cancelled" else "")
+                + ")",
+                (status, text, error, error_code, run_id),
             ).rowcount
             if changed:
                 db.execute(
                     "INSERT INTO events(run_id,type,data) VALUES (?,?,?)",
                     (run_id, "status", json.dumps({"status": status})),
                 )
+                db.execute(
+                    "UPDATE sessions SET last_activity=? WHERE id=(SELECT session_id FROM runs WHERE id=?)",
+                    (time.time(), run_id),
+                )
 
     def recover(self):
         for row in self.rows(
-            "SELECT id FROM runs WHERE status IN ('queued','running','waiting_for_input')"
+            "SELECT id,status FROM runs WHERE status IN ('queued','running','waiting_for_input','cancelling')"
         ):
             self.finish(
                 row["id"],
-                "interrupted",
+                "cancelled" if row["status"] == "cancelling" else "interrupted",
                 error="The server restarted. You can retry this request.",
+                error_code="server_restarted",
             )
+        self.execute("DELETE FROM upload_reservations")
+        staging = self.root / "staging"
+        if staging.exists():
+            shutil.rmtree(staging)
 
     def register_file(self, session_id, path, kind, run_id=None, name=None):
         path = Path(path).resolve()
@@ -130,3 +197,61 @@ class Store:
         if not path.is_file():
             raise FileNotFoundError(record["id"])
         return path
+
+    def owner_usage(self, owner, db=None):
+        """Account for workspace files, memory, transcripts, and reserved uploads."""
+        if db is None:
+            with self.connect() as connection:
+                return self.owner_usage(owner, connection)
+        total = 0
+        for row in db.execute("SELECT id FROM sessions WHERE owner=?", (owner,)):
+            session_id = row["id"]
+            paths = list(self.session_dir(session_id).rglob("*"))
+            paths.extend((self.root / "diagnostics" / session_id).rglob("*"))
+            paths.extend((self.root / "memory").glob(f"{session_id}.db*"))
+            for path in paths:
+                try:
+                    if path.is_file() and not path.is_symlink():
+                        total += path.stat().st_size
+                except FileNotFoundError:
+                    pass
+        total += db.execute(
+            "SELECT COALESCE(SUM(u.bytes),0) FROM upload_reservations u JOIN sessions s ON s.id=u.session_id WHERE s.owner=?",
+            (owner,),
+        ).fetchone()[0]
+        total += db.execute(
+            "SELECT COALESCE(SUM(length(CAST(r.query || r.final_text || COALESCE(r.question,'') || COALESCE(r.answer,'') AS BLOB))),0) FROM runs r JOIN sessions s ON s.id=r.session_id WHERE s.owner=?",
+            (owner,),
+        ).fetchone()[0]
+        total += db.execute(
+            "SELECT COALESCE(SUM(length(CAST(e.data AS BLOB))),0) FROM events e JOIN runs r ON r.id=e.run_id JOIN sessions s ON s.id=r.session_id WHERE s.owner=?",
+            (owner,),
+        ).fetchone()[0]
+        return total
+
+    def cleanup(self, retention_days):
+        """Remove inactive conversations, including files and agent memory."""
+        cutoff = time.time() - retention_days * 86400
+        with self.transaction() as db:
+            rows = db.execute(
+                "SELECT id FROM sessions s WHERE last_activity<? AND NOT EXISTS (SELECT 1 FROM runs r WHERE r.session_id=s.id AND r.status IN ('queued','running','waiting_for_input','cancelling')) AND NOT EXISTS (SELECT 1 FROM upload_reservations u WHERE u.session_id=s.id)",
+                (cutoff,),
+            ).fetchall()
+            for row in rows:
+                session_id = row["id"]
+                workspace = self.session_dir(session_id)
+                if workspace.exists():
+                    shutil.rmtree(workspace)
+                diagnostics = self.root / "diagnostics" / session_id
+                if diagnostics.exists():
+                    shutil.rmtree(diagnostics)
+                for path in (self.root / "memory").glob(f"{session_id}.db*"):
+                    path.unlink(missing_ok=True)
+                db.execute("DELETE FROM files WHERE session_id=?", (session_id,))
+                db.execute(
+                    "DELETE FROM events WHERE run_id IN (SELECT id FROM runs WHERE session_id=?)",
+                    (session_id,),
+                )
+                db.execute("DELETE FROM runs WHERE session_id=?", (session_id,))
+                db.execute("DELETE FROM sessions WHERE id=?", (session_id,))
+        return len(rows)

--- a/src/chemgraph/api/worker.py
+++ b/src/chemgraph/api/worker.py
@@ -1,0 +1,272 @@
+"""One bounded run per spawned process; HTTP connections never own execution."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+import time
+from uuid import uuid4
+
+from chemgraph.api.settings import Settings
+from chemgraph.api.store import Store
+
+logger = logging.getLogger(__name__)
+
+
+def execute_run(
+    root: str, run_id: str, settings_data: dict, parent_pid: int | None = None
+):
+    """Spawn entry point. Only primitive values cross the process boundary."""
+    if parent_pid is not None:
+        import threading
+
+        def watch_parent():
+            while os.getppid() == parent_pid:
+                time.sleep(1)
+            # A killed API cannot join its workers. Stop this worker rather than
+            # leaving an orphan calculation running after restart recovery.
+            os._exit(1)
+
+        threading.Thread(target=watch_parent, daemon=True).start()
+    settings = Settings(**settings_data)
+    store = Store(Path(root))
+    run = store.one("SELECT * FROM runs WHERE id=?", (run_id,))
+    session = store.one("SELECT * FROM sessions WHERE id=?", (run["session_id"],))
+    workspace = store.session_dir(session["id"])
+    turn_dir = workspace / run_id
+    turn_dir.mkdir(parents=True, exist_ok=True)
+    os.chdir(turn_dir)
+    os.environ["CHEMGRAPH_LOG_DIR"] = str(turn_dir)
+    store.execute("UPDATE runs SET status='running' WHERE id=?", (run_id,))
+    store.event(run_id, "status", {"status": "running"})
+
+    async def ask(question):
+        question_id = str(uuid4())
+        with store.connect() as db:
+            db.execute(
+                "UPDATE runs SET status='waiting_for_input', question_id=?, question=?, answer=NULL WHERE id=?",
+                (question_id, question, run_id),
+            )
+        store.event(run_id, "status", {"status": "waiting_for_input"})
+        while True:
+            row = store.one("SELECT answer FROM runs WHERE id=?", (run_id,))
+            if row["answer"] is not None:
+                store.execute(
+                    "UPDATE runs SET status='running', question_id=NULL, question=NULL WHERE id=?",
+                    (run_id,),
+                )
+                store.event(run_id, "status", {"status": "running"})
+                return row["answer"]
+            await asyncio.sleep(0.2)
+
+    def event(kind, payload):
+        # Keep raw provider responses, exception reprs, tool arguments and paths
+        # off the browser event stream. The API exposes registered artifacts.
+        if kind in {
+            "tool_call_started",
+            "tool_call_finished",
+            "tool_call_failed",
+            "llm_call_started",
+            "llm_call_finished",
+        }:
+            store.event(
+                run_id, "progress", {"kind": kind, "tool": payload.get("tool_name")}
+            )
+
+    async def run_agent():
+        import json
+        from chemgraph.agent.llm_agent import ChemGraph
+        from chemgraph.api.chemistry import web_tools
+        from chemgraph.memory.store import SessionStore
+
+        provider = settings.providers[session["model"]]
+        api_key = os.getenv(provider.api_key_env) if provider.api_key_env else None
+        if provider.api_key_env and not api_key:
+            raise ValueError("The selected provider is not configured on the server.")
+        memory = SessionStore(str(store.root / "memory" / f"{session['id']}.db"))
+        previous = memory.get_session(session["id"])
+        agent = ChemGraph(
+            model_name=provider.model,
+            base_url=provider.base_url,
+            api_key=api_key,
+            argo_user=provider.argo_user,
+            workflow_type=session["workflow"],
+            return_option="last_message",
+            human_supervised=True,
+            human_input_handler=ask,
+            on_event=event,
+            session_store=memory,
+            log_dir=str(turn_dir),
+            tools=web_tools(workspace, settings.calculators),
+        )
+        agent.uuid = session["id"]
+        agent._session_created = previous is not None
+        query = run["query"]
+        attachment_ids = json.loads(run["attachments"])
+        if attachment_ids:
+            paths = [
+                store.file_path(store.one("SELECT * FROM files WHERE id=?", (file_id,)))
+                for file_id in attachment_ids
+            ]
+            query += (
+                "\n\nAttached files (use these exact workspace paths):\n"
+                + "\n".join(str(p) for p in paths)
+            )
+        query += f"\n\nApproved calculators: {', '.join(settings.calculators)}. Write new outputs in {turn_dir}."
+        result = await agent.run(query, resume_from=session["id"] if previous else None)
+        content = getattr(result, "content", result)
+        if isinstance(content, list):
+            return "\n".join(
+                part.get("text", "") for part in content if isinstance(part, dict)
+            )
+        return str(content)
+
+    try:
+        if settings.demo:
+            # Explicit development-only demo: real EMT, no model or network.
+            text = asyncio.run(demo_run(turn_dir, run["query"], ask, event))
+        else:
+            text = asyncio.run(run_agent())
+        from ui.artifacts import classify_artifacts
+
+        kinds = classify_artifacts([p.name for p in turn_dir.iterdir() if p.is_file()])
+        by_name = {name: kind for kind, names in kinds.items() for name in names}
+        for path in sorted(turn_dir.rglob("*")):
+            if (
+                path.is_file()
+                and not path.is_symlink()
+                and path.suffix.lower()
+                in {".xyz", ".pdb", ".cif", ".traj", ".json", ".csv", ".png", ".html"}
+            ):
+                store.register_file(
+                    session["id"], path, by_name.get(path.name, "data"), run_id
+                )
+        # Display transcript paths as opaque relative names, not host paths.
+        text = text.replace(str(workspace) + "/", "")
+        store.finish(run_id, "completed", text=text)
+    except Exception:
+        logger.exception("Web run %s failed", run_id)
+        store.finish(
+            run_id,
+            "failed",
+            error="The calculation failed. Check the server log using this run ID, then retry.",
+        )
+
+
+async def demo_run(turn_dir, query, ask, event):
+    from ase import Atoms
+    from ase.calculators.emt import EMT
+    from ase.io import write
+    from ase.optimize import BFGS
+
+    if "confirm" in query.lower():
+        await ask("Optimize this copper dimer with the EMT calculator?")
+    event("tool_call_started", {"tool_name": "run_ase"})
+    atoms = Atoms("Cu2", positions=[[0, 0, 0], [0, 0, 2.5]])
+    atoms.calc = EMT()
+    with BFGS(
+        atoms, trajectory=str(turn_dir / "copper_opt.traj"), logfile=None
+    ) as optimizer:
+        optimizer.run(fmax=0.05, steps=10)
+    write(str(turn_dir / "copper.xyz"), atoms)
+    event("tool_call_finished", {"tool_name": "run_ase"})
+    await asyncio.sleep(0.2)
+    return f"Demo calculation complete. The copper dimer has a potential energy of **{atoms.get_potential_energy():.4f} eV** using EMT. Inspect the structure and optimization trajectory in Results."
+
+
+class Supervisor:
+    """Bounded process scheduler with durable queued work and explicit recovery."""
+
+    def __init__(self, store: Store, settings: Settings):
+        self.store, self.settings = store, settings
+        self.children = {}
+        self.task = None
+
+    async def start(self):
+        # The service is intentionally single-process. Prevent a second API
+        # instance from interrupting live runs or executing queued work twice.
+        import fcntl
+
+        self.lock = open(self.store.root / "server.lock", "a")
+        try:
+            fcntl.flock(self.lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            self.lock.close()
+            raise RuntimeError(
+                "Only one API process may use this data directory."
+            ) from None
+        self.store.recover()
+        self.task = asyncio.create_task(self.loop())
+
+    async def stop(self):
+        self.task.cancel()
+        try:
+            await self.task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("Web scheduler stopped unexpectedly")
+        for run_id, (process, _) in self.children.items():
+            await asyncio.to_thread(self.terminate, process)
+            self.store.finish(
+                run_id,
+                "interrupted",
+                error="The server stopped. You can retry this request.",
+            )
+        self.lock.close()
+
+    @staticmethod
+    def terminate(process):
+        if process.is_alive():
+            process.terminate()
+        process.join(timeout=2)
+        if process.is_alive():
+            process.kill()
+            process.join()
+
+    async def loop(self):
+        import multiprocessing
+
+        context = multiprocessing.get_context("spawn")
+        while True:
+            for run_id, (process, started) in list(self.children.items()):
+                timed_out = time.monotonic() - started > self.settings.run_timeout
+                if not process.is_alive() or timed_out:
+                    await asyncio.to_thread(self.terminate, process)
+                    self.store.finish(
+                        run_id,
+                        "interrupted",
+                        error="The worker stopped or exceeded its time limit. You can retry.",
+                    )
+                    del self.children[run_id]
+            for row in self.store.rows(
+                "SELECT id FROM runs WHERE status='queued' ORDER BY created"
+            ):
+                if len(self.children) >= self.settings.max_workers:
+                    break
+                if row["id"] in self.children:
+                    continue
+                process = context.Process(
+                    target=execute_run,
+                    args=(
+                        str(self.store.root),
+                        row["id"],
+                        self.settings.model_dump(),
+                        os.getpid(),
+                    ),
+                    daemon=True,
+                )
+                try:
+                    process.start()
+                except Exception:
+                    logger.exception("Could not start web worker %s", row["id"])
+                    self.store.finish(
+                        row["id"],
+                        "failed",
+                        error="The server could not start a calculation worker. Please retry.",
+                    )
+                    continue
+                self.children[row["id"]] = (process, time.monotonic())
+            await asyncio.sleep(0.2)

--- a/src/chemgraph/api/worker.py
+++ b/src/chemgraph/api/worker.py
@@ -11,6 +11,8 @@ from uuid import uuid4
 
 from chemgraph.api.settings import Settings
 from chemgraph.api.store import Store
+from chemgraph.api.providers import credentials, session_status
+from chemgraph.api.errors import public_error, RunStopped, StorageLimit
 
 logger = logging.getLogger(__name__)
 
@@ -39,22 +41,49 @@ def execute_run(
     turn_dir.mkdir(parents=True, exist_ok=True)
     os.chdir(turn_dir)
     os.environ["CHEMGRAPH_LOG_DIR"] = str(turn_dir)
-    store.execute("UPDATE runs SET status='running' WHERE id=?", (run_id,))
+    if not store.execute(
+        "UPDATE runs SET status='running' WHERE id=? AND status IN ('queued','running')",
+        (run_id,),
+    ):
+        return
     store.event(run_id, "status", {"status": "running"})
+
+    def guard():
+        row = store.one("SELECT status FROM runs WHERE id=?", (run_id,))
+        if row["status"] not in {"running", "waiting_for_input"}:
+            raise RunStopped()
+        if store.owner_usage(session["owner"]) > settings.user_storage_limit:
+            raise StorageLimit()
+
+    secret_values = []
+    for provider in settings.providers.values():
+        try:
+            key = credentials(provider).api_key
+            if key and not key.startswith("dummy_"):
+                secret_values.append(key)
+        except ValueError:
+            pass
+
+    def safe_text(value):
+        text = str(value).replace(str(workspace) + "/", "")
+        for secret in secret_values:
+            text = text.replace(secret, "[redacted]")
+        return text
 
     async def ask(question):
         question_id = str(uuid4())
-        with store.connect() as db:
+        with store.transaction() as db:
             db.execute(
-                "UPDATE runs SET status='waiting_for_input', question_id=?, question=?, answer=NULL WHERE id=?",
-                (question_id, question, run_id),
+                "UPDATE runs SET status='waiting_for_input', question_id=?, question=?, answer=NULL,waiting_since=? WHERE id=? AND status='running'",
+                (question_id, safe_text(question), time.time(), run_id),
             )
         store.event(run_id, "status", {"status": "waiting_for_input"})
         while True:
+            guard()
             row = store.one("SELECT answer FROM runs WHERE id=?", (run_id,))
             if row["answer"] is not None:
                 store.execute(
-                    "UPDATE runs SET status='running', question_id=NULL, question=NULL WHERE id=?",
+                    "UPDATE runs SET status='running', question_id=NULL, question=NULL,waiting_since=NULL WHERE id=? AND status='waiting_for_input'",
                     (run_id,),
                 )
                 store.event(run_id, "status", {"status": "running"})
@@ -72,34 +101,53 @@ def execute_run(
             "llm_call_finished",
         }:
             store.event(
-                run_id, "progress", {"kind": kind, "tool": payload.get("tool_name")}
+                run_id,
+                "progress",
+                {
+                    "kind": kind,
+                    "tool": safe_text(payload["tool_name"])
+                    if payload.get("tool_name")
+                    else None,
+                },
             )
 
     async def run_agent():
         import json
         from chemgraph.agent.llm_agent import ChemGraph
         from chemgraph.api.chemistry import web_tools
-        from chemgraph.memory.store import SessionStore
+        from chemgraph.api.memory import WebSessionStore
 
         provider = settings.providers[session["model"]]
-        api_key = os.getenv(provider.api_key_env) if provider.api_key_env else None
-        if provider.api_key_env and not api_key:
+        if not session_status(settings, session)["configured"]:
             raise ValueError("The selected provider is not configured on the server.")
-        memory = SessionStore(str(store.root / "memory" / f"{session['id']}.db"))
-        previous = memory.get_session(session["id"])
+        shared = credentials(provider)
+        memory = WebSessionStore(
+            str(store.root / "memory" / f"{session['id']}.db"),
+            run["query"],
+            settings.context_limit,
+        )
+        with memory._connect() as db:
+            previous = db.execute(
+                "SELECT 1 FROM sessions WHERE session_id=?", (session["id"],)
+            ).fetchone()
+        diagnostic_dir = store.root / "diagnostics" / session["id"] / run_id
+        diagnostic_dir.mkdir(parents=True, exist_ok=True)
         agent = ChemGraph(
             model_name=provider.model,
             base_url=provider.base_url,
-            api_key=api_key,
-            argo_user=provider.argo_user,
+            api_key=shared.api_key,
+            argo_user=shared.argo_user,
+            model_timeout=settings.provider_timeout,
             workflow_type=session["workflow"],
             return_option="last_message",
             human_supervised=True,
             human_input_handler=ask,
             on_event=event,
             session_store=memory,
-            log_dir=str(turn_dir),
-            tools=web_tools(workspace, settings.calculators),
+            log_dir=str(diagnostic_dir),
+            tools=web_tools(
+                workspace, settings.calculators, guard=guard, publish=publish
+            ),
         )
         agent.uuid = session["id"]
         agent._session_created = previous is not None
@@ -123,35 +171,43 @@ def execute_run(
             )
         return str(content)
 
+    published = set()
+
+    def publish(path):
+        path = Path(path).resolve()
+        path.relative_to(turn_dir.resolve())
+        if path.is_file() and not path.is_symlink():
+            published.add(path)
+
     try:
         if settings.demo:
             # Explicit development-only demo: real EMT, no model or network.
             text = asyncio.run(demo_run(turn_dir, run["query"], ask, event))
+            for name in ("copper.xyz", "copper_opt.traj"):
+                publish(turn_dir / name)
         else:
             text = asyncio.run(run_agent())
         from ui.artifacts import classify_artifacts
 
-        kinds = classify_artifacts([p.name for p in turn_dir.iterdir() if p.is_file()])
+        guard()
+        kinds = classify_artifacts([p.name for p in published])
         by_name = {name: kind for kind, names in kinds.items() for name in names}
-        for path in sorted(turn_dir.rglob("*")):
-            if (
-                path.is_file()
-                and not path.is_symlink()
-                and path.suffix.lower()
-                in {".xyz", ".pdb", ".cif", ".traj", ".json", ".csv", ".png", ".html"}
-            ):
-                store.register_file(
-                    session["id"], path, by_name.get(path.name, "data"), run_id
-                )
+        for path in sorted(published):
+            store.register_file(
+                session["id"], path, by_name.get(path.name, "data"), run_id
+            )
         # Display transcript paths as opaque relative names, not host paths.
-        text = text.replace(str(workspace) + "/", "")
-        store.finish(run_id, "completed", text=text)
-    except Exception:
+        store.finish(run_id, "completed", text=safe_text(text))
+    except RunStopped:
+        pass  # The supervisor finalizes cancellation after joining the process.
+    except Exception as exc:
         logger.exception("Web run %s failed", run_id)
+        code, message = public_error(exc)
         store.finish(
             run_id,
             "failed",
-            error="The calculation failed. Check the server log using this run ID, then retry.",
+            error=message,
+            error_code=code,
         )
 
 
@@ -214,6 +270,7 @@ class Supervisor:
                 run_id,
                 "interrupted",
                 error="The server stopped. You can retry this request.",
+                stopped=True,
             )
         self.lock.close()
 
@@ -230,24 +287,77 @@ class Supervisor:
         import multiprocessing
 
         context = multiprocessing.get_context("spawn")
+        last_cleanup = 0
         while True:
+            if time.monotonic() - last_cleanup > 3600:
+                await asyncio.to_thread(
+                    self.store.cleanup, self.settings.retention_days
+                )
+                last_cleanup = time.monotonic()
             for run_id, (process, started) in list(self.children.items()):
+                row = self.store.one(
+                    "SELECT r.*,s.owner FROM runs r JOIN sessions s ON s.id=r.session_id WHERE r.id=?",
+                    (run_id,),
+                )
                 timed_out = time.monotonic() - started > self.settings.run_timeout
-                if not process.is_alive() or timed_out:
+                waiting_expired = (
+                    row["waiting_since"] is not None
+                    and time.time() - row["waiting_since"]
+                    > self.settings.clarification_timeout
+                )
+                cancelled = row["status"] == "cancelling"
+                over_quota = (
+                    await asyncio.to_thread(self.store.owner_usage, row["owner"])
+                    > self.settings.user_storage_limit
+                )
+                if (
+                    row["status"] in {"completed", "failed", "interrupted", "cancelled"}
+                    or not process.is_alive()
+                    or timed_out
+                    or waiting_expired
+                    or cancelled
+                    or over_quota
+                ):
                     await asyncio.to_thread(self.terminate, process)
                     self.store.finish(
                         run_id,
-                        "interrupted",
-                        error="The worker stopped or exceeded its time limit. You can retry.",
+                        "cancelled" if cancelled else "interrupted",
+                        error="The run was cancelled."
+                        if cancelled
+                        else "The clarification request expired."
+                        if waiting_expired
+                        else "Your workspace storage limit was reached."
+                        if over_quota
+                        else "The worker stopped or exceeded its time limit. You can retry.",
+                        error_code="cancelled"
+                        if cancelled
+                        else "clarification_timeout"
+                        if waiting_expired
+                        else "storage_limit"
+                        if over_quota
+                        else "worker_interrupted",
+                        stopped=True,
                     )
                     del self.children[run_id]
             for row in self.store.rows(
-                "SELECT id FROM runs WHERE status='queued' ORDER BY created"
+                "SELECT r.id,s.owner FROM runs r JOIN sessions s ON s.id=r.session_id WHERE r.status='queued' ORDER BY r.created"
             ):
                 if len(self.children) >= self.settings.max_workers:
                     break
                 if row["id"] in self.children:
                     continue
+                with self.store.transaction() as db:
+                    if db.execute(
+                        "SELECT 1 FROM runs r JOIN sessions s ON s.id=r.session_id WHERE s.owner=? AND r.status IN ('running','waiting_for_input','cancelling')",
+                        (row["owner"],),
+                    ).fetchone():
+                        continue
+                    # Claim before spawning, so cancellation cannot race dispatch.
+                    if not db.execute(
+                        "UPDATE runs SET status='running' WHERE id=? AND status='queued'",
+                        (row["id"],),
+                    ).rowcount:
+                        continue
                 process = context.Process(
                     target=execute_run,
                     args=(
@@ -266,6 +376,7 @@ class Supervisor:
                         row["id"],
                         "failed",
                         error="The server could not start a calculation worker. Please retry.",
+                        stopped=True,
                     )
                     continue
                 self.children[row["id"]] = (process, time.monotonic())

--- a/src/chemgraph/graphs/multi_agent.py
+++ b/src/chemgraph/graphs/multi_agent.py
@@ -30,7 +30,7 @@ from langgraph.types import Send, interrupt
 
 from chemgraph.utils.logging_config import setup_logger
 from chemgraph.utils.parsing import extract_json_block, parse_response_formatter
-from chemgraph.state.multi_agent_state import ExecutorState, PlannerState
+from chemgraph.state.multi_agent_state import ExecutorState, ExecutorOutputState, PlannerState
 from chemgraph.schemas.multi_agent_response import PlannerResponse
 from chemgraph.prompt.multi_agent_prompt import (
     planner_prompt as default_planner_prompt,
@@ -679,7 +679,7 @@ def construct_executor_subgraph(
     CompiledStateGraph
         Compiled executor subgraph.
     """
-    workflow = StateGraph(ExecutorState)
+    workflow = StateGraph(ExecutorState, output_schema=ExecutorOutputState)
     workflow.add_node(
         "executor_agent",
         partial(

--- a/src/chemgraph/models/endpoints/anthropic_direct.py
+++ b/src/chemgraph/models/endpoints/anthropic_direct.py
@@ -51,6 +51,8 @@ def prepare(request: ModelRequest) -> PreparedModel:
         api_key=api_key,
         max_tokens=6000,
     )
+    if request.base_url is not None:
+        client_kwargs["base_url"] = request.base_url
     return PreparedModel(
         endpoint_name="anthropic_direct",
         protocol=PROTOCOL,

--- a/src/chemgraph/models/endpoints/google_direct.py
+++ b/src/chemgraph/models/endpoints/google_direct.py
@@ -51,6 +51,8 @@ def prepare(request: ModelRequest) -> PreparedModel:
         api_key=api_key,
         max_output_tokens=6000,
     )
+    if request.base_url is not None:
+        client_kwargs["base_url"] = request.base_url
     return PreparedModel(
         endpoint_name="google_direct",
         protocol=PROTOCOL,

--- a/src/chemgraph/models/endpoints/ollama.py
+++ b/src/chemgraph/models/endpoints/ollama.py
@@ -32,6 +32,8 @@ def prepare(request: ModelRequest) -> PreparedModel:
         model_name=request.model,
         temperature=request.temperature,
     )
+    if request.base_url is not None:
+        client_kwargs["base_url"] = request.base_url
     return PreparedModel(
         endpoint_name="ollama",
         protocol=PROTOCOL,

--- a/src/chemgraph/models/groq.py
+++ b/src/chemgraph/models/groq.py
@@ -14,6 +14,7 @@ def load_groq_model(
     api_key: str = None,
     prompt: str = None,
     base_url: str = None,
+    timeout_s: float = None,
 ) -> ChatGroq:
     """Load a GROQ chat model into LangChain.
     This function loads a GROQ model and configures it for use with LangChain.
@@ -73,6 +74,8 @@ def load_groq_model(
             temperature=temperature,
             api_key=api_key,
             max_tokens=6000,
+            **({"base_url": base_url} if base_url is not None else {}),
+            **({"timeout": timeout_s} if timeout_s is not None else {}),
         )
         # No guarantee that api_key is valid, authentication happens only during invocation
         logger.info(f"Requested model: {model_name}")

--- a/src/chemgraph/models/loader.py
+++ b/src/chemgraph/models/loader.py
@@ -13,6 +13,7 @@ per-model quirks. Protocol builders own the sole client-construction sites.
 from __future__ import annotations
 
 from typing import Optional
+from dataclasses import replace
 
 from chemgraph.models.endpoints import ModelRequest, PreparedModel
 from chemgraph.models.endpoints.registry import select_endpoint
@@ -72,6 +73,7 @@ def load_chat_model_prepared(
     reasoning_effort: Optional[str] = None,
     *,
     settings: LLMSettings | None = None,
+    timeout_s: float | None = None,
 ) -> tuple["object", PreparedModel]:
     """Load a chat model and return it alongside its resolved metadata.
 
@@ -91,6 +93,11 @@ def load_chat_model_prepared(
     )
     spec = _select_endpoint(request)
     prepared = spec.prepare_request(request)
+    timeout = timeout_s if timeout_s is not None else (settings.timeout_s if settings else None)
+    if timeout is not None:
+        kwargs = dict(prepared.client_kwargs)
+        kwargs["timeout_s" if spec.protocol in {"ollama", "groq"} else "timeout"] = timeout
+        prepared = replace(prepared, client_kwargs=kwargs)
     client = spec.protocol_build(prepared.client_kwargs)
     return client, prepared
 

--- a/src/chemgraph/models/local_model.py
+++ b/src/chemgraph/models/local_model.py
@@ -3,7 +3,7 @@ from chemgraph.models.supported_models import supported_ollama_models
 
 
 def load_ollama_model(
-    model_name: str, temperature: float, base_url: str = None
+    model_name: str, temperature: float, base_url: str = None, timeout_s: float = None
 ) -> ChatOllama:
     """Load an Ollama chat model into LangChain.
 
@@ -46,6 +46,8 @@ def load_ollama_model(
     kwargs = {"model": model_name, "temperature": temperature}
     if base_url:
         kwargs["base_url"] = base_url
+    if timeout_s is not None:
+        kwargs["client_kwargs"] = {"timeout": timeout_s}
     llm = ChatOllama(**kwargs)
     print(f"Successfully loaded model: {model_name}")
     return llm

--- a/src/chemgraph/state/multi_agent_state.py
+++ b/src/chemgraph/state/multi_agent_state.py
@@ -42,6 +42,14 @@ class ExecutorState(TypedDict):
     retry_count: int
 
 
+class ExecutorOutputState(TypedDict):
+    """Only finalized results cross from an executor into its parent planner."""
+
+    executor_results: list
+    executor_logs: dict[str, list]
+    failed_tasks: list
+
+
 class PlannerState(TypedDict):
     """Global state for the main planner-executor graph.
 

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -1,0 +1,229 @@
+"""Hermetic contracts for the optional web API; no model credentials needed."""
+
+import json
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from chemgraph.api.app import create_app
+from chemgraph.api.settings import Provider, Settings
+from chemgraph.api.store import Store
+
+
+@pytest.fixture
+def client(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path, providers={"Test model": Provider(model="gpt-test")}
+    )
+    with TestClient(
+        create_app(settings, start_workers=False),
+        headers={
+            "X-Auth-Request-User": "alice",
+            "Origin": "http://localhost:8080",
+        },
+    ) as client:
+        yield client
+
+
+def new_session(client):
+    response = client.post("/api/v1/sessions", json={"model": "Test model"})
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def submit(client, session_id, **kwargs):
+    return client.post(
+        f"/api/v1/sessions/{session_id}/runs",
+        json={
+            "query": "Optimize this structure",
+            "request_id": str(uuid4()),
+            **kwargs,
+        },
+    )
+
+
+def test_gateway_identity_origin_and_provider_secrets(client):
+    assert client.get("/healthz").status_code == 200
+    assert (
+        client.get(
+            "/api/v1/capabilities", headers={"X-Auth-Request-User": ""}
+        ).status_code
+        == 401
+    )
+    assert (
+        client.post(
+            "/api/v1/sessions",
+            json={"model": "Test model"},
+            headers={"Origin": "https://untrusted.example"},
+        ).status_code
+        == 403
+    )
+    assert (
+        client.post("/api/v1/sessions", json={"model": "unapproved"}).status_code == 422
+    )
+    caps = client.get("/api/v1/capabilities").json()
+    assert caps["models"] == ["Test model"]
+    assert "gpt-test" not in json.dumps(caps)
+    assert (
+        client.get("/api/v1/openapi.json").json()["info"]["title"]
+        == "ChemGraph Web API"
+    )
+
+
+def test_every_resource_is_owned_and_downloads_are_attachments(client):
+    session_id = new_session(client)
+    upload = client.post(
+        f"/api/v1/sessions/{session_id}/uploads?filename=../structure.xyz",
+        content=b"1\ntest\nCu 0 0 0\n",
+    )
+    assert upload.status_code == 201
+    file = upload.json()
+    assert file["name"] == "structure.xyz"
+    run = submit(client, session_id, attachments=[file["id"]]).json()
+    paths = [
+        f"/api/v1/sessions/{session_id}",
+        f"/api/v1/runs/{run['id']}",
+        f"/api/v1/runs/{run['id']}/events",
+        file["url"],
+        file["preview_url"],
+    ]
+    for path in paths:
+        assert (
+            client.get(path, headers={"X-Auth-Request-User": "bob"}).status_code == 404
+        )
+    assert (
+        client.get("/api/v1/sessions", headers={"X-Auth-Request-User": "bob"}).json()
+        == []
+    )
+    response = client.get(file["url"])
+    assert response.content == b"1\ntest\nCu 0 0 0\n"
+    assert response.headers["Content-Disposition"].startswith("attachment;")
+    assert client.get(file["preview_url"]).status_code == 200
+    assert "path" not in file
+    assert (
+        client.post(
+            f"/api/v1/sessions/{session_id}/uploads?filename=x.xyz",
+            content=b"x",
+            headers={"X-Auth-Request-User": "bob"},
+        ).status_code
+        == 404
+    )
+    assert submit(client, session_id, query="No", attachments=[]).status_code == 409
+
+
+def test_submission_idempotency_busy_sessions_and_foreign_attachments(client):
+    session_id = new_session(client)
+    other = new_session(client)
+    file = client.post(
+        f"/api/v1/sessions/{other}/uploads?filename=x.csv", content=b"x,y"
+    ).json()
+    assert submit(client, session_id, attachments=[file["id"]]).status_code == 404
+    request_id = str(uuid4())
+    response = submit(client, session_id, request_id=request_id)
+    assert response.status_code == 202
+    assert (
+        submit(client, session_id, request_id=request_id).json()["id"]
+        == response.json()["id"]
+    )
+    assert (
+        submit(client, session_id, request_id=request_id, query="Changed").status_code
+        == 409
+    )
+    assert submit(client, session_id).status_code == 409
+    assert submit(client, other).status_code == 202
+
+
+def test_missing_provider_credentials_are_reported_before_queueing(client, monkeypatch):
+    monkeypatch.delenv("CHEMGRAPH_TEST_MISSING_KEY", raising=False)
+    client.app.state.settings.providers[
+        "Test model"
+    ].api_key_env = "CHEMGRAPH_TEST_MISSING_KEY"
+    session_id = new_session(client)
+    assert submit(client, session_id).status_code == 503
+    assert client.get(f"/api/v1/sessions/{session_id}").json()["runs"] == []
+
+
+def test_human_responses_reject_stale_blank_duplicate_and_other_users(client):
+    run = submit(client, new_session(client)).json()
+    question_id = str(uuid4())
+    store = client.app.state.store
+    store.execute(
+        "UPDATE runs SET status='waiting_for_input',question_id=?,question='Proceed?' WHERE id=?",
+        (question_id, run["id"]),
+    )
+    path = f"/api/v1/runs/{run['id']}/response"
+    answer = {"question_id": question_id, "answer": "Yes"}
+    assert (
+        client.post(
+            path, json=answer, headers={"X-Auth-Request-User": "bob"}
+        ).status_code
+        == 404
+    )
+    assert (
+        client.post(path, json={**answer, "question_id": str(uuid4())}).status_code
+        == 409
+    )
+    assert client.post(path, json={**answer, "answer": " "}).status_code == 422
+    assert client.post(path, json=answer).status_code == 202
+    assert client.post(path, json=answer).status_code == 409
+    assert client.get(f"/api/v1/runs/{run['id']}").json()["responses"] == [
+        {"question": "Proceed?", "answer": "Yes"}
+    ]
+
+
+def test_sse_replay_and_restart_preserve_completed_results(client):
+    store = client.app.state.store
+    run = submit(client, new_session(client)).json()
+    store.event(run["id"], "progress", {"tool": "run_ase"})
+    store.finish(run["id"], "completed", text="1 eV")
+    events = store.rows(
+        "SELECT id FROM events WHERE run_id=? ORDER BY id", (run["id"],)
+    )
+    response = client.get(
+        f"/api/v1/runs/{run['id']}/events",
+        headers={"Last-Event-ID": str(events[0]["id"])},
+    )
+    assert response.headers["content-type"].startswith("text/event-stream")
+    assert '"queued"' not in response.text
+    assert "run_ase" in response.text and "event: end" in response.text
+    unfinished = submit(client, new_session(client)).json()
+    restarted = Store(store.root)
+    restarted.recover()
+    assert (
+        restarted.one("SELECT status FROM runs WHERE id=?", (unfinished["id"],))[
+            "status"
+        ]
+        == "interrupted"
+    )
+    assert (
+        restarted.one("SELECT final_text FROM runs WHERE id=?", (run["id"],))[
+            "final_text"
+        ]
+        == "1 eV"
+    )
+
+
+def test_upload_limits_and_symlink_escape(client, tmp_path):
+    session_id = new_session(client)
+    client.app.state.settings.upload_limit = 4
+    base = f"/api/v1/sessions/{session_id}/uploads"
+    assert client.post(base + "?filename=x.xyz", content=b"12345").status_code == 413
+    assert client.post(base + "?filename=x.xyz", content=b"").status_code == 422
+    assert client.post(base + "?filename=x.py", content=b"1234").status_code == 422
+    assert not list((tmp_path / "sessions").rglob("*.xyz"))
+    artifact = client.post(base + "?filename=x.xyz", content=b"1234").json()
+    store = client.app.state.store
+    path = store.file_path(
+        store.one("SELECT * FROM files WHERE id=?", (artifact["id"],))
+    )
+    outside = tmp_path / "private.txt"
+    outside.write_text("secret")
+    path.unlink()
+    try:
+        path.symlink_to(outside)
+    except OSError:
+        pytest.skip("Symlinks unavailable on this platform")
+    assert client.get(artifact["url"]).status_code == 404

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -16,7 +16,7 @@ from chemgraph.api.store import Store
 @pytest.fixture
 def client(tmp_path):
     settings = Settings(
-        data_dir=tmp_path, providers={"Test model": Provider(model="gpt-test")}
+        data_dir=tmp_path, providers={"Test model": Provider(model="gpt-test", base_url="http://localhost:9999/v1")}
     )
     with TestClient(
         create_app(settings, start_workers=False),
@@ -137,11 +137,12 @@ def test_submission_idempotency_busy_sessions_and_foreign_attachments(client):
 
 
 def test_missing_provider_credentials_are_reported_before_queueing(client, monkeypatch):
+    session_id = new_session(client)
     monkeypatch.delenv("CHEMGRAPH_TEST_MISSING_KEY", raising=False)
     client.app.state.settings.providers[
         "Test model"
     ].api_key_env = "CHEMGRAPH_TEST_MISSING_KEY"
-    session_id = new_session(client)
+    assert client.post("/api/v1/sessions", json={"model": "Test model"}).status_code == 503
     assert submit(client, session_id).status_code == 503
     assert client.get(f"/api/v1/sessions/{session_id}").json()["runs"] == []
 

--- a/tests/test_web_deployment.py
+++ b/tests/test_web_deployment.py
@@ -1,0 +1,53 @@
+"""Render deployment configuration without contacting a container or cluster."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("override", [None, "{}"])
+def test_compose_keeps_provider_file_unless_json_is_explicit(override):
+    docker = shutil.which("docker")
+    if not docker:
+        pytest.skip("Docker Compose is not installed")
+    # Never import host credentials or a local .env into rendered test output.
+    env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
+    if override is not None:
+        env["CHEMGRAPH_WEB_PROVIDERS"] = override
+    result = subprocess.run(
+        [
+            docker,
+            "compose",
+            "--env-file",
+            "/dev/null",
+            "-f",
+            "compose.web.yml",
+            "config",
+            "--format",
+            "json",
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    api = json.loads(result.stdout)["services"]["web-api"]
+    assert api["environment"].get("CHEMGRAPH_WEB_PROVIDERS") == override
+    assert (
+        api["environment"]["CHEMGRAPH_WEB_PROVIDERS_FILE"]
+        == "/etc/chemgraph/providers.toml"
+    )
+    mount = next(
+        v for v in api["volumes"] if v["target"] == "/etc/chemgraph/providers.toml"
+    )
+    assert mount["read_only"]
+    assert mount["source"] == str(ROOT / "web-providers.example.toml")
+    assert not mount.get("bind", {}).get("create_host_path", False)
+    assert not api.get("ports")

--- a/tests/test_web_deployment.py
+++ b/tests/test_web_deployment.py
@@ -12,12 +12,22 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.mark.parametrize("override", [None, "{}"])
-def test_compose_keeps_provider_file_unless_json_is_explicit(override):
+def test_compose_keeps_provider_file_unless_json_is_explicit(override, tmp_path):
     docker = shutil.which("docker")
     if not docker:
         pytest.skip("Docker Compose is not installed")
     # Never import host credentials or a local .env into rendered test output.
-    env = {key: os.environ[key] for key in ("PATH", "HOME") if key in os.environ}
+    env = {
+        key: os.environ[key]
+        for key in ("PATH", "HOME", "USERPROFILE", "SYSTEMROOT")
+        if key in os.environ
+    }
+    if subprocess.run(
+        [docker, "compose", "version"], env=env, capture_output=True
+    ).returncode:
+        pytest.skip("Docker Compose plugin is not installed")
+    empty_env = tmp_path / "empty.env"
+    empty_env.write_text("")
     if override is not None:
         env["CHEMGRAPH_WEB_PROVIDERS"] = override
     result = subprocess.run(
@@ -25,7 +35,7 @@ def test_compose_keeps_provider_file_unless_json_is_explicit(override):
             docker,
             "compose",
             "--env-file",
-            "/dev/null",
+            str(empty_env),
             "-f",
             "compose.web.yml",
             "config",

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -1,0 +1,52 @@
+"""Workspace and configuration checks without the optional HTTP dependencies."""
+
+import pytest
+
+from chemgraph.api.settings import Settings
+
+def test_workspace_tools_enforce_paths_calculators_and_emt(tmp_path, monkeypatch):
+    from chemgraph.api.chemistry import web_tools, workspace_path, structure_xyz
+
+    workspace = tmp_path / "conversation"
+    turn = workspace / "turn"
+    turn.mkdir(parents=True)
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(turn))
+    monkeypatch.chdir(turn)
+    outside = tmp_path / "private.json"
+    outside.write_text('{"secret": "value"}')
+    with pytest.raises(ValueError):
+        workspace_path(workspace, str(outside), reading=True)
+    with pytest.raises(ValueError):
+        workspace_path(workspace, "../old-result.json")
+    tools = {tool.name: tool for tool in web_tools(workspace, ("emt",))}
+    assert set(tools) == {
+        "molecule_name_to_smiles",
+        "smiles_to_coordinate_file",
+        "run_ase",
+        "extract_output_json",
+        "calculator",
+    }
+    (turn / "copper.xyz").write_text("2\nCu dimer\nCu 0 0 0\nCu 0 0 2.5\n")
+    params = {
+        "input_structure_file": "copper.xyz",
+        "output_results_file": "result.json",
+        "driver": "energy",
+        "calculator": {"calculator_type": "emt"},
+    }
+    result = tools["run_ase"].invoke({"ase_input": params})
+    assert result["potential_energy"] > 0
+    assert "Cu" in structure_xyz(turn / "copper.xyz")
+    assert (turn / "result.json").exists()
+    with pytest.raises(ValueError):
+        tools["extract_output_json"].invoke({"json_file": str(outside)})
+    with pytest.raises(ValueError):
+        tools["run_ase"].invoke(
+            {"ase_input": {**params, "calculator": {"calculator_type": "mace_mp"}}}
+        )
+
+
+def test_settings_require_explicit_demo_user_and_approved_calculators():
+    with pytest.raises(ValueError):
+        Settings(demo=True)
+    with pytest.raises(ValueError):
+        Settings(calculators=("orca",))

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -25,6 +25,7 @@ def test_workspace_tools_enforce_paths_calculators_and_emt(tmp_path, monkeypatch
         "run_ase",
         "extract_output_json",
         "calculator",
+        "read_workspace_file",
     }
     (turn / "copper.xyz").write_text("2\nCu dimer\nCu 0 0 0\nCu 0 0 2.5\n")
     params = {

--- a/tests/test_web_integration.py
+++ b/tests/test_web_integration.py
@@ -1,0 +1,241 @@
+"""Real web workers/graphs against a deterministic loopback model endpoint."""
+
+from http.server import ThreadingHTTPServer
+import json
+import threading
+import time
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("fcntl")
+from fastapi.testclient import TestClient
+
+from chemgraph.api.app import create_app
+from chemgraph.api.settings import Provider, Settings
+from chemgraph.api.memory import WebSessionStore
+from tests.web_model_server import Handler
+
+
+@pytest.fixture
+def endpoint(monkeypatch):
+    monkeypatch.setenv("VLLM_API_KEY", "test-only-placeholder")
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def wait_for(client, run_id, states):
+    deadline = time.monotonic() + 25
+    while time.monotonic() < deadline:
+        run = client.get(f"/api/v1/runs/{run_id}").json()
+        if run["status"] in states:
+            return run
+        time.sleep(0.05)
+    pytest.fail(f"Run did not reach {states}: {run}")
+
+
+@pytest.mark.parametrize("workflow", ["single_agent", "multi_agent"])
+def test_real_graph_emt_clarification_memory_and_artifacts(
+    tmp_path, endpoint, workflow
+):
+    settings = Settings(
+        data_dir=tmp_path,
+        dev_user="test",
+        providers={"Lab": Provider(model="test-model", base_url=endpoint)},
+    )
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+        session = client.post(
+            "/api/v1/sessions", json={"model": "Lab", "workflow": workflow}
+        ).json()["id"]
+        attachment = client.post(
+            f"/api/v1/sessions/{session}/uploads?filename=copper.xyz",
+            content=b"2\nCopper\nCu 0 0 0\nCu 0 0 2.5\n",
+        ).json()
+        first_query = "Confirm optimization of the attached copper with EMT"
+        run = client.post(
+            f"/api/v1/sessions/{session}/runs",
+            json={
+                "query": first_query,
+                "attachments": [attachment["id"]],
+                "request_id": str(uuid4()),
+            },
+        ).json()
+        waiting = wait_for(client, run["id"], {"waiting_for_input", "failed"})
+        assert waiting["status"] == "waiting_for_input", waiting
+        client.post(
+            f"/api/v1/runs/{run['id']}/response",
+            json={"question_id": waiting["question_id"], "answer": "Yes, continue"},
+        )
+        finished = wait_for(client, run["id"], {"completed", "failed", "interrupted"})
+        assert finished["status"] == "completed", finished
+        assert "EMT potential energy" in finished["final_text"]
+        artifacts = {item["name"]: item for item in finished["artifacts"]}
+        assert set(artifacts) == {"copper-result.json", "copper_opt.traj"}
+        result = client.get(artifacts["copper-result.json"]["url"]).json()
+        assert result["potential_energy"] > 0
+        assert (
+            client.get(artifacts["copper_opt.traj"]["preview_url"]).text.count("Cu") > 2
+        )
+        events = client.get(f"/api/v1/runs/{run['id']}/events").text
+        assert "run_ase" in events and "tool_call_finished" in events
+        assert list((tmp_path / "diagnostics" / session).rglob("state_thread_*.json"))
+        for index in range(3):
+            followup = client.post(
+                f"/api/v1/sessions/{session}/runs",
+                json={
+                    "query": f"Follow-up: recall our work ({index})",
+                    "request_id": str(uuid4()),
+                },
+            ).json()
+            answer = wait_for(client, followup["id"], {"completed", "failed"})
+            assert "Previous context retained" in answer["final_text"], answer
+        memory = WebSessionStore(
+            str(tmp_path / "memory" / f"{session}.db"), "unused", 1000
+        )
+        messages = memory.get_session(session).messages
+        humans = [message.content for message in messages if message.role == "human"]
+        assert humans[0] == first_query
+        assert all(
+            "Previous Session" not in content and "Now, continuing" not in content
+            for content in humans
+        )
+        assert len(memory.build_context_summary(session)) <= 1000
+
+
+@pytest.mark.parametrize(
+    "status,code", [(401, "provider_authentication"), (429, "provider_rate_limit")]
+)
+def test_provider_failures_do_not_expose_raw_responses(
+    tmp_path, endpoint, status, code
+):
+    settings = Settings(
+        data_dir=tmp_path,
+        dev_user="test",
+        providers={"Lab": Provider(model=f"fail-{status}", base_url=endpoint)},
+    )
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+        session = client.post("/api/v1/sessions", json={"model": "Lab"}).json()["id"]
+        run = client.post(
+            f"/api/v1/sessions/{session}/runs",
+            json={"query": "test provider failure", "request_id": str(uuid4())},
+        ).json()
+        failed = wait_for(client, run["id"], {"failed", "interrupted"})
+        assert failed["error_code"] == code, failed
+        assert "PRIVATE_PROVIDER_RESPONSE_MARKER" not in json.dumps(failed)
+        assert not failed["artifacts"]
+
+
+def test_waiting_owner_does_not_starve_other_users_and_can_cancel(tmp_path):
+    settings = Settings(data_dir=tmp_path, demo=True, dev_user="alice")
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+
+        def start():
+            session = client.post("/api/v1/sessions", json={"model": "demo"}).json()[
+                "id"
+            ]
+            return client.post(
+                f"/api/v1/sessions/{session}/runs",
+                json={"query": "Confirm", "request_id": str(uuid4())},
+            ).json()["id"]
+
+        alice = start()
+        wait_for(client, alice, {"waiting_for_input"})
+        queued = start()
+        settings.dev_user = "bob"
+        bob = start()
+        wait_for(client, bob, {"waiting_for_input"})
+        settings.dev_user = "alice"
+        assert client.get(f"/api/v1/runs/{queued}").json()["status"] == "queued"
+        client.post(f"/api/v1/runs/{alice}/cancel")
+        assert wait_for(client, alice, {"cancelled"})["error_code"] == "cancelled"
+        wait_for(client, queued, {"waiting_for_input"})
+
+
+def test_clarification_timeout_releases_worker(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path, demo=True, dev_user="test", clarification_timeout=1
+    )
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+        session = client.post("/api/v1/sessions", json={"model": "demo"}).json()["id"]
+        run = client.post(
+            f"/api/v1/sessions/{session}/runs",
+            json={"query": "Confirm", "request_id": str(uuid4())},
+        ).json()
+        failed = wait_for(client, run["id"], {"interrupted"})
+        assert failed["error_code"] == "clarification_timeout"
+
+
+@pytest.mark.llm
+def test_enabled_live_providers_smoke(tmp_path):
+    """Operator opt-in: use the real configured providers with EMT only."""
+    settings = Settings.from_env().model_copy(
+        update={
+            "data_dir": tmp_path,
+            "dev_user": "live-smoke",
+            "demo": False,
+            "calculators": ("emt",),
+            "provider_timeout": 30,
+            "run_timeout": 180,
+        }
+    )
+    assert settings.providers, (
+        "Configure CHEMGRAPH_WEB_PROVIDERS_FILE or CHEMGRAPH_WEB_PROVIDERS first."
+    )
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+        for label in settings.providers:
+            session_response = client.post("/api/v1/sessions", json={"model": label})
+            assert session_response.status_code == 201, session_response.text
+            session = session_response.json()["id"]
+            attachment = client.post(
+                f"/api/v1/sessions/{session}/uploads?filename=copper.xyz",
+                content=b"2\nCopper\nCu 0 0 0\nCu 0 0 2.5\n",
+            ).json()
+            run = client.post(
+                f"/api/v1/sessions/{session}/runs",
+                json={
+                    "query": "Use run_ase with EMT to calculate the single-point potential energy of the attached copper. Save results to copper.json and report the energy in eV.",
+                    "attachments": [attachment["id"]],
+                    "request_id": str(uuid4()),
+                },
+            ).json()
+            deadline = time.monotonic() + 190
+            while time.monotonic() < deadline:
+                result = client.get(f"/api/v1/runs/{run['id']}").json()
+                if result["status"] == "waiting_for_input":
+                    client.post(
+                        f"/api/v1/runs/{run['id']}/response",
+                        json={
+                            "question_id": result["question_id"],
+                            "answer": "Proceed with the attached copper, EMT, single-point energy.",
+                        },
+                    )
+                if result["status"] in {"completed", "failed", "interrupted"}:
+                    break
+                time.sleep(0.5)
+            assert result["status"] == "completed", result
+            artifacts = [
+                item for item in result["artifacts"] if item["name"].endswith(".json")
+            ]
+            assert artifacts, "The provider must actually call the chemistry tool."
+            assert any(
+                client.get(item["url"]).json().get("potential_energy", 0) > 0
+                for item in artifacts
+            )

--- a/tests/test_web_limits.py
+++ b/tests/test_web_limits.py
@@ -1,0 +1,174 @@
+"""Admission, ownership, cancellation, provenance, and retention contracts."""
+
+import time
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient
+
+from chemgraph.api.app import create_app
+from chemgraph.api.settings import Provider, Settings
+from chemgraph.api.store import Store
+
+
+@pytest.fixture
+def client(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path,
+        providers={
+            "Lab": Provider(model="test-model", base_url="http://localhost:9999/v1")
+        },
+    )
+    with TestClient(
+        create_app(settings, start_workers=False),
+        headers={"Origin": settings.public_origin, "X-Auth-Request-User": "alice"},
+    ) as value:
+        yield value
+
+
+def conversation(client, user="alice"):
+    response = client.post(
+        "/api/v1/sessions", json={"model": "Lab"}, headers={"X-Auth-Request-User": user}
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def submit(client, session_id, user="alice", **kwargs):
+    return client.post(
+        f"/api/v1/sessions/{session_id}/runs",
+        json={"query": "Optimize copper", "request_id": str(uuid4()), **kwargs},
+        headers={"X-Auth-Request-User": user},
+    )
+
+
+def test_admission_limits_are_per_owner_and_retries_bypass_limits(client):
+    session = conversation(client)
+    request_id = str(uuid4())
+    first = submit(client, session, request_id=request_id)
+    assert submit(client, conversation(client)).status_code == 202
+    assert submit(client, conversation(client)).status_code == 429
+    assert (
+        submit(client, session, request_id=request_id).json()["id"]
+        == first.json()["id"]
+    )
+    client.app.state.settings.max_queued = 2
+    assert submit(client, conversation(client, "bob"), "bob").status_code == 429
+    client.post(f"/api/v1/runs/{first.json()['id']}/cancel")
+    assert submit(client, conversation(client, "bob"), "bob").status_code == 202
+
+
+def test_cancellation_is_owned_and_cannot_be_overwritten(client):
+    session = conversation(client)
+    run = submit(client, session).json()
+    path = f"/api/v1/runs/{run['id']}/cancel"
+    assert client.post(path, headers={"X-Auth-Request-User": "bob"}).status_code == 404
+    store = client.app.state.store
+    store.execute("UPDATE runs SET status='running' WHERE id=?", (run["id"],))
+    assert client.post(path).json()["status"] == "cancelling"
+    store.finish(run["id"], "completed", text="late result")
+    assert client.get(f"/api/v1/runs/{run['id']}").json()["status"] == "cancelling"
+    assert submit(client, session).status_code == 409
+    store.finish(run["id"], "interrupted", stopped=True)
+    assert client.post(path).json()["status"] == "cancelled"
+    assert submit(client, session).status_code == 202
+
+
+def test_model_change_archives_history_without_retargeting_context(client, monkeypatch):
+    session = conversation(client)
+    run = submit(client, session).json()
+    store = client.app.state.store
+    store.finish(run["id"], "completed", text="Saved answer")
+    provider = client.app.state.settings.providers["Lab"]
+    provider.base_url = "https://different.example/v1"
+    detail = client.get(f"/api/v1/sessions/{session}").json()
+    assert detail["runs"][0]["final_text"] == "Saved answer"
+    assert detail["model_status"]["code"] == "model_changed"
+    response = submit(client, session)
+    assert response.status_code == 503
+    assert response.json()["error"]["submission_rejected"]
+    client.app.state.settings.providers.clear()
+    assert (
+        client.get(f"/api/v1/sessions/{session}").json()["model_status"]["code"]
+        == "model_removed"
+    )
+
+
+def test_storage_quota_accounts_for_uploads_and_reservations(client):
+    session = conversation(client)
+    settings = client.app.state.settings
+    settings.user_storage_limit = 5
+    path = f"/api/v1/sessions/{session}/uploads?filename=a.txt"
+    assert client.post(path, content=b"1234").status_code == 201
+    assert client.post(path, content=b"56").status_code == 413
+    assert submit(client, session).status_code == 413
+    settings.user_storage_limit = 12
+    store = client.app.state.store
+    store.execute(
+        "INSERT INTO upload_reservations VALUES (?,?,?)", ("reserved", session, 8)
+    )
+    assert client.post(path, content=b"1").status_code == 413
+    store.execute("DELETE FROM upload_reservations")
+    assert client.post(path, content=b"56").status_code == 201
+
+
+def test_retention_removes_all_stores_but_preserves_active_and_uploading(client):
+    store = client.app.state.store
+    old = conversation(client)
+    active = conversation(client)
+    uploading = conversation(client)
+    finished = submit(client, old).json()
+    store.finish(finished["id"], "completed", text="Old answer")
+    submit(client, active)
+    store.execute(
+        "INSERT INTO upload_reservations VALUES (?,?,?)", ("reserved", uploading, 1)
+    )
+    store.execute("UPDATE sessions SET last_activity=?", (time.time() - 40 * 86400,))
+    for directory in (
+        store.session_dir(old),
+        store.root / "diagnostics" / old,
+        store.root / "memory",
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+    (store.session_dir(old) / "result.xyz").write_text("output")
+    (store.root / "diagnostics" / old / "state.json").write_text("diagnostic")
+    (store.root / "memory" / f"{old}.db").write_text("memory")
+    assert store.cleanup(30) == 1
+    assert client.get(f"/api/v1/sessions/{old}").status_code == 404
+    assert client.get(f"/api/v1/sessions/{active}").status_code == 200
+    assert client.get(f"/api/v1/sessions/{uploading}").status_code == 200
+    assert not store.session_dir(old).exists()
+    assert not (store.root / "diagnostics" / old).exists()
+    assert not (store.root / "memory" / f"{old}.db").exists()
+
+
+def test_upgrade_preserves_history_and_revokes_only_diagnostic_downloads(client):
+    session = conversation(client)
+    store = client.app.state.store
+    store.execute("UPDATE sessions SET created='2020-01-01T00:00:00Z',last_activity=0")
+    workspace = store.session_dir(session)
+    workspace.mkdir(parents=True)
+    diagnostic = workspace / "state_thread_legacy.json"
+    diagnostic.write_text('{"raw_model_response": "private"}')
+    result = workspace / "result.json"
+    result.write_text('{"potential_energy": 1.0}')
+    diagnostic_id = store.register_file(session, diagnostic, "data")
+    result_id = store.register_file(session, result, "data")
+    uploaded_id = store.register_file(session, diagnostic, "upload")
+
+    upgraded = Store(store.root)
+    migrated_activity = upgraded.one("SELECT last_activity FROM sessions")[
+        "last_activity"
+    ]
+    assert migrated_activity >= time.time() - 10
+    assert upgraded.cleanup(30) == 0
+    assert client.get(f"/api/v1/artifacts/{diagnostic_id}/content").status_code == 404
+    assert client.get(f"/api/v1/artifacts/{result_id}/content").status_code == 200
+    assert client.get(f"/api/v1/artifacts/{uploaded_id}/content").status_code == 200
+    assert diagnostic.exists()  # Retained for access-restricted diagnostics.
+    assert (
+        Store(store.root).one("SELECT last_activity FROM sessions")["last_activity"]
+        == migrated_activity
+    )

--- a/tests/test_web_providers.py
+++ b/tests/test_web_providers.py
@@ -1,0 +1,248 @@
+"""Offline configuration, credential isolation, and endpoint client contracts."""
+
+import json
+import os
+import sys
+from dataclasses import replace
+
+import pytest
+
+from chemgraph.api.settings import ConfigurationError, Provider, Settings
+from chemgraph.api.providers import credentials, model_status, provenance
+from chemgraph.models.endpoints import ModelRequest
+from chemgraph.models.endpoints.registry import select_endpoint
+from chemgraph.models.supported_models import (
+    supported_alcf_models,
+    supported_ollama_models,
+    supported_anthropic_models,
+    supported_gemini_models,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolate_env(monkeypatch):
+    for name in list(os.environ):
+        if name.startswith("CHEMGRAPH_WEB_") or name in {
+            "ARGO_USER",
+            "ALCF_ACCESS_TOKEN",
+            "OPENAI_API_KEY",
+            "VLLM_API_KEY",
+            "VLLM_BASE_URL",
+            "ANTHROPIC_API_KEY",
+            "GEMINI_API_KEY",
+            "GROQ_API_KEY",
+            "OPENROUTER_API_KEY",
+            "REVIEW_KEY",
+        }:
+            monkeypatch.delenv(name)
+
+
+def test_provider_file_and_complete_json_override(tmp_path, monkeypatch):
+    path = tmp_path / "providers.toml"
+    path.write_text('[providers.Argo]\nmodel="argo:gpt-4o"\nargo_user="service-user"\n')
+    monkeypatch.setenv("CHEMGRAPH_WEB_PROVIDERS_FILE", str(path))
+    assert list(Settings.from_env().providers) == ["Argo"]
+    monkeypatch.setenv("CHEMGRAPH_WEB_PROVIDERS", "{}")
+    path.write_text("invalid TOML ignored because JSON overrides it")
+    assert Settings.from_env().providers == {}
+    monkeypatch.delenv("CHEMGRAPH_WEB_PROVIDERS")
+    with pytest.raises(ConfigurationError):
+        Settings.from_env()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "[]",
+        "null",
+        '{"Lab":{"model":"argo:gpt-4o","api_key":"literal-secret-marker"}}',
+        '{" ":{"model":"argo:gpt-4o"}}',
+        '{"Lab":{"model":"argo:gpt-4o","base_url":"https://user:literal-secret-marker@example.com"}}',
+    ],
+)
+def test_invalid_configuration_never_echoes_values(monkeypatch, value):
+    monkeypatch.setenv("CHEMGRAPH_WEB_PROVIDERS", value)
+    with pytest.raises(ConfigurationError) as exc:
+        Settings.from_env()
+    assert "literal-secret-marker" not in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "model", ["argo:unknown-model", "alcf:unknown-model", "codex:gpt-5", "groq:"]
+)
+def test_invalid_routes_fail_before_serving(model):
+    with pytest.raises(ConfigurationError):
+        model_status(Settings(providers={"Lab": Provider(model=model)}))
+
+
+def test_shared_identity_and_alcf_override(monkeypatch):
+    argo = Provider(model="argo:gpt-4o")
+    assert not model_status(Settings(providers={"Argo": argo}))["Argo"]["configured"]
+    monkeypatch.setenv("ARGO_USER", "shared-user")
+    monkeypatch.setenv("OPENAI_API_KEY", "never-forward-this")
+    assert credentials(argo).argo_user == "shared-user"
+    assert credentials(argo).api_key is None
+    assert (
+        credentials(argo.model_copy(update={"argo_user": "explicit-user"})).argo_user
+        == "explicit-user"
+    )
+    alcf = Provider(model=supported_alcf_models[0])
+    monkeypatch.setenv("ALCF_ACCESS_TOKEN", "alcf-token")
+    assert credentials(alcf).api_key == "alcf-token"
+    overridden = alcf.model_copy(update={"api_key_env": "REVIEW_KEY"})
+    with pytest.raises(ValueError, match="missing_credentials"):
+        credentials(overridden)
+    monkeypatch.setenv("REVIEW_KEY", "override-token")
+    assert credentials(overridden).api_key == "override-token"
+
+
+@pytest.mark.parametrize(
+    "model,variable",
+    [
+        ("gpt-4o", "OPENAI_API_KEY"),
+        (supported_anthropic_models[0], "ANTHROPIC_API_KEY"),
+        (supported_gemini_models[0], "GEMINI_API_KEY"),
+        ("groq:test", "GROQ_API_KEY"),
+        ("openrouter:test/model", "OPENROUTER_API_KEY"),
+    ],
+)
+def test_provider_specific_defaults(model, variable, monkeypatch):
+    provider = Provider(model=model)
+    assert not model_status(Settings(providers={"Model": provider}))["Model"][
+        "configured"
+    ]
+    monkeypatch.setenv(variable, "test-token")
+    assert credentials(provider).api_key == "test-token"
+
+
+def test_custom_endpoint_never_inherits_hosted_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "hosted-key")
+    provider = Provider(model="test-model", base_url="http://localhost:9999/v1")
+    resolved = credentials(provider)
+    assert resolved.api_key != "hosted-key"
+    prepared = select_endpoint(
+        ModelRequest(model=provider.model, base_url=provider.base_url)
+    ).prepare_request(
+        ModelRequest(
+            model=provider.model, base_url=provider.base_url, api_key=resolved.api_key
+        )
+    )
+    assert prepared.client_kwargs["api_key"] == resolved.api_key
+
+
+def test_provenance_ignores_credential_rotation_but_tracks_endpoint(monkeypatch):
+    settings = Settings(
+        providers={"Lab": Provider(model="argo:gpt-4o", argo_user="shared")}
+    )
+    before = provenance(settings, "Lab")
+    settings.providers["Lab"].argo_user = "rotated"
+    assert provenance(settings, "Lab") == before
+    settings.providers["Lab"].base_url = "https://lab.example/v1"
+    assert provenance(settings, "Lab") != before
+
+
+@pytest.mark.parametrize(
+    "configured,expected",
+    [
+        ({}, 1),
+        ({"Lab": {"model": "argo:gpt-4o"}}, 1),
+        ({"Lab": {"model": "argo:gpt-4o", "argo_user": "shared"}}, 0),
+        ({"Lab": {"model": "alcf:bad"}}, 2),
+    ],
+)
+def test_check_config_is_noninteractive_and_creates_no_storage(
+    configured, expected, monkeypatch, tmp_path, capsys
+):
+    from chemgraph.api.__main__ import main
+    import socket
+
+    monkeypatch.setattr(
+        socket,
+        "create_connection",
+        lambda *a, **k: pytest.fail("Configuration contacted the network"),
+    )
+    monkeypatch.setattr(
+        "getpass.getpass",
+        lambda *a, **k: pytest.fail("Configuration prompted for a credential"),
+    )
+    monkeypatch.setattr(sys, "argv", ["chemgraph.api", "--check-config"])
+    monkeypatch.setenv("CHEMGRAPH_WEB_PROVIDERS", json.dumps(configured))
+    monkeypatch.setenv("CHEMGRAPH_WEB_DATA_DIR", str(tmp_path / "unused"))
+    before = dict(os.environ)
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == expected
+    assert dict(os.environ) == before
+    assert not (tmp_path / "unused").exists()
+    output = capsys.readouterr()
+    if expected != 2:
+        assert json.loads(output.out)["connectivity_verified"] is False
+
+
+@pytest.mark.parametrize(
+    "model,module,client_name",
+    [
+        (supported_ollama_models[0], "chemgraph.models.local_model", "ChatOllama"),
+        (
+            supported_anthropic_models[0],
+            "chemgraph.models.protocols.anthropic_native",
+            "ChatAnthropic",
+        ),
+        (
+            supported_gemini_models[0],
+            "chemgraph.models.protocols.google_native",
+            "ChatGoogleGenerativeAI",
+        ),
+    ],
+)
+def test_custom_urls_reach_final_clients(model, module, client_name, monkeypatch):
+    from chemgraph.models.loader import load_chat_model_prepared
+
+    captured = []
+    monkeypatch.setattr(
+        f"{module}.{client_name}", lambda **kwargs: captured.append(kwargs) or object()
+    )
+    load_chat_model_prepared(
+        model, api_key="test-token", base_url="https://provider.example", timeout_s=17
+    )
+    assert captured[0]["base_url"] == "https://provider.example"
+    if client_name == "ChatOllama":
+        assert captured[0]["client_kwargs"]["timeout"] == 17
+    else:
+        assert captured[0]["timeout"] == 17
+
+
+def test_check_config_does_not_construct_clients(monkeypatch):
+    from chemgraph.api import providers
+    from chemgraph.models.endpoints import registry
+
+    original = registry.select_endpoint
+    monkeypatch.setattr(
+        registry,
+        "select_endpoint",
+        lambda request: replace(
+            original(request),
+            protocol_build=lambda **kw: pytest.fail("Client constructed"),
+        ),
+    )
+    assert providers.model_status(
+        Settings(providers={"Argo": Provider(model="argo:gpt-4o", argo_user="shared")})
+    )["Argo"]["configured"]
+
+
+@pytest.mark.parametrize(
+    "exception,expected",
+    [
+        (TimeoutError("private text"), "provider_timeout"),
+        (ConnectionError("private text"), "provider_connection"),
+    ],
+)
+def test_safe_transport_errors(exception, expected):
+    from chemgraph.api.errors import public_error
+
+    outer = RuntimeError("raw provider response")
+    outer.__cause__ = exception
+    code, message = public_error(outer)
+    assert code == expected
+    assert "private text" not in message and "raw provider response" not in message

--- a/tests/test_web_worker.py
+++ b/tests/test_web_worker.py
@@ -1,0 +1,161 @@
+"""Exercise real process scheduling and a mocked model through the web worker."""
+
+import asyncio
+import time
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("fcntl")
+
+from fastapi.testclient import TestClient
+from chemgraph.api.app import create_app
+from chemgraph.api.settings import Provider, Settings
+from chemgraph.api.store import Store
+from chemgraph.api.worker import execute_run, Supervisor
+
+
+def wait_for(client, run_id, expected):
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        row = client.get(f"/api/v1/runs/{run_id}").json()
+        if row["status"] in expected:
+            return row
+        time.sleep(0.1)
+    pytest.fail(f"Run {run_id} did not reach {expected}: {row}")
+
+
+def test_processes_emt_artifacts_and_human_response(tmp_path):
+    settings = Settings(data_dir=tmp_path, demo=True, dev_user="local-demo")
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+        ids = []
+        for query in ("Optimize copper", "Confirm optimization"):
+            session = client.post("/api/v1/sessions", json={"model": "demo"}).json()
+            result = client.post(
+                f"/api/v1/sessions/{session['id']}/runs",
+                json={"query": query, "request_id": str(uuid4())},
+            )
+            assert result.status_code == 202
+            ids.append(result.json()["id"])
+        first = wait_for(client, ids[0], {"completed", "failed"})
+        assert first["status"] == "completed", first
+        waiting = wait_for(client, ids[1], {"waiting_for_input", "failed"})
+        assert waiting["status"] == "waiting_for_input", waiting
+        assert (
+            client.post(
+                f"/api/v1/runs/{ids[1]}/response",
+                json={"question_id": waiting["question_id"], "answer": "Yes"},
+            ).status_code
+            == 202
+        )
+        second = wait_for(client, ids[1], {"completed", "failed"})
+        assert second["status"] == "completed", second
+        first_files = {item["name"]: item for item in first["artifacts"]}
+        second_files = {item["name"]: item for item in second["artifacts"]}
+        assert "copper_opt.traj" in first_files
+        assert first_files["copper.xyz"]["id"] != second_files["copper.xyz"]["id"]
+        assert client.get(first_files["copper.xyz"]["preview_url"]).status_code == 200
+        assert (
+            client.get(first_files["copper_opt.traj"]["preview_url"]).text.count("Cu")
+            >= 4
+        )
+        assert str(tmp_path) not in first["final_text"]
+        assert client.get(f"/api/v1/runs/{ids[0]}/events").text.count("event: end") == 1
+
+
+def test_server_rejects_second_supervisor(tmp_path):
+    async def exercise():
+        settings = Settings(data_dir=tmp_path)
+        one = Supervisor(Store(tmp_path), settings)
+        two = Supervisor(Store(tmp_path), settings)
+        await one.start()
+        try:
+            with pytest.raises(RuntimeError, match="one API process"):
+                await two.start()
+        finally:
+            await one.stop()
+
+    asyncio.run(exercise())
+
+
+def test_worker_reuses_memory_and_does_not_forward_secret_events(tmp_path, monkeypatch):
+    from langchain_core.messages import AIMessage
+    from chemgraph.agent import llm_agent
+    from chemgraph.memory.schemas import SessionMessage
+
+    settings = Settings(
+        data_dir=tmp_path,
+        providers={"test": Provider(model="test-model", api_key_env="WEB_TEST_KEY")},
+    )
+    store = Store(tmp_path)
+    session_id = str(uuid4())
+    store.execute(
+        "INSERT INTO sessions(id,owner,model,workflow,title) VALUES (?,?,?,?,?)",
+        (session_id, "owner", "test", "single_agent", "Test"),
+    )
+    monkeypatch.setenv("WEB_TEST_KEY", "private-test-key")
+    # execute_run changes only the child environment in production. Restore the
+    # cwd/env here because this mocked test calls the entry point in-process.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("CHEMGRAPH_LOG_DIR", str(tmp_path))
+    seen = []
+
+    class Agent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def run(self, query, resume_from=None):
+            assert self.kwargs["api_key"] == "private-test-key"
+            seen.append(resume_from)
+            self.kwargs["on_event"](
+                "tool_call_started",
+                {"tool_name": "run_ase", "arguments": "private-test-key"},
+            )
+            memory = self.kwargs["session_store"]
+            if not memory.get_session(self.uuid):
+                memory.create_session(self.uuid, "test-model", "single_agent")
+            memory.save_messages(
+                self.uuid,
+                [
+                    SessionMessage(role="human", content=query),
+                    SessionMessage(role="ai", content="Done"),
+                ],
+            )
+            return AIMessage(content="Done")
+
+    monkeypatch.setattr(llm_agent, "ChemGraph", Agent)
+    for _ in range(2):
+        run_id = str(uuid4())
+        store.execute(
+            "INSERT INTO runs(id,session_id,query,request_id) VALUES (?,?,?,?)",
+            (run_id, session_id, "Question", str(uuid4())),
+        )
+        execute_run(str(tmp_path), run_id, settings.model_dump())
+        assert (
+            store.one("SELECT status FROM runs WHERE id=?", (run_id,))["status"]
+            == "completed"
+        )
+    assert seen == [None, session_id]
+    assert "private-test-key" not in str(store.rows("SELECT * FROM events"))
+
+
+def test_shutdown_interrupts_waiting_run(tmp_path):
+    settings = Settings(data_dir=tmp_path, dev_user="demo", demo=True)
+    with TestClient(
+        create_app(settings), headers={"Origin": settings.public_origin}
+    ) as client:
+        session_id = client.post("/api/v1/sessions", json={"model": "demo"}).json()[
+            "id"
+        ]
+        run_id = client.post(
+            f"/api/v1/sessions/{session_id}/runs",
+            json={"query": "Confirm", "request_id": str(uuid4())},
+        ).json()["id"]
+        wait_for(client, run_id, {"waiting_for_input"})
+    assert (
+        Store(tmp_path).one("SELECT status FROM runs WHERE id=?", (run_id,))["status"]
+        == "interrupted"
+    )

--- a/tests/test_web_worker.py
+++ b/tests/test_web_worker.py
@@ -14,6 +14,7 @@ from chemgraph.api.app import create_app
 from chemgraph.api.settings import Provider, Settings
 from chemgraph.api.store import Store
 from chemgraph.api.worker import execute_run, Supervisor
+from chemgraph.api.providers import provenance
 
 
 def wait_for(client, run_id, expected):
@@ -88,13 +89,13 @@ def test_worker_reuses_memory_and_does_not_forward_secret_events(tmp_path, monke
 
     settings = Settings(
         data_dir=tmp_path,
-        providers={"test": Provider(model="test-model", api_key_env="WEB_TEST_KEY")},
+        providers={"test": Provider(model="test-model", base_url="http://localhost:9999/v1", api_key_env="WEB_TEST_KEY")},
     )
     store = Store(tmp_path)
     session_id = str(uuid4())
     store.execute(
-        "INSERT INTO sessions(id,owner,model,workflow,title) VALUES (?,?,?,?,?)",
-        (session_id, "owner", "test", "single_agent", "Test"),
+        "INSERT INTO sessions(id,owner,model,workflow,title,provenance) VALUES (?,?,?,?,?,?)",
+        (session_id, "owner", "test", "single_agent", "Test", provenance(settings, "test")),
     )
     monkeypatch.setenv("WEB_TEST_KEY", "private-test-key")
     # execute_run changes only the child environment in production. Restore the

--- a/tests/web-providers.test.toml
+++ b/tests/web-providers.test.toml
@@ -1,0 +1,13 @@
+# Test-only endpoint, with no real credentials or external provider calls.
+[providers.Lab]
+model = "test-model"
+base_url = "http://model:9999/v1"
+
+[providers.Unavailable]
+model = "test-model"
+base_url = "http://model:9999/v1"
+api_key_env = "CHEMGRAPH_TEST_MISSING"
+
+[providers."Auth failure"]
+model = "fail-401"
+base_url = "http://model:9999/v1"

--- a/tests/web_model_server.py
+++ b/tests/web_model_server.py
@@ -1,0 +1,171 @@
+"""Test-only OpenAI-compatible endpoint. Never imported by the runtime package."""
+
+import argparse
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import re
+
+
+def reply(body):
+    messages = body["messages"]
+    text = "\n".join(
+        str(message.get("content", ""))
+        for message in messages
+        if message["role"] != "system"
+    )
+    system = str(messages[0].get("content", ""))
+    tools = {tool["function"]["name"] for tool in body.get("tools", [])}
+
+    def call(name, arguments):
+        return {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": f"test_{name}",
+                    "type": "function",
+                    "function": {"name": name, "arguments": json.dumps(arguments)},
+                }
+            ],
+        }
+
+    if "Follow-up:" in text:
+        content = (
+            "Previous context retained: copper and EMT."
+            if "copper" in text.lower() and "EMT" in text
+            else "Missing previous context."
+        )
+        if "**Planner**" in system:
+            content = json.dumps(
+                {"next_step": "FINISH", "thought_process": content, "tasks": []}
+            )
+        return {"role": "assistant", "content": content}
+
+    needs_confirmation = (
+        "confirm" in text.lower() and "yes, continue" not in text.lower()
+    )
+    if "**Planner**" in system:
+        if "UPDATED: Results from Executor Tasks" in text:
+            result = text.split("UPDATED: Results from Executor Tasks ###", 1)[1]
+            response = {"next_step": "FINISH", "thought_process": result, "tasks": []}
+        elif needs_confirmation:
+            response = {
+                "next_step": "ask_human",
+                "thought_process": "Request confirmation",
+                "clarification": "Optimize the attached copper with EMT?",
+                "tasks": [],
+            }
+        else:
+            response = {
+                "next_step": "executor_subgraph",
+                "thought_process": "Run EMT",
+                "tasks": [{"task_index": 1, "prompt": text}],
+            }
+        return {"role": "assistant", "content": json.dumps(response)}
+
+    if needs_confirmation and "ask_human" in tools:
+        return call("ask_human", {"question": "Optimize the attached copper with EMT?"})
+    tool_results = [
+        message
+        for message in messages
+        if message["role"] == "tool" and message.get("tool_call_id") == "test_run_ase"
+    ]
+    # The existing single-agent graph supplies its transcript as text, while
+    # multi-agent executors send native role/tool messages.
+    energies = re.findall(r'"potential_energy":\s*([0-9.e+\-]+)', text)
+    if not tool_results and "ToolMessage" in text and energies:
+        return {
+            "role": "assistant",
+            "content": f"Calculation complete. EMT potential energy: **{float(energies[-1]):.4f} eV**.",
+        }
+    if tool_results:
+        result = json.loads(tool_results[-1]["content"])
+        energy = result.get("potential_energy")
+        if energy is None:
+            raise ValueError("EMT result did not contain potential energy")
+        return {
+            "role": "assistant",
+            "content": f"Calculation complete. EMT potential energy: **{energy:.4f} eV**.",
+        }
+    match = re.search(r"(/[^\s'\"\\]+/uploads/[^\s'\"\\]+\.xyz)", text)
+    if match is None:
+        raise ValueError("Test requires an attached XYZ structure")
+    return call(
+        "run_ase",
+        {
+            "ase_input": {
+                "input_structure_file": match.group(1),
+                "output_results_file": "copper-result.json",
+                "driver": "opt",
+                "steps": 10,
+                "fmax": 0.05,
+                "calculator": {"calculator_type": "emt"},
+            }
+        },
+    )
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+    def do_GET(self):
+        self.send_response(200 if self.path == "/healthz" else 404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        if body.get("model", "").startswith("fail-"):
+            status = int(body["model"].split("-", 1)[1])
+            payload = {
+                "error": {
+                    "message": "PRIVATE_PROVIDER_RESPONSE_MARKER",
+                    "type": "provider_error",
+                    "code": "test_failure",
+                }
+            }
+        else:
+            try:
+                message = reply(body)
+                status = 200
+                payload = {
+                    "id": "test-completion",
+                    "object": "chat.completion",
+                    "created": 1,
+                    "model": body.get("model"),
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": message,
+                            "finish_reason": "tool_calls"
+                            if message.get("tool_calls")
+                            else "stop",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "total_tokens": 2,
+                    },
+                }
+            except Exception as exc:
+                status, payload = 400, {"error": {"message": str(exc)}}
+        data = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9999)
+    args = parser.parse_args()
+    ThreadingHTTPServer((args.host, args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/web_model_server.py
+++ b/tests/web_model_server.py
@@ -87,14 +87,22 @@ def reply(body):
             "role": "assistant",
             "content": f"Calculation complete. EMT potential energy: **{energy:.4f} eV**.",
         }
-    match = re.search(r"(/[^\s'\"\\]+/uploads/[^\s'\"\\]+\.xyz)", text)
-    if match is None:
+    words = text.replace("\\", " ").replace('"', " ").replace("'", " ").split()
+    attachment = next(
+        (
+            word[word.index("/") :]
+            for word in words
+            if "/uploads/" in word and word.endswith(".xyz")
+        ),
+        None,
+    )
+    if attachment is None:
         raise ValueError("Test requires an attached XYZ structure")
     return call(
         "run_ase",
         {
             "ase_input": {
-                "input_structure_file": match.group(1),
+                "input_structure_file": attachment,
                 "output_results_file": "copper-result.json",
                 "driver": "opt",
                 "steps": 10,

--- a/web-providers.example.toml
+++ b/web-providers.example.toml
@@ -1,0 +1,30 @@
+# Shared, administrator-managed providers for the internal SSO deployment.
+# Credentials belong in the API environment or deployment secrets, never here.
+# File edits and credential rotation require an API restart.
+
+[providers.Argo]
+model = "argo:gpt-4o"
+# Set ARGO_USER to the institution-approved shared service identity.
+# argo_user = "approved-service-user"
+# Optional: override the registry's institutional URL.
+# base_url = "https://apps.inside.anl.gov/argoapi/v1"
+
+# Uncomment an ALCF entry after selecting a supported model from your endpoint.
+# [providers.ALCF]
+# model = "alcf:meta-llama/Llama-3.3-70B-Instruct"
+# api_key_env = "ALCF_ACCESS_TOKEN"
+# The registry selects the serving cluster unless base_url is supplied.
+
+# Existing hosted and local integrations remain available.
+# [providers.OpenAI]
+# model = "gpt-4o-mini"
+# api_key_env = "OPENAI_API_KEY"
+# [providers.Ollama]
+# model = "llama3.2"
+# base_url = "http://host.docker.internal:11434"
+# [providers.Custom]
+# model = "lab-model"
+# base_url = "http://model-server:8000/v1"
+# api_key_env = "LAB_MODEL_API_KEY"
+# Without api_key_env, custom routes use VLLM_API_KEY or a no-auth placeholder.
+# OPENAI_API_KEY is never inherited by a custom route in the web service.


### PR DESCRIPTION
## Summary

Add an independently deployed React interface and Python API for internal institutional users behind SSO. Users can run chemistry with administrator-approved Argo, ALCF, hosted, or local models; answer clarification requests; continue conversations; and inspect structures, trajectories, and downloaded results. Provider credentials are shared and server-managed in this release. Per-user provider credentials remain future work.

- Load approved providers from a read-only TOML file, retaining explicit JSON replacement for compatibility. Validate routes and credentials offline with `python -m chemgraph.api --check-config`; keep history available when a model lacks credentials. React shows configuration readiness without implying verified connectivity.
- Execute both existing ChemGraph graphs in bounded worker processes with attachments, tool progress, bounded conversation context, safe provider errors, and explicit retries that retain attachments. Fix custom endpoint URL/timeout forwarding and a multi-agent subgraph boundary that dropped executor results before the planner received them.
- Enforce ownership, request deduplication, fair scheduling, cancellation, clarification/run time limits, upload reservations, per-user storage budgets, and retention. Publish chemistry outputs separately from internal graph diagnostics. Preserve history as read-only when its model/endpoint changes or demo is disabled; migrate earlier history conservatively and revoke legacy diagnostic downloads.
- Provide separate frontend/API images, Compose configuration, Kubernetes ConfigMap/Secret templates, a deterministic test-only model endpoint, browser CI against Vite and the built Nginx proxy, and an operator guide in `docs/react_web_interface.md`.

The service uses one API replica. Browser refresh preserves active work; API restarts mark unfinished runs interrupted for explicit retry. Existing SDK/graph retries remain, with no automatic whole-run retry. The existing Streamlit interface remains available.

## Deployment acceptance

The implementation and deterministic local validation are complete; no institutional deployment was performed. Before release, validate the site's supported SSO gateway, TLS and network boundary, two-user isolation, persistent storage and backup/restore, shared-account approval, and an optional live EMT smoke test for each enabled Argo/ALCF provider (`--run-llm`). The guide calls out the retired ingress-nginx example and requires translation to an institution-supported gateway. Live providers and institutional SSO were not exercised locally.

## Related issues

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Docs
- [x] Chore / refactor / CI

## How was this tested?

- `ruff check .` and `git diff --check origin/main...HEAD` pass.
- Core suite: **1108 passed, 22 skipped, 2 deselected** with `pytest tests/ -k "not tblite"`. Includes actual single-/multi-agent graphs, clarification, a real EMT optimization, retained context, progress, downloads, provider failures, admission/cancellation, migration, retention, and secret exclusion. No external model service or credential required.
- Frontend unit tests: **7 passed**; TypeScript/Vite production build passes.
- Playwright: **2 passed** in development demo mode, **3 passed** in development real-model mode, and **3 passed** through the built Docker/Nginx proxy. Covers uploads, clarification, reconnect, downloads, WebGL structures, trajectory controls, multi-agent context, unavailable models, safe authentication errors, and mobile layout.
- Both Docker images build, API `pip check` passes, the isolated deployment becomes healthy, Compose configuration/precedence checks pass, and Kubernetes renders nine resources. Workflow YAML parses successfully.
- Optional live-provider smoke test remains behind the existing `--run-llm` gate and is excluded from normal CI.

## Checklist

- [x] Continues the approved `feature/react-ui` branch and targets `main`
- [x] `ruff check .` passes
- [x] `pytest tests/ -k "not tblite"` passes
- [x] Added/updated hermetic tests for changed behavior
- [x] Updated user and operator documentation
- [ ] Complete institutional deployment acceptance checks before release
